### PR TITLE
Remove incorrect pulsar temperatures

### DIFF
--- a/data/extrasolar.stc
+++ b/data/extrasolar.stc
@@ -74522,7 +74522,6 @@ Barycenter "V2134 Oph:MXB 1658-298"
 	OrbitBarycenter "MXB 1658-298"
 	AppMag 18.3
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	EllipticalOrbit
 	{
@@ -74637,7 +74636,6 @@ Barycenter "V2134 Oph:MXB 1658-298"
 	Distance 27723.26
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	UniformRotation
 	{
@@ -77850,7 +77848,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	OrbitBarycenter "PSR B1620-26"
 	AppMag 24
 	SpectralType "D"
-	Temperature 3410
 	Radius 6500
 	EllipticalOrbit
 	{
@@ -77870,7 +77867,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	OrbitBarycenter "PSR B1620-26"
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 5040
 	Radius 10
 	EllipticalOrbit
 	{
@@ -77896,7 +77892,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 3913.872
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	UniformRotation
 	{
@@ -77914,7 +77909,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 1646.83666
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 1960
 	Radius 10
 	UniformRotation
 	{
@@ -77932,7 +77926,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 2054.7828
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 7030
 	Radius 10
 	UniformRotation
 	{
@@ -77950,7 +77943,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 684.9276
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	UniformRotation
 	{
@@ -77968,7 +77960,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 4566.184 # Hongjun An, et al. (2017)
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 10700
 	Radius 10
 	UniformRotation
 	{
@@ -77986,7 +77977,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 9099.7524
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	UniformRotation
 	{
@@ -78004,7 +77994,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 1630.78
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6510
 	Radius 10
 	UniformRotation
 	{
@@ -78022,7 +78011,6 @@ Barycenter "PSR B1620-26:PSR J1623-2631"
 	Distance 741.26364
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 6640
 	Radius 10
 	UniformRotation
 	{
@@ -78819,7 +78807,6 @@ Barycenter "SW Sex"
 	Distance 26092.48
 	AbsMag 16
 	SpectralType "Q"
-	Temperature 9200
 	Radius 10
 	UniformRotation
 	{


### PR DESCRIPTION
Apparently several planet-hosting pulsars had incorrect (far too cool) temperatures. This issue needs to be fixed, especially if there aren't going to be full updates to the default exoplanet catalog in the near future.