### PR TITLE
Fix constellation line in Eridanus

### DIFF
--- a/data/asterisms.dat
+++ b/data/asterisms.dat
@@ -198,7 +198,7 @@
 
 "Eridanus"
 [
-[ "Lambda Eri" "Beta Eri" "Omega Eri" "Mu Eri" "Nu Eri" "Omicron1 Eri" "Gamma Eri" "Pi Eri" "Delta Eri" "Epsilon Eri" "Eta Eri" "Tau1 Eri" "Tau2 Eri" "Tau3 Eri" "Tau4 Eri" "Tau5 Eri" "Tau6 Eri" "Tau9 Eri" "Upsilon1 Eri" "Upsilon2 Eri" "43 Eri" "41 Eri" "G Eri" "F Eri" "E Eri" "Theta Eri" "Iota Eri" "S Eri" "Kappa Eri" "Phi Eri" "Chi Eri" "Alpha Eri" ]
+[ "Lambda Eri" "Beta Eri" "Omega Eri" "Mu Eri" "Nu Eri" "Omicron1 Eri" "Gamma Eri" "Pi Eri" "Delta Eri" "Epsilon Eri" "Eta Eri" "Tau1 Eri" "Tau2 Eri" "Tau3 Eri" "Tau4 Eri" "Tau5 Eri" "Tau6 Eri" "Tau9 Eri" "Upsilon1 Eri" "Upsilon2 Eri" "43 Eri" "41 Eri" "G Eri" "F Eri" "E Eri" "Theta Eri" "Iota Eri" "HIP 12413" "Kappa Eri" "Phi Eri" "Chi Eri" "Alpha Eri" ]
 ]
 
 "Fornax"


### PR DESCRIPTION
The line should go through the star s Eri, not S Eri. Since name lookup is currently case-sensitive, use the HIP id instead to specify the star.

Fixes #94