### PR TITLE
Update globular and open cluster catalog

### DIFF
--- a/data/globulars.dsc
+++ b/data/globulars.dsc
@@ -1,2126 +1,2383 @@
-# "Catalog of Parameters for 150 Milky Way Globular Clusters",
+# Globular clusters
+# Extracted by Elvis O. Mendes from "Fundamental parameters of Galactic
+# globular clusters" by Holger Baumgardt, Antonio Sollima, Michael Hilker,
+# Andrea Bellini, Eugene Vasiliev, Vincent Henault-Brunet & Nolan Dickson,
+# March 2023, Monthly Notices of the Royal Astronomical Society, availiable
+# at http://people.smp.uq.edu.au/HolgerBaumgardt/globular/index.html.
 #
-# 2003 Update, by William E. Harris.
-# http://physwww.physics.mcmaster.ca/~harris/mwgc.dat
-# Bibliography: http://physwww.mcmaster.ca/%7Eharris/mwgc.ref
 #
-# Supplemented by diameters <=> 25mu isophote from
-# Brian A. Skiff/Lowell Observatory, NGC/IC project,
-# http://www.ngcic.org/data_archive/gc.txt.
+# For extragalactic clusters, the tidal radius was calculated with
+# Equation 1 from "The Influence of Orbital Eccentricity on Tidal
+# Radii of Star Clusters" by Webb, Jeremy J., Harris, William E.,
+# Sills, Alison, Hurley, Jarrod R., The Astrophysical Journal,
+# Volume 764, Issue 2, article id. 124, 12 pp. (2013).
 #
-# Supplemented by diameters <=> 25mu isophote from
-# the SEDS 2007 catalog (H. Frommert)
-# http://www.seds.org/~spider/spider/MWGC/mwgc.html.
 #
-# Supplemented by a cross-index for alternate identifiers
-# generated from and compatible with the SIMBAD world data base,
-# using the batch interface
-# http://simbad.u-strasbg.fr/simbad/sim-fscript.
+# Since no galaxy mass values were given, different references were
+# used for the masses of Fornax Dwarf and the Magellanic Clouds:
 #
-# Adapted for Celestia with Perl script: globulars.pl Revision: 1.0.0 
-# Processed 2009-2-4 3 34 0 11:41:11 UTC
+# - Fornax Dwarf: 1.6e8 MSun, "The Morphology and Structure of
+# Stellar Populations in the Fornax Dwarf Spheroidal Galaxy
+# from Dark Energy Survey Data", M. Y. Wang et al. 2019 ApJ 881 118.
 #
-# by Dr. Fridger Schrempp, fridger.schrempp@desy.de
-# ------------------------------------------------------ 
+# - SMC: 6.5e9 MSun, "The total mass and dark halo properties of
+# the Small Magellanic Cloud", Kenji Bekki, Snežana Stanimirović
+# Monthly Notices of the Royal Astronomical Society, Volume 395,
+# Issue 1, pp. 342-350.
+#
+# - LMC: 1.38e11 MSun, "The total mass of the Large Magellanic Cloud
+# from its perturbation on the Orphan stream", D. Erkal et al. 2019,
+# Monthly Notices of the Royal Astronomical Society, Volume 487,
+# Issue 2, p.2685-2700.
 
+Globular "Lindsay 1:ESO 28-8:OGLE-CL SMC 313"
+{
+	RA 0.065122
+	Dec -73.47186
+	Distance 185582.979
+	Radius 233.486
+	CoreRadius 0.83
+	KingConcentration 0.717
+	AbsMag -7.326
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Lindsay 1"
+}
 
 Globular "47 Tuc:NGC 104:Melotte 1:HD 2051:RBS 55:GCl 1:C 0021-723:XI Tuc"
 {
-        RA          	    0.4014  # [hours]
-        Dec         	  -72.0808  # [degrees]
-        Distance    	 1.468e+04  # [ly]
-        Radius      	     106.7  # [ly], mu25 Isophote
-        CoreRadius  	       0.4  # [arcmin]
-        KingConcentration     2.03  # c = log10(r_t/r_c)
-        AbsMag      	     -9.42  # [V mags]
-        Axis       	[ -0.7429  -0.2364  -0.6263]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 104"
+	RA 0.401586
+	Dec -72.08131
+	Distance 14742.268
+	Radius 406.489
+	CoreRadius 0.464
+	KingConcentration 2.31
+	AbsMag -9.196
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=47 Tuc"
+}
+
+Globular "Kron 3:Lindsay 8:ESO 28-19:OGLE-CL SMC 319"
+{
+	RA 0.412953
+	Dec -72.79361
+	Distance 197650.765
+	Radius 145.326
+	CoreRadius 0.409
+	KingConcentration 0.791
+	AbsMag -7.502
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Kron 3"
+}
+
+Globular "NGC 121:Kron 2:Lindsay 10:ESO 50-12:OGLE-CL SMC 311"
+{
+	RA 0.446928
+	Dec -71.53594
+	Distance 211675.489
+	Radius 205.794
+	CoreRadius 0.14
+	KingConcentration 1.377
+	AbsMag -8.451
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 121"
+}
+
+Globular "Lindsay 38:ESO 51-3:OGLE-CL SMC 308"
+{
+	RA 0.813833
+	Dec -69.87017
+	Distance 217546.304
+	Radius 92.908
+	CoreRadius 0.363
+	KingConcentration 0.606
+	AbsMag -5.041
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Lindsay 38"
 }
 
 Globular "NGC 288:Melotte 3:GCl 2:C 0050-268"
 {
-        RA          	    0.8797  # [hours]
-        Dec         	  -26.5900  # [degrees]
-        Distance    	  2.87e+04  # [ly]
-        Radius      	     54.27  # [ly], mu25 Isophote
-        CoreRadius  	      1.42  # [arcmin]
-        KingConcentration     0.96  # c = log10(r_t/r_c)
-        AbsMag      	     -6.74  # [V mags]
-        Axis       	[  0.7644   0.4432   0.4683]
-        Angle       	     148.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 288"
+	RA 0.879233
+	Dec -26.58261
+	Distance 29321.458
+	Radius 310.37
+	CoreRadius 1.338
+	KingConcentration 1.434
+	AbsMag -6.669
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 288"
+}
+
+Globular "NGC 330:Kron 35:Lindsay 54:ESO 29-24:OGLE-CL SMC 107:[RZ2005] 98"
+{
+	RA 0.938397
+	Dec -72.45897
+	Distance 196346.139
+	Radius 19.434
+	CoreRadius 0.151
+	KingConcentration 0.352
+	AbsMag -9.348
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 330"
+}
+
+Globular "NGC 339:Kron 36:Lindsay 59:ESO 29-25:[RZ2005] 104"
+{
+	RA 0.962933
+	Dec -74.47033
+	Distance 187866.074
+	Radius 96.146
+	CoreRadius 0.517
+	KingConcentration 0.531
+	AbsMag -6.682
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 339"
 }
 
 Globular "NGC 362:Melotte 4:LI-SMC 158:GCl 3:C 0100-711"
 {
-        RA          	    1.0539  # [hours]
-        Dec         	  -70.8483  # [degrees]
-        Distance    	 2.772e+04  # [ly]
-        Radius      	     56.45  # [ly], mu25 Isophote
-        CoreRadius  	      0.19  # [arcmin]
-        KingConcentration     1.93  # c = log10(r_t/r_c)
-        AbsMag      	     -8.41  # [V mags]
-        Axis       	[ -0.7974  -0.2191  -0.5622]
-        Angle       	     176.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 362"
+	RA 1.053961
+	Dec -70.84878
+	Distance 28799.608
+	Radius 283.56
+	CoreRadius 0.167
+	KingConcentration 2.306
+	AbsMag -8.25
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 362"
+}
+
+Globular "NGC 416:Kron 59:Lindsay 83:ESO 29-32:OGLE-CL SMC 158:[RZ2005] 171"
+{
+	RA 1.133103
+	Dec -72.35547
+	Distance 196998.452
+	Radius 100.478
+	CoreRadius 0.16
+	KingConcentration 1.04
+	AbsMag -7.795
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 416"
+}
+
+Globular "NGC 419:Kron 58:Lindsay 85:ESO 29-33:LI-SMC 182:[RZ2005] 174"
+{
+	RA 1.138214
+	Dec -72.88439
+	Distance 191779.95
+	Radius 79.996
+	CoreRadius 0.216
+	KingConcentration 0.823
+	AbsMag -9.007
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 419"
+}
+
+Globular "Lindsay 113:ESO 30-4:OGLE-CL MBR 47"
+{
+	RA 1.824914
+	Dec -73.72783
+	Distance 187539.917
+	Radius 203.203
+	CoreRadius 0.6
+	KingConcentration 0.793
+	AbsMag -5.188
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Lindsay 113"
+}
+
+Globular "Whiting 1:WHI B0200-03"
+{
+	RA 2.049167
+	Dec -3.25278
+	Distance 99771.236
+	Radius 143.248
+	CoreRadius 0.211
+	KingConcentration 1.369
+	AbsMag -2.808
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Whiting 1"
+}
+
+Globular "Fornax 1:C 0235-344:ESO 355-29"
+{
+	RA 2.61725
+	Dec -34.18333
+	Distance 456618.929
+	Radius 238.115
+	CoreRadius 0.231
+	KingConcentration 0.89
+	AbsMag -5.541
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Fornax 1"
+}
+
+Globular "Fornax 3:NGC 1049:C 0237-345:ESO 356-3:MCG-06-06-017"
+{
+	RA 2.663378
+	Dec -34.25794
+	Distance 456618.929
+	Radius 114.926
+	CoreRadius 0.035
+	KingConcentration 1.395
+	AbsMag -7.551
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Fornax 3"
 }
 
 Globular "NGC 1261:GCl 5:C 0310-554"
 {
-        RA          	    3.2042  # [hours]
-        Dec         	  -55.2169  # [degrees]
-        Distance    	 5.349e+04  # [ly]
-        Radius      	      52.9  # [ly], mu25 Isophote
-        CoreRadius  	      0.39  # [arcmin]
-        KingConcentration     1.27  # c = log10(r_t/r_c)
-        AbsMag      	     -7.81  # [V mags]
-        Axis       	[  0.9332   0.1748    0.314]
-        Angle       	     169.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1261"
+	RA 3.204503
+	Dec -55.21622
+	Distance 53489.646
+	Radius 450.487
+	CoreRadius 0.22
+	KingConcentration 2.119
+	AbsMag -7.764
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1261"
 }
 
 Globular "Pal 1:ZW VII 7:LEDA 13165:C 0325+794"
 {
-        RA          	    3.5564  # [hours]
-        Dec         	   79.5806  # [degrees]
-        Distance    	 3.555e+04  # [ly]
-        Radius      	     14.48  # [ly], mu25 Isophote
-        CoreRadius  	      0.22  # [arcmin]
-        KingConcentration     1.61  # c = log10(r_t/r_c)
-        AbsMag      	     -2.47  # [V mags]
-        Axis       	[  0.6602   0.7462 -0.08515]
-        Angle       	      49.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 1"
+	RA 3.555567
+	Dec 79.58105
+	Distance 36464.283
+	Radius 74.494
+	CoreRadius 0.141
+	KingConcentration 1.696
+	AbsMag -1.292
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 1"
 }
 
-Globular "AM 1:Name E1:LEDA 14098:ESO 201-10:C 0354-498:C 0353-497"
+Globular "AM 1:E1:LEDA 14098:ESO 201-10:C 0354-498:C 0353-497"
 {
-        RA          	    3.9172  # [hours]
-        Dec         	  -49.6144  # [degrees]
-        Distance    	 3.976e+05  # [ly]
-        Radius      	     28.91  # [ly], mu25 Isophote
-        CoreRadius  	      0.15  # [arcmin]
-        KingConcentration     1.11  # c = log10(r_t/r_c)
-        AbsMag      	     -4.71  # [V mags]
-        Axis       	[  0.9623   0.1438   0.2309]
-        Angle       	     163.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Name E1"
+	RA 3.917306
+	Dec -49.61528
+	Distance 387832.549
+	Radius 856.519
+	CoreRadius 0.2
+	KingConcentration 1.579
+	AbsMag -5.306
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=AM 1"
 }
 
-Globular "Eridanus:Name ERI star cluster:Name CL ERID 1:C 0422-213"
+Globular "Eridanus:ERI star cluster:CL ERID 1:C 0422-213"
 {
-        RA          	    4.0679  # [hours]
-        Dec         	   -1.0175  # [degrees]
-        Distance    	 2.942e+05  # [ly]
-        Radius      	     42.79  # [ly], mu25 Isophote
-        CoreRadius  	      0.25  # [arcmin]
-        KingConcentration     1.10  # c = log10(r_t/r_c)
-        AbsMag      	     -5.14  # [V mags]
-        Axis       	[  0.9559   0.2442   0.1634]
-        Angle       	     116.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Eridanus"
+	RA 4.412374
+	Dec -21.18678
+	Distance 276189.221
+	Radius 513.044
+	CoreRadius 0.375
+	KingConcentration 1.232
+	AbsMag -4.619
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Eridanus"
+}
+
+Globular "Reticulum:Sersic Cluster:C 0435-590:KMHK 10"
+{
+	RA 4.603053
+	Dec -58.86264
+	Distance 155250.436
+	Radius 168.611
+	CoreRadius 0.942
+	KingConcentration 0.598
+	AbsMag -6.138
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Reticulum"
+}
+
+Globular "NGC 1651:KMHK 20:[SL63] 7:ESO 55-30:LW 12:[WZ2011] 142"
+{
+	RA 4.625619
+	Dec -70.58633
+	Distance 160142.781
+	Radius 44.669
+	CoreRadius 0.306
+	KingConcentration 0.496
+	AbsMag -6.325
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1651"
 }
 
 Globular "Pal 2:C 0443+313"
 {
-        RA          	    4.7681  # [hours]
-        Dec         	   31.3808  # [degrees]
-        Distance    	 9.002e+04  # [ly]
-        Radius      	     28.81  # [ly], mu25 Isophote
-        CoreRadius  	      0.24  # [arcmin]
-        KingConcentration     1.45  # c = log10(r_t/r_c)
-        AbsMag      	     -8.01  # [V mags]
-        Axis       	[  0.9706   0.2293  0.07269]
-        Angle       	     83.75  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 2"
+	RA 4.768308
+	Dec 31.3815
+	Distance 85355.124
+	Radius 395.726
+	CoreRadius 0.221
+	KingConcentration 1.859
+	AbsMag -4.449
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 2"
+}
+
+Globular "NGC 1755:KMHK 272:[WZ2011] 672:ESO 56-28:[SL63] 99"
+{
+	RA 4.920925
+	Dec -68.2056
+	Distance 152641.185
+	Radius 23.307
+	CoreRadius 0.152
+	KingConcentration 0.538
+	AbsMag -8.501
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1755"
+}
+
+Globular "NGC 1783:HD 270921:CD-66 283:KMHK 383:ESO 85-29"
+{
+	RA 4.985825
+	Dec -65.98716
+	Distance 160468.938
+	Radius 77.094
+	CoreRadius 0.328
+	KingConcentration 0.701
+	AbsMag -8.07
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1783"
+}
+
+Globular "NGC 1806:KMHK 462:[WZ2011] 702:ESO 56-47:[SL63] 184"
+{
+	RA 5.036389
+	Dec -67.98805
+	Distance 160468.938
+	Radius 27.21
+	CoreRadius 0.428
+	KingConcentration 0.135
+	AbsMag -7.46
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1806"
+}
+
+Globular "NGC 1846:KMHK 557:[SL63] 243:ESO 56-67:OGLE-CL LMC 128:[WZ2011] 780"
+{
+	RA 5.126389
+	Dec -67.46083
+	Distance 160468.938
+	Radius 30.412
+	CoreRadius 0.521
+	KingConcentration 0.097
+	AbsMag -7.78
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1846"
+}
+
+Globular "NGC 1850:HD 34039:BRHT 5a"
+{
+	RA 5.1459
+	Dec -68.76242
+	Distance 152315.028
+	Radius 11.668
+	CoreRadius 0.266
+	KingConcentration -0.004
+	AbsMag -8.777
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1850"
+}
+
+Globular "NGC 1856:OGLE-CL LMC 157:[WZ2011] 483:ESO 56-73:[SL63] 271"
+{
+	RA 5.158356
+	Dec -69.12886
+	Distance 159164.312
+	Radius 8.903
+	CoreRadius 0.154
+	KingConcentration 0.096
+	AbsMag -8.382
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1856"
+}
+
+Globular "NGC 1866:HD 34574:KMHK 664:LW 163:CD-65 314"
+{
+	RA 5.227403
+	Dec -65.46466
+	Distance 163404.345
+	Radius 57.973
+	CoreRadius 0.257
+	KingConcentration 0.677
+	AbsMag -8.969
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1866"
 }
 
 Globular "NGC 1851:GCl 9:C 0512-400"
 {
-        RA          	    5.2350  # [hours]
-        Dec         	  -40.0472  # [degrees]
-        Distance    	 3.947e+04  # [ly]
-        Radius      	     68.88  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     2.29  # c = log10(r_t/r_c)
-        AbsMag      	     -8.33  # [V mags]
-        Axis       	[  0.9947  0.06136  0.08233]
-        Angle       	     153.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1851"
+	RA 5.235211
+	Dec -40.04655
+	Distance 38975.687
+	Radius 403.423
+	CoreRadius 0.04
+	KingConcentration 2.946
+	AbsMag -8.317
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1851"
 }
 
 Globular "M 79:NGC 1904:GCl 10:C 0522-245"
 {
-        RA          	    5.4028  # [hours]
-        Dec         	  -24.5242  # [degrees]
-        Distance    	 4.208e+04  # [ly]
-        Radius      	     58.75  # [ly], mu25 Isophote
-        CoreRadius  	      0.16  # [arcmin]
-        KingConcentration     1.72  # c = log10(r_t/r_c)
-        AbsMag      	     -7.86  # [V mags]
-        Axis       	[  0.9965  0.05857  0.05969]
-        Angle       	     138.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1904"
+	RA 5.403056
+	Dec -24.52442
+	Distance 42661.254
+	Radius 215.948
+	CoreRadius 0.087
+	KingConcentration 2.302
+	AbsMag -7.643
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 79"
+}
+
+Globular "NGC 1978:KMHK 944:[WZ2011] 946:ESO 85-90:[SL63] 501"
+{
+	RA 5.479086
+	Dec -66.23636
+	Distance 156228.905
+	Radius 71.057
+	CoreRadius 0.291
+	KingConcentration 0.731
+	AbsMag -8.202
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 1978"
+}
+
+Globular "Hodge 301:M-OB 1"
+{
+	RA 5.63813
+	Dec -69.06668
+	Distance 163404.345
+	Radius 14.953
+	CoreRadius 0.165
+	KingConcentration 0.281
+	AbsMag -7.759
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Hodge 301"
+}
+
+Globular "R 136:RMC 136:HD 38268:TYC 9163-1014-1:Brey 82"
+{
+	RA 5.645111
+	Dec -69.10094
+	Distance 163404.345
+	Radius 38.756
+	CoreRadius 0.056
+	KingConcentration 1.166
+	AbsMag -10.409
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=R 136"
+}
+
+Globular "SL 639:M-OB 3"
+{
+	RA 5.661009
+	Dec -69.19778
+	Distance 163404.345
+	Radius 12.779
+	CoreRadius 0.079
+	KingConcentration 0.532
+	AbsMag -6.969
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=SL 639"
+}
+
+Globular "Hodge 6:LW 274:ESO 57-30"
+{
+	RA 5.704805
+	Dec -71.59097
+	Distance 163404.345
+	Radius 47.762
+	CoreRadius 0.289
+	KingConcentration 0.541
+	AbsMag -6.409
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Hodge 6"
+}
+
+Globular "NGC 2121:KMHK 1398:[SL63] 725:ESO 57-40:LW 303:[WZ2011] 67"
+{
+	RA 5.803672
+	Dec -71.4797
+	Distance 149379.621
+	Radius 69.359
+	CoreRadius 0.489
+	KingConcentration 0.513
+	AbsMag -5.934
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2121"
+}
+
+Globular "NGC 2173:KMHK 1570:[SL63] 807:ESO 33-34:LW 348"
+{
+	RA 5.966221
+	Dec -72.97867
+	Distance 158838.156
+	Radius 51.752
+	CoreRadius 0.268
+	KingConcentration 0.621
+	AbsMag -6.558
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2173"
+}
+
+Globular "NGC 2155:KMHK 1563:[SL63] 803:ESO 86-45:LW 347:[WZ2011] 999"
+{
+	RA 5.975583
+	Dec -65.47739
+	Distance 149053.465
+	Radius 55.655
+	CoreRadius 0.272
+	KingConcentration 0.673
+	AbsMag -5.71
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2155"
+}
+
+Globular "NGC 2203:KMHK 1639:[SL63] 836:ESO 34-4:LW 380"
+{
+	RA 6.078505
+	Dec -75.43781
+	Distance 156881.218
+	Radius 96.181
+	CoreRadius 0.345
+	KingConcentration 0.786
+	AbsMag -7.121
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2203"
 }
 
 Globular "NGC 2298:C 0647-359"
 {
-        RA          	    6.8164  # [hours]
-        Dec         	  -36.0053  # [degrees]
-        Distance    	  3.49e+04  # [ly]
-        Radius      	     25.38  # [ly], mu25 Isophote
-        CoreRadius  	      0.34  # [arcmin]
-        KingConcentration     1.28  # c = log10(r_t/r_c)
-        AbsMag      	      -6.3  # [V mags]
-        Axis       	[  0.9939 -0.06913 -0.08623]
-        Angle       	     149.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2298"
+	RA 6.816503
+	Dec -36.00531
+	Distance 32061.172
+	Radius 238.453
+	CoreRadius 0.15
+	KingConcentration 2.231
+	AbsMag -5.903
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2298"
 }
 
 Globular "NGC 2419:GCl 12:C 0734+390"
 {
-        RA          	    7.6356  # [hours]
-        Dec         	   38.8819  # [degrees]
-        Distance    	 2.746e+05  # [ly]
-        Radius      	     183.7  # [ly], mu25 Isophote
-        CoreRadius  	      0.35  # [arcmin]
-        KingConcentration     1.40  # c = log10(r_t/r_c)
-        AbsMag      	     -9.58  # [V mags]
-        Axis       	[  0.9412  -0.3281 -0.08082]
-        Angle       	     77.93  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2419"
+	RA 7.635686
+	Dec 38.88194
+	Distance 288550.547
+	Radius 2397.152
+	CoreRadius 0.323
+	KingConcentration 1.946
+	AbsMag -9.174
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2419"
 }
 
 Globular "Pyxis:C J0908-373:C J0907-372"
 {
-        RA          	    9.1325  # [hours]
-        Dec         	  -37.2214  # [degrees]
-        Distance    	 1.295e+05  # [ly]
-        Radius      	     37.67  # [ly], mu25 Isophote
-        CoreRadius  	      1.38  # [arcmin]
-        KingConcentration     0.65  # c = log10(r_t/r_c)
-        AbsMag      	     -5.75  # [V mags]
-        Axis       	[  0.9122  -0.2529  -0.3225]
-        Angle       	     153.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pyxis"
+	RA 9.13246
+	Dec -37.2266
+	Distance 119144.925
+	Radius 433.07
+	CoreRadius 1.267
+	KingConcentration 0.994
+	AbsMag -4.613
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pyxis"
 }
 
 Globular "NGC 2808:GCl 13:C 0911-646"
 {
-        RA          	    9.2006  # [hours]
-        Dec         	  -64.8631  # [degrees]
-        Distance    	 3.131e+04  # [ly]
-        Radius      	     63.76  # [ly], mu25 Isophote
-        CoreRadius  	      0.26  # [arcmin]
-        KingConcentration     1.78  # c = log10(r_t/r_c)
-        AbsMag      	     -9.39  # [V mags]
-        Axis       	[  0.9135  -0.1673  -0.3708]
-        Angle       	     178.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2808"
+	RA 9.200861
+	Dec -64.86349
+	Distance 32811.332
+	Radius 523.579
+	CoreRadius 0.253
+	KingConcentration 2.336
+	AbsMag -8.883
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 2808"
 }
 
-Globular "Name E3:Name E 3:ESO 37-1:C 0921-770"
+Globular "E 3:E3:ESO 37-1:C 0921-770"
 {
-        RA          	    9.3497  # [hours]
-        Dec         	  -77.2825  # [degrees]
-        Distance    	 1.403e+04  # [ly]
-        Radius      	      20.4  # [ly], mu25 Isophote
-        CoreRadius  	      1.87  # [arcmin]
-        KingConcentration     0.75  # c = log10(r_t/r_c)
-        AbsMag      	     -2.77  # [V mags]
-        Axis       	[ -0.9047   0.1322   0.4051]
-        Angle       	     170.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Name E3"
+	RA 9.349186
+	Dec -77.28189
+	Distance 25701.123
+	Radius 65.101
+	CoreRadius 0.55
+	KingConcentration 1.2
+	AbsMag -2.633
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=E 3"
 }
 
-Globular "Pal 3:Name SEX C:SPB 132:UGC 5439:C 1003+003"
+Globular "Pal 3:SEX C:SPB 132:UGC 5439:C 1003+00315"
 {
-        RA          	   10.0919  # [hours]
-        Dec         	    0.0714  # [degrees]
-        Distance    	 3.024e+05  # [ly]
-        Radius      	     70.36  # [ly], mu25 Isophote
-        CoreRadius  	      0.48  # [arcmin]
-        KingConcentration     1.00  # c = log10(r_t/r_c)
-        AbsMag      	      -5.7  # [V mags]
-        Axis       	[  0.8153  -0.4843  -0.3174]
-        Angle       	     123.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 3"
+	RA 10.092108
+	Dec 0.07167
+	Distance 309326.709
+	Radius 749.116
+	CoreRadius 0.552
+	KingConcentration 1.178
+	AbsMag -5.325
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 3"
 }
 
 Globular "NGC 3201:GCl 15:C 1015-461"
 {
-        RA          	   10.2933  # [hours]
-        Dec         	  -46.4111  # [degrees]
-        Distance    	 1.631e+04  # [ly]
-        Radius      	     47.44  # [ly], mu25 Isophote
-        CoreRadius  	      1.43  # [arcmin]
-        KingConcentration     1.30  # c = log10(r_t/r_c)
-        AbsMag      	     -7.46  # [V mags]
-        Axis       	[  0.8424  -0.2975  -0.4492]
-        Angle       	       163  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 3201"
+	RA 10.293562
+	Dec -46.41248
+	Distance 15459.812
+	Radius 268.557
+	CoreRadius 1.204
+	KingConcentration 1.695
+	AbsMag -6.609
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 3201"
 }
 
 Globular "Pal 4:UGCA 237:GCl 17:C 1126+292"
 {
-        RA          	   11.4878  # [hours]
-        Dec         	   28.9736  # [degrees]
-        Distance    	 3.562e+05  # [ly]
-        Radius      	     67.34  # [ly], mu25 Isophote
-        CoreRadius  	      0.55  # [arcmin]
-        KingConcentration     0.78  # c = log10(r_t/r_c)
-        AbsMag      	     -6.02  # [V mags]
-        Axis       	[  0.6096  -0.7505  -0.2554]
-        Angle       	     112.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 4"
+	RA 11.487889
+	Dec 28.97337
+	Distance 330689.951
+	Radius 676.905
+	CoreRadius 0.372
+	KingConcentration 1.277
+	AbsMag -5.8
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 4"
+}
+
+Globular "Crater:Laevens 1:PSO J174.0675-10.8774"
+{
+	RA 11.604583
+	Dec -10.87697
+	Distance 480200.035
+	Radius 801.627
+	CoreRadius 0.319
+	KingConcentration 1.255
+	AbsMag -5.1
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Crater"
 }
 
 Globular "NGC 4147:GCl 18:C 1207+188"
 {
-        RA          	   12.1683  # [hours]
-        Dec         	   18.5419  # [degrees]
-        Distance    	 6.295e+04  # [ly]
-        Radius      	     40.29  # [ly], mu25 Isophote
-        CoreRadius  	       0.1  # [arcmin]
-        KingConcentration     1.80  # c = log10(r_t/r_c)
-        AbsMag      	     -6.16  # [V mags]
-        Axis       	[  0.5761  -0.7466  -0.3326]
-        Angle       	     124.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4147"
+	RA 12.168417
+	Dec 18.54264
+	Distance 60469.392
+	Radius 305.706
+	CoreRadius 0.08
+	KingConcentration 2.338
+	AbsMag -6.051
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4147"
 }
 
 Globular "NGC 4372:GCl 19:C 1223-724"
 {
-        RA          	   12.4292  # [hours]
-        Dec         	  -72.6592  # [degrees]
-        Distance    	 1.892e+04  # [ly]
-        Radius      	     13.76  # [ly], mu25 Isophote
-        CoreRadius  	      1.75  # [arcmin]
-        KingConcentration     1.30  # c = log10(r_t/r_c)
-        AbsMag      	     -7.77  # [V mags]
-        Axis       	[ -0.6658     0.26   0.6994]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4372"
+	RA 12.429273
+	Dec -72.65908
+	Distance 18623.529
+	Radius 241.388
+	CoreRadius 2.137
+	KingConcentration 1.319
+	AbsMag -6.413
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4372"
 }
 
 Globular "Ruprecht 106:C 1236-508:C 1235-509"
 {
-        RA          	   12.6444  # [hours]
-        Dec         	  -51.1503  # [degrees]
-        Distance    	 6.915e+04  # [ly]
-        Radius      	     20.11  # [ly], mu25 Isophote
-        CoreRadius  	         1  # [arcmin]
-        KingConcentration     0.70  # c = log10(r_t/r_c)
-        AbsMag      	     -6.35  # [V mags]
-        Axis       	[  0.6416  -0.3967  -0.6565]
-        Angle       	     170.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ruprecht 106"
+	RA 12.6445
+	Dec -51.15028
+	Distance 67546.986
+	Radius 239.66
+	CoreRadius 0.835
+	KingConcentration 1.165
+	AbsMag -5.531
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Rup 106"
 }
 
 Globular "M 68:NGC 4590:HD 110032:GCl 20:C 1236-264"
 {
-        RA          	   12.6578  # [hours]
-        Dec         	  -26.7428  # [degrees]
-        Distance    	 3.327e+04  # [ly]
-        Radius      	     53.23  # [ly], mu25 Isophote
-        CoreRadius  	      0.69  # [arcmin]
-        KingConcentration     1.64  # c = log10(r_t/r_c)
-        AbsMag      	     -7.35  # [V mags]
-        Axis       	[  0.6203  -0.5384  -0.5704]
-        Angle       	     154.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4590"
+	RA 12.657772
+	Dec -26.74406
+	Distance 33920.263
+	Radius 255.315
+	CoreRadius 0.615
+	KingConcentration 1.624
+	AbsMag -7.095
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 68"
 }
 
-Globular "NGC 4833:GCl 21:C 1256-706"
+Globular "BH 140:VDBH 140:C 1250-669:IRAS 12498-6654"
 {
-        RA          	   12.9931  # [hours]
-        Dec         	  -70.8747  # [degrees]
-        Distance    	  2.12e+04  # [ly]
-        Radius      	     43.17  # [ly], mu25 Isophote
-        CoreRadius  	         1  # [arcmin]
-        KingConcentration     1.25  # c = log10(r_t/r_c)
-        AbsMag      	     -8.16  # [V mags]
-        Axis       	[ -0.6092   0.2878   0.7389]
-        Angle       	     177.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4833"
+	RA 12.898195
+	Dec -67.17728
+	Distance 15688.122
+	Radius 168.851
+	CoreRadius 3.438
+	KingConcentration 1.032
+	AbsMag -4.271
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=BH 140"
+}
+
+Globular "NGC 4833:GCl 21:C 1256-7066"
+{
+	RA 12.992756
+	Dec -70.8765
+	Distance 21134.933
+	Radius 251.336
+	CoreRadius 0.674
+	KingConcentration 1.783
+	AbsMag -6.868
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 4833"
 }
 
 Globular "M 53:NGC 5024:GCl 22:C 1310+184"
 {
-        RA          	   13.2153  # [hours]
-        Dec         	   18.1692  # [degrees]
-        Distance    	 5.806e+04  # [ly]
-        Radius      	     109.8  # [ly], mu25 Isophote
-        CoreRadius  	      0.36  # [arcmin]
-        KingConcentration     1.78  # c = log10(r_t/r_c)
-        AbsMag      	      -8.7  # [V mags]
-        Axis       	[  0.4714  -0.8044  -0.3615]
-        Angle       	     133.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5024"
+	RA 13.215347
+	Dec 18.16817
+	Distance 60338.93
+	Radius 596.997
+	CoreRadius 0.347
+	KingConcentration 1.991
+	AbsMag -8.636
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 53"
 }
 
 Globular "NGC 5053:GCl 23:C 1313+179"
 {
-        RA          	   13.2742  # [hours]
-        Dec         	   17.6981  # [degrees]
-        Distance    	 5.349e+04  # [ly]
-        Radius      	      77.8  # [ly], mu25 Isophote
-        CoreRadius  	      1.98  # [arcmin]
-        KingConcentration     0.84  # c = log10(r_t/r_c)
-        AbsMag      	     -6.72  # [V mags]
-        Axis       	[  0.4668  -0.8052  -0.3658]
-        Angle       	     134.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5053"
+	RA 13.274192
+	Dec 17.70025
+	Distance 57207.829
+	Radius 298.89
+	CoreRadius 1.803
+	KingConcentration 0.998
+	AbsMag -6.3
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5053"
 }
 
 Globular "OME Cen:NGC 5139:HD 116790:GCl 24:C 1323-472"
 {
-        RA          	   13.4458  # [hours]
-        Dec         	  -47.4769  # [degrees]
-        Distance    	 1.729e+04  # [ly]
-        Radius      	     138.3  # [ly], mu25 Isophote
-        CoreRadius  	       1.4  # [arcmin]
-        KingConcentration     1.61  # c = log10(r_t/r_c)
-        AbsMag      	    -10.29  # [V mags]
-        Axis       	[  0.5561  -0.4524  -0.6972]
-        Angle       	     169.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5139"
+	RA 13.446466
+	Dec -47.47947
+	Distance 17710.291
+	Radius 680.362
+	CoreRadius 2.722
+	KingConcentration 1.686
+	AbsMag -10.174
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ω Cen"
 }
 
 Globular "M 3:NGC 5272:GCl 25:C 1339+286"
 {
-        RA          	   13.7031  # [hours]
-        Dec         	   28.3756  # [degrees]
-        Distance    	 3.392e+04  # [ly]
-        Radius      	     88.81  # [ly], mu25 Isophote
-        CoreRadius  	      0.55  # [arcmin]
-        KingConcentration     1.84  # c = log10(r_t/r_c)
-        AbsMag      	     -8.93  # [V mags]
-        Axis       	[   0.392  -0.8693  -0.3009]
-        Angle       	     133.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5272"
+	RA 13.703228
+	Dec 28.37728
+	Distance 33202.719
+	Radius 421.557
+	CoreRadius 0.331
+	KingConcentration 2.12
+	AbsMag -8.649
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 3"
 }
 
 Globular "NGC 5286:GCl 26:C 1343-511"
 {
-        RA          	   13.7739  # [hours]
-        Dec         	  -51.3733  # [degrees]
-        Distance    	 3.588e+04  # [ly]
-        Radius      	      57.4  # [ly], mu25 Isophote
-        CoreRadius  	      0.29  # [arcmin]
-        KingConcentration     1.46  # c = log10(r_t/r_c)
-        AbsMag      	     -8.61  # [V mags]
-        Axis       	[  0.5221  -0.4397  -0.7308]
-        Angle       	       172  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5286"
+	RA 13.774114
+	Dec -51.37425
+	Distance 36203.358
+	Radius 311.414
+	CoreRadius 0.152
+	KingConcentration 2.29
+	AbsMag -7.877
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5286"
 }
 
 Globular "AM 4:C 1353-269"
 {
-        RA          	   13.9306  # [hours]
-        Dec         	  -27.1728  # [degrees]
-        Distance    	 9.752e+04  # [ly]
-        Radius      	     42.55  # [ly], mu25 Isophote
-        CoreRadius  	      0.42  # [arcmin]
-        KingConcentration     0.50  # c = log10(r_t/r_c)
-        AbsMag      	      -1.6  # [V mags]
-        Axis       	[  0.4853  -0.5978  -0.6381]
-        Angle       	     160.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=AM 4"
+	RA 13.939271
+	Dec -27.16517
+	Distance 94617.965
+	Radius 94.096
+	CoreRadius 0.251
+	KingConcentration 1.134
+	AbsMag -0.823
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=AM 4"
 }
 
 Globular "NGC 5466:GCl 27:C 1403+287"
 {
-        RA          	   14.0908  # [hours]
-        Dec         	   28.5344  # [degrees]
-        Distance    	 5.186e+04  # [ly]
-        Radius      	     67.89  # [ly], mu25 Isophote
-        CoreRadius  	      1.64  # [arcmin]
-        KingConcentration     1.32  # c = log10(r_t/r_c)
-        AbsMag      	     -6.96  # [V mags]
-        Axis       	[  0.3545  -0.8841  -0.3046]
-        Angle       	     137.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5466"
+	RA 14.090914
+	Dec 28.53444
+	Distance 52576.408
+	Radius 250.162
+	CoreRadius 1.312
+	KingConcentration 1.096
+	AbsMag -6.717
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5466"
 }
 
 Globular "NGC 5634:GCl 28:C 1427-057"
 {
-        RA          	   14.4936  # [hours]
-        Dec         	   -5.9764  # [degrees]
-        Distance    	 8.219e+04  # [ly]
-        Radius      	     65.75  # [ly], mu25 Isophote
-        CoreRadius  	      0.21  # [arcmin]
-        KingConcentration     1.60  # c = log10(r_t/r_c)
-        AbsMag      	     -7.69  # [V mags]
-        Axis       	[  0.3925  -0.7416  -0.5441]
-        Angle       	     154.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5634"
+	RA 14.493689
+	Dec -5.97643
+	Distance 84670.196
+	Radius 627.949
+	CoreRadius 0.081
+	KingConcentration 2.499
+	AbsMag -7.562
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5634"
 }
 
 Globular "NGC 5694:GCl 29:C 1436-263"
 {
-        RA          	   14.6600  # [hours]
-        Dec         	  -26.5383  # [degrees]
-        Distance    	 1.132e+05  # [ly]
-        Radius      	     70.78  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     1.85  # c = log10(r_t/r_c)
-        AbsMag      	     -7.81  # [V mags]
-        Axis       	[  0.4021  -0.6297  -0.6647]
-        Angle       	     163.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5694"
+	RA 14.660083
+	Dec -26.53878
+	Distance 113632.882
+	Radius 745.659
+	CoreRadius 0.002
+	KingConcentration 4.058
+	AbsMag -7.85
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5694"
 }
 
 Globular "IC 4499:GCl 30:C 1452-820"
 {
-        RA          	   15.0050  # [hours]
-        Dec         	  -82.2136  # [degrees]
-        Distance    	 6.165e+04  # [ly]
-        Radius      	     71.73  # [ly], mu25 Isophote
-        CoreRadius  	      0.96  # [arcmin]
-        KingConcentration     1.11  # c = log10(r_t/r_c)
-        AbsMag      	     -7.33  # [V mags]
-        Axis       	[  -0.379   0.2491   0.8912]
-        Angle       	       174  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 4499"
+	RA 15.005146
+	Dec -82.21379
+	Distance 61610.94
+	Radius 359.816
+	CoreRadius 0.914
+	KingConcentration 1.342
+	AbsMag -6.541
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 4499"
 }
 
 Globular "NGC 5824:GCl 31:C 1500-328"
 {
-        RA          	   15.0661  # [hours]
-        Dec         	  -33.0678  # [degrees]
-        Distance    	 1.044e+05  # [ly]
-        Radius      	     112.3  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.49  # c = log10(r_t/r_c)
-        AbsMag      	     -8.84  # [V mags]
-        Axis       	[  0.3609  -0.6018  -0.7125]
-        Angle       	     167.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5824"
+	RA 15.066277
+	Dec -33.06814
+	Distance 103424.187
+	Radius 831.242
+	CoreRadius 0.066
+	KingConcentration 2.621
+	AbsMag -8.646
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5824"
 }
 
-Globular "Pal 5:Name Serpens Dwarf:UGC 9792:GCl 32:C 1513+000"
+Globular "Pal 5:Serpens Dwarf:UGC 9792:GCl 32:C 1513+000"
 {
-        RA          	   15.2681  # [hours]
-        Dec         	   -0.1114  # [degrees]
-        Distance    	 7.567e+04  # [ly]
-        Radius      	     35.22  # [ly], mu25 Isophote
-        CoreRadius  	      3.25  # [arcmin]
-        KingConcentration     0.70  # c = log10(r_t/r_c)
-        AbsMag      	     -5.17  # [V mags]
-        Axis       	[  0.2984  -0.7974  -0.5245]
-        Angle       	     157.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 5"
+	RA 15.267945
+	Dec -0.121
+	Distance 71558.709
+	Radius 162.198
+	CoreRadius 2.405
+	KingConcentration 0.511
+	AbsMag -4.846
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 5"
 }
 
 Globular "NGC 5897:GCl 33:C 1514-208"
 {
-        RA          	   15.2900  # [hours]
-        Dec         	  -21.0103  # [degrees]
-        Distance    	 4.044e+04  # [ly]
-        Radius      	     64.71  # [ly], mu25 Isophote
-        CoreRadius  	      1.96  # [arcmin]
-        KingConcentration     0.79  # c = log10(r_t/r_c)
-        AbsMag      	     -7.21  # [V mags]
-        Axis       	[  0.3232  -0.6832  -0.6548]
-        Angle       	     164.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5897"
+	RA 15.290111
+	Dec -21.01012
+	Distance 40932.625
+	Radius 234.963
+	CoreRadius 1.37
+	KingConcentration 1.159
+	AbsMag -7.013
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5897"
 }
 
 Globular "M 5:NGC 5904:GCl 34:C 1516+022"
 {
-        RA          	   15.3092  # [hours]
-        Dec         	    2.0828  # [degrees]
-        Distance    	 2.446e+04  # [ly]
-        Radius      	     81.83  # [ly], mu25 Isophote
-        CoreRadius  	      0.42  # [arcmin]
-        KingConcentration     1.83  # c = log10(r_t/r_c)
-        AbsMag      	     -8.81  # [V mags]
-        Axis       	[  0.2905  -0.8094  -0.5105]
-        Angle       	     157.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5904"
+	RA 15.309227
+	Dec 2.08103
+	Distance 24396.497
+	Radius 265.133
+	CoreRadius 0.519
+	KingConcentration 1.857
+	AbsMag -8.42
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 5"
 }
 
 Globular "NGC 5927:VDBH 173:GCl 35:C 1524-505"
 {
-        RA          	   15.4667  # [hours]
-        Dec         	  -50.6728  # [degrees]
-        Distance    	 2.479e+04  # [ly]
-        Radius      	     21.63  # [ly], mu25 Isophote
-        CoreRadius  	      0.42  # [arcmin]
-        KingConcentration     1.60  # c = log10(r_t/r_c)
-        AbsMag      	      -7.8  # [V mags]
-        Axis       	[  0.3228  -0.4929   -0.808]
-        Angle       	     174.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5927"
+	RA 15.466858
+	Dec -50.67303
+	Distance 26973.132
+	Radius 210.371
+	CoreRadius 0.553
+	KingConcentration 1.686
+	AbsMag -6.848
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5927"
 }
 
 Globular "NGC 5946:VDBH 175:GCl 36:C 1531-504"
 {
-        RA          	   15.5911  # [hours]
-        Dec         	  -50.6594  # [degrees]
-        Distance    	 3.457e+04  # [ly]
-        Radius      	     15.09  # [ly], mu25 Isophote
-        CoreRadius  	      0.08  # [arcmin]
-        KingConcentration     2.48  # c = log10(r_t/r_c)
-        AbsMag      	      -7.2  # [V mags]
-        Axis       	[  0.3074  -0.4956  -0.8123]
-        Angle       	     175.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5946"
-}
-
-Globular "VDBH 176:ESO 224-8:C 1535-499"
-{
-        RA          	   15.6519  # [hours]
-        Dec         	  -50.0506  # [degrees]
-        Distance    	 5.088e+04  # [ly]
-        Radius      	      22.2  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -4.35  # [V mags]
-        Axis       	[  0.2997  -0.5012  -0.8118]
-        Angle       	       175  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=VDBH 176"
+	RA 15.59127
+	Dec -50.65971
+	Distance 31441.475
+	Radius 153.554
+	CoreRadius 0.132
+	KingConcentration 2.105
+	AbsMag -5.43
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5946"
 }
 
 Globular "NGC 5986:GCl 37:ESO 329-18:C 1542-376"
 {
-        RA          	   15.7675  # [hours]
-        Dec         	  -37.7861  # [degrees]
-        Distance    	 3.392e+04  # [ly]
-        Radius      	     47.36  # [ly], mu25 Isophote
-        CoreRadius  	      0.63  # [arcmin]
-        KingConcentration     1.22  # c = log10(r_t/r_c)
-        AbsMag      	     -8.44  # [V mags]
-        Axis       	[  0.2798  -0.5888  -0.7583]
-        Angle       	     171.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5986"
+	RA 15.7675
+	Dec -37.78642
+	Distance 34376.882
+	Radius 223.841
+	CoreRadius 0.245
+	KingConcentration 1.961
+	AbsMag -7.414
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 5986"
+}
+
+Globular "FSR 1716"
+{
+	RA 16.175
+	Dec -53.74889
+	Distance 24233.419
+	Radius 111.285
+	CoreRadius 0.824
+	KingConcentration 1.283
+	AbsMag -1.295
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=FSR 1716"
+}
+
+Globular "Pal 14:Arp 1:GCl 38:C 1608+150"
+{
+	RA 16.1835
+	Dec 14.95778
+	Distance 239985.863
+	Radius 149.412
+	CoreRadius 0.741
+	KingConcentration 0.461
+	AbsMag -5.204
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 14"
 }
 
 Globular "Lynga 7:VDBH 184:ESO 178-11:C 1607-551"
 {
-        RA          	   16.1842  # [hours]
-        Dec         	  -55.3144  # [degrees]
-        Distance    	 2.348e+04  # [ly]
-        Radius      	     8.539  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.86  # unknown!! Data base average used
-        Axis       	[  0.2344  -0.4722  -0.8497]
-        Angle       	     177.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Lynga 7"
-}
-
-Globular "Pal 14:Cl Arp 1:GCl 38:C 1608+150"
-{
-        RA          	   16.1844  # [hours]
-        Dec         	   14.9581  # [degrees]
-        Distance    	  2.41e+05  # [ly]
-        Radius      	     77.13  # [ly], mu25 Isophote
-        CoreRadius  	      0.94  # [arcmin]
-        KingConcentration     0.75  # c = log10(r_t/r_c)
-        AbsMag      	     -4.73  # [V mags]
-        Axis       	[  0.1805  -0.8855  -0.4281]
-        Angle       	     162.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 14"
+	RA 16.184347
+	Dec -55.31778
+	Distance 25766.354
+	Radius 125.309
+	CoreRadius 0.574
+	KingConcentration 1.464
+	AbsMag -4.618
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Lynga 7"
 }
 
 Globular "M 80:NGC 6093:GCl 39:C 1614-228"
 {
-        RA          	   16.2839  # [hours]
-        Dec         	  -22.9750  # [degrees]
-        Distance    	 3.262e+04  # [ly]
-        Radius      	     47.44  # [ly], mu25 Isophote
-        CoreRadius  	      0.15  # [arcmin]
-        KingConcentration     1.95  # c = log10(r_t/r_c)
-        AbsMag      	     -8.23  # [V mags]
-        Axis       	[  0.2075  -0.6945  -0.6889]
-        Angle       	     170.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6093"
+	RA 16.284003
+	Dec -22.97608
+	Distance 33724.569
+	Radius 205.022
+	CoreRadius 0.07
+	KingConcentration 2.476
+	AbsMag -7.643
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 80"
+}
+
+Globular "RLGC 1:Ryu 059"
+{
+	RA 16.285669
+	Dec -44.59406
+	Distance 94063.499
+	Radius 555.934
+	CoreRadius 0.312
+	KingConcentration 1.813
+	AbsMag -4.2
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ryu 059"
 }
 
 Globular "M 4:NGC 6121:GCl 41:C 1620-264"
 {
-        RA          	   16.3931  # [hours]
-        Dec         	  -26.5253  # [degrees]
-        Distance    	      7176  # [ly]
-        Radius      	     37.57  # [ly], mu25 Isophote
-        CoreRadius  	      0.83  # [arcmin]
-        KingConcentration     1.59  # c = log10(r_t/r_c)
-        AbsMag      	      -7.2  # [V mags]
-        Axis       	[  0.1967  -0.6744  -0.7117]
-        Angle       	     171.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6121"
+	RA 16.393116
+	Dec -26.52575
+	Distance 6033.893
+	Radius 175.929
+	CoreRadius 0.836
+	KingConcentration 2.079
+	AbsMag -5.686156
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 4"
 }
 
-Globular "NGC 6101:GCl 40:C 1620-720"
+Globular "NGC 6101:GCl 40:C 1620-720:GCl 40:C 1620-720"
 {
-        RA          	   16.4300  # [hours]
-        Dec         	  -72.2017  # [degrees]
-        Distance    	  4.99e+04  # [ly]
-        Radius      	     36.29  # [ly], mu25 Isophote
-        CoreRadius  	      1.15  # [arcmin]
-        KingConcentration     0.80  # c = log10(r_t/r_c)
-        AbsMag      	     -6.91  # [V mags]
-        Axis       	[ -0.2038   0.3448   0.9163]
-        Angle       	     178.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6101"
+	RA 16.430033
+	Dec -72.20219
+	Distance 47129.597
+	Radius 290.116
+	CoreRadius 1.313
+	KingConcentration 1.207
+	AbsMag -7.119
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6101"
 }
 
 Globular "NGC 6144:GCl 42:C 1624-259"
 {
-        RA          	   16.4539  # [hours]
-        Dec         	  -26.0247  # [degrees]
-        Distance    	 2.772e+04  # [ly]
-        Radius      	     68.55  # [ly], mu25 Isophote
-        CoreRadius  	      0.94  # [arcmin]
-        KingConcentration     1.55  # c = log10(r_t/r_c)
-        AbsMag      	     -6.75  # [V mags]
-        Axis       	[   0.189  -0.6785  -0.7098]
-        Angle       	       172  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6144"
+	RA 16.453851
+	Dec -26.0235
+	Distance 26581.745
+	Radius 93.998
+	CoreRadius 0.422
+	KingConcentration 1.46
+	AbsMag -5.316
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6144"
 }
 
 Globular "NGC 6139:GCl 43:C 1624-387"
 {
-        RA          	   16.4611  # [hours]
-        Dec         	  -38.8489  # [degrees]
-        Distance    	 3.294e+04  # [ly]
-        Radius      	     39.29  # [ly], mu25 Isophote
-        CoreRadius  	      0.14  # [arcmin]
-        KingConcentration     1.78  # c = log10(r_t/r_c)
-        AbsMag      	     -8.36  # [V mags]
-        Axis       	[  0.1945  -0.5944  -0.7803]
-        Angle       	     174.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6139"
+	RA 16.461231
+	Dec -38.84878
+	Distance 32746.1
+	Radius 191.486
+	CoreRadius 0.099
+	KingConcentration 2.306
+	AbsMag -6.039
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6139"
 }
 
 Globular "Terzan 3:GCl 43.1:ESO 390-6:C 1625-352"
 {
-        RA          	   16.4778  # [hours]
-        Dec         	  -35.3536  # [degrees]
-        Distance    	 2.446e+04  # [ly]
-        Radius      	     10.67  # [ly], mu25 Isophote
-        CoreRadius  	      1.18  # [arcmin]
-        KingConcentration     0.70  # c = log10(r_t/r_c)
-        AbsMag      	     -4.61  # [V mags]
-        Axis       	[  0.1909  -0.6183  -0.7624]
-        Angle       	     173.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 3"
+	RA 16.477499
+	Dec -35.33983
+	Distance 24918.347
+	Radius 68.819
+	CoreRadius 1.066
+	KingConcentration 0.95
+	AbsMag -3.825
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 3"
 }
 
 Globular "M 107:NGC 6171:GCl 44:C 1629-129"
 {
-        RA          	   16.5419  # [hours]
-        Dec         	  -13.0536  # [degrees]
-        Distance    	 2.087e+04  # [ly]
-        Radius      	     39.47  # [ly], mu25 Isophote
-        CoreRadius  	      0.54  # [arcmin]
-        KingConcentration     1.51  # c = log10(r_t/r_c)
-        AbsMag      	     -7.13  # [V mags]
-        Axis       	[    0.17   -0.757  -0.6309]
-        Angle       	     170.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6171"
+	RA 16.542183
+	Dec -13.05378
+	Distance 18362.604
+	Radius 114.611
+	CoreRadius 0.318
+	KingConcentration 1.83
+	AbsMag -5.473
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 107"
 }
 
 Globular "ESO 452-SC11:ESO 452-11:C 1636-283"
 {
-        RA          	   16.6569  # [hours]
-        Dec         	  -28.3978  # [degrees]
-        Distance    	 2.544e+04  # [ly]
-        Radius      	      4.44  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -3.97  # [V mags]
-        Axis       	[  0.1656  -0.6665  -0.7269]
-        Angle       	     173.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 452-SC11"
+	RA 16.656945
+	Dec -28.39917
+	Distance 24102.956
+	Radius 34.409
+	CoreRadius 0.293
+	KingConcentration 1.224
+	AbsMag -2.583
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 452-SC11"
 }
 
 Globular "M 13:NGC 6205:GCl 45:C 1639+365"
 {
-        RA          	   16.6947  # [hours]
-        Dec         	   36.4603  # [degrees]
-        Distance    	 2.511e+04  # [ly]
-        Radius      	     73.06  # [ly], mu25 Isophote
-        CoreRadius  	      0.78  # [arcmin]
-        KingConcentration     1.51  # c = log10(r_t/r_c)
-        AbsMag      	      -8.7  # [V mags]
-        Axis       	[  0.1068  -0.9602  -0.2582]
-        Angle       	     164.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6205"
+	RA 16.694787
+	Dec 36.45986
+	Distance 24200.803
+	Radius 424.884
+	CoreRadius 0.811
+	KingConcentration 1.872
+	AbsMag -8.542
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 13"
 }
 
 Globular "NGC 6229:GCl 47:C 1645+476"
 {
-        RA          	   16.7828  # [hours]
-        Dec         	   47.5278  # [degrees]
-        Distance    	 9.915e+04  # [ly]
-        Radius      	      64.9  # [ly], mu25 Isophote
-        CoreRadius  	      0.13  # [arcmin]
-        KingConcentration     1.62  # c = log10(r_t/r_c)
-        AbsMag      	     -8.05  # [V mags]
-        Axis       	[ 0.08709  -0.9825  -0.1647]
-        Angle       	     164.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6229"
+	RA 16.783017
+	Dec 47.5278
+	Distance 98205.685
+	Radius 624.72
+	CoreRadius 0.127
+	KingConcentration 2.237
+	AbsMag -8.064
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6229"
 }
 
 Globular "M 12:NGC 6218:GCl 46:C 1644-018"
 {
-        RA          	   16.7872  # [hours]
-        Dec         	   -1.9478  # [degrees]
-        Distance    	 1.598e+04  # [ly]
-        Radius      	     37.19  # [ly], mu25 Isophote
-        CoreRadius  	      0.72  # [arcmin]
-        KingConcentration     1.39  # c = log10(r_t/r_c)
-        AbsMag      	     -7.32  # [V mags]
-        Axis       	[  0.1341  -0.8191  -0.5578]
-        Angle       	     170.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6218"
+	RA 16.787271
+	Dec -1.94853
+	Distance 16666.591
+	Radius 148.793
+	CoreRadius 0.78
+	KingConcentration 1.595
+	AbsMag -6.452
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 12"
+}
+
+Globular "FSR 1735"
+{
+	RA 16.869611
+	Dec -47.05806
+	Distance 29614.999
+	Radius 115.198
+	CoreRadius 0.197
+	KingConcentration 1.832
+	AbsMag -0.41
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=FSR 1735"
 }
 
 Globular "NGC 6235:GCl 48:C 1650-220"
 {
-        RA          	   16.8903  # [hours]
-        Dec         	  -22.1772  # [degrees]
-        Distance    	 3.718e+04  # [ly]
-        Radius      	     27.04  # [ly], mu25 Isophote
-        CoreRadius  	      0.36  # [arcmin]
-        KingConcentration     1.33  # c = log10(r_t/r_c)
-        AbsMag      	     -6.44  # [V mags]
-        Axis       	[  0.1342  -0.7084  -0.6929]
-        Angle       	     173.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6235"
+	RA 16.890379
+	Dec -22.17745
+	Distance 38943.071
+	Radius 120.45
+	CoreRadius 0.334
+	KingConcentration 1.503
+	AbsMag -5.765
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6235"
 }
 
 Globular "M 10:NGC 6254:GCl 49:C 1654-040"
 {
-        RA          	   16.9522  # [hours]
-        Dec         	   -4.0994  # [degrees]
-        Distance    	 1.435e+04  # [ly]
-        Radius      	     41.75  # [ly], mu25 Isophote
-        CoreRadius  	      0.86  # [arcmin]
-        KingConcentration     1.40  # c = log10(r_t/r_c)
-        AbsMag      	     -7.48  # [V mags]
-        Axis       	[  0.1172  -0.8102  -0.5743]
-        Angle       	     171.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6254"
+	RA 16.952515
+	Dec -4.10031
+	Distance 16536.128
+	Radius 175.342
+	CoreRadius 0.502
+	KingConcentration 1.861
+	AbsMag -6.915
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 10"
 }
 
 Globular "NGC 6256:VDBH 208:GCl 49.1:ESO 391-6:C 1656-370"
 {
-        RA          	   16.9922  # [hours]
-        Dec         	  -37.1214  # [degrees]
-        Distance    	  2.74e+04  # [ly]
-        Radius      	     16.34  # [ly], mu25 Isophote
-        CoreRadius  	      0.02  # [arcmin]
-        KingConcentration     2.58  # c = log10(r_t/r_c)
-        AbsMag      	     -6.52  # [V mags]
-        Axis       	[  0.1273  -0.6128  -0.7799]
-        Angle       	     176.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6256"
+	RA 16.992407
+	Dec -37.12097
+	Distance 23613.722
+	Radius 88.975
+	CoreRadius 0.033
+	KingConcentration 2.591
+	AbsMag -3.739
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6256"
 }
 
 Globular "Pal 15:Zwicky 1:UGC 10642:LEDA 59400:K73 781:GCl 50:C 1657-004"
 {
-        RA          	   17.0006  # [hours]
-        Dec         	   -0.5419  # [degrees]
-        Distance    	 1.455e+05  # [ly]
-        Radius      	     63.47  # [ly], mu25 Isophote
-        CoreRadius  	      1.25  # [arcmin]
-        KingConcentration     0.60  # c = log10(r_t/r_c)
-        AbsMag      	     -5.49  # [V mags]
-        Axis       	[  0.1097  -0.8284  -0.5493]
-        Angle       	     171.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 15"
+	RA 16.997507
+	Dec -0.539
+	Distance 143834.963
+	Radius 340.866
+	CoreRadius 1.158
+	KingConcentration 0.847
+	AbsMag -4.532
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 15"
 }
 
 Globular "M 62:NGC 6266:VDBH 210:GCl 51:C 1658-300"
 {
-        RA          	   17.0200  # [hours]
-        Dec         	  -30.1136  # [degrees]
-        Distance    	 2.251e+04  # [ly]
-        Radius      	      49.1  # [ly], mu25 Isophote
-        CoreRadius  	      0.18  # [arcmin]
-        KingConcentration     1.70  # c = log10(r_t/r_c)
-        AbsMag      	     -9.19  # [V mags]
-        Axis       	[  0.1216  -0.6598  -0.7415]
-        Angle       	     175.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6266"
+	RA 17.020277
+	Dec -30.11339
+	Distance 19667.23
+	Radius 167.677
+	CoreRadius 0.131
+	KingConcentration 2.349
+	AbsMag -7.302
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 62"
 }
 
 Globular "M 19:NGC 6273:HD 153799:GCl 52:C 1659-262"
 {
-        RA          	   17.0436  # [hours]
-        Dec         	  -26.2681  # [degrees]
-        Distance    	 2.805e+04  # [ly]
-        Radius      	     69.36  # [ly], mu25 Isophote
-        CoreRadius  	      0.43  # [arcmin]
-        KingConcentration     1.53  # c = log10(r_t/r_c)
-        AbsMag      	     -9.18  # [V mags]
-        Axis       	[  0.1173  -0.6847  -0.7193]
-        Angle       	     175.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6273"
+	RA 17.043833
+	Dec -26.26797
+	Distance 27201.442
+	Radius 129.419
+	CoreRadius 0.408
+	KingConcentration 1.603
+	AbsMag -7.726
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 19"
 }
 
 Globular "NGC 6284:GCl 53:C 1701-246"
 {
-        RA          	   17.0744  # [hours]
-        Dec         	  -24.7647  # [degrees]
-        Distance    	  4.99e+04  # [ly]
-        Radius      	        45  # [ly], mu25 Isophote
-        CoreRadius  	      0.07  # [arcmin]
-        KingConcentration     2.52  # c = log10(r_t/r_c)
-        AbsMag      	     -7.97  # [V mags]
-        Axis       	[   0.113  -0.6944  -0.7107]
-        Angle       	     175.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6284"
+	RA 17.074674
+	Dec -24.7648
+	Distance 46346.821
+	Radius 239.007
+	CoreRadius 0.065
+	KingConcentration 2.434
+	AbsMag -6.773
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6284"
+}
+
+Globular "Patchick 125:Gran 3"
+{
+	RA 17.083733
+	Dec -35.496
+	Distance 37410.137
+	Radius 98.532
+	CoreRadius 1.118
+	KingConcentration 0.908
+	AbsMag -2.668
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Patchick 125"
 }
 
 Globular "NGC 6287:GCl 54:C 1702-226"
 {
-        RA          	   17.0858  # [hours]
-        Dec         	  -22.7081  # [degrees]
-        Distance    	 3.033e+04  # [ly]
-        Radius      	     21.18  # [ly], mu25 Isophote
-        CoreRadius  	      0.26  # [arcmin]
-        KingConcentration     1.61  # c = log10(r_t/r_c)
-        AbsMag      	     -7.36  # [V mags]
-        Axis       	[  0.1109  -0.7072  -0.6983]
-        Angle       	     174.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6287"
+	RA 17.085927
+	Dec -22.70801
+	Distance 25864.201
+	Radius 73.744
+	CoreRadius 0.139
+	KingConcentration 1.849
+	AbsMag -5.096
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6287"
+}
+
+Globular "Patchick 126"
+{
+	RA 17.094055
+	Dec -47.34222
+	Distance 26092.51
+	Radius 41.944
+	CoreRadius 0.056
+	KingConcentration 1.995
+	AbsMag -0.095
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Patchick 126"
 }
 
 Globular "NGC 6293:VDBH 215:GCl 55:C 1707-265"
 {
-        RA          	   17.1694  # [hours]
-        Dec         	  -26.5819  # [degrees]
-        Distance    	  2.87e+04  # [ly]
-        Radius      	     34.23  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.45  # c = log10(r_t/r_c)
-        AbsMag      	     -7.77  # [V mags]
-        Axis       	[   0.102  -0.6839  -0.7224]
-        Angle       	     175.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6293"
+	RA 17.1695
+	Dec -26.58208
+	Distance 29973.771
+	Radius 78.897
+	CoreRadius 0.022
+	KingConcentration 2.605
+	AbsMag -6.417
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6293"
+}
+
+Globular "Gran 2"
+{
+	RA 17.192667
+	Dec -24.849
+	Distance 51663.17
+	Radius 180.364
+	CoreRadius 0.616
+	KingConcentration 1.289
+	AbsMag -3.439
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Gran 2"
 }
 
 Globular "NGC 6304:VDBH 216:GCl 56:ESO 454-2:C 1711-294"
 {
-        RA          	   17.2422  # [hours]
-        Dec         	  -29.4622  # [degrees]
-        Distance    	 1.957e+04  # [ly]
-        Radius      	     22.77  # [ly], mu25 Isophote
-        CoreRadius  	      0.21  # [arcmin]
-        KingConcentration     1.80  # c = log10(r_t/r_c)
-        AbsMag      	     -7.32  # [V mags]
-        Axis       	[ 0.09393   -0.666    -0.74]
-        Angle       	     176.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6304"
+	RA 17.242293
+	Dec -29.46203
+	Distance 20058.617
+	Radius 88.943
+	CoreRadius 0.218
+	KingConcentration 1.845
+	AbsMag -5.764
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6304"
 }
 
 Globular "NGC 6316:VDBH 219:GCl 57:C 1713-280"
 {
-        RA          	   17.2769  # [hours]
-        Dec         	  -28.1400  # [degrees]
-        Distance    	 3.588e+04  # [ly]
-        Radius      	     28.18  # [ly], mu25 Isophote
-        CoreRadius  	      0.17  # [arcmin]
-        KingConcentration     1.54  # c = log10(r_t/r_c)
-        AbsMag      	     -8.35  # [V mags]
-        Axis       	[ 0.08929  -0.6748  -0.7326]
-        Angle       	     176.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6316"
+	RA 17.277028
+	Dec -28.14011
+	Distance 36366.436
+	Radius 154.859
+	CoreRadius 0.228
+	KingConcentration 1.807
+	AbsMag -6.226
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6316"
 }
 
 Globular "M 92:NGC 6341:GCl 59:C 1715+432"
 {
-        RA          	   17.2853  # [hours]
-        Dec         	   43.1364  # [degrees]
-        Distance    	 2.675e+04  # [ly]
-        Radius      	     54.46  # [ly], mu25 Isophote
-        CoreRadius  	      0.23  # [arcmin]
-        KingConcentration     1.82  # c = log10(r_t/r_c)
-        AbsMag      	      -8.2  # [V mags]
-        Axis       	[ 0.05394  -0.9778  -0.2027]
-        Angle       	     171.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6341"
+	RA 17.285384
+	Dec 43.13594
+	Distance 27723.292
+	Radius 368.557
+	CoreRadius 0.117
+	KingConcentration 2.591
+	AbsMag -8.137
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 92"
 }
 
 Globular "NGC 6325:GCl 58:ESO 519-11:C 1714-237"
 {
-        RA          	   17.2997  # [hours]
-        Dec         	  -23.7658  # [degrees]
-        Distance    	 2.609e+04  # [ly]
-        Radius      	     15.56  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.50  # c = log10(r_t/r_c)
-        AbsMag      	     -6.95  # [V mags]
-        Axis       	[ 0.08528  -0.7025  -0.7065]
-        Angle       	     176.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6325"
+	RA 17.299755
+	Dec -23.76768
+	Distance 24559.575
+	Radius 66.601
+	CoreRadius 0.05
+	KingConcentration 2.269
+	AbsMag -3.484
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6325"
 }
 
 Globular "M 9:NGC 6333:HD 156587:GCl 60:C 1716-184"
 {
-        RA          	   17.3197  # [hours]
-        Dec         	  -18.5164  # [degrees]
-        Distance    	 2.577e+04  # [ly]
-        Radius      	     44.97  # [ly], mu25 Isophote
-        CoreRadius  	      0.58  # [arcmin]
-        KingConcentration     1.15  # c = log10(r_t/r_c)
-        AbsMag      	     -7.94  # [V mags]
-        Axis       	[ 0.08128  -0.7344  -0.6738]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6333"
+	RA 17.319939
+	Dec -18.51626
+	Distance 27070.979
+	Radius 108.48
+	CoreRadius 0.335
+	KingConcentration 1.613
+	AbsMag -6.945
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 9"
 }
 
 Globular "NGC 6342:GCl 61:C 1718-195"
 {
-        RA          	   17.3528  # [hours]
-        Dec         	  -19.5872  # [degrees]
-        Distance    	 2.805e+04  # [ly]
-        Radius      	     17.95  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.47  # c = log10(r_t/r_c)
-        AbsMag      	     -6.44  # [V mags]
-        Axis       	[ 0.07765  -0.7283  -0.6809]
-        Angle       	     176.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6342"
+	RA 17.352771
+	Dec -19.58766
+	Distance 26125.126
+	Radius 48.826
+	CoreRadius 0.073
+	KingConcentration 1.945
+	AbsMag -4.658
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6342"
 }
 
 Globular "NGC 6356:HD 157361:GCl 62:C 1720-177"
 {
-        RA          	   17.3931  # [hours]
-        Dec         	  -17.8131  # [degrees]
-        Distance    	 4.958e+04  # [ly]
-        Radius      	     72.11  # [ly], mu25 Isophote
-        CoreRadius  	      0.23  # [arcmin]
-        KingConcentration     1.54  # c = log10(r_t/r_c)
-        AbsMag      	     -8.52  # [V mags]
-        Axis       	[ 0.07233   -0.739  -0.6698]
-        Angle       	     176.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6356"
+	RA 17.393053
+	Dec -17.81303
+	Distance 51076.089
+	Radius 385.517
+	CoreRadius 0.336
+	KingConcentration 1.888
+	AbsMag -7.654
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6356"
 }
 
 Globular "NGC 6355:GCl 63:ESO 519-15:C 1720-263"
 {
-        RA          	   17.3994  # [hours]
-        Dec         	  -26.3536  # [degrees]
-        Distance    	 3.099e+04  # [ly]
-        Radius      	     18.93  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.48  # c = log10(r_t/r_c)
-        AbsMag      	     -8.08  # [V mags]
-        Axis       	[ 0.07377   -0.687  -0.7229]
-        Angle       	     176.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6355"
+	RA 17.399569
+	Dec -26.35283
+	Distance 28212.527
+	Radius 47.521
+	CoreRadius 0.079
+	KingConcentration 1.862
+	AbsMag -4.645
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6355"
 }
 
 Globular "NGC 6352:VDBH 226:GCl 64:C 1721-484"
 {
-        RA          	   17.4247  # [hours]
-        Dec         	  -48.4228  # [degrees]
-        Distance    	 1.859e+04  # [ly]
-        Radius      	     24.34  # [ly], mu25 Isophote
-        CoreRadius  	      0.83  # [arcmin]
-        KingConcentration     1.10  # c = log10(r_t/r_c)
-        AbsMag      	     -6.48  # [V mags]
-        Axis       	[  0.0743  -0.5359   -0.841]
-        Angle       	     178.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6352"
+	RA 17.424752
+	Dec -48.42217
+	Distance 18069.063
+	Radius 102.87
+	CoreRadius 0.527
+	KingConcentration 1.569
+	AbsMag -5.658
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6352"
 }
 
 Globular "IC 1257:C 1724-070"
 {
-        RA          	   17.4522  # [hours]
-        Dec         	   -7.0931  # [degrees]
-        Distance    	 8.154e+04  # [ly]
-        Radius      	      59.3  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.15  # [V mags]
-        Axis       	[ 0.06225  -0.7989  -0.5982]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 1257"
+	RA 17.452362
+	Dec -7.09306
+	Distance 86724.981
+	Radius 194.944
+	CoreRadius 0.128
+	KingConcentration 1.781
+	AbsMag -3.314
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 1257"
 }
 
 Globular "Haute-Provence 3:Terzan 2:VDBH 228:GCl 64.1:ESO 454-29:C 1724-307"
 {
-        RA          	   17.4592  # [hours]
-        Dec         	  -30.8022  # [degrees]
-        Distance    	 2.838e+04  # [ly]
-        Radius      	     2.476  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.53  # c = log10(r_t/r_c)
-        AbsMag      	     -5.27  # [V mags]
-        Axis       	[ 0.06734  -0.6587  -0.7493]
-        Angle       	     177.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 2"
+	RA 17.459195
+	Dec -30.80233
+	Distance 25277.119
+	Radius 40.606
+	CoreRadius 0.204
+	KingConcentration 1.432
+	AbsMag -1.337
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 2"
 }
 
 Globular "NGC 6366:GCl 65:C 1725-050"
 {
-        RA          	   17.4622  # [hours]
-        Dec         	   -5.0767  # [degrees]
-        Distance    	 1.174e+04  # [ly]
-        Radius      	      22.2  # [ly], mu25 Isophote
-        CoreRadius  	      1.83  # [arcmin]
-        KingConcentration     0.92  # c = log10(r_t/r_c)
-        AbsMag      	     -5.77  # [V mags]
-        Axis       	[ 0.06049  -0.8094  -0.5842]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6366"
+	RA 17.462291
+	Dec -5.07986
+	Distance 11219.779
+	Radius 123.45
+	CoreRadius 2.338
+	KingConcentration 1.209
+	AbsMag -3.833
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6366"
 }
 
 Globular "Haute-Provence 4:Terzan 4:GCl 66.1:C 1727-315"
 {
-        RA          	   17.5108  # [hours]
-        Dec         	  -31.5956  # [degrees]
-        Distance    	 2.968e+04  # [ly]
-        Radius      	     9.066  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.09  # [V mags]
-        Axis       	[ 0.06104  -0.6538  -0.7542]
-        Angle       	     177.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 4"
+	RA 17.510834
+	Dec -31.59553
+	Distance 24755.269
+	Radius 51.207
+	CoreRadius 0.177
+	KingConcentration 1.605
+	AbsMag -0.971
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 4"
 }
 
-Globular "VDBH 229:Haute-Provence 1:Dufay 1:GCl 67:ESO 455-11:C 1727-299"
+Globular "HP 1"
 {
-        RA          	   17.5181  # [hours]
-        Dec         	  -29.9817  # [degrees]
-        Distance    	 4.599e+04  # [ly]
-        Radius      	     8.027  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.44  # c = log10(r_t/r_c)
-        AbsMag      	     -6.44  # [V mags]
-        Axis       	[ 0.05987  -0.6644   -0.745]
-        Angle       	     177.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Haute-Provence 1"
+	RA 17.518111
+	Dec -29.98167
+	Distance 22830.946
+	Radius 60.535
+	CoreRadius 0.486
+	KingConcentration 1.273
+	AbsMag -3.155
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=HP 1"
+}
+
+Globular "FSR 1758"
+{
+	RA 17.52
+	Dec -39.808
+	Distance 36170.742
+	Radius 358.772
+	CoreRadius 3.137
+	KingConcentration 1.036
+	AbsMag -6.085
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=FSR 1758"
 }
 
 Globular "NGC 6362:GCl 66:C 1726-670"
 {
-        RA          	   17.5317  # [hours]
-        Dec         	  -67.0481  # [degrees]
-        Distance    	 2.479e+04  # [ly]
-        Radius      	     54.08  # [ly], mu25 Isophote
-        CoreRadius  	      1.32  # [arcmin]
-        KingConcentration     1.10  # c = log10(r_t/r_c)
-        AbsMag      	     -6.94  # [V mags]
-        Axis       	[-0.06127   0.3931   0.9174]
-        Angle       	       180  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6362"
+	RA 17.53194
+	Dec -67.04833
+	Distance 24950.963
+	Radius 164.611
+	CoreRadius 1.303
+	KingConcentration 1.241
+	AbsMag -6.968
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6362"
 }
 
 Globular "Liller 1:Liller I:C 1730-333"
 {
-        RA          	   17.5567  # [hours]
-        Dec         	  -33.3889  # [degrees]
-        Distance    	 3.131e+04  # [ly]
-        Radius      	     19.16  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     2.32  # c = log10(r_t/r_c)
-        AbsMag      	     -7.63  # [V mags]
-        Axis       	[ 0.05559  -0.6421  -0.7646]
-        Angle       	     178.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Liller 1"
+	RA 17.556822
+	Dec -33.38956
+	Distance 26288.204
+	Radius 126.777
+	CoreRadius 0.077
+	KingConcentration 2.334
+	AbsMag 1.198
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Liller 1"
 }
 
-Globular "Ton 1:NGC 6380:Pismis 25:VDBH 233:Name Tonantzintla 1:GCl 68:ESO 333-14:C 1731-390"
+Globular "Ton 1:NGC 6380:Pismis 25:VDBH 233:Tonantzintla 1:GCl 68:ESO 333-14:C 1731-390"
 {
-        RA          	   17.5744  # [hours]
-        Dec         	  -39.0692  # [degrees]
-        Distance    	  3.49e+04  # [ly]
-        Radius      	     18.27  # [ly], mu25 Isophote
-        CoreRadius  	      0.34  # [arcmin]
-        KingConcentration     1.55  # c = log10(r_t/r_c)
-        AbsMag      	     -7.46  # [V mags]
-        Axis       	[ 0.05409  -0.6035  -0.7955]
-        Angle       	     178.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6380"
+	RA 17.574574
+	Dec -39.06953
+	Distance 31343.628
+	Radius 131.245
+	CoreRadius 0.34
+	KingConcentration 1.627
+	AbsMag -4.214
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6380"
 }
 
 Globular "Haute-Provence 2:Terzan 1:VDBH 235:GCl 69:ESO 455-23:C 1732-304"
 {
-        RA          	   17.5964  # [hours]
-        Dec         	  -30.4817  # [degrees]
-        Distance    	 1.827e+04  # [ly]
-        Radius      	     6.376  # [ly], mu25 Isophote
-        CoreRadius  	      0.04  # [arcmin]
-        KingConcentration     2.44  # c = log10(r_t/r_c)
-        AbsMag      	      -4.9  # [V mags]
-        Axis       	[ 0.05022  -0.6615  -0.7483]
-        Angle       	     178.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 1"
+	RA 17.596445
+	Dec -30.48178
+	Distance 18493.067
+	Radius 124.657
+	CoreRadius 0.218
+	KingConcentration 2.026
+	AbsMag -1.368
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 1"
 }
 
 Globular "Ton 2:Pismis 26:VDBH 236:Tonantzintla 2:GCl 71:C 1732-385"
 {
-        RA          	   17.6028  # [hours]
-        Dec         	  -38.5533  # [degrees]
-        Distance    	 2.642e+04  # [ly]
-        Radius      	     8.454  # [ly], mu25 Isophote
-        CoreRadius  	      0.54  # [arcmin]
-        KingConcentration     1.30  # c = log10(r_t/r_c)
-        AbsMag      	     -6.14  # [V mags]
-        Axis       	[ 0.05043  -0.6072  -0.7929]
-        Angle       	     178.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pismis 26"
+	RA 17.6028
+	Dec -38.5561
+	Distance 22798.331
+	Radius 70.287
+	CoreRadius 0.487
+	KingConcentration 1.338
+	AbsMag -2.562
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ton 2"
 }
 
 Globular "NGC 6388:VDBH 234:C 1732-447:GCl 70"
 {
-        RA          	   17.6047  # [hours]
-        Dec         	  -44.7350  # [degrees]
-        Distance    	 3.262e+04  # [ly]
-        Radius      	     49.34  # [ly], mu25 Isophote
-        CoreRadius  	      0.12  # [arcmin]
-        KingConcentration     1.71  # c = log10(r_t/r_c)
-        AbsMag      	     -9.42  # [V mags]
-        Axis       	[ 0.05079  -0.5635  -0.8245]
-        Angle       	     178.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6388"
+	RA 17.604785
+	Dec -44.7355
+	Distance 36431.667
+	Radius 315.882
+	CoreRadius 0.148
+	KingConcentration 2.305
+	AbsMag -8.42
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6388"
 }
 
 Globular "M 14:NGC 6402:GCl 72:C 1735-032"
 {
-        RA          	   17.6267  # [hours]
-        Dec         	   -3.2458  # [degrees]
-        Distance    	 3.033e+04  # [ly]
-        Radius      	     48.53  # [ly], mu25 Isophote
-        CoreRadius  	      0.83  # [arcmin]
-        KingConcentration     1.60  # c = log10(r_t/r_c)
-        AbsMag      	     -9.12  # [V mags]
-        Axis       	[ 0.04159  -0.8194  -0.5717]
-        Angle       	     177.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6402"
+	RA 17.62671
+	Dec -3.24592
+	Distance 29810.693
+	Radius 241.193
+	CoreRadius 0.752
+	KingConcentration 1.568
+	AbsMag -6.935
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 14"
 }
 
 Globular "NGC 6401:GCl 73:ESO 520-11:C 1735-238"
 {
-        RA          	   17.6433  # [hours]
-        Dec         	  -23.9094  # [degrees]
-        Distance    	 3.425e+04  # [ly]
-        Radius      	     23.91  # [ly], mu25 Isophote
-        CoreRadius  	      0.25  # [arcmin]
-        KingConcentration     1.68  # c = log10(r_t/r_c)
-        AbsMag      	      -7.9  # [V mags]
-        Axis       	[ 0.04348  -0.7035  -0.7093]
-        Angle       	     178.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6401"
+	RA 17.643479
+	Dec -23.9096
+	Distance 24266.035
+	Radius 51.565
+	CoreRadius 0.166
+	KingConcentration 1.643
+	AbsMag -4.388
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6401"
 }
 
 Globular "NGC 6397:GCl 74:C 1736-536"
 {
-        RA          	   17.6781  # [hours]
-        Dec         	  -53.6736  # [degrees]
-        Distance    	      7502  # [ly]
-        Radius      	     33.82  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.50  # c = log10(r_t/r_c)
-        AbsMag      	     -6.63  # [V mags]
-        Axis       	[ 0.04186  -0.4978  -0.8663]
-        Angle       	     179.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6397"
+	RA 17.678359
+	Dec -53.67434
+	Distance 8088.678
+	Radius 161.904
+	CoreRadius 0.194
+	KingConcentration 2.55
+	AbsMag -6.522
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6397"
 }
 
 Globular "Pal 6:GCl 75:ESO 520-21:C 1740-262"
 {
-        RA          	   17.7283  # [hours]
-        Dec         	  -26.2225  # [degrees]
-        Distance    	 1.924e+04  # [ly]
-        Radius      	     3.359  # [ly], mu25 Isophote
-        CoreRadius  	      0.66  # [arcmin]
-        KingConcentration     1.10  # c = log10(r_t/r_c)
-        AbsMag      	     -6.81  # [V mags]
-        Axis       	[ 0.03338  -0.6893  -0.7237]
-        Angle       	     178.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 6"
+	RA 17.728387
+	Dec -26.22499
+	Distance 22994.025
+	Radius 34.018
+	CoreRadius 0.297
+	KingConcentration 1.233
+	AbsMag -2.641
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 6"
 }
 
 Globular "NGC 6426:GCl 76:C 1742+031"
 {
-        RA          	   17.7483  # [hours]
-        Dec         	    3.1703  # [degrees]
-        Distance    	 6.752e+04  # [ly]
-        Radius      	     41.24  # [ly], mu25 Isophote
-        CoreRadius  	      0.26  # [arcmin]
-        KingConcentration     1.71  # c = log10(r_t/r_c)
-        AbsMag      	     -6.69  # [V mags]
-        Axis       	[ 0.02703  -0.8505  -0.5252]
-        Angle       	     177.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6426"
+	RA 17.748531
+	Dec 3.17014
+	Distance 67546.986
+	Radius 289.268
+	CoreRadius 0.435
+	KingConcentration 1.53
+	AbsMag -5.451
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6426"
 }
 
-Globular "Djorg 1"
+Globular "Djor 1"
 {
-        RA          	   17.7911  # [hours]
-        Dec         	  -33.0656  # [degrees]
-        Distance    	 3.914e+04  # [ly]
-        Radius      	     23.53  # [ly], mu25 Isophote
-        CoreRadius  	      0.32  # [arcmin]
-        KingConcentration     1.50  # c = log10(r_t/r_c)
-        AbsMag      	     -6.26  # [V mags]
-        Axis       	[ 0.02618  -0.6451  -0.7637]
-        Angle       	     179.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Djorg 1"
+	RA 17.791305
+	Dec -33.06639
+	Distance 32224.25
+	Radius 82.713
+	CoreRadius 0.278
+	KingConcentration 1.501
+	AbsMag -1.894
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Djor 1"
 }
 
 Globular "Terzan 5:GCl 76.1:ESO 520-27:C 1745-247"
 {
-        RA          	   17.8011  # [hours]
-        Dec         	  -24.7792  # [degrees]
-        Distance    	  3.36e+04  # [ly]
-        Radius      	     23.45  # [ly], mu25 Isophote
-        CoreRadius  	      0.18  # [arcmin]
-        KingConcentration     1.87  # c = log10(r_t/r_c)
-        AbsMag      	     -7.87  # [V mags]
-        Axis       	[ 0.02432  -0.6986  -0.7151]
-        Angle       	     178.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 5"
+	RA 17.801347
+	Dec -24.77906
+	Distance 21591.552
+	Radius 167.188
+	CoreRadius 0.348
+	KingConcentration 1.884
+	AbsMag -1.744
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 5"
 }
 
 Globular "NGC 6440:MXB 1746-20:GCl 77:C 1746-203"
 {
-        RA          	   17.8144  # [hours]
-        Dec         	  -20.3603  # [degrees]
-        Distance    	  2.74e+04  # [ly]
-        Radius      	     17.53  # [ly], mu25 Isophote
-        CoreRadius  	      0.13  # [arcmin]
-        KingConcentration     1.69  # c = log10(r_t/r_c)
-        AbsMag      	     -8.75  # [V mags]
-        Axis       	[ 0.02234  -0.7257  -0.6877]
-        Angle       	     178.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6440"
+	RA 17.814678
+	Dec -20.36042
+	Distance 26907.901
+	Radius 110.502
+	CoreRadius 0.154
+	KingConcentration 1.962
+	AbsMag -5.612
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6440"
+}
+
+Globular "Gran 5"
+{
+	RA 17.8152
+	Dec -24.17
+	Distance 16014.278
+	Radius 70.156
+	CoreRadius 0.301
+	KingConcentration 1.699
+	AbsMag -1.345
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Gran 5"
 }
 
 Globular "NGC 6441:VDBH 248:GCl 78:C 1746-370"
 {
-        RA          	   17.8367  # [hours]
-        Dec         	  -37.0514  # [degrees]
-        Distance    	 3.816e+04  # [ly]
-        Radius      	     53.28  # [ly], mu25 Isophote
-        CoreRadius  	      0.11  # [arcmin]
-        KingConcentration     1.86  # c = log10(r_t/r_c)
-        AbsMag      	     -9.64  # [V mags]
-        Axis       	[ 0.02067  -0.6182  -0.7858]
-        Angle       	     179.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6441"
+	RA 17.836961
+	Dec -37.05145
+	Distance 41519.707
+	Radius 353.26
+	CoreRadius 0.173
+	KingConcentration 2.228
+	AbsMag -8.404
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6441"
 }
 
 Globular "Haute-Provence 5:Terzan 6:VDBH 249:GCl 78.1:ESO 455-49:C 1747-313:C 1747-312"
 {
-        RA          	   17.8461  # [hours]
-        Dec         	  -31.2753  # [degrees]
-        Distance    	 3.099e+04  # [ly]
-        Radius      	     6.309  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.54  # c = log10(r_t/r_c)
-        AbsMag      	     -7.67  # [V mags]
-        Axis       	[  0.0192   -0.657  -0.7536]
-        Angle       	     179.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 6"
+	RA 17.846217
+	Dec -31.27539
+	Distance 23711.569
+	Radius 45.303
+	CoreRadius 0.184
+	KingConcentration 1.552
+	AbsMag 0.162
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 6"
 }
 
 Globular "NGC 6453:VDBH 251:GCl 79:C 1748-346"
 {
-        RA          	   17.8475  # [hours]
-        Dec         	  -34.5992  # [degrees]
-        Distance    	 3.131e+04  # [ly]
-        Radius      	     34.61  # [ly], mu25 Isophote
-        CoreRadius  	      0.07  # [arcmin]
-        KingConcentration     2.49  # c = log10(r_t/r_c)
-        AbsMag      	     -6.88  # [V mags]
-        Axis       	[ 0.01919  -0.6349  -0.7724]
-        Angle       	     179.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6453"
+	RA 17.847701
+	Dec -34.59848
+	Distance 32843.947
+	Radius 107.371
+	CoreRadius 0.044
+	KingConcentration 2.404
+	AbsMag -5.825
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6453"
 }
 
-Globular "Name UKS 1:UKS 1751-24.1:C 1751-241"
+Globular "UKS 1:UKS 1751-24.1:C 1751-241"
 {
-        RA          	   17.9075  # [hours]
-        Dec         	  -24.1453  # [degrees]
-        Distance    	 2.707e+04  # [ly]
-        Radius      	     7.875  # [ly], mu25 Isophote
-        CoreRadius  	      0.15  # [arcmin]
-        KingConcentration     2.10  # c = log10(r_t/r_c)
-        AbsMag      	     -6.88  # [V mags]
-        Axis       	[ 0.01129  -0.7027  -0.7114]
-        Angle       	     179.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Name UKS 1"
+	RA 17.907554
+	Dec -24.14528
+	Distance 50815.164
+	Radius 156.653
+	CoreRadius 0.225
+	KingConcentration 1.673
+	AbsMag 1.327
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=UKS 1"
+}
+
+Globular "VVV-CL001"
+{
+	RA 17.911805
+	Dec -24.01472
+	Distance 26353.435
+	Radius 118.786
+	CoreRadius 0.238
+	KingConcentration 1.813
+	AbsMag -0.337
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=VVV-CL001"
+}
+
+Globular "ESO 456-SC29:Gran 1"
+{
+	RA 17.976733
+	Dec -32.02
+	Distance 26973.132
+	Radius 62.133
+	CoreRadius 0.569
+	KingConcentration 1.143
+	AbsMag -2.178
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 456-SC29"
 }
 
 Globular "NGC 6496:GCl 80:C 1755-442"
 {
-        RA          	   17.9839  # [hours]
-        Dec         	  -44.2650  # [degrees]
-        Distance    	 3.751e+04  # [ly]
-        Radius      	     30.55  # [ly], mu25 Isophote
-        CoreRadius  	      1.05  # [arcmin]
-        KingConcentration     0.70  # c = log10(r_t/r_c)
-        AbsMag      	     -7.23  # [V mags]
-        Axis       	[0.002069  -0.5677  -0.8233]
-        Angle       	       180  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6496"
+	RA 17.984357
+	Dec -44.26595
+	Distance 31441.475
+	Radius 94.977
+	CoreRadius 0.909
+	KingConcentration 1.058
+	AbsMag -6.27
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6496"
 }
 
 Globular "Terzan 9:GCl 80.1:C 1758-268"
 {
-        RA          	   18.0272  # [hours]
-        Dec         	  -26.8397  # [degrees]
-        Distance    	  2.12e+04  # [ly]
-        Radius      	      1.85  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.44  # c = log10(r_t/r_c)
-        AbsMag      	     -3.85  # [V mags]
-        Axis       	[0.003351   0.6858   0.7278]
-        Angle       	     179.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 9"
+	RA 18.027445
+	Dec -26.83972
+	Distance 18819.223
+	Radius 103.098
+	CoreRadius 0.167
+	KingConcentration 2.053
+	AbsMag -1.076
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 9"
 }
 
 Globular "ESO456-SC38:Djorg 2:ESO 456-38:C 1758-278"
 {
-        RA          	   18.0303  # [hours]
-        Dec         	  -27.8258  # [degrees]
-        Distance    	 2.185e+04  # [ly]
-        Radius      	     31.47  # [ly], mu25 Isophote
-        CoreRadius  	      0.33  # [arcmin]
-        KingConcentration     1.50  # c = log10(r_t/r_c)
-        AbsMag      	     -6.98  # [V mags]
-        Axis       	[0.003739   0.6795   0.7336]
-        Angle       	     179.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Djorg 2"
+	RA 18.030292
+	Dec -27.82582
+	Distance 28571.299
+	Radius 50.326
+	CoreRadius 0.514
+	KingConcentration 1.071
+	AbsMag -4.013
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 456-SC38"
 }
 
 Globular "NGC 6517:GCl 81:C 1759-089"
 {
-        RA          	   18.0306  # [hours]
-        Dec         	   -8.9589  # [degrees]
-        Distance    	 3.523e+04  # [ly]
-        Radius      	     20.49  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     1.83  # c = log10(r_t/r_c)
-        AbsMag      	     -8.28  # [V mags]
-        Axis       	[0.003505   0.7906   0.6123]
-        Angle       	     179.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6517"
+	RA 18.030717
+	Dec -8.95878
+	Distance 30104.234
+	Radius 154.468
+	CoreRadius 0.052
+	KingConcentration 2.529
+	AbsMag -4.136
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6517"
 }
 
 Globular "Terzan 10:GCl 82.1:ESO 521-16:C 1800-260"
 {
-        RA          	   18.0492  # [hours]
-        Dec         	  -26.0667  # [degrees]
-        Distance    	 1.859e+04  # [ly]
-        Radius      	     12.17  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.31  # [V mags]
-        Axis       	[0.006038   0.6907   0.7231]
-        Angle       	     179.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 10"
+	RA 18.049389
+	Dec -26.06694
+	Distance 33300.566
+	Radius 135.518
+	CoreRadius 0.101
+	KingConcentration 2.141
+	AbsMag -0.315
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 10"
 }
 
 Globular "NGC 6522:VDBH 256:GCl 82:C 1800-300"
 {
-        RA          	   18.0594  # [hours]
-        Dec         	  -30.0339  # [degrees]
-        Distance    	 2.544e+04  # [ly]
-        Radius      	     34.78  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     2.52  # c = log10(r_t/r_c)
-        AbsMag      	     -7.67  # [V mags]
-        Axis       	[0.007389   0.6652   0.7466]
-        Angle       	     179.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6522"
+	RA 18.059464
+	Dec -30.03397
+	Distance 23776.8
+	Radius 50.098
+	CoreRadius 0.184
+	KingConcentration 1.595
+	AbsMag -6.034
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6522"
 }
 
 Globular "NGC 6535:GCl 83:C 1801-003"
 {
-        RA          	   18.0639  # [hours]
-        Dec         	   -0.2969  # [degrees]
-        Distance    	 2.218e+04  # [ly]
-        Radius      	     10.97  # [ly], mu25 Isophote
-        CoreRadius  	      0.42  # [arcmin]
-        KingConcentration     1.30  # c = log10(r_t/r_c)
-        AbsMag      	     -4.75  # [V mags]
-        Axis       	[0.007003   0.8346   0.5509]
-        Angle       	     179.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6535"
+	RA 18.06403
+	Dec -0.29764
+	Distance 20743.546
+	Radius 80.561
+	CoreRadius 0.108
+	KingConcentration 2.092
+	AbsMag -3.917
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6535"
 }
 
 Globular "NGC 6528:VDBH 257:GCl 84:ESO 456-48:C 1801-300"
 {
-        RA          	   18.0803  # [hours]
-        Dec         	  -30.0558  # [degrees]
-        Distance    	 2.577e+04  # [ly]
-        Radius      	     18.74  # [ly], mu25 Isophote
-        CoreRadius  	      0.09  # [arcmin]
-        KingConcentration     2.27  # c = log10(r_t/r_c)
-        AbsMag      	     -6.56  # [V mags]
-        Axis       	[0.009979   0.6651   0.7467]
-        Angle       	     179.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6528"
+	RA 18.080447
+	Dec -30.05578
+	Distance 25538.044
+	Radius 35.812
+	CoreRadius 0.119
+	KingConcentration 1.609
+	AbsMag -4.759
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6528"
 }
 
 Globular "NGC 6539:GCl 85:C 1802-075"
 {
-        RA          	   18.0803  # [hours]
-        Dec         	   -7.5858  # [degrees]
-        Distance    	  2.74e+04  # [ly]
-        Radius      	     31.48  # [ly], mu25 Isophote
-        CoreRadius  	      0.54  # [arcmin]
-        KingConcentration     1.60  # c = log10(r_t/r_c)
-        AbsMag      	      -8.3  # [V mags]
-        Axis       	[0.009147   0.7978   0.6028]
-        Angle       	     179.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6539"
+	RA 18.080485
+	Dec -7.58586
+	Distance 26614.36
+	Radius 146.314
+	CoreRadius 0.586
+	KingConcentration 1.509
+	AbsMag -4.618
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6539"
 }
 
 Globular "Djorg 3:NGC 6540:VDBH 258:C 1803-278"
 {
-        RA          	   18.1022  # [hours]
-        Dec         	  -27.7653  # [degrees]
-        Distance    	 1.207e+04  # [ly]
-        Radius      	     2.633  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.50  # c = log10(r_t/r_c)
-        AbsMag      	     -5.38  # [V mags]
-        Axis       	[ 0.01262   0.6799   0.7332]
-        Angle       	     179.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6540"
+	RA 18.102377
+	Dec -27.76529
+	Distance 19275.842
+	Radius 74.07
+	CoreRadius 0.052
+	KingConcentration 2.402
+	AbsMag -4.118
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6540"
+}
+
+Globular "VVV-CL160"
+{
+	RA 18.115833
+	Dec -20.01111
+	Distance 22178.634
+	Radius 63.666
+	CoreRadius 0.409
+	KingConcentration 1.382
+	AbsMag 1.437
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=VVV-CL160"
 }
 
 Globular "NGC 6544:GCl 87:C 1804-250"
 {
-        RA          	   18.1222  # [hours]
-        Dec         	  -24.9975  # [degrees]
-        Distance    	      8807  # [ly]
-        Radius      	     11.78  # [ly], mu25 Isophote
-        CoreRadius  	      0.05  # [arcmin]
-        KingConcentration     1.61  # c = log10(r_t/r_c)
-        AbsMag      	     -6.66  # [V mags]
-        Axis       	[ 0.01496   0.6973   0.7166]
-        Angle       	     179.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6544"
+	RA 18.122255
+	Dec -24.99822
+	Distance 8414.835
+	Radius 155.74
+	CoreRadius 0.266
+	KingConcentration 2.378
+	AbsMag -4.198
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6544"
 }
 
 Globular "NGC 6541:GCl 86:C 1804-437"
 {
-        RA          	   18.1339  # [hours]
-        Dec         	  -43.5000  # [degrees]
-        Distance    	 2.283e+04  # [ly]
-        Radius      	     49.81  # [ly], mu25 Isophote
-        CoreRadius  	       0.3  # [arcmin]
-        KingConcentration     1.99  # c = log10(r_t/r_c)
-        AbsMag      	     -8.37  # [V mags]
-        Axis       	[ 0.01717   0.5731   0.8193]
-        Angle       	     179.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6541"
+	RA 18.133989
+	Dec -43.71489
+	Distance 24820.5
+	Radius 122.048
+	CoreRadius 0.05
+	KingConcentration 2.532
+	AbsMag -7.797
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6541"
 }
 
 Globular "2MASS-GC01:[HJK2000] GC01"
 {
-        RA          	   18.1392  # [hours]
-        Dec         	  -19.8297  # [degrees]
-        Distance    	 1.174e+04  # [ly]
-        Radius      	     5.636  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.86  # unknown!! Data base average used
-        Axis       	[ 0.01672   0.7289   0.6844]
-        Angle       	     179.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=2MASS-GC01"
+	RA 18.13939
+	Dec -19.82972
+	Distance 10991.47
+	Radius 99.282
+	CoreRadius 0.184
+	KingConcentration 2.228
+	AbsMag 15.102
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=2MASS-GC01"
 }
 
 Globular "ESO 280-SC06:ESO 280-6"
 {
-        RA          	   18.1517  # [hours]
-        Dec         	  -46.4231  # [degrees]
-        Distance    	 7.078e+04  # [ly]
-        Radius      	     15.44  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.86  # unknown!! Data base average used
-        Axis       	[ 0.01955   0.5519   0.8336]
-        Angle       	     179.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 280-SC06"
+	RA 18.151667
+	Dec -46.42333
+	Distance 68329.761
+	Radius 248.042
+	CoreRadius 0.404
+	KingConcentration 1.49
+	AbsMag -4.376
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=ESO 280-SC06"
 }
 
 Globular "NGC 6553:GCl 88:C 1806-259"
 {
-        RA          	   18.1547  # [hours]
-        Dec         	  -25.9086  # [degrees]
-        Distance    	 1.957e+04  # [ly]
-        Radius      	     26.19  # [ly], mu25 Isophote
-        CoreRadius  	      0.55  # [arcmin]
-        KingConcentration     1.17  # c = log10(r_t/r_c)
-        AbsMag      	     -7.77  # [V mags]
-        Axis       	[ 0.01899   0.6916    0.722]
-        Angle       	     179.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6553"
+	RA 18.154866
+	Dec -25.90807
+	Distance 17384.135
+	Radius 156.001
+	CoreRadius 0.335
+	KingConcentration 1.964
+	AbsMag -5.594
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6553"
 }
 
 Globular "2MASS-GC02:[HJK2000] GC02"
 {
-        RA          	   18.1600  # [hours]
-        Dec         	  -20.7789  # [degrees]
-        Distance    	 1.305e+04  # [ly]
-        Radius      	     3.605  # [ly], mu25 Isophote
-        CoreRadius            0.83  # unknown!! Data base average used
-        KingConcentration     1.47  # unknown!! Data base average used
-        AbsMag      	     -6.86  # unknown!! Data base average used
-        Axis       	[ 0.01929   0.7232   0.6904]
-        Angle       	     179.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=2MASS-GC02"
+	RA 18.16014
+	Dec -20.77889
+	Distance 17938.601
+	Radius 51.207
+	CoreRadius 0.388
+	KingConcentration 1.404
+	AbsMag 10.898
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=2MASS-GC02"
 }
 
 Globular "NGC 6558:VDBH 259:GCl 89:ESO 456-62:C 1807-317"
 {
-        RA          	   18.1714  # [hours]
-        Dec         	  -31.7639  # [degrees]
-        Distance    	 2.414e+04  # [ly]
-        Radius      	     14.74  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.54  # c = log10(r_t/r_c)
-        AbsMag      	     -6.46  # [V mags]
-        Axis       	[ 0.02141   0.6538   0.7564]
-        Angle       	     179.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6558"
+	RA 18.171598
+	Dec -31.76451
+	Distance 25407.582
+	Radius 29.158
+	CoreRadius 0.066
+	KingConcentration 1.775
+	AbsMag -4.798
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6558"
 }
 
 Globular "Pal 7:IC 1276:GCl 90:C 1808-072"
 {
-        RA          	   18.1789  # [hours]
-        Dec         	   -7.2075  # [degrees]
-        Distance    	 1.761e+04  # [ly]
-        Radius      	     20.49  # [ly], mu25 Isophote
-        CoreRadius  	      1.08  # [arcmin]
-        KingConcentration     1.29  # c = log10(r_t/r_c)
-        AbsMag      	     -6.67  # [V mags]
-        Axis       	[ 0.02034   0.7997   0.6001]
-        Angle       	     178.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 1276"
+	RA 18.178963
+	Dec -7.2076
+	Distance 14840.115
+	Radius 123.124
+	CoreRadius 0.657
+	KingConcentration 1.637
+	AbsMag -3.37
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=IC 1276"
 }
 
 Globular "Terzan 11:Terzan 12:GCl 90.1:ESO 522-1:C 1809-227"
 {
-        RA          	   18.2042  # [hours]
-        Dec         	  -22.7419  # [degrees]
-        Distance    	 1.566e+04  # [ly]
-        Radius      	     5.465  # [ly], mu25 Isophote
-        CoreRadius  	      0.83  # [arcmin]
-        KingConcentration     0.57  # c = log10(r_t/r_c)
-        AbsMag      	     -4.14  # [V mags]
-        Axis       	[ 0.02479   0.7112   0.7026]
-        Angle       	     178.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 11"
+	RA 18.204389
+	Dec -22.74194
+	Distance 16862.285
+	Radius 81.18
+	CoreRadius 0.439
+	KingConcentration 1.576
+	AbsMag 0.253
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 12"
 }
 
 Globular "NGC 6569:VDBH 260:GCl 91:ESO 456-77:C 1810-318"
 {
-        RA          	   18.2272  # [hours]
-        Dec         	  -31.8269  # [degrees]
-        Distance    	  3.49e+04  # [ly]
-        Radius      	     32.49  # [ly], mu25 Isophote
-        CoreRadius  	      0.37  # [arcmin]
-        KingConcentration     1.27  # c = log10(r_t/r_c)
-        AbsMag      	      -8.3  # [V mags]
-        Axis       	[ 0.02838   0.6532   0.7566]
-        Angle       	       179  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6569"
+	RA 18.227445
+	Dec -31.82689
+	Distance 34344.267
+	Radius 139.954
+	CoreRadius 0.291
+	KingConcentration 1.683
+	AbsMag -6.212
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6569"
+}
+
+Globular "AL 3:BH 261"
+{
+	RA 18.235167
+	Dec -28.635
+	Distance 19960.77
+	Radius 67.286
+	CoreRadius 0.202
+	KingConcentration 1.758
+	AbsMag -2.674
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=AL 3"
 }
 
 Globular "NGC 6584:GCl 92:C 1814-522"
 {
-        RA          	   18.3103  # [hours]
-        Dec         	  -52.2150  # [degrees]
-        Distance    	 4.371e+04  # [ly]
-        Radius      	     41.96  # [ly], mu25 Isophote
-        CoreRadius  	      0.59  # [arcmin]
-        KingConcentration     1.20  # c = log10(r_t/r_c)
-        AbsMag      	     -7.68  # [V mags]
-        Axis       	[ 0.04029   0.5088   0.8599]
-        Angle       	     179.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6584"
+	RA 18.310443
+	Dec -52.21578
+	Distance 44389.883
+	Radius 193.9
+	CoreRadius 0.293
+	KingConcentration 1.71
+	AbsMag -6.909
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6584"
 }
 
 Globular "NGC 6624:VDBH 262:KOHX 13:GCl 93:ESO 457-11:C 1820-303"
 {
-        RA          	   18.3944  # [hours]
-        Dec         	  -30.3611  # [degrees]
-        Distance    	 2.577e+04  # [ly]
-        Radius      	     32.98  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     2.53  # c = log10(r_t/r_c)
-        AbsMag      	     -7.49  # [V mags]
-        Axis       	[ 0.04906   0.6623   0.7476]
-        Angle       	     178.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6624"
+	RA 18.394586
+	Dec -30.36103
+	Distance 26157.741
+	Radius 54.86
+	CoreRadius 0.081
+	KingConcentration 1.947
+	AbsMag -6.491
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6624"
 }
 
 Globular "M 28:NGC 6626:GCl 94:C 1821-249"
 {
-        RA          	   18.4089  # [hours]
-        Dec         	  -24.8700  # [degrees]
-        Distance    	 1.827e+04  # [ly]
-        Radius      	     29.75  # [ly], mu25 Isophote
-        CoreRadius  	      0.24  # [arcmin]
-        KingConcentration     1.67  # c = log10(r_t/r_c)
-        AbsMag      	     -8.18  # [V mags]
-        Axis       	[ 0.05001   0.6973    0.715]
-        Angle       	     177.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6626"
+	RA 18.409136
+	Dec -24.86985
+	Distance 17514.597
+	Radius 154.663
+	CoreRadius 0.205
+	KingConcentration 2.171
+	AbsMag -6.8
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 28"
 }
 
 Globular "NGC 6638:GCl 95:C 1827-255"
 {
-        RA          	   18.5156  # [hours]
-        Dec         	  -25.4975  # [degrees]
-        Distance    	 3.131e+04  # [ly]
-        Radius      	     33.25  # [ly], mu25 Isophote
-        CoreRadius  	      0.26  # [arcmin]
-        KingConcentration     1.41  # c = log10(r_t/r_c)
-        AbsMag      	     -7.13  # [V mags]
-        Axis       	[ 0.06317   0.6929   0.7183]
-        Angle       	     177.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6638"
+	RA 18.515582
+	Dec -25.49747
+	Distance 31898.094
+	Radius 94.748
+	CoreRadius 0.169
+	KingConcentration 1.782
+	AbsMag -6.162
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6638"
 }
 
 Globular "M 69:NGC 6637:HD 170534:GCl 96:C 1828-323"
 {
-        RA          	   18.5231  # [hours]
-        Dec         	  -32.3481  # [degrees]
-        Distance    	 2.968e+04  # [ly]
-        Radius      	     42.31  # [ly], mu25 Isophote
-        CoreRadius  	      0.34  # [arcmin]
-        KingConcentration     1.39  # c = log10(r_t/r_c)
-        AbsMag      	     -7.64  # [V mags]
-        Axis       	[  0.0654   0.6487   0.7583]
-        Angle       	     177.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6637"
+	RA 18.523083
+	Dec -32.34808
+	Distance 29027.918
+	Radius 78.93
+	CoreRadius 0.22
+	KingConcentration 1.628
+	AbsMag -7.127
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 69"
 }
 
 Globular "NGC 6642:GCl 97:ESO 522-32:C 1828-235"
 {
-        RA          	   18.5317  # [hours]
-        Dec         	  -23.4753  # [degrees]
-        Distance    	  2.74e+04  # [ly]
-        Radius      	     23.11  # [ly], mu25 Isophote
-        CoreRadius  	       0.1  # [arcmin]
-        KingConcentration     2.00  # c = log10(r_t/r_c)
-        AbsMag      	     -6.77  # [V mags]
-        Axis       	[  0.0647   0.7054   0.7058]
-        Angle       	     177.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6642"
+	RA 18.531731
+	Dec -23.4756
+	Distance 26255.588
+	Radius 52.903
+	CoreRadius 0.047
+	KingConcentration 2.169
+	AbsMag -4.879
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6642"
 }
 
 Globular "NGC 6652:GCl 98:C 1832-330"
 {
-        RA          	   18.5958  # [hours]
-        Dec         	  -32.9903  # [degrees]
-        Distance    	 3.294e+04  # [ly]
-        Radius      	     28.75  # [ly], mu25 Isophote
-        CoreRadius  	      0.07  # [arcmin]
-        KingConcentration     1.81  # c = log10(r_t/r_c)
-        AbsMag      	     -6.68  # [V mags]
-        Axis       	[ 0.07461    0.644   0.7614]
-        Angle       	     177.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6652"
+	RA 18.596008
+	Dec -32.99072
+	Distance 30854.393
+	Radius 57.73
+	CoreRadius 0.062
+	KingConcentration 2.018
+	AbsMag -5.959
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6652"
 }
 
 Globular "M 22:NGC 6656:HD 171560:GCl 99:C 1833-239"
 {
-        RA          	   18.6067  # [hours]
-        Dec         	  -23.9033  # [degrees]
-        Distance    	 1.044e+04  # [ly]
-        Radius      	     48.58  # [ly], mu25 Isophote
-        CoreRadius  	      1.42  # [arcmin]
-        KingConcentration     1.31  # c = log10(r_t/r_c)
-        AbsMag      	      -8.5  # [V mags]
-        Axis       	[ 0.07393   0.7023    0.708]
-        Angle       	     176.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6656"
+	RA 18.606651
+	Dec -23.90475
+	Distance 10763.16
+	Radius 250.553
+	CoreRadius 0.917
+	KingConcentration 1.941
+	AbsMag -7.533
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 22"
 }
 
 Globular "Pal 8:GCl 100:ESO 591-12:C 1838-198"
 {
-        RA          	   18.6914  # [hours]
-        Dec         	  -19.8258  # [degrees]
-        Distance    	 4.208e+04  # [ly]
-        Radius      	     31.82  # [ly], mu25 Isophote
-        CoreRadius  	       0.4  # [arcmin]
-        KingConcentration     1.53  # c = log10(r_t/r_c)
-        AbsMag      	     -5.52  # [V mags]
-        Axis       	[ 0.08302   0.7265   0.6821]
-        Angle       	     175.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 8"
+	RA 18.691819
+	Dec -19.82886
+	Distance 36920.902
+	Radius 120.58
+	CoreRadius 0.571
+	KingConcentration 1.294
+	AbsMag -5.159
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 8"
 }
 
 Globular "M 70:NGC 6681:GCl 101:C 1840-323"
 {
-        RA          	   18.7200  # [hours]
-        Dec         	  -32.2919  # [degrees]
-        Distance    	 2.936e+04  # [ly]
-        Radius      	     34.16  # [ly], mu25 Isophote
-        CoreRadius  	      0.03  # [arcmin]
-        KingConcentration     2.42  # c = log10(r_t/r_c)
-        AbsMag      	     -7.11  # [V mags]
-        Axis       	[ 0.08997   0.6478   0.7565]
-        Angle       	     176.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6681"
+	RA 18.720211
+	Dec -32.29211
+	Distance 30528.237
+	Radius 89.595
+	CoreRadius 0.026
+	KingConcentration 2.594
+	AbsMag -6.946
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 70"
+}
+
+Globular "RLGC 2:Ryu 879"
+{
+	RA 18.757825
+	Dec -5.19258
+	Distance 51695.786
+	Radius 313.306
+	CoreRadius 0.069
+	KingConcentration 2.477
+	AbsMag -2.14
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=RLGC 2"
 }
 
 Globular "NGC 6712:OCl 72.0:GCl 103:C 1850-087:AO 1850-08"
 {
-        RA          	   18.8844  # [hours]
-        Dec         	   -8.7061  # [degrees]
-        Distance    	 2.251e+04  # [ly]
-        Radius      	     32.08  # [ly], mu25 Isophote
-        CoreRadius  	      0.94  # [arcmin]
-        KingConcentration     0.90  # c = log10(r_t/r_c)
-        AbsMag      	      -7.5  # [V mags]
-        Axis       	[  0.1013   0.7879   0.6075]
-        Angle       	     173.6  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6712"
+	RA 18.884535
+	Dec -8.70596
+	Distance 24070.341
+	Radius 108.447
+	CoreRadius 0.312
+	KingConcentration 1.696
+	AbsMag -5.74
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6712"
 }
 
 Globular "M 54:NGC 6715:GCl 104:C 1851-305"
 {
-        RA          	   18.9175  # [hours]
-        Dec         	  -30.4783  # [degrees]
-        Distance    	 8.741e+04  # [ly]
-        Radius      	     152.6  # [ly], mu25 Isophote
-        CoreRadius  	      0.11  # [arcmin]
-        KingConcentration     1.83  # c = log10(r_t/r_c)
-        AbsMag      	    -10.01  # [V mags]
-        Axis       	[   0.114    0.658   0.7443]
-        Angle       	     175.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6715"
+	RA 18.91759
+	Dec -30.47986
+	Distance 85713.896
+	Radius 910.466
+	CoreRadius 0.072
+	KingConcentration 2.705
+	AbsMag -9.528
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 54"
 }
 
 Globular "Pal 9:NGC 6717:GCl 105:ESO 523-14:C 1852-227"
 {
-        RA          	   18.9183  # [hours]
-        Dec         	  -22.7008  # [degrees]
-        Distance    	 2.316e+04  # [ly]
-        Radius      	     18.19  # [ly], mu25 Isophote
-        CoreRadius  	      0.08  # [arcmin]
-        KingConcentration     2.09  # c = log10(r_t/r_c)
-        AbsMag      	     -5.66  # [V mags]
-        Axis       	[  0.1114   0.7072   0.6982]
-        Angle       	     174.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6717"
+	RA 18.918345
+	Dec -22.70147
+	Distance 24526.96
+	Radius 58.121
+	CoreRadius 0.133
+	KingConcentration 1.789
+	AbsMag -5.401
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6717"
 }
 
 Globular "NGC 6723:GCl 106:C 1856-367"
 {
-        RA          	   18.9925  # [hours]
-        Dec         	  -36.6317  # [degrees]
-        Distance    	 2.838e+04  # [ly]
-        Radius      	     53.65  # [ly], mu25 Isophote
-        CoreRadius  	      0.94  # [arcmin]
-        KingConcentration     1.05  # c = log10(r_t/r_c)
-        AbsMag      	     -7.84  # [V mags]
-        Axis       	[  0.1252   0.6163   0.7775]
-        Angle       	     176.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6723"
+	RA 18.992541
+	Dec -36.63225
+	Distance 26973.132
+	Radius 125.701
+	CoreRadius 0.615
+	KingConcentration 1.416
+	AbsMag -7.378
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6723"
 }
 
 Globular "NGC 6749:Berkeley 42:GCl 107:C 1902+018"
 {
-        RA          	   19.0875  # [hours]
-        Dec         	    1.9008  # [degrees]
-        Distance    	 2.577e+04  # [ly]
-        Radius      	     14.99  # [ly], mu25 Isophote
-        CoreRadius  	      0.77  # [arcmin]
-        KingConcentration     0.83  # c = log10(r_t/r_c)
-        AbsMag      	      -6.7  # [V mags]
-        Axis       	[  0.1177   0.8391   0.5311]
-        Angle       	     170.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6749"
+	RA 19.087604
+	Dec 1.89976
+	Distance 24755.269
+	Radius 205.348
+	CoreRadius 0.67
+	KingConcentration 1.629
+	AbsMag -3.491
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6749"
 }
 
 Globular "NGC 6752:GCl 108:C 1906-600"
 {
-        RA          	   19.1811  # [hours]
-        Dec         	  -59.9847  # [degrees]
-        Distance    	 1.305e+04  # [ly]
-        Radius      	     55.03  # [ly], mu25 Isophote
-        CoreRadius  	      0.17  # [arcmin]
-        KingConcentration     2.51  # c = log10(r_t/r_c)
-        AbsMag      	     -7.73  # [V mags]
-        Axis       	[  0.1537   0.4444   0.8825]
-        Angle       	       179  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6752"
+	RA 19.18114
+	Dec -59.98455
+	Distance 13437.643
+	Radius 216.6
+	CoreRadius 0.25
+	KingConcentration 2.345
+	AbsMag -7.724
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6752"
 }
 
 Globular "NGC 6760:GCl 109:C 1908+009"
 {
-        RA          	   19.1867  # [hours]
-        Dec         	    1.0306  # [degrees]
-        Distance    	 2.414e+04  # [ly]
-        Radius      	      33.7  # [ly], mu25 Isophote
-        CoreRadius  	      0.33  # [arcmin]
-        KingConcentration     1.59  # c = log10(r_t/r_c)
-        AbsMag      	     -7.86  # [V mags]
-        Axis       	[   0.129   0.8339   0.5367]
-        Angle       	     170.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6760"
+	RA 19.186685
+	Dec 1.03047
+	Distance 27429.751
+	Radius 239.464
+	CoreRadius 0.441
+	KingConcentration 1.832
+	AbsMag -5.734
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6760"
 }
 
-Globular "M 56:NGC 6779:GCl 110:C 1914+300"
+Globular "M 56:NGC 6779:GCl 110:C 1914+300"1
 {
-        RA          	   19.2764  # [hours]
-        Dec         	   30.1847  # [degrees]
-        Distance    	 3.294e+04  # [ly]
-        Radius      	     42.16  # [ly], mu25 Isophote
-        CoreRadius  	      0.37  # [arcmin]
-        KingConcentration     1.36  # c = log10(r_t/r_c)
-        AbsMag      	     -7.38  # [V mags]
-        Axis       	[  0.1113   0.9441   0.3102]
-        Angle       	     165.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6779"
+	RA 19.276546
+	Dec 30.18347
+	Distance 34018.11
+	Radius 300.618
+	CoreRadius 0.323
+	KingConcentration 1.973
+	AbsMag -6.941
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 56"
 }
 
 Globular "Terzan 7:GCl 109.1:C 1914-347"
 {
-        RA          	   19.2953  # [hours]
-        Dec         	  -34.6575  # [degrees]
-        Distance    	 7.567e+04  # [ly]
-        Radius      	     13.21  # [ly], mu25 Isophote
-        CoreRadius  	      0.61  # [arcmin]
-        KingConcentration     1.08  # c = log10(r_t/r_c)
-        AbsMag      	     -5.05  # [V mags]
-        Axis       	[  0.1624   0.6262   0.7626]
-        Angle       	     174.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 7"
+	RA 19.295532
+	Dec -34.65772
+	Distance 79190.769
+	Radius 202.347
+	CoreRadius 0.561
+	KingConcentration 1.195
+	AbsMag -5.076
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 7"
 }
 
 Globular "Pal 10:GCl 111:C 1916+184"
 {
-        RA          	   19.3006  # [hours]
-        Dec         	   18.5717  # [degrees]
-        Distance    	 1.924e+04  # [ly]
-        Radius      	      11.2  # [ly], mu25 Isophote
-        CoreRadius  	      0.81  # [arcmin]
-        KingConcentration     0.58  # c = log10(r_t/r_c)
-        AbsMag      	     -5.79  # [V mags]
-        Axis       	[  0.1256   0.9063   0.4034]
-        Angle       	     166.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 10"
+	RA 19.300582
+	Dec 18.57167
+	Distance 29158.38
+	Radius 206.718
+	CoreRadius 0.858
+	KingConcentration 1.454
+	AbsMag -2.387
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 10"
 }
 
-Globular "Cl Arp 2:GCl 112:C 1925-304"
+Globular "Arp 2:GCl 112:C 1925-304"
 {
-        RA          	   19.4789  # [hours]
-        Dec         	  -30.3539  # [degrees]
-        Distance    	 9.328e+04  # [ly]
-        Radius      	     31.21  # [ly], mu25 Isophote
-        CoreRadius  	      1.59  # [arcmin]
-        KingConcentration     0.90  # c = log10(r_t/r_c)
-        AbsMag      	     -5.29  # [V mags]
-        Axis       	[  0.1832    0.652   0.7358]
-        Angle       	     173.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Cl Arp 2"
+	RA 19.478921
+	Dec -30.35564
+	Distance 93704.727
+	Radius 283.887
+	CoreRadius 0.997
+	KingConcentration 1.019
+	AbsMag -5.642
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Arp 2"
 }
 
 Globular "M 55:NGC 6809:GCl 113:C 1936-310"
 {
-        RA          	   19.6664  # [hours]
-        Dec         	  -30.9622  # [degrees]
-        Distance    	 1.729e+04  # [ly]
-        Radius      	     47.77  # [ly], mu25 Isophote
-        CoreRadius  	      2.83  # [arcmin]
-        KingConcentration     0.76  # c = log10(r_t/r_c)
-        AbsMag      	     -7.55  # [V mags]
-        Axis       	[  0.2065    0.645   0.7358]
-        Angle       	     172.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6809"
+	RA 19.666585
+	Dec -30.96475
+	Distance 17449.366
+	Radius 169.699
+	CoreRadius 1.6
+	KingConcentration 1.32
+	AbsMag -7.352
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 55"
 }
 
 Globular "Terzan 8:GCl 113.1:C 1938-341"
 {
-        RA          	   19.6958  # [hours]
-        Dec         	  -34.0003  # [degrees]
-        Distance    	  8.48e+04  # [ly]
-        Radius      	     43.17  # [ly], mu25 Isophote
-        CoreRadius  	         1  # [arcmin]
-        KingConcentration     0.60  # c = log10(r_t/r_c)
-        AbsMag      	     -5.05  # [V mags]
-        Axis       	[  0.2117   0.6245   0.7517]
-        Angle       	     172.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Terzan 8"
+	RA 19.695669
+	Dec -33.99947
+	Distance 89823.466
+	Radius 352.934
+	CoreRadius 1.253
+	KingConcentration 1.033
+	AbsMag -6.15
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Ter 8"
 }
 
 Globular "Pal 11:GCl 114:C 1942-081"
 {
-        RA          	   19.7539  # [hours]
-        Dec         	   -8.0072  # [degrees]
-        Distance    	  4.24e+04  # [ly]
-        Radius      	     61.67  # [ly], mu25 Isophote
-        CoreRadius  	         2  # [arcmin]
-        KingConcentration     0.69  # c = log10(r_t/r_c)
-        AbsMag      	     -6.86  # [V mags]
-        Axis       	[  0.1997   0.7796   0.5936]
-        Angle       	     167.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 11"
+	RA 19.754
+	Dec -8.00722
+	Distance 45727.124
+	Radius 106.914
+	CoreRadius 1.005
+	KingConcentration 0.903
+	AbsMag -3.874
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 11"
+}
+
+Globular "Sagittarius II:Sgr II:Laevens 5"
+{
+	RA 19.877647
+	Dec -22.06525
+	Distance 216991.838
+	Radius 1252.93
+	CoreRadius 1.062
+	KingConcentration 1.272
+	AbsMag -5.075
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Sagittarius II"
 }
 
 Globular "M 71:NGC 6838:GCl 115:C 1951+186"
 {
-        RA          	   19.8961  # [hours]
-        Dec         	   18.7783  # [degrees]
-        Distance    	 1.305e+04  # [ly]
-        Radius      	     13.66  # [ly], mu25 Isophote
-        CoreRadius  	      0.63  # [arcmin]
-        KingConcentration     1.15  # c = log10(r_t/r_c)
-        AbsMag      	      -5.6  # [V mags]
-        Axis       	[  0.1832   0.8988   0.3981]
-        Angle       	     160.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6838"
+	RA 19.896249
+	Dec 18.77919
+	Distance 13046.255
+	Radius 133.561
+	CoreRadius 0.92
+	KingConcentration 1.583
+	AbsMag -5.85
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 71"
 }
 
-Globular "M 75:NGC 6864:GCl 116:C 2003-220"
+Globular "M 75:NGC 6864:GCl 116:C 2003-220"7.
 {
-        RA          	   20.1011  # [hours]
-        Dec         	  -21.9214  # [degrees]
-        Distance    	 6.752e+04  # [ly]
-        Radius      	     66.78  # [ly], mu25 Isophote
-        CoreRadius  	       0.1  # [arcmin]
-        KingConcentration     1.86  # c = log10(r_t/r_c)
-        AbsMag      	     -8.55  # [V mags]
-        Axis       	[  0.2526   0.6932   0.6751]
-        Angle       	     168.2  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6864"
+	RA 20.101319
+	Dec -21.92116
+	Distance 66927.289
+	Radius 508.869
+	CoreRadius 0.069
+	KingConcentration 2.58
+	AbsMag -8.051
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 75"
 }
 
-Globular "NGC 6934:GCl 117:C 2031+072"
+Globular "NGC 6934:GCl 117:C 2031+072"3
 {
-        RA          	   20.5697  # [hours]
-        Dec         	    7.4042  # [degrees]
-        Distance    	 5.121e+04  # [ly]
-        Radius      	     52.88  # [ly], mu25 Isophote
-        CoreRadius  	      0.25  # [arcmin]
-        KingConcentration     1.52  # c = log10(r_t/r_c)
-        AbsMag      	     -7.46  # [V mags]
-        Axis       	[   0.269   0.8376   0.4754]
-        Angle       	     157.1  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6934"
+	RA 20.569826
+	Dec 7.40447
+	Distance 51271.783
+	Radius 290.899
+	CoreRadius 0.155
+	KingConcentration 2.099
+	AbsMag -7.242
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6934"
 }
 
 Globular "M 72:NGC 6981:GCl 118:C 2050-127"
 {
-        RA          	   20.8908  # [hours]
-        Dec         	  -12.5369  # [degrees]
-        Distance    	 5.545e+04  # [ly]
-        Radius      	     53.23  # [ly], mu25 Isophote
-        CoreRadius  	      0.54  # [arcmin]
-        KingConcentration     1.23  # c = log10(r_t/r_c)
-        AbsMag      	     -7.04  # [V mags]
-        Axis       	[  0.3339   0.7268   0.6002]
-        Angle       	     160.7  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 6981"
+	RA 20.891028
+	Dec -12.53731
+	Distance 54337.653
+	Radius 176.092
+	CoreRadius 0.433
+	KingConcentration 1.41
+	AbsMag -6.788
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 72"
 }
 
 Globular "NGC 7006:GCl 119:C 2059+160"
 {
-        RA          	   21.0247  # [hours]
-        Dec         	   16.1875  # [degrees]
-        Distance    	 1.354e+05  # [ly]
-        Radius      	     70.87  # [ly], mu25 Isophote
-        CoreRadius  	      0.24  # [arcmin]
-        KingConcentration     1.42  # c = log10(r_t/r_c)
-        AbsMag      	     -7.68  # [V mags]
-        Axis       	[  0.2993   0.8634   0.4061]
-        Angle       	     150.5  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7006"
+	RA 21.024842
+	Dec 16.18732
+	Distance 128244.688
+	Radius 549.769
+	CoreRadius 0.149
+	KingConcentration 1.996
+	AbsMag -7.283
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7006"
+}
+
+Globular "Laevens 3"
+{
+	RA 21.115113
+	Dec 14.9805
+	Distance 201466.795
+	Radius 169.536
+	CoreRadius 0.124
+	KingConcentration 1.369
+	AbsMag -2.854
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Laevens 3"
 }
 
 Globular "M 15:NGC 7078:GCl 120:C 2127+119"
 {
-        RA          	   21.4994  # [hours]
-        Dec         	   12.1669  # [degrees]
-        Distance    	  3.36e+04  # [ly]
-        Radius      	     87.95  # [ly], mu25 Isophote
-        CoreRadius  	      0.07  # [arcmin]
-        KingConcentration     2.49  # c = log10(r_t/r_c)
-        AbsMag      	     -9.17  # [V mags]
-        Axis       	[  0.3562   0.8311   0.4271]
-        Angle       	     147.4  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7078"
+	RA 21.499536
+	Dec 12.167
+	Distance 34931.3479999999
+	Radius 430.95
+	CoreRadius 0.019
+	KingConcentration 3.343
+	AbsMag -8.869
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 15"
 }
 
 Globular "M 2:NGC 7089:HD 205146:GCl 121:C 2130-010"
 {
-        RA          	   21.5581  # [hours]
-        Dec         	   -0.8231  # [degrees]
-        Distance    	 3.751e+04  # [ly]
-        Radius      	     87.29  # [ly], mu25 Isophote
-        CoreRadius  	      0.34  # [arcmin]
-        KingConcentration     1.80  # c = log10(r_t/r_c)
-        AbsMag      	     -9.02  # [V mags]
-        Axis       	[  0.3889   0.7665   0.5111]
-        Angle       	     151.8  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7089"
+	RA 21.557505
+	Dec -0.82325
+	Distance 38127.681
+	Radius 361.283
+	CoreRadius 0.209
+	KingConcentration 2.193
+	AbsMag -8.859
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 2"
 }
 
 Globular "M 30:NGC 7099:GCl 122:C 2137-234"
 {
-        RA          	   21.6728  # [hours]
-        Dec         	  -23.1792  # [degrees]
-        Distance    	 2.609e+04  # [ly]
-        Radius      	     45.54  # [ly], mu25 Isophote
-        CoreRadius  	      0.06  # [arcmin]
-        KingConcentration     2.49  # c = log10(r_t/r_c)
-        AbsMag      	     -7.43  # [V mags]
-        Axis       	[  0.4361   0.6378   0.6349]
-        Angle       	     160.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7099"
+	RA 21.672809
+	Dec -23.17986
+	Distance 27592.83
+	Radius 232.223
+	CoreRadius 0.037
+	KingConcentration 2.898
+	AbsMag -7.267
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=M 30"
 }
 
 Globular "Pal 12:GCl 123:C 2143-214"
 {
-        RA          	   21.7772  # [hours]
-        Dec         	  -21.2508  # [degrees]
-        Distance    	  6.23e+04  # [ly]
-        Radius      	     26.28  # [ly], mu25 Isophote
-        CoreRadius  	       0.2  # [arcmin]
-        KingConcentration     1.94  # c = log10(r_t/r_c)
-        AbsMag      	     -4.48  # [V mags]
-        Axis       	[  0.4454   0.6451   0.6209]
-        Angle       	     158.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 12"
+	RA 21.777453
+	Dec -21.25261
+	Distance 60306.314
+	Radius 208.577
+	CoreRadius 0.589
+	KingConcentration 1.305
+	AbsMag -4.345
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 12"
 }
 
 Globular "Pal 13:UGCA 435:TC 408:GCl 124:C 2304+124"
 {
-        RA          	   23.1122  # [hours]
-        Dec         	   12.7719  # [degrees]
-        Distance    	 8.415e+04  # [ly]
-        Radius      	     8.567  # [ly], mu25 Isophote
-        CoreRadius  	      0.65  # [arcmin]
-        KingConcentration     0.68  # c = log10(r_t/r_c)
-        AbsMag      	     -3.74  # [V mags]
-        Axis       	[    0.52   0.7618   0.3864]
-        Angle       	     133.3  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 13"
+	RA 23.112346
+	Dec 12.77154
+	Distance 76581.517
+	Radius 122.798
+	CoreRadius 0.048
+	KingConcentration 2.057
+	AbsMag -2.963
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=Pal 13"
 }
 
 Globular "NGC 7492:GCl 125:C 2305-159"
 {
-        RA          	   23.1406  # [hours]
-        Dec         	  -15.6114  # [degrees]
-        Distance    	 8.415e+04  # [ly]
-        Radius      	      51.4  # [ly], mu25 Isophote
-        CoreRadius  	      0.83  # [arcmin]
-        KingConcentration     1.00  # c = log10(r_t/r_c)
-        AbsMag      	     -5.77  # [V mags]
-        Axis       	[   0.584   0.6118   0.5335]
-        Angle       	     148.9  # [degrees]
-        InfoURL  "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7492"
+	RA 23.140745
+	Dec -15.61147
+	Distance 79549.541
+	Radius 279.483
+	CoreRadius 0.598
+	KingConcentration 1.306
+	AbsMag -5.796
+	InfoURL "http://simbad.u-strasbg.fr/sim-id.pl?Ident=NGC 7492"
 }
-

--- a/data/openclusters.dsc
+++ b/data/openclusters.dsc
@@ -1,8662 +1,54574 @@
 # Open clusters
-# Extracted by Andrew Tribick from "New catalog of optically visible open
-# clusters and candidates (V2.8)", Dias W.S., Alessi B.S., Moitinho A.,
-# Lepine J.R.D., Astron. Astrophys. 389, 871 (2002), available at
-# http://cdsarc.u-strasbg.fr/viz-bin/Cat?B/ocl
+# Extracted by Elvis O. Mendes from "Improving the open cluster census.
+# II. An all-sky cluster catalogue with Gaia DR3, Hunt, Emily L.,
+# Reffert, Sabine, Astronomy & Astrophysics, Volume 673, id.A114, 31 pp.
+# (2023), available at: https://doi.org/10.1051/0004-6361/2023462852
 
-OpenCluster "Berkeley 58"
+OpenCluster "HSC 932"
 {
-	RA 0.003333
-	Dec 60.966667
-	Distance 12117
-	Radius 8.8
+	RA 0.00363336
+	Dec 61.06519101
+	Radius 48.768
+	Distance 2379.119
 }
 
-OpenCluster "Berkeley 59"
+OpenCluster "Berkeley 58:MWSC 1:OCL 277"
 {
-	RA 0.037222
-	Dec 67.416667
-	Distance 3261
-	Radius 4.7
+	RA 0.0036433
+	Dec 60.92973741
+	Radius 40.555
+	Distance 9813.706
 }
 
-OpenCluster "Berkeley 104"
+OpenCluster "HSC 924"
 {
-	RA 0.058333
-	Dec 63.583333
-	Distance 14237
-	Radius 6.2
+	RA 0.01904569
+	Dec 58.61733144
+	Radius 111.002
+	Distance 2396.484
 }
 
-OpenCluster "Blanco 1"
+OpenCluster "CWNU 2131"
 {
-	RA 0.068611
-	Dec -28.166667
-	Distance 877
-	Radius 8.9
+	RA 0.02382931
+	Dec 70.50844691
+	Radius 38.887
+	Distance 4823.426
 }
 
-OpenCluster "Alessi 20"
+OpenCluster "Stock 18"
 {
-	RA 0.156389
-	Dec 58.665833
-	Distance 1467
-	Radius 8.5
+	RA 0.02693347
+	Dec 64.62365565
+	Radius 28.019
+	Distance 9193.981
 }
 
-OpenCluster "ASCC 1"
+OpenCluster "Theia 4310"
 {
-	RA 0.160000
-	Dec 62.680000
-	Distance 13046
-	Radius 45.5
+	RA 0.02832002
+	Dec 63.53312045
+	Radius 50.159
+	Distance 3549.864
 }
 
-OpenCluster "King 13"
+OpenCluster "CWNU 2881"
 {
-	RA 0.168333
-	Dec 61.166667
-	Distance 10111
-	Radius 7.4
+	RA 0.0337997
+	Dec 63.9767718
+	Radius 45.216
+	Distance 5156.997
 }
 
-OpenCluster "Berkeley 60"
+OpenCluster "Berkeley 59:Theia 670"
 {
-	RA 0.295000
-	Dec 60.933333
-	Distance 14237
-	Radius 6.2
+	RA 0.03797817
+	Dec 67.42861858
+	Radius 83.01
+	Distance 3311.811
 }
 
-OpenCluster "ASCC 2"
+OpenCluster "UBC 1191"
 {
-	RA 0.331111
-	Dec 55.710000
-	Distance 3914
-	Radius 20.5
+	RA 0.03933945
+	Dec 59.46052337
+	Radius 108.521
+	Distance 9042.812
+}
+
+OpenCluster "UBC 1193"
+{
+	RA 0.04057093
+	Dec 61.89233674
+	Radius 53.438
+	Distance 9057.621
+}
+
+OpenCluster "OC 0214:UBC 406"
+{
+	RA 0.04290928
+	Dec 60.94582242
+	Radius 35.734
+	Distance 10026.086
+}
+
+OpenCluster "Berkeley 104:MWSC 8:OCL 282"
+{
+	RA 0.05720878
+	Dec 63.59006219
+	Radius 41.596
+	Distance 13217.431
+}
+
+OpenCluster "Blanco 1:ESO 409-9:MWSC 7:OCL 43:zeta Scl"
+{
+	RA 0.06099893
+	Dec -30.01061575
+	Radius 169.449
+	Distance 764.48
+}
+
+OpenCluster "CWNU 1354"
+{
+	RA 0.07033688
+	Dec 63.80032633
+	Radius 43.077
+	Distance 14625.79
+}
+
+OpenCluster "OCSN 41"
+{
+	RA 0.07183821
+	Dec 54.289551
+	Radius 22.702
+	Distance 1302.464
+}
+
+OpenCluster "Gulliver 24:Theia 2742"
+{
+	RA 0.07601968
+	Dec 62.83642111
+	Radius 36.871
+	Distance 4763.915
+}
+
+OpenCluster "UBC 597"
+{
+	RA 0.12457418
+	Dec 62.98041818
+	Radius 33.269
+	Distance 9753.304
+}
+
+OpenCluster "Czernik 1:MWSC 17:OCL 283"
+{
+	RA 0.12715709
+	Dec 61.47938373
+	Radius 46.753
+	Distance 9188.308
+}
+
+OpenCluster "UBC 1196"
+{
+	RA 0.13257527
+	Dec 62.1684959
+	Radius 50.194
+	Distance 8588.618
+}
+
+OpenCluster "HSC 943"
+{
+	RA 0.13801226
+	Dec 64.55060468
+	Radius 52.132
+	Distance 10117.353
+}
+
+OpenCluster "CWNU 2348"
+{
+	RA 0.14967495
+	Dec 52.33743812
+	Radius 29.386
+	Distance 5231.707
+}
+
+OpenCluster "CWNU 1595:Theia 2584"
+{
+	RA 0.1533409
+	Dec 60.13582435
+	Radius 62.156
+	Distance 9138.424
+}
+
+OpenCluster "HSC 911"
+{
+	RA 0.16066837
+	Dec 38.02471569
+	Radius 65.639
+	Distance 347.312
+}
+
+OpenCluster "HSC 946"
+{
+	RA 0.16187725
+	Dec 65.34098846
+	Radius 73.322
+	Distance 17940.604
+}
+
+OpenCluster "Berkeley 1"
+{
+	RA 0.16370183
+	Dec 60.47095503
+	Radius 37.667
+	Distance 11904.008
+}
+
+OpenCluster "Berkeley 1:CWNU 1749:Theia 2584"
+{
+	RA 0.16590166
+	Dec 60.41405062
+	Radius 41.144
+	Distance 7089.399
+}
+
+OpenCluster "HSC 941"
+{
+	RA 0.16855658
+	Dec 61.35774088
+	Radius 82.689
+	Distance 4769.066
+}
+
+OpenCluster "FSR 475:King 13:MWSC 21:OCL 285:OC 0216:OC 0217:OC 0218:OC 0219"
+{
+	RA 0.16916992
+	Dec 61.16796768
+	Radius 63.498
+	Distance 11682.539
+}
+
+OpenCluster "UBC 1575"
+{
+	RA 0.16945739
+	Dec 60.54823558
+	Radius 41.676
+	Distance 8702.455
+}
+
+OpenCluster "Alessi 20:Theia 34"
+{
+	RA 0.17623331
+	Dec 58.75651282
+	Radius 44.42
+	Distance 1383.901
+}
+
+OpenCluster "UBC 1195"
+{
+	RA 0.1848229
+	Dec 57.96726635
+	Radius 140.441
+	Distance 10784.472
+}
+
+OpenCluster "HSC 944"
+{
+	RA 0.18846234
+	Dec 62.79879202
+	Radius 34.943
+	Distance 5704.554
+}
+
+OpenCluster "OC 0223:Theia 19"
+{
+	RA 0.21471862
+	Dec 65.56574729
+	Radius 17.794
+	Distance 2282.62
+}
+
+OpenCluster "Casado 15:OC 0220"
+{
+	RA 0.21718335
+	Dec 62.4711727
+	Radius 34.78
+	Distance 9609.528
+}
+
+OpenCluster "UBC 596"
+{
+	RA 0.22762786
+	Dec 53.82733174
+	Radius 27.598
+	Distance 5933.37
+}
+
+OpenCluster "Theia 4244"
+{
+	RA 0.22942118
+	Dec 61.05179294
+	Radius 120.488
+	Distance 3291.573
+}
+
+OpenCluster "HSC 942"
+{
+	RA 0.23547385
+	Dec 59.94911308
+	Radius 44.557
+	Distance 7821.195
+}
+
+OpenCluster "HSC 949"
+{
+	RA 0.24621441
+	Dec 67.34511664
+	Radius 53.723
+	Distance 2845.481
+}
+
+OpenCluster "Theia 3832:UBC 1200"
+{
+	RA 0.24839663
+	Dec 62.81820284
+	Radius 98.752
+	Distance 11890.767
+}
+
+OpenCluster "Casado 17:Theia 2330:UBC 1201"
+{
+	RA 0.25143221
+	Dec 63.55325329
+	Radius 67.316
+	Distance 6554.393
+}
+
+OpenCluster "FSR 0480:FSR 480:MWSC 25:SAI 3"
+{
+	RA 0.25164747
+	Dec 61.50923635
+	Radius 108.106
+	Distance 15903.833
+}
+
+OpenCluster "UBC 182"
+{
+	RA 0.2716828
+	Dec 52.24142249
+	Radius 49.648
+	Distance 5148.057
+}
+
+OpenCluster "OC 0225:Theia 974"
+{
+	RA 0.27174099
+	Dec 64.96622485
+	Radius 38.934
+	Distance 2377.594
+}
+
+OpenCluster "DSH J0016.3+5957:FSR 478:JS 1:Juchert-Saloran 1:Juchert-Saloranta 1:Juchert Saloran 1:MWSC 28:OC 0221"
+{
+	RA 0.2720848
+	Dec 59.9652785
+	Radius 80.108
+	Distance 14147.738
+}
+
+OpenCluster "HSC 950"
+{
+	RA 0.27376454
+	Dec 66.6031086
+	Radius 38.698
+	Distance 2528.385
+}
+
+OpenCluster "HSC 947"
+{
+	RA 0.28199913
+	Dec 62.83538922
+	Radius 124.539
+	Distance 10786.337
+}
+
+OpenCluster "Berkeley 60:MWSC 29:OCL 288:OC 0222"
+{
+	RA 0.29579801
+	Dec 60.94083702
+	Radius 61.802
+	Distance 11170.872
+}
+
+OpenCluster "HSC 951"
+{
+	RA 0.30275002
+	Dec 65.82627429
+	Radius 25.17
+	Distance 6111.092
+}
+
+OpenCluster "CWNU 272:UBC 1199"
+{
+	RA 0.30287071
+	Dec 59.44111543
+	Radius 96.851
+	Distance 7447.259
+}
+
+OpenCluster "UBC 407"
+{
+	RA 0.30908627
+	Dec 63.36640988
+	Radius 145.644
+	Distance 10096.101
+}
+
+OpenCluster "CWNU 1006:Theia 698"
+{
+	RA 0.32807102
+	Dec 68.74632783
+	Radius 131.708
+	Distance 1076.622
+}
+
+OpenCluster "ASCC 2:MWSC 31:UBC 183"
+{
+	RA 0.33543927
+	Dec 55.73308491
+	Radius 44.105
+	Distance 3446.824
+}
+
+OpenCluster "CWNU 343:CWNU 512"
+{
+	RA 0.33969124
+	Dec 68.73355195
+	Radius 48.709
+	Distance 3001.457
+}
+
+OpenCluster "Theia 1073:UBC 408:UPK 237"
+{
+	RA 0.34683454
+	Dec 65.48298538
+	Radius 64.495
+	Distance 2380.216
+}
+
+OpenCluster "Alessi 94:Theia 841:UBC 2"
+{
+	RA 0.35123881
+	Dec 46.53083994
+	Radius 98.89
+	Distance 1804.513
+}
+
+OpenCluster "ASCC 2:MWSC 31:Theia 618"
+{
+	RA 0.35240824
+	Dec 55.78443413
+	Radius 30.133
+	Distance 2326.961
+}
+
+OpenCluster "CWNU 2499:Teutsch J0021.7+6303"
+{
+	RA 0.3622775
+	Dec 63.05757906
+	Radius 116.382
+	Distance 13213.603
 }
 
 OpenCluster "Mayer 1"
 {
-	RA 0.365000
-	Dec 61.750000
-	Distance 4660
-	Radius 4.7
+	RA 0.36583285
+	Dec 61.74963453
+	Radius 47.209
+	Distance 8650.186
 }
 
-OpenCluster "King 1"
+OpenCluster "HSC 921"
 {
-	RA 0.367778
-	Dec 64.380556
-	Distance 3522
-	Radius 12.6
+	RA 0.36757119
+	Dec 30.87952658
+	Radius 121.536
+	Distance 564.06
+}
+
+OpenCluster "FSR 490:King 1:MWSC 35:OCL 290:Theia 6674"
+{
+	RA 0.36819894
+	Dec 64.38266553
+	Radius 90.232
+	Distance 5621.945
+}
+
+OpenCluster "CWNU 2463"
+{
+	RA 0.36831795
+	Dec 63.15492607
+	Radius 55.19
+	Distance 11066.154
+}
+
+OpenCluster "CWNU 1780"
+{
+	RA 0.38174403
+	Dec 62.23930573
+	Radius 40.702
+	Distance 6464.063
+}
+
+OpenCluster "HSC 948"
+{
+	RA 0.38216339
+	Dec 58.34471819
+	Radius 90.678
+	Distance 21443.984
+}
+
+OpenCluster "Theia 4670:UBC 184"
+{
+	RA 0.38551117
+	Dec 59.44947345
+	Radius 35.176
+	Distance 5606.282
+}
+
+OpenCluster "MWSC 37:SAI 4"
+{
+	RA 0.39366877
+	Dec 62.70806266
+	Radius 92.934
+	Distance 9553.053
+}
+
+OpenCluster "HSC 954"
+{
+	RA 0.40005454
+	Dec 64.71922193
+	Radius 75.949
+	Distance 10344.488
+}
+
+OpenCluster "CWNU 177:CWNU 479:Theia 2936:UBC 1197:UBC 1202"
+{
+	RA 0.40465007
+	Dec 52.69504069
+	Radius 78.272
+	Distance 5496.372
+}
+
+OpenCluster "HSC 959"
+{
+	RA 0.40555638
+	Dec 67.22359858
+	Radius 89.214
+	Distance 16361.923
+}
+
+OpenCluster "NGC 103:Collinder 1:FSR 491:MWSC 40:OCL 291"
+{
+	RA 0.4207244
+	Dec 61.32619918
+	Radius 98.566
+	Distance 10316.732
 }
 
 OpenCluster "Stock 20"
 {
-	RA 0.420833
-	Dec 62.616667
-	Distance 2964
-	Radius 1.7
+	RA 0.42072894
+	Dec 62.6260346
+	Radius 107.93
+	Distance 8441.103
 }
 
-OpenCluster "NGC 103"
+OpenCluster "Berkeley 2:FSR 489:MWSC 41:OCL 289"
 {
-	RA 0.421111
-	Dec 61.323333
-	Distance 9869
-	Radius 5.7
+	RA 0.42145388
+	Dec 60.39113775
+	Radius 164.931
+	Distance 18107.695
 }
 
-OpenCluster "Berkeley 2"
+OpenCluster "FSR 0494"
 {
-	RA 0.421667
-	Dec 60.400000
-	Distance 17123
-	Radius 5.0
+	RA 0.42639957
+	Dec 63.75551362
+	Radius 63.902
+	Distance 12972.403
 }
 
-OpenCluster "NGC 129"
+OpenCluster "FSR 0496:Theia 5710"
 {
-	RA 0.500000
-	Dec 60.218333
-	Distance 5300
-	Radius 14.6
+	RA 0.43856954
+	Dec 63.99421355
+	Radius 220.075
+	Distance 4761.624
 }
 
-OpenCluster "Stock 21"
+OpenCluster "FSR 0498"
 {
-	RA 0.506944
-	Dec 57.923611
-	Distance 3623
-	Radius 2.1
+	RA 0.48683402
+	Dec 62.39816635
+	Radius 49.91
+	Distance 8476.822
 }
 
-OpenCluster "ASCC 3"
+OpenCluster "UBC 33"
 {
-	RA 0.519167
-	Dec 55.280000
-	Distance 5544
-	Radius 20.3
+	RA 0.48831099
+	Dec 60.47130275
+	Radius 53.116
+	Distance 4807.48
 }
 
-OpenCluster "NGC 133"
+OpenCluster "CWNU 196:UBC 1204"
 {
-	RA 0.521944
-	Dec 63.350000
-	Distance 2054
-	Radius 2.1
+	RA 0.49233201
+	Dec 57.45480208
+	Radius 29.581
+	Distance 6562.982
+}
+
+OpenCluster "Theia 1851"
+{
+	RA 0.50021935
+	Dec 62.83402803
+	Radius 95.659
+	Distance 12618.72
+}
+
+OpenCluster "Theia 713"
+{
+	RA 0.50272249
+	Dec 68.41178418
+	Radius 307.561
+	Distance 1532.129
+}
+
+OpenCluster "NGC 129:Theia 2238"
+{
+	RA 0.50603331
+	Dec 60.20598162
+	Radius 110.91
+	Distance 5834.756
+}
+
+OpenCluster "FSR 495:MWSC 52:OCL 293:Stock 21"
+{
+	RA 0.50675171
+	Dec 57.92143754
+	Radius 33.148
+	Distance 6390.834
+}
+
+OpenCluster "CWNU 2926"
+{
+	RA 0.5091683
+	Dec 64.48717846
+	Radius 86.98
+	Distance 5520.903
+}
+
+OpenCluster "CWNU 1215:OC 0227"
+{
+	RA 0.50921209
+	Dec 65.50280702
+	Radius 42.068
+	Distance 2277.385
+}
+
+OpenCluster "NGC 133:UBC 185"
+{
+	RA 0.52007972
+	Dec 63.38622375
+	Radius 46.782
+	Distance 12904.321
+}
+
+OpenCluster "HSC 952"
+{
+	RA 0.52210613
+	Dec 50.0584405
+	Radius 88.885
+	Distance 4817.115
 }
 
 OpenCluster "NGC 136"
 {
-	RA 0.525278
-	Dec 61.510000
-	Distance 13350
-	Radius 2.9
+	RA 0.5260394
+	Dec 61.50836864
+	Radius 111.393
+	Distance 14833.943
 }
 
-OpenCluster "King 14"
+OpenCluster "Alter 1:King 14:MWSC 57:OCL 297"
 {
-	RA 0.534167
-	Dec 63.155556
-	Distance 9654
-	Radius 11.2
+	RA 0.53240517
+	Dec 63.17061346
+	Radius 53.991
+	Distance 7691.421
 }
 
-OpenCluster "King 15"
+OpenCluster "HSC 961"
 {
-	RA 0.548333
-	Dec 61.866667
-	Distance 10313
-	Radius 4.5
+	RA 0.53868718
+	Dec 59.67244125
+	Radius 54.365
+	Distance 5049.433
+}
+
+OpenCluster "HSC 962"
+{
+	RA 0.54616411
+	Dec 60.02753863
+	Radius 90.145
+	Distance 6081.614
+}
+
+OpenCluster "HSC 960"
+{
+	RA 0.54920426
+	Dec 58.36278476
+	Radius 94.305
+	Distance 13554.716
 }
 
 OpenCluster "NGC 146"
 {
-	RA 0.549444
-	Dec 63.334167
-	Distance 11317
-	Radius 9.1
+	RA 0.55088534
+	Dec 63.30475397
+	Radius 46.388
+	Distance 9006.1
 }
 
-OpenCluster "NGC 189"
+OpenCluster "FSR 501:King 15:MWSC 58:OCL 298"
 {
-	RA 0.659722
-	Dec 61.095000
-	Distance 2452
-	Radius 1.8
+	RA 0.5512279
+	Dec 61.85439133
+	Radius 49.655
+	Distance 10349.309
+}
+
+OpenCluster "UBC 1205"
+{
+	RA 0.55334281
+	Dec 65.27170115
+	Radius 57.873
+	Distance 11105.201
+}
+
+OpenCluster "HSC 964"
+{
+	RA 0.56253311
+	Dec 63.17485307
+	Radius 52.345
+	Distance 12189.033
+}
+
+OpenCluster "HXHWL 39:Theia 2175"
+{
+	RA 0.57137804
+	Dec 68.86378954
+	Radius 53.203
+	Distance 3222.614
+}
+
+OpenCluster "Theia 3716"
+{
+	RA 0.58341796
+	Dec 62.9834816
+	Radius 41.291
+	Distance 8794.076
+}
+
+OpenCluster "CWNU 1722"
+{
+	RA 0.58352232
+	Dec 60.56641237
+	Radius 46.538
+	Distance 10500.357
+}
+
+OpenCluster "UPK 241"
+{
+	RA 0.58890747
+	Dec 65.46252711
+	Radius 48.494
+	Distance 3089.239
+}
+
+OpenCluster "HSC 957"
+{
+	RA 0.59183539
+	Dec 49.44014703
+	Radius 58.748
+	Distance 2541.308
+}
+
+OpenCluster "HSC 966"
+{
+	RA 0.59833357
+	Dec 61.365882
+	Radius 90.447
+	Distance 3701.095
+}
+
+OpenCluster "CWNU 1298"
+{
+	RA 0.60210328
+	Dec 62.7495556
+	Radius 73.118
+	Distance 8408.857
+}
+
+OpenCluster "HSC 965"
+{
+	RA 0.60745539
+	Dec 59.19612226
+	Radius 39.402
+	Distance 10195.48
+}
+
+OpenCluster "HSC 970"
+{
+	RA 0.65489093
+	Dec 62.34941838
+	Radius 17.773
+	Distance 5795.359
+}
+
+OpenCluster "NGC 189:Collinder 462:MWSC 62:OCL 301:Theia 4932"
+{
+	RA 0.6596636
+	Dec 61.0880203
+	Radius 128.504
+	Distance 4076.945
 }
 
 OpenCluster "Stock 24"
 {
-	RA 0.661667
-	Dec 61.950000
-	Distance 9191
-	Radius 6.7
+	RA 0.66299468
+	Dec 61.96535777
+	Radius 55.239
+	Distance 8976.033
 }
 
-OpenCluster "Dias 1"
+OpenCluster "HSC 969"
 {
-	RA 0.709722
-	Dec 64.068056
-	Distance 5512
-	Radius 3.7
+	RA 0.66603151
+	Dec 58.33814087
+	Radius 153.193
+	Distance 4439.566
 }
 
-OpenCluster "NGC 225"
+OpenCluster "HSC 976"
 {
-	RA 0.727500
-	Dec 61.775000
-	Distance 2142
-	Radius 3.7
+	RA 0.66663751
+	Dec 79.31976132
+	Radius 208.068
+	Distance 531.888
 }
 
-OpenCluster "King 16"
+OpenCluster "FSR 0505:FSR 505:SAI 8"
 {
-	RA 0.729167
-	Dec 64.185556
-	Distance 6262
-	Radius 16.0
+	RA 0.67068115
+	Dec 61.57441302
+	Radius 61.171
+	Distance 19032.724
 }
 
-OpenCluster "Berkeley 4"
+OpenCluster "CWNU 203"
 {
-	RA 0.750278
-	Dec 64.384722
-	Distance 8023
-	Radius 7.2
+	RA 0.67547015
+	Dec 66.89237633
+	Radius 41.455
+	Distance 8016.385
 }
 
-OpenCluster "NGC 188"
+OpenCluster "CWNU 2044:Casado 13"
 {
-	RA 0.791111
-	Dec 85.255000
-	Distance 6676
-	Radius 16.5
+	RA 0.68608436
+	Dec 63.59094925
+	Radius 81.644
+	Distance 12278.932
 }
 
-OpenCluster "King 2"
+OpenCluster "HSC 974"
 {
-	RA 0.850000
-	Dec 58.183333
-	Distance 18754
-	Radius 13.6
+	RA 0.68644822
+	Dec 66.93058065
+	Radius 86.165
+	Distance 3145.402
+}
+
+OpenCluster "FSR 0508:FSR 508:MWSC 66:SAI 9"
+{
+	RA 0.69802025
+	Dec 64.9565464
+	Radius 87.285
+	Distance 13736.175
+}
+
+OpenCluster "UBC 1206"
+{
+	RA 0.70224353
+	Dec 67.56941679
+	Radius 42.396
+	Distance 9790.634
+}
+
+OpenCluster "Alicante 4:Cmg 672:Dias 1:MWSC 67:OC 0228:Steine 11"
+{
+	RA 0.70911467
+	Dec 64.05373251
+	Radius 21.547
+	Distance 8247.76
+}
+
+OpenCluster "Casado 14"
+{
+	RA 0.72454018
+	Dec 62.61645693
+	Radius 89.644
+	Distance 12325.163
+}
+
+OpenCluster "CWNU 1040:Theia 6"
+{
+	RA 0.72515931
+	Dec 61.97538963
+	Radius 61.188
+	Distance 1771.969
+}
+
+OpenCluster "FSR 512:King 16:MWSC 70:OCL 306"
+{
+	RA 0.72862914
+	Dec 64.18138482
+	Radius 33.617
+	Distance 8997.108
+}
+
+OpenCluster "Czernik 2:FSR 510:MWSC 69:OCL 304"
+{
+	RA 0.72940153
+	Dec 60.19953663
+	Radius 71.003
+	Distance 6246.288
+}
+
+OpenCluster "NGC 225:Collinder 7:MWSC 68:OCL 305:Theia 747"
+{
+	RA 0.73204862
+	Dec 61.79330952
+	Radius 228.357
+	Distance 2216.703
+}
+
+OpenCluster "HSC 973"
+{
+	RA 0.74032096
+	Dec 55.20407892
+	Radius 77.272
+	Distance 6762.151
+}
+
+OpenCluster "HSC 975"
+{
+	RA 0.74412953
+	Dec 63.80474686
+	Radius 56.908
+	Distance 10265.961
+}
+
+OpenCluster "Berkeley 4:MWSC 73:OCL 307:OC 0229:OC 0230"
+{
+	RA 0.75328201
+	Dec 64.39012758
+	Radius 86.858
+	Distance 9686.258
+}
+
+OpenCluster "COIN-Gaia 1:Steine 12:Teutsch J0047.3+6643:Theia 713"
+{
+	RA 0.78315965
+	Dec 66.73910853
+	Radius 117.974
+	Distance 2061.653
+}
+
+OpenCluster "HSC 977"
+{
+	RA 0.7870273
+	Dec 60.10275857
+	Radius 76.294
+	Distance 2240.652
+}
+
+OpenCluster "NGC 188:Melotte 2:Collinder 6:MWSC 74:OCL 309"
+{
+	RA 0.78914859
+	Dec 85.2514619
+	Radius 119.944
+	Distance 5942.102
+}
+
+OpenCluster "HSC 978"
+{
+	RA 0.79140292
+	Dec 61.2897248
+	Radius 40.536
+	Distance 2923.696
+}
+
+OpenCluster "UBC 1207"
+{
+	RA 0.79441581
+	Dec 61.36988238
+	Radius 104.151
+	Distance 8052.719
+}
+
+OpenCluster "CWNU 454"
+{
+	RA 0.79965256
+	Dec 63.91215792
+	Radius 43.555
+	Distance 10006.517
+}
+
+OpenCluster "CWNU 1697"
+{
+	RA 0.80093581
+	Dec 55.90875899
+	Radius 162.064
+	Distance 11850.648
+}
+
+OpenCluster "Berkeley 61:FSR 514:MWSC 75:OCL 308"
+{
+	RA 0.80283781
+	Dec 67.19772949
+	Radius 65.927
+	Distance 10370.71
+}
+
+OpenCluster "LISC 3534:Theia 322"
+{
+	RA 0.80584737
+	Dec 49.9056108
+	Radius 148.921
+	Distance 1476.766
+}
+
+OpenCluster "CWNU 53:UBC 1603"
+{
+	RA 0.8114833
+	Dec 65.51068272
+	Radius 71.607
+	Distance 8014.508
+}
+
+OpenCluster "CWNU 2536"
+{
+	RA 0.81651421
+	Dec 61.86203449
+	Radius 27.42
+	Distance 9200.741
+}
+
+OpenCluster "Theia 322"
+{
+	RA 0.81753302
+	Dec 50.77280434
+	Radius 31.356
+	Distance 1154.721
+}
+
+OpenCluster "Dolidze 13"
+{
+	RA 0.82199819
+	Dec 64.19735491
+	Radius 40.1
+	Distance 10253.628
+}
+
+OpenCluster "Casado 12:UBC 1208"
+{
+	RA 0.84845623
+	Dec 63.64862794
+	Radius 71.459
+	Distance 8739.419
+}
+
+OpenCluster "King 2:MWSC 79:OCL 311"
+{
+	RA 0.84924855
+	Dec 58.18735587
+	Radius 297.849
+	Distance 16816.047
+}
+
+OpenCluster "HSC 980"
+{
+	RA 0.85755403
+	Dec 62.97228938
+	Radius 131.329
+	Distance 12631.294
+}
+
+OpenCluster "UBC 412"
+{
+	RA 0.86190285
+	Dec 63.81819472
+	Radius 83.125
+	Distance 13090.498
+}
+
+OpenCluster "HSC 981"
+{
+	RA 0.86768607
+	Dec 60.83024487
+	Radius 106.714
+	Distance 943.462
+}
+
+OpenCluster "FSR 0519:FSR 519:MWSC 83:UBC 1209:UBC 411"
+{
+	RA 0.87738001
+	Dec 64.61671481
+	Radius 125.392
+	Distance 8754.258
 }
 
 OpenCluster "IC 1590"
 {
-	RA 0.880278
-	Dec 56.628333
-	Distance 9589
-	Radius 5.6
+	RA 0.88048064
+	Dec 56.63166956
+	Radius 61.286
+	Distance 8827.934
 }
 
-OpenCluster "ASCC 4"
+OpenCluster "Alessi 1:CA 1:Casado-Alessi 1:Casado Alessi 1:LeDrew 1:MWSC 88:Theia 1254"
 {
-	RA 0.886111
-	Dec 61.580000
-	Distance 2446
-	Radius 17.1
+	RA 0.89030156
+	Dec 49.54811287
+	Radius 105.369
+	Distance 2262.627
 }
 
-OpenCluster "Alessi 1"
+OpenCluster "FSR 0522"
 {
-	RA 0.890833
-	Dec 49.566667
-	Distance 985
-	Radius 6.9
+	RA 0.89187212
+	Dec 65.79510055
+	Radius 68.244
+	Distance 17169.782
 }
 
-OpenCluster "ASCC 5"
+OpenCluster "CWNU 38"
 {
-	RA 0.966111
-	Dec 55.840000
-	Distance 4892
-	Radius 11.1
+	RA 0.90070632
+	Dec 55.9650474
+	Radius 30.226
+	Distance 3511.665
 }
 
-OpenCluster "Skiff J0058+68.4"
+OpenCluster "HSC 983"
 {
-	RA 0.974722
-	Dec 68.468889
-	Distance 5218
-	Radius 16.5
+	RA 0.90599731
+	Dec 59.86267703
+	Radius 56.045
+	Distance 6201.582
+}
+
+OpenCluster "OC 0231"
+{
+	RA 0.9152701
+	Dec 62.04621487
+	Radius 29.814
+	Distance 9390.513
+}
+
+OpenCluster "UBC 1211"
+{
+	RA 0.92108953
+	Dec 59.09886812
+	Radius 331.321
+	Distance 15834.883
+}
+
+OpenCluster "HSC 985"
+{
+	RA 0.92242659
+	Dec 59.38049947
+	Radius 107.274
+	Distance 6426.254
+}
+
+OpenCluster "HSC 986"
+{
+	RA 0.93575189
+	Dec 47.37038149
+	Radius 58.245
+	Distance 1277.9
+}
+
+OpenCluster "UBC 1210"
+{
+	RA 0.94471021
+	Dec 66.95373545
+	Radius 48.649
+	Distance 11405.44
+}
+
+OpenCluster "FSR 0524:FSR 524:MWSC 92:SAI 11"
+{
+	RA 0.95452014
+	Dec 62.12098582
+	Radius 61.373
+	Distance 11593.919
+}
+
+OpenCluster "ASCC 5:MWSC 93"
+{
+	RA 0.96460548
+	Dec 55.82917381
+	Radius 23.021
+	Distance 5678.328
+}
+
+OpenCluster "FSR 523:MWSC 94:MWSC 95:Skiff 1:Skiff J0058+68.4"
+{
+	RA 0.9718088
+	Dec 68.47575145
+	Radius 78.854
+	Distance 8387.441
+}
+
+OpenCluster "Theia 2924"
+{
+	RA 0.97494626
+	Dec 60.73334038
+	Radius 337.232
+	Distance 8526.894
+}
+
+OpenCluster "CWNU 14"
+{
+	RA 0.98585757
+	Dec 53.75959024
+	Radius 55.339
+	Distance 2025.51
+}
+
+OpenCluster "UBC 1212"
+{
+	RA 1.00196382
+	Dec 58.32224708
+	Radius 64.977
+	Distance 12301.848
+}
+
+OpenCluster "AT 21:Alessi-Teutsch 1:Alessi-Teutsch 21:Alessi 23:COIN-Gaia 2:Theia 2869:Theia 3945"
+{
+	RA 1.00652445
+	Dec 55.4063363
+	Radius 55.94
+	Distance 4021.197
+}
+
+OpenCluster "CWNU 2004"
+{
+	RA 1.01783541
+	Dec 63.11381102
+	Radius 70.277
+	Distance 13053.142
+}
+
+OpenCluster "HSC 988"
+{
+	RA 1.02035906
+	Dec 65.18644747
+	Radius 107.047
+	Distance 18049.877
 }
 
 OpenCluster "Berkeley 62"
 {
-	RA 1.016667
-	Dec 63.950000
-	Distance 7567
-	Radius 5.5
+	RA 1.02089162
+	Dec 63.9414744
+	Radius 83.864
+	Distance 8418.958
+}
+
+OpenCluster "UBC 84"
+{
+	RA 1.02829228
+	Dec 61.68942816
+	Radius 165.009
+	Distance 7840.206
+}
+
+OpenCluster "CWNU 423"
+{
+	RA 1.03083185
+	Dec 62.26610279
+	Radius 27.935
+	Distance 3220.886
+}
+
+OpenCluster "COIN-Gaia 29"
+{
+	RA 1.03833256
+	Dec 63.65125431
+	Radius 145.484
+	Distance 8768.234
+}
+
+OpenCluster "HSC 991"
+{
+	RA 1.04373792
+	Dec 59.79768405
+	Radius 82.303
+	Distance 14683.4
+}
+
+OpenCluster "Czernik 3"
+{
+	RA 1.05179772
+	Dec 62.78479599
+	Radius 44.765
+	Distance 12418.318
+}
+
+OpenCluster "HSC 998"
+{
+	RA 1.05640459
+	Dec 45.86565236
+	Radius 55.963
+	Distance 1860.102
+}
+
+OpenCluster "Theia 3739:UBC 1213"
+{
+	RA 1.06453919
+	Dec 61.89218793
+	Radius 30.823
+	Distance 7319.059
+}
+
+OpenCluster "HSC 992"
+{
+	RA 1.06882338
+	Dec 63.03498342
+	Radius 251.94
+	Distance 1659.476
+}
+
+OpenCluster "HSC 1002"
+{
+	RA 1.06963729
+	Dec 40.48389476
+	Radius 60.667
+	Distance 11928.155
+}
+
+OpenCluster "HSC 990"
+{
+	RA 1.07049136
+	Dec 67.40699072
+	Radius 57.454
+	Distance 16948.473
+}
+
+OpenCluster "HSC 994"
+{
+	RA 1.09359198
+	Dec 58.99639166
+	Radius 111.132
+	Distance 9104.153
+}
+
+OpenCluster "HSC 995"
+{
+	RA 1.09367768
+	Dec 58.50251066
+	Radius 57.498
+	Distance 552.115
+}
+
+OpenCluster "UBC 36"
+{
+	RA 1.09751281
+	Dec 59.63032747
+	Radius 44.417
+	Distance 6243.973
+}
+
+OpenCluster "HSC 993"
+{
+	RA 1.09855708
+	Dec 63.00219283
+	Radius 103.004
+	Distance 4915.203
 }
 
 OpenCluster "NGC 366"
 {
-	RA 1.107222
-	Dec 62.230000
-	Distance 5822
-	Radius 3.0
+	RA 1.1085138
+	Dec 62.21842084
+	Radius 56.495
+	Distance 8278.838
 }
 
-OpenCluster "Pfleiderer 1"
+OpenCluster "OCSN 43:Theia 232"
 {
-	RA 1.135278
-	Dec 65.647222
-	Distance 23484
-	Radius 17.1
+	RA 1.1240863
+	Dec 50.35142
+	Radius 110.792
+	Distance 1049.54
+}
+
+OpenCluster "HSC 999"
+{
+	RA 1.13786487
+	Dec 57.48535717
+	Radius 103.176
+	Distance 3874.889
 }
 
 OpenCluster "NGC 381"
 {
-	RA 1.138611
-	Dec 61.583333
-	Distance 3744
-	Radius 3.3
+	RA 1.14024093
+	Dec 61.58378093
+	Radius 39.754
+	Distance 3675.252
 }
 
-OpenCluster "Platais 2"
+OpenCluster "UBC 1604"
 {
-	RA 1.230556
-	Dec 32.028333
-	Distance 655
-	Radius 32.0
+	RA 1.14753323
+	Dec 67.43981731
+	Radius 27.212
+	Distance 6264.41
+}
+
+OpenCluster "CWNU 1059:Theia 4228"
+{
+	RA 1.14837224
+	Dec 66.20116975
+	Radius 65.323
+	Distance 3293.153
+}
+
+OpenCluster "HSC 996"
+{
+	RA 1.15929715
+	Dec 64.60456731
+	Radius 106.302
+	Distance 3633.393
+}
+
+OpenCluster "OC 0232"
+{
+	RA 1.1715347
+	Dec 62.73180018
+	Radius 66.686
+	Distance 8263.757
+}
+
+OpenCluster "HSC 1001"
+{
+	RA 1.17413804
+	Dec 57.7303163
+	Radius 105.562
+	Distance 10648.129
+}
+
+OpenCluster "UBC 413"
+{
+	RA 1.17664518
+	Dec 60.46324129
+	Radius 107.075
+	Distance 8041.383
+}
+
+OpenCluster "UBC 1215"
+{
+	RA 1.17787718
+	Dec 61.66592532
+	Radius 64.806
+	Distance 12902.506
+}
+
+OpenCluster "HSC 997"
+{
+	RA 1.18682575
+	Dec 65.22631571
+	Radius 31.63
+	Distance 8808.761
+}
+
+OpenCluster "CWNU 71:OC 0233"
+{
+	RA 1.18948397
+	Dec 57.55025807
+	Radius 93.182
+	Distance 7349.734
+}
+
+OpenCluster "HSC 1000"
+{
+	RA 1.22663323
+	Dec 63.75893536
+	Radius 30.501
+	Distance 3043.178
+}
+
+OpenCluster "HSC 1005"
+{
+	RA 1.22803705
+	Dec 60.97099563
+	Radius 67.372
+	Distance 2480.271
+}
+
+OpenCluster "HSC 1004"
+{
+	RA 1.22933496
+	Dec 61.24706931
+	Radius 36.359
+	Distance 2618.253
+}
+
+OpenCluster "OCSN 45:Theia 446"
+{
+	RA 1.23682606
+	Dec 62.75652675
+	Radius 259.625
+	Distance 1249.259
+}
+
+OpenCluster "UBC 85"
+{
+	RA 1.23897639
+	Dec 57.79919138
+	Radius 151.909
+	Distance 8404.438
+}
+
+OpenCluster "Theia 872"
+{
+	RA 1.2426844
+	Dec 63.87870232
+	Radius 77.863
+	Distance 2403.754
+}
+
+OpenCluster "CWNU 378:Theia 200"
+{
+	RA 1.24671521
+	Dec 60.74999394
+	Radius 63.805
+	Distance 2763.252
+}
+
+OpenCluster "COIN-Gaia 3"
+{
+	RA 1.24848438
+	Dec 60.50717156
+	Radius 49.242
+	Distance 3978.828
 }
 
 OpenCluster "NGC 433"
 {
-	RA 1.253056
-	Dec 60.126667
-	Distance 7576
-	Radius 2.2
+	RA 1.25265516
+	Dec 60.13237085
+	Radius 38.655
+	Distance 6508.251
+}
+
+OpenCluster "HSC 1020"
+{
+	RA 1.26499362
+	Dec 48.66905474
+	Radius 97.564
+	Distance 868.743
 }
 
 OpenCluster "NGC 436"
 {
-	RA 1.266111
-	Dec 58.811667
-	Distance 9830
-	Radius 7.1
+	RA 1.26670127
+	Dec 58.81506392
+	Radius 74.574
+	Distance 10397.873
 }
 
-OpenCluster "NGC 457"
+OpenCluster "HSC 1003"
 {
-	RA 1.326389
-	Dec 58.286667
-	Distance 7922
-	Radius 23.0
+	RA 1.27788945
+	Dec 64.84008171
+	Radius 110.005
+	Distance 18047.297
+}
+
+OpenCluster "HSC 1006"
+{
+	RA 1.27967759
+	Dec 64.11914069
+	Radius 38.105
+	Distance 3084.498
+}
+
+OpenCluster "HSC 1016"
+{
+	RA 1.28696743
+	Dec 54.12996516
+	Radius 122.844
+	Distance 18514.157
+}
+
+OpenCluster "FSR 0534:FSR 534:MWSC 112"
+{
+	RA 1.29020266
+	Dec 61.29159515
+	Radius 29.921
+	Distance 9215.316
+}
+
+OpenCluster "CWNU 345:Theia 3502:Theia 7837"
+{
+	RA 1.2989569
+	Dec 71.18454785
+	Radius 80.457
+	Distance 3057.972
+}
+
+OpenCluster "HSC 1011"
+{
+	RA 1.30381547
+	Dec 61.17922331
+	Radius 32.765
+	Distance 8798.942
+}
+
+OpenCluster "Teutsch 187"
+{
+	RA 1.31308554
+	Dec 59.44121832
+	Radius 127.095
+	Distance 19504.276
+}
+
+OpenCluster "FSR 0537"
+{
+	RA 1.31333234
+	Dec 60.36088603
+	Radius 143.591
+	Distance 11119.732
+}
+
+OpenCluster "UBC 1216"
+{
+	RA 1.31367533
+	Dec 63.563385
+	Radius 74.895
+	Distance 8776.087
+}
+
+OpenCluster "OC 0235:UBC 39"
+{
+	RA 1.32269719
+	Dec 61.02468741
+	Radius 104.036
+	Distance 6314.153
+}
+
+OpenCluster "Dragonfly Cluster:E.T. Cluster:Owl Cluster:Kachina Doll Cluster:PHI Cassiopeiae Cluster:NGC 457:Melotte 7:Collinder 12:Caldwell 13"
+{
+	RA 1.32616819
+	Dec 58.27566127
+	Radius 161.667
+	Distance 9131.72
+}
+
+OpenCluster "FSR 0536"
+{
+	RA 1.32914474
+	Dec 63.05790171
+	Radius 62.724
+	Distance 10506.282
+}
+
+OpenCluster "HSC 1007"
+{
+	RA 1.33542627
+	Dec 66.86905781
+	Radius 54.359
+	Distance 3518.722
+}
+
+OpenCluster "Theia 772:XDOCC 1"
+{
+	RA 1.33687696
+	Dec 58.33538794
+	Radius 50.892
+	Distance 2569.723
+}
+
+OpenCluster "HSC 1012"
+{
+	RA 1.34437811
+	Dec 63.3391126
+	Radius 76.698
+	Distance 9605.193
+}
+
+OpenCluster "HSC 1014"
+{
+	RA 1.34584423
+	Dec 62.51007304
+	Radius 47.03
+	Distance 10176.117
+}
+
+OpenCluster "HSC 1010"
+{
+	RA 1.37508365
+	Dec 65.89935726
+	Radius 30.363
+	Distance 2385.817
+}
+
+OpenCluster "HSC 1021"
+{
+	RA 1.37827376
+	Dec 57.22068421
+	Radius 125.31
+	Distance 11230.903
+}
+
+OpenCluster "HSC 1029"
+{
+	RA 1.3903776
+	Dec 48.99880064
+	Radius 57.791
+	Distance 2901.267
+}
+
+OpenCluster "HSC 1013"
+{
+	RA 1.39308435
+	Dec 65.43109943
+	Radius 88.658
+	Distance 11028.663
+}
+
+OpenCluster "HSC 1008"
+{
+	RA 1.39316253
+	Dec 66.9758447
+	Radius 40.795
+	Distance 9255.428
+}
+
+OpenCluster "CWNU 1229"
+{
+	RA 1.39358881
+	Dec 61.83559539
+	Radius 63.158
+	Distance 3018.116
+}
+
+OpenCluster "CWNU 55:OC 0234:Theia 6599"
+{
+	RA 1.39605042
+	Dec 65.41921957
+	Radius 111.71
+	Distance 3890.306
+}
+
+OpenCluster "COIN-Gaia 30:Theia 757"
+{
+	RA 1.41141415
+	Dec 70.57543933
+	Radius 100.35
+	Distance 2325.003
+}
+
+OpenCluster "COIN-Gaia 31"
+{
+	RA 1.41940042
+	Dec 61.14001692
+	Radius 130.624
+	Distance 8276.861
+}
+
+OpenCluster "UBC 1217"
+{
+	RA 1.42924076
+	Dec 66.47842048
+	Radius 75.732
+	Distance 10019.436
+}
+
+OpenCluster "FSR 0542"
+{
+	RA 1.43062844
+	Dec 62.99400346
+	Radius 45.02
+	Distance 10799.176
+}
+
+OpenCluster "HSC 1022"
+{
+	RA 1.43183556
+	Dec 59.73387432
+	Radius 36.132
+	Distance 2790.459
+}
+
+OpenCluster "MWSC 120:SAI 14"
+{
+	RA 1.4327408
+	Dec 62.617064
+	Radius 63.348
+	Distance 12580.016
+}
+
+OpenCluster "HSC 1019"
+{
+	RA 1.46035817
+	Dec 62.71105808
+	Radius 28.578
+	Distance 9201.368
 }
 
 OpenCluster "NGC 559"
 {
-	RA 1.493056
-	Dec 63.303889
-	Distance 7077
-	Radius 10.7
+	RA 1.49259719
+	Dec 63.30433847
+	Radius 93.748
+	Distance 9041.673
 }
 
-OpenCluster "NGC 581"
+OpenCluster "CWNU 87"
 {
-	RA 1.556389
-	Dec 60.650000
-	Distance 7156
-	Radius 5.2
+	RA 1.50750019
+	Dec 59.6329703
+	Radius 33.164
+	Distance 9223.784
 }
 
-OpenCluster "Trumpler 1"
+OpenCluster "UBC 40"
 {
-	RA 1.595000
-	Dec 61.283333
-	Distance 8359
-	Radius 3.6
+	RA 1.50867958
+	Dec 60.2378214
+	Radius 30.236
+	Distance 7374.215
 }
 
-OpenCluster "NGC 609"
+OpenCluster "OC 0237"
 {
-	RA 1.606389
-	Dec 64.538333
-	Distance 12984
-	Radius 5.7
+	RA 1.51087702
+	Dec 62.41318516
+	Radius 61.364
+	Distance 8816.854
 }
 
-OpenCluster "NGC 637"
+OpenCluster "UBC 1219"
 {
-	RA 1.717778
-	Dec 64.040000
-	Distance 7045
-	Radius 3.1
+	RA 1.51161961
+	Dec 58.02619822
+	Radius 49.036
+	Distance 11182.914
+}
+
+OpenCluster "UBC 41"
+{
+	RA 1.55010269
+	Dec 59.78219092
+	Radius 54.644
+	Distance 7339.841
+}
+
+OpenCluster "HSC 1018"
+{
+	RA 1.55592009
+	Dec 66.91804655
+	Radius 50.792
+	Distance 18714.729
+}
+
+OpenCluster "M 103:NGC 581:Theia 2079"
+{
+	RA 1.55732967
+	Dec 60.65580521
+	Radius 38.581
+	Distance 8240.745
+}
+
+OpenCluster "Gulliver 16:Schoenball 1"
+{
+	RA 1.56271668
+	Dec 60.76217687
+	Radius 41.595
+	Distance 14407.969
+}
+
+OpenCluster "Theia 5504"
+{
+	RA 1.57218037
+	Dec 57.25466416
+	Radius 133.754
+	Distance 2891.069
+}
+
+OpenCluster "HSC 1025"
+{
+	RA 1.57854012
+	Dec 61.89421751
+	Radius 22.487
+	Distance 9515.018
+}
+
+OpenCluster "HSC 1026"
+{
+	RA 1.58488304
+	Dec 61.72655121
+	Radius 118.202
+	Distance 8773.896
+}
+
+OpenCluster "Collinder 15:FSR 552:MWSC 127:OCL 328:Trumpler 1"
+{
+	RA 1.59437619
+	Dec 61.28429246
+	Radius 57.792
+	Distance 8477.963
+}
+
+OpenCluster "HSC 1054"
+{
+	RA 1.59627362
+	Dec 49.146259
+	Radius 80.695
+	Distance 1212.974
+}
+
+OpenCluster "NGC 609:Collinder 16:FSR 548:King 3:MWSC 128:OCL 325"
+{
+	RA 1.60685896
+	Dec 64.53717065
+	Radius 223.756
+	Distance 17012.468
+}
+
+OpenCluster "HSC 1032"
+{
+	RA 1.63316562
+	Dec 60.96078716
+	Radius 58.567
+	Distance 5640.852
+}
+
+OpenCluster "UBC 1222"
+{
+	RA 1.63387216
+	Dec 56.50808134
+	Radius 157.206
+	Distance 10441.94
+}
+
+OpenCluster "HSC 1031"
+{
+	RA 1.63791568
+	Dec 61.5659484
+	Radius 66.06
+	Distance 3079.898
+}
+
+OpenCluster "UBC 186:UBC 602"
+{
+	RA 1.6426196
+	Dec 60.5251661
+	Radius 109.432
+	Distance 8843.757
+}
+
+OpenCluster "HSC 1015"
+{
+	RA 1.64499754
+	Dec 71.80843408
+	Radius 126.947
+	Distance 17311.032
+}
+
+OpenCluster "UBC 1605"
+{
+	RA 1.65280922
+	Dec 64.04801823
+	Radius 45.776
+	Distance 9505.152
+}
+
+OpenCluster "HSC 1043"
+{
+	RA 1.65495749
+	Dec 57.42893924
+	Radius 133.89
+	Distance 9147.051
+}
+
+OpenCluster "CWNU 1909"
+{
+	RA 1.65923412
+	Dec 57.44906051
+	Radius 21.632
+	Distance 5544.709
+}
+
+OpenCluster "FSR 0551:FSR 551:MWSC 131"
+{
+	RA 1.66360608
+	Dec 64.86765172
+	Radius 46.816
+	Distance 3010.809
+}
+
+OpenCluster "HSC 1036"
+{
+	RA 1.67666178
+	Dec 60.90776607
+	Radius 48.259
+	Distance 13019.499
+}
+
+OpenCluster "FSR 0553:FSR 553:MWSC 132:OC 0238"
+{
+	RA 1.68120883
+	Dec 64.50629389
+	Radius 52.145
+	Distance 8754.158
+}
+
+OpenCluster "HSC 1056"
+{
+	RA 1.68189319
+	Dec 52.93590562
+	Radius 106.096
+	Distance 4272.986
+}
+
+OpenCluster "HSC 1028"
+{
+	RA 1.68671937
+	Dec 64.27562735
+	Radius 113.899
+	Distance 15898.051
+}
+
+OpenCluster "UPK 260"
+{
+	RA 1.70093517
+	Dec 58.40032945
+	Radius 138.027
+	Distance 2660.626
+}
+
+OpenCluster "UBC 1221"
+{
+	RA 1.70331597
+	Dec 59.53681014
+	Radius 72.48
+	Distance 10971.501
+}
+
+OpenCluster "HSC 1037"
+{
+	RA 1.71296491
+	Dec 62.00817253
+	Radius 31.516
+	Distance 2735.296
+}
+
+OpenCluster "NGC 637:Theia 1808"
+{
+	RA 1.71808543
+	Dec 64.0406834
+	Radius 58.27
+	Distance 8569.205
+}
+
+OpenCluster "HSC 1034"
+{
+	RA 1.72609683
+	Dec 63.17169118
+	Radius 49.853
+	Distance 10527.508
 }
 
 OpenCluster "NGC 654"
 {
-	RA 1.733333
-	Dec 61.885000
-	Distance 7860
-	Radius 5.7
+	RA 1.73338455
+	Dec 61.8878144
+	Radius 79.107
+	Distance 9180.591
 }
 
 OpenCluster "NGC 659"
 {
-	RA 1.740000
-	Dec 60.673333
-	Distance 6321
-	Radius 4.6
+	RA 1.73909752
+	Dec 60.67220672
+	Radius 69.266
+	Distance 9677.829
+}
+
+OpenCluster "HSC 1042"
+{
+	RA 1.74209797
+	Dec 61.29954244
+	Radius 85.743
+	Distance 15054.539
+}
+
+OpenCluster "COIN-Gaia 4:OC 0239:Theia 2190"
+{
+	RA 1.74311836
+	Dec 58.7513819
+	Radius 81.412
+	Distance 6455.485
+}
+
+OpenCluster "HSC 1055"
+{
+	RA 1.74523601
+	Dec 56.10889302
+	Radius 83.918
+	Distance 8801.793
+}
+
+OpenCluster "CWNU 115:Theia 6066:UBC 1224"
+{
+	RA 1.7561719
+	Dec 59.77725835
+	Radius 56.123
+	Distance 11028.011
+}
+
+OpenCluster "Theia 850"
+{
+	RA 1.76162095
+	Dec 66.86756871
+	Radius 84.973
+	Distance 2003.95
+}
+
+OpenCluster "NGC 663:Theia 1874"
+{
+	RA 1.76896683
+	Dec 61.19834029
+	Radius 100.479
+	Distance 8696.455
+}
+
+OpenCluster "HSC 1039"
+{
+	RA 1.77583293
+	Dec 63.58693125
+	Radius 52.608
+	Distance 3310.682
+}
+
+OpenCluster "Theia 5630"
+{
+	RA 1.77698578
+	Dec 60.11371615
+	Radius 83.797
+	Distance 2765.448
+}
+
+OpenCluster "Theia 850:Theia 962"
+{
+	RA 1.78191541
+	Dec 68.42240878
+	Radius 83.276
+	Distance 2319.162
+}
+
+OpenCluster "ASCC 6:MWSC 141:Theia 2326"
+{
+	RA 1.78947725
+	Dec 57.73860678
+	Radius 74.094
+	Distance 4898.497
 }
 
 OpenCluster "Collinder 463"
 {
-	RA 1.762500
-	Dec 71.810000
-	Distance 2289
-	Radius 19.0
+	RA 1.81903909
+	Dec 71.8038282
+	Radius 143.101
+	Distance 2756.332
 }
 
-OpenCluster "NGC 663"
+OpenCluster "COIN-Gaia 5:Theia 588"
 {
-	RA 1.769167
-	Dec 61.235000
-	Distance 7893
-	Radius 16.1
+	RA 1.8308454
+	Dec 58.05006828
+	Radius 53.852
+	Distance 2885.325
 }
 
-OpenCluster "ASCC 6"
+OpenCluster "Theia 2038:UBC 188"
 {
-	RA 1.786944
-	Dec 57.730000
-	Distance 3914
-	Radius 20.5
+	RA 1.83322782
+	Dec 53.89528106
+	Radius 94.666
+	Distance 8707.233
 }
 
-OpenCluster "Berkeley 5"
+OpenCluster "Theia 752"
 {
-	RA 1.796667
-	Dec 62.933333
-	Distance 20222
-	Radius 5.9
+	RA 1.83741826
+	Dec 63.2879456
+	Radius 69.044
+	Distance 2351.109
 }
 
-OpenCluster "IC 166"
+OpenCluster "UBC 1229"
 {
-	RA 1.875000
-	Dec 61.833333
-	Distance 15656
-	Radius 15.9
+	RA 1.84547521
+	Dec 59.11133457
+	Radius 114.408
+	Distance 8923.417
+}
+
+OpenCluster "Berkeley 6"
+{
+	RA 1.85372544
+	Dec 61.05801023
+	Radius 35.228
+	Distance 9125.068
+}
+
+OpenCluster "UBC 1230"
+{
+	RA 1.86123189
+	Dec 59.52913995
+	Radius 86.953
+	Distance 11421.985
 }
 
 OpenCluster "Stock 4"
 {
-	RA 1.880000
-	Dec 57.066667
-	Distance 5016
-	Radius 8.8
+	RA 1.86746766
+	Dec 57.05604404
+	Radius 48.32
+	Distance 4231.478
+}
+
+OpenCluster "IC 166:FSR 563:MWSC 146:OCL 334:Tombaugh 3"
+{
+	RA 1.87238254
+	Dec 61.85513377
+	Radius 119.422
+	Distance 14412.6
+}
+
+OpenCluster "COIN-Gaia 32:Theia 2796"
+{
+	RA 1.87461152
+	Dec 63.10107552
+	Radius 51.126
+	Distance 3982.994
+}
+
+OpenCluster "Gaia 2"
+{
+	RA 1.8752788
+	Dec 53.04925648
+	Radius 85.626
+	Distance 18188.235
+}
+
+OpenCluster "COIN-Gaia 6"
+{
+	RA 1.87585805
+	Dec 58.63532703
+	Radius 62.109
+	Distance 10041.422
+}
+
+OpenCluster "HSC 1041"
+{
+	RA 1.87807796
+	Dec 65.38646358
+	Radius 92.104
+	Distance 11659.645
+}
+
+OpenCluster "HSC 2229"
+{
+	RA 1.8814153
+	Dec -46.56995309
+	Radius 159.774
+	Distance 824.564
+}
+
+OpenCluster "HSC 1072"
+{
+	RA 1.89019896
+	Dec 55.58491813
+	Radius 31.975
+	Distance 5626.971
 }
 
 OpenCluster "Berkeley 7"
 {
-	RA 1.903333
-	Dec 62.366667
-	Distance 8382
-	Radius 4.9
+	RA 1.90283989
+	Dec 62.36606203
+	Radius 91.556
+	Distance 8684.968
 }
 
-OpenCluster "NGC 752"
+OpenCluster "CWNU 111"
 {
-	RA 1.961389
-	Dec 37.785000
-	Distance 1490
-	Radius 16.3
+	RA 1.91238899
+	Dec 67.81335398
+	Radius 39.459
+	Distance 4796.059
 }
 
-OpenCluster "NGC 744"
+OpenCluster "HSC 1049"
 {
-	RA 1.975833
-	Dec 55.473333
-	Distance 3936
-	Radius 2.9
+	RA 1.91695276
+	Dec 63.55814906
+	Radius 79.921
+	Distance 3393.453
 }
 
-OpenCluster "ASCC 7"
+OpenCluster "HSC 1053"
 {
-	RA 1.981944
-	Dec 58.970000
-	Distance 6523
-	Radius 28.5
+	RA 1.91818502
+	Dec 62.41402174
+	Radius 138.997
+	Distance 18597.431
 }
 
-OpenCluster "Berkeley 8"
+OpenCluster "HSC 1027"
 {
-	RA 2.018333
-	Dec 75.483333
-	Distance 10274
-	Radius 7.5
+	RA 1.91955151
+	Dec 71.08356103
+	Radius 25.692
+	Distance 3242.979
 }
 
-OpenCluster "Stock 5"
+OpenCluster "Czernik 5:FSR 570:MWSC 150:OCL 338"
 {
-	RA 2.075000
-	Dec 64.433333
-	Distance 1715
-	Radius 6.0
+	RA 1.92793073
+	Dec 61.35396042
+	Radius 64.163
+	Distance 11047.093
 }
 
-OpenCluster "Stock 2"
+OpenCluster "UBC 1225"
 {
-	RA 2.245278
-	Dec 59.485000
-	Distance 988
-	Radius 8.6
+	RA 1.92915056
+	Dec 63.7798703
+	Radius 101.743
+	Distance 9430.233
 }
 
-OpenCluster "NGC 869"
+OpenCluster "UBC 1231"
 {
-	RA 2.316667
-	Dec 57.128333
-	Distance 6781
-	Radius 17.8
+	RA 1.93981199
+	Dec 59.07078318
+	Radius 40.534
+	Distance 6872.7
 }
 
-OpenCluster "Basel 10"
+OpenCluster "NGC 752:Melotte 12:Collinder 23:MWSC 151:OCL 363"
 {
-	RA 2.324444
-	Dec 58.300000
-	Distance 6340
-	Radius 1.8
+	RA 1.94400438
+	Dec 37.79271833
+	Radius 270.364
+	Distance 1414.35
 }
 
-OpenCluster "ASCC 8"
+OpenCluster "HSC 1063"
 {
-	RA 2.346944
-	Dec 59.610000
-	Distance 7175
-	Radius 37.6
+	RA 1.94498022
+	Dec 60.77349631
+	Radius 30.247
+	Distance 4018.914
 }
 
-OpenCluster "Berkeley 64"
+OpenCluster "UBC 417"
 {
-	RA 2.351667
-	Dec 65.900000
-	Distance 12984
-	Radius 3.8
+	RA 1.94941647
+	Dec 54.43152463
+	Radius 47.569
+	Distance 6136.579
 }
 
-OpenCluster "NGC 884"
+OpenCluster "CWNU 377:Theia 4940"
 {
-	RA 2.373056
-	Dec 57.125833
-	Distance 9589
-	Radius 25.4
+	RA 1.95593455
+	Dec 68.66734912
+	Radius 60.282
+	Distance 3194.17
 }
 
-OpenCluster "Stock 6"
+OpenCluster "CWNU 114:IRAS 01546+6319:UBC 1606"
 {
-	RA 2.395000
-	Dec 63.866667
-	Distance 4077
-	Radius 8.3
+	RA 1.9593517
+	Dec 63.19830395
+	Radius 31.555
+	Distance 5552.89
 }
 
-OpenCluster "Tombaugh 4"
+OpenCluster "HSC 1060"
 {
-	RA 2.486111
-	Dec 61.795000
-	Distance 7077
-	Radius 7.2
+	RA 1.96639985
+	Dec 61.93786457
+	Radius 59.329
+	Distance 8661.429
 }
 
-OpenCluster "Markarian 6"
+OpenCluster "IRAS 01546+6319"
 {
-	RA 2.494444
-	Dec 60.706667
-	Distance 2276
-	Radius 2.0
+	RA 1.96690225
+	Dec 63.59880885
+	Radius 166.956
+	Distance 14396.963
 }
 
-OpenCluster "IC 1805"
+OpenCluster "HSC 1061"
 {
-	RA 2.545000
-	Dec 61.450000
-	Distance 7645
-	Radius 22.2
+	RA 1.97293463
+	Dec 62.07843462
+	Radius 41.074
+	Distance 11682.633
 }
 
-OpenCluster "Czernik 8"
+OpenCluster "HSC 1065"
 {
-	RA 2.550000
-	Dec 58.733333
-	Distance 4595
-	Radius 1.3
+	RA 1.9732961
+	Dec 59.63539686
+	Radius 66.621
+	Distance 11509.06
 }
 
-OpenCluster "NGC 957"
+OpenCluster "NGC 744:Collinder 22:FSR 574:MWSC 153:OCL 344:Theia 3014"
 {
-	RA 2.555833
-	Dec 57.560000
-	Distance 5919
-	Radius 8.6
+	RA 1.97615455
+	Dec 55.4814908
+	Radius 61.586
+	Distance 4261.597
+}
+
+OpenCluster "HSC 1040"
+{
+	RA 1.97616286
+	Dec 68.09229328
+	Radius 39.767
+	Distance 893.984
+}
+
+OpenCluster "NGC 743:Theia 112"
+{
+	RA 1.9775744
+	Dec 60.1516545
+	Radius 70.706
+	Distance 3452.646
+}
+
+OpenCluster "UBC 1227"
+{
+	RA 1.98162134
+	Dec 63.24184937
+	Radius 39.061
+	Distance 10264.233
+}
+
+OpenCluster "CWNU 2238"
+{
+	RA 1.99263399
+	Dec 59.3083734
+	Radius 75.033
+	Distance 6833.313
+}
+
+OpenCluster "UBC 1226"
+{
+	RA 1.99648924
+	Dec 63.83689928
+	Radius 50.6
+	Distance 11059.051
+}
+
+OpenCluster "HSC 1073"
+{
+	RA 2.00556524
+	Dec 59.15288683
+	Radius 64.872
+	Distance 7245.797
+}
+
+OpenCluster "FSR 0558:FSR 558:MWSC 157"
+{
+	RA 2.00981848
+	Dec 67.7917117
+	Radius 100.646
+	Distance 9094.494
+}
+
+OpenCluster "HSC 1069"
+{
+	RA 2.01897274
+	Dec 60.25257071
+	Radius 37.073
+	Distance 10323.436
+}
+
+OpenCluster "Berkeley 8:FSR 545:MWSC 158:OCL 323"
+{
+	RA 2.0198204
+	Dec 75.49071205
+	Radius 269.863
+	Distance 10584.522
+}
+
+OpenCluster "COIN-Gaia 33"
+{
+	RA 2.02016237
+	Dec 61.47734027
+	Radius 49.362
+	Distance 15929.361
+}
+
+OpenCluster "Gulliver 51"
+{
+	RA 2.02210269
+	Dec 63.79603195
+	Radius 59.036
+	Distance 4685.297
+}
+
+OpenCluster "UBC 193:UPK 282"
+{
+	RA 2.02587936
+	Dec 43.76479905
+	Radius 85.8
+	Distance 2513.072
+}
+
+OpenCluster "HSC 1059"
+{
+	RA 2.03152011
+	Dec 63.63208264
+	Radius 50.494
+	Distance 9576.859
+}
+
+OpenCluster "Czernik 6:MWSC 159:OCL 340"
+{
+	RA 2.0352472
+	Dec 62.84020525
+	Radius 31.361
+	Distance 8898.364
+}
+
+OpenCluster "UBC 1228"
+{
+	RA 2.04177251
+	Dec 64.67654976
+	Radius 114.124
+	Distance 10648.528
+}
+
+OpenCluster "HSC 1066"
+{
+	RA 2.0427393
+	Dec 61.47025077
+	Radius 80.127
+	Distance 9733.457
+}
+
+OpenCluster "HSC 1057"
+{
+	RA 2.04801359
+	Dec 64.42014701
+	Radius 108.793
+	Distance 17137.978
+}
+
+OpenCluster "Theia 3402"
+{
+	RA 2.04975567
+	Dec 62.99550799
+	Radius 55.775
+	Distance 10317.361
+}
+
+OpenCluster "UBC 1234"
+{
+	RA 2.05342374
+	Dec 58.8900927
+	Radius 42.776
+	Distance 7529.04
+}
+
+OpenCluster "Theia 2252:UBC 1235"
+{
+	RA 2.06629886
+	Dec 58.98926196
+	Radius 97.093
+	Distance 6684.153
+}
+
+OpenCluster "Patchick 12:UBC 44"
+{
+	RA 2.07275195
+	Dec 54.36272724
+	Radius 71.068
+	Distance 8199.999
+}
+
+OpenCluster "Stock 5:Theia 1003"
+{
+	RA 2.07857995
+	Dec 64.3646628
+	Radius 20.508
+	Distance 3061.934
+}
+
+OpenCluster "COIN-Gaia 34:Theia 1088"
+{
+	RA 2.08226045
+	Dec 61.7806542
+	Radius 49.782
+	Distance 3027.42
+}
+
+OpenCluster "HSC 1078"
+{
+	RA 2.0850766
+	Dec 57.76805451
+	Radius 46.355
+	Distance 2097.335
+}
+
+OpenCluster "MWSC 165:SAI 16"
+{
+	RA 2.09265238
+	Dec 62.26544544
+	Radius 161.419
+	Distance 12741.965
+}
+
+OpenCluster "Theia 49:UPK 265"
+{
+	RA 2.10038734
+	Dec 65.45926931
+	Radius 61.103
+	Distance 2751.457
+}
+
+OpenCluster "Riddle 4"
+{
+	RA 2.12334812
+	Dec 60.26162524
+	Radius 56.658
+	Distance 8737.031
+}
+
+OpenCluster "HSC 1081"
+{
+	RA 2.15490868
+	Dec 58.71738964
+	Radius 63.63
+	Distance 11582.319
+}
+
+OpenCluster "HSC 1064"
+{
+	RA 2.15524347
+	Dec 65.01316541
+	Radius 78.522
+	Distance 6402.527
+}
+
+OpenCluster "UBC 604"
+{
+	RA 2.16206216
+	Dec 65.41992977
+	Radius 34.344
+	Distance 8738.082
+}
+
+OpenCluster "UBC 1232"
+{
+	RA 2.17097878
+	Dec 64.14938514
+	Radius 58.643
+	Distance 9487.034
+}
+
+OpenCluster "HSC 1080"
+{
+	RA 2.17187135
+	Dec 59.37905832
+	Radius 84.134
+	Distance 2110.713
+}
+
+OpenCluster "HSC 1730"
+{
+	RA 2.19420864
+	Dec -27.55052768
+	Radius 66.567
+	Distance 1476.667
+}
+
+OpenCluster "UBC 86"
+{
+	RA 2.20342712
+	Dec 57.65795927
+	Radius 32.645
+	Distance 7734.104
+}
+
+OpenCluster "CWNU 3"
+{
+	RA 2.20446727
+	Dec 64.60367548
+	Radius 61.83
+	Distance 2496.302
+}
+
+OpenCluster "Stock 2:Theia 3862"
+{
+	RA 2.21129139
+	Dec 57.83903547
+	Radius 113.458
+	Distance 2986.084
+}
+
+OpenCluster "HSC 1071"
+{
+	RA 2.21520726
+	Dec 64.31872858
+	Radius 26.182
+	Distance 3054.547
+}
+
+OpenCluster "UBC 416"
+{
+	RA 2.22084348
+	Dec 63.85942388
+	Radius 41.114
+	Distance 8833.763
+}
+
+OpenCluster "CWNU 66"
+{
+	RA 2.22363823
+	Dec 61.46474072
+	Radius 35.763
+	Distance 7332.514
+}
+
+OpenCluster "HSC 1067"
+{
+	RA 2.22449906
+	Dec 65.44720478
+	Radius 143.36
+	Distance 2253.776
+}
+
+OpenCluster "HSC 1070"
+{
+	RA 2.22920525
+	Dec 64.89265535
+	Radius 48.07
+	Distance 10235.996
+}
+
+OpenCluster "COIN-Gaia 35"
+{
+	RA 2.2306829
+	Dec 60.03188231
+	Radius 20.387
+	Distance 8182.347
+}
+
+OpenCluster "HSC 1147"
+{
+	RA 2.24526912
+	Dec 30.38465679
+	Radius 88.832
+	Distance 978.762
+}
+
+OpenCluster "COIN-Gaia 7:Theia 2483"
+{
+	RA 2.25023138
+	Dec 58.45906461
+	Radius 49.63
+	Distance 4611.895
+}
+
+OpenCluster "Stock 2:Theia 524"
+{
+	RA 2.25666953
+	Dec 59.57700901
+	Radius 294.268
+	Distance 1207.582
+}
+
+OpenCluster "IRAS 02130+5509"
+{
+	RA 2.27583035
+	Dec 55.41234707
+	Radius 42.324
+	Distance 5519.781
+}
+
+OpenCluster "HSC 1090"
+{
+	RA 2.28507547
+	Dec 59.21202375
+	Radius 79.375
+	Distance 3458.905
+}
+
+OpenCluster "HXHWL 63:LISC-III 2920:Theia 2254"
+{
+	RA 2.28736276
+	Dec 60.23350839
+	Radius 27.309
+	Distance 4762.096
+}
+
+OpenCluster "CWNU 346"
+{
+	RA 2.30308427
+	Dec 61.15592012
+	Radius 16.123
+	Distance 6442.253
+}
+
+OpenCluster "HSC 1085"
+{
+	RA 2.30648274
+	Dec 60.66561554
+	Radius 143.757
+	Distance 7076.378
+}
+
+OpenCluster "ASCC 8:MWSC 180:Stock 2:UBC 418"
+{
+	RA 2.30968938
+	Dec 59.62225476
+	Radius 98.362
+	Distance 8523.801
+}
+
+OpenCluster "HSC 1086"
+{
+	RA 2.31120993
+	Dec 60.58316213
+	Radius 88.528
+	Distance 6368.693
+}
+
+OpenCluster "Theia 701"
+{
+	RA 2.31468899
+	Dec 53.31613374
+	Radius 118.653
+	Distance 1315.105
+}
+
+OpenCluster "h Persei Cluster:NGC 869:Melotte 13:Collinder 24"
+{
+	RA 2.31770036
+	Dec 57.14011243
+	Radius 25.901
+	Distance 7435.138
+}
+
+OpenCluster "Berkeley 63:MWSC 177:OCL 346"
+{
+	RA 2.32338075
+	Dec 63.71936307
+	Radius 86.933
+	Distance 15347.909
+}
+
+OpenCluster "Basel 10:Dolidze 47b:FSR 586:MWSC 176:OCL 349.1:OC 0245"
+{
+	RA 2.32430573
+	Dec 58.29413605
+	Radius 27.761
+	Distance 6781.379
+}
+
+OpenCluster "UBC 419"
+{
+	RA 2.32603416
+	Dec 58.88350021
+	Radius 74.506
+	Distance 7552.828
+}
+
+OpenCluster "FSR 179:SAI 17"
+{
+	RA 2.34810331
+	Dec 59.18693953
+	Radius 57.999
+	Distance 14638.303
+}
+
+OpenCluster "CWNU 65"
+{
+	RA 2.35572626
+	Dec 62.56934724
+	Radius 50.371
+	Distance 6644.9
+}
+
+OpenCluster "CWNU 2352"
+{
+	RA 2.35925122
+	Dec 57.99767709
+	Radius 43.544
+	Distance 10247.472
+}
+
+OpenCluster "Berkeley 64:MWSC 182:OCL 344:OC 0241"
+{
+	RA 2.36217291
+	Dec 65.88846252
+	Radius 65.4
+	Distance 15840.652
+}
+
+OpenCluster "XI Persei Cluster:NGC 884:Melotte 14:Collinder 25"
+{
+	RA 2.3679553
+	Dec 57.14091475
+	Radius 35.541
+	Distance 7479.257
+}
+
+OpenCluster "HSC 1052"
+{
+	RA 2.36844365
+	Dec 71.31354201
+	Radius 25.889
+	Distance 2858.029
+}
+
+OpenCluster "HSC 1074"
+{
+	RA 2.37420687
+	Dec 66.64088671
+	Radius 135.837
+	Distance 2811.713
+}
+
+OpenCluster "Theia 1432"
+{
+	RA 2.37820067
+	Dec 54.25729446
+	Radius 102.138
+	Distance 2209.369
+}
+
+OpenCluster "HSC 1104"
+{
+	RA 2.39437777
+	Dec 56.73617451
+	Radius 68.641
+	Distance 12094.454
+}
+
+OpenCluster "CWNU 1266"
+{
+	RA 2.39604697
+	Dec 62.40240127
+	Radius 65.612
+	Distance 3211.902
+}
+
+OpenCluster "NGC 886:Stock 6:Theia 1270:Theia 746:UBC 189"
+{
+	RA 2.39615545
+	Dec 63.79043508
+	Radius 103.82
+	Distance 3263.988
+}
+
+OpenCluster "CWNU 99:UBC 1233"
+{
+	RA 2.41789464
+	Dec 66.53387344
+	Radius 42.251
+	Distance 9435.59
+}
+
+OpenCluster "HSC 1101"
+{
+	RA 2.42051338
+	Dec 58.22114483
+	Radius 91.078
+	Distance 13366.841
+}
+
+OpenCluster "CWNU 466"
+{
+	RA 2.42192481
+	Dec 64.34336725
+	Radius 45.214
+	Distance 2966.798
+}
+
+OpenCluster "COIN-Gaia 36:UBC 1236"
+{
+	RA 2.4227399
+	Dec 59.93511474
+	Radius 82.834
+	Distance 6850.227
+}
+
+OpenCluster "HSC 1102"
+{
+	RA 2.42602387
+	Dec 58.31433683
+	Radius 33.457
+	Distance 9133.185
+}
+
+OpenCluster "FSR 0591:FSR 591:MWSC 196"
+{
+	RA 2.46169658
+	Dec 58.77126936
+	Radius 100.245
+	Distance 8928.517
+}
+
+OpenCluster "HSC 1068"
+{
+	RA 2.46991439
+	Dec 68.95978623
+	Radius 76.941
+	Distance 2009.031
+}
+
+OpenCluster "HSC 1099"
+{
+	RA 2.47469942
+	Dec 60.13688494
+	Radius 49.007
+	Distance 10684.737
+}
+
+OpenCluster "OC 0243"
+{
+	RA 2.48539532
+	Dec 62.94893589
+	Radius 38.589
+	Distance 9285.867
+}
+
+OpenCluster "FSR 585:MWSC 199:OCL 349:Tombaugh 4"
+{
+	RA 2.48629428
+	Dec 61.78974661
+	Radius 40.161
+	Distance 9721.438
+}
+
+OpenCluster "OC 0249:UBC 190"
+{
+	RA 2.4917222
+	Dec 59.83295026
+	Radius 41.432
+	Distance 8664.913
+}
+
+OpenCluster "Theia 742:Theia 862"
+{
+	RA 2.49336478
+	Dec 56.74556282
+	Radius 203.38
+	Distance 2273.744
+}
+
+OpenCluster "Stock 7:Theia 964"
+{
+	RA 2.49495716
+	Dec 60.65512277
+	Radius 111.333
+	Distance 2182.221
+}
+
+OpenCluster "Theia 1270:Theia 746"
+{
+	RA 2.49818128
+	Dec 63.39420588
+	Radius 132.164
+	Distance 3611.827
+}
+
+OpenCluster "FSR 0596:FSR 596:OC 0252"
+{
+	RA 2.49888839
+	Dec 58.1227238
+	Radius 40.564
+	Distance 7587.624
+}
+
+OpenCluster "Theia 900"
+{
+	RA 2.50832863
+	Dec 59.05209814
+	Radius 59.943
+	Distance 2862.302
+}
+
+OpenCluster "Theia 3699:UBC 194"
+{
+	RA 2.51450959
+	Dec 48.32896662
+	Radius 37.392
+	Distance 4255.76
+}
+
+OpenCluster "HSC 1140"
+{
+	RA 2.51516953
+	Dec 41.73808194
+	Radius 125.532
+	Distance 2458.2
+}
+
+OpenCluster "FSR 0569:FSR 569:MWSC 207:Theia 51:UBC 187"
+{
+	RA 2.5211709
+	Dec 72.46688259
+	Radius 49.922
+	Distance 2906.861
+}
+
+OpenCluster "IC 1805:UBC 1237"
+{
+	RA 2.52335227
+	Dec 61.46647436
+	Radius 49.363
+	Distance 6958.855
+}
+
+OpenCluster "IC 1805:OC 0248"
+{
+	RA 2.54626162
+	Dec 61.47003158
+	Radius 88.395
+	Distance 6587.115
+}
+
+OpenCluster "Czernik 8:FSR 597:MWSC 210:OCL 359:Theia 1755"
+{
+	RA 2.54976717
+	Dec 58.76553937
+	Radius 67.814
+	Distance 8589.282
+}
+
+OpenCluster "UBC 1239"
+{
+	RA 2.55650046
+	Dec 60.01037649
+	Radius 46.398
+	Distance 8912.246
+}
+
+OpenCluster "NGC 957:Collinder 28:FSR 603:FoF 2134:MWSC 211:OCL 362:OC 0253:UBC 421"
+{
+	RA 2.55748657
+	Dec 57.55745745
+	Radius 122.803
+	Distance 7199.235
 }
 
 OpenCluster "Czernik 9"
 {
-	RA 2.558889
-	Dec 59.886667
-	Distance 5414
-	Radius 2.5
+	RA 2.55961297
+	Dec 59.88243383
+	Radius 33.096
+	Distance 9165.112
+}
+
+OpenCluster "Czernik 10"
+{
+	RA 2.5651471
+	Dec 60.17546576
+	Radius 6.348
+	Distance 11234.364
+}
+
+OpenCluster "UPK 303"
+{
+	RA 2.57539042
+	Dec 40.80712489
+	Radius 209.486
+	Distance 688.868
+}
+
+OpenCluster "HSC 1062"
+{
+	RA 2.59382607
+	Dec 72.29706903
+	Radius 78.463
+	Distance 1511.991
 }
 
 OpenCluster "King 4"
 {
-	RA 2.595000
-	Dec 59.000000
-	Distance 10346
-	Radius 7.5
+	RA 2.60171824
+	Dec 59.02054524
+	Radius 56.019
+	Distance 7774.118
 }
 
-OpenCluster "Trumpler 2"
+OpenCluster "HSC 1106"
 {
-	RA 2.614722
-	Dec 55.915000
-	Distance 2364
-	Radius 5.8
+	RA 2.60311087
+	Dec 60.30935003
+	Radius 62.183
+	Distance 6908.419
+}
+
+OpenCluster "HSC 1094"
+{
+	RA 2.60760327
+	Dec 63.84500266
+	Radius 51.24
+	Distance 12637.538
+}
+
+OpenCluster "COIN-Gaia 8:Theia 346"
+{
+	RA 2.61099705
+	Dec 50.01007597
+	Radius 131.414
+	Distance 2312.596
+}
+
+OpenCluster "Collinder 29:MWSC 219:OCL 365:Theia 851:Trumpler 2"
+{
+	RA 2.62033694
+	Dec 55.92562249
+	Radius 154.259
+	Distance 2200.42
+}
+
+OpenCluster "Theia 2345:Theia 586"
+{
+	RA 2.62095829
+	Dec 62.49642564
+	Radius 45.702
+	Distance 2633.035
+}
+
+OpenCluster "HSC 1195"
+{
+	RA 2.62399165
+	Dec 27.30531547
+	Radius 85.271
+	Distance 341.491
+}
+
+OpenCluster "Theia 2945"
+{
+	RA 2.64349557
+	Dec 61.96648661
+	Radius 41.446
+	Distance 4571.381
 }
 
 OpenCluster "Berkeley 65"
 {
-	RA 2.650000
-	Dec 60.416667
-	Distance 7417
-	Radius 5.4
+	RA 2.65109785
+	Dec 60.40004842
+	Radius 30.297
+	Distance 6693.922
 }
 
-OpenCluster "NGC 1039"
+OpenCluster "HSC 1103"
 {
-	RA 2.701389
-	Dec 42.761667
-	Distance 1627
-	Radius 8.3
+	RA 2.65503909
+	Dec 62.44004935
+	Radius 41.176
+	Distance 2384.451
 }
 
-OpenCluster "NGC 1027"
+OpenCluster "HSC 1093"
 {
-	RA 2.711944
-	Dec 61.633611
-	Distance 3359
-	Radius 3.0
+	RA 2.6550722
+	Dec 64.61883206
+	Radius 77.67
+	Distance 19656.812
 }
 
-OpenCluster "Czernik 13"
+OpenCluster "Czernik 12:FSR 619:MWSC 222:OCL 367:Theia 6569"
 {
-	RA 2.745000
-	Dec 62.350000
-	Distance 12919
-	Radius 7.5
+	RA 2.65659115
+	Dec 54.91819179
+	Radius 38.349
+	Distance 6244.662
 }
 
-OpenCluster "ASCC 9"
+OpenCluster "HSC 1155"
 {
-	RA 2.781944
-	Dec 57.730000
-	Distance 9458
-	Radius 28.1
+	RA 2.66560807
+	Dec 40.55641456
+	Radius 238.435
+	Distance 923.645
 }
 
-OpenCluster "IC 1848"
+OpenCluster "CWNU 16:Theia 5292"
 {
-	RA 2.853333
-	Dec 60.433333
-	Distance 6529
-	Radius 17.1
+	RA 2.66805854
+	Dec 48.79153726
+	Radius 80.391
+	Distance 3304.791
 }
 
-OpenCluster "Berkeley 66"
+OpenCluster "HSC 1076"
 {
-	RA 3.071667
-	Dec 58.766667
-	Distance 16308
-	Radius 9.5
+	RA 2.69595031
+	Dec 70.42951923
+	Radius 38.528
+	Distance 10264.792
 }
 
-OpenCluster "NGC 1193"
+OpenCluster "HSC 1084"
 {
-	RA 3.098889
-	Dec 44.383333
-	Distance 14025
-	Radius 6.1
+	RA 2.69659846
+	Dec 67.18016087
+	Radius 91.317
+	Distance 18520.637
 }
 
-OpenCluster "NGC 1252"
+OpenCluster "HSC 1116"
 {
-	RA 3.180278
-	Dec -56.233333
-	Distance 2576
-	Radius 3.0
+	RA 2.69762698
+	Dec 56.40350255
+	Radius 64.256
+	Distance 7699.774
 }
 
-OpenCluster "NGC 1220"
+OpenCluster "Spiral Cluster:M 34:NGC 1039:Melotte 17:Collinder 31:MWSC 223:OCL 382:Theia 251"
 {
-	RA 3.194444
-	Dec 53.345000
-	Distance 5871
-	Radius 3.4
+	RA 2.70321171
+	Dec 42.72207819
+	Radius 86.715
+	Distance 1597.291
 }
 
-OpenCluster "Trumpler 3"
+OpenCluster "UBC 422"
 {
-	RA 3.196667
-	Dec 63.250000
-	Distance 2716
-	Radius 5.5
+	RA 2.70381516
+	Dec 58.18436655
+	Radius 113.265
+	Distance 8359.691
 }
 
-OpenCluster "NGC 1245"
+OpenCluster "NGC 1027:Theia 2345"
 {
-	RA 3.245000
-	Dec 47.236667
-	Distance 9132
-	Radius 53.1
+	RA 2.71013075
+	Dec 61.62295847
+	Radius 77.781
+	Distance 3543.213
 }
 
-OpenCluster "King 5"
+OpenCluster "HSC 1092"
 {
-	RA 3.245833
-	Dec 52.686667
-	Distance 7273
-	Radius 15.0
+	RA 2.71045182
+	Dec 65.4402258
+	Radius 38.575
+	Distance 8665.425
 }
 
-OpenCluster "Stock 23"
+OpenCluster "HSC 1112"
 {
-	RA 3.269722
-	Dec 60.115556
-	Distance 3261
-	Radius 13.8
+	RA 2.72388146
+	Dec 58.83272229
+	Radius 58.449
+	Distance 1045.597
 }
 
-OpenCluster "Alessi 13"
+OpenCluster "HSC 1083"
 {
-	RA 3.361667
-	Dec -35.700000
-	Distance 326
-	Radius 9.5
+	RA 2.7254512
+	Dec 67.62696892
+	Radius 142.44
+	Distance 12756.078
 }
 
-OpenCluster "Melotte 20"
+OpenCluster "Czernik 13:MWSC 227:OCL 356:Theia 3361"
 {
-	RA 3.405278
-	Dec 49.861667
-	Distance 603
-	Radius 26.3
+	RA 2.7410346
+	Dec 62.32121587
+	Radius 50.809
+	Distance 9838.32
 }
 
-OpenCluster "Alessi-Teutsch 9"
+OpenCluster "CWNU 1252"
 {
-	RA 3.457500
-	Dec 34.953333
-	Distance 2283
-	Radius 19.1
+	RA 2.74113666
+	Dec 60.53592376
+	Radius 31.418
+	Distance 2683.028
 }
 
-OpenCluster "King 6"
+OpenCluster "UPK 305"
 {
-	RA 3.463889
-	Dec 56.399722
-	Distance 2840
-	Radius 2.1
+	RA 2.74402699
+	Dec 38.89253177
+	Radius 99.732
+	Distance 1318.004
 }
 
-OpenCluster "NGC 1342"
+OpenCluster "CWNU 1076"
 {
-	RA 3.527222
-	Dec 37.376667
-	Distance 2169
-	Radius 4.7
+	RA 2.74902624
+	Dec 56.70873943
+	Radius 133.122
+	Distance 1156.209
 }
 
-OpenCluster "ASCC 11"
+OpenCluster "UBC 1241"
 {
-	RA 3.538056
-	Dec 44.840000
-	Distance 2120
-	Radius 13.0
+	RA 2.75531662
+	Dec 58.69274142
+	Radius 59.26
+	Distance 10637.084
 }
 
-OpenCluster "Berkeley 9"
+OpenCluster "Theia 742:Theia 863"
 {
-	RA 3.543611
-	Dec 52.651111
-	Distance 2674
-	Radius 1.3
+	RA 2.76040942
+	Dec 56.4529818
+	Radius 123.472
+	Distance 2258.411
 }
 
-OpenCluster "NGC 1348"
+OpenCluster "HSC 1107"
 {
-	RA 3.568333
-	Dec 51.408333
-	Distance 5936
-	Radius 5.2
+	RA 2.76833597
+	Dec 62.78034147
+	Radius 62.383
+	Distance 23450.216
 }
 
-OpenCluster "Berkeley 10"
+OpenCluster "HSC 1176"
 {
-	RA 3.658889
-	Dec 66.485833
-	Distance 7469
-	Radius 10.9
+	RA 2.76842614
+	Dec 37.78768188
+	Radius 113.807
+	Distance 2130.522
 }
 
-OpenCluster "IC 348"
+OpenCluster "HSC 1118"
 {
-	RA 3.742778
-	Dec 32.163333
-	Distance 1255
-	Radius 1.5
+	RA 2.77020779
+	Dec 57.26632949
+	Radius 32.155
+	Distance 3368.448
 }
 
-OpenCluster "Pleiades:Melotte 22"
+OpenCluster "ASCC 9:Theia 1659"
 {
-	RA 3.783333
-	Dec 24.116667
-	Distance 433
-	Radius 7.6
+	RA 2.77492674
+	Dec 57.77684685
+	Radius 54.038
+	Distance 7499.239
 }
 
-OpenCluster "Juchert 11"
+OpenCluster "HSC 1313"
 {
-	RA 3.788333
-	Dec 53.909722
-	Distance 11742
-	Radius 8.5
+	RA 2.79361285
+	Dec 5.08407291
+	Radius 61.534
+	Distance 2136.251
 }
 
-OpenCluster "Tombaugh 5"
+OpenCluster "CWNU 1894"
 {
-	RA 3.796667
-	Dec 59.050000
-	Distance 5707
-	Radius 11.6
+	RA 2.7970079
+	Dec 63.03231231
+	Radius 42.533
+	Distance 19237.419
 }
 
-OpenCluster "NGC 1444"
+OpenCluster "UBC 47"
 {
-	RA 3.823611
-	Dec 52.658333
-	Distance 3910
-	Radius 2.3
+	RA 2.79895617
+	Dec 63.79796208
+	Radius 26.808
+	Distance 4802.466
 }
 
-OpenCluster "Juchert 9"
+OpenCluster "HSC 1546"
 {
-	RA 3.922500
-	Dec 58.391667
-	Distance 14351
-	Radius 6.3
+	RA 2.81043557
+	Dec -15.33399751
+	Radius 95.851
+	Distance 1989.016
+}
+
+OpenCluster "UPK 296"
+{
+	RA 2.82154496
+	Dec 48.60716368
+	Radius 146.586
+	Distance 1693.203
+}
+
+OpenCluster "HSC 1105"
+{
+	RA 2.82773423
+	Dec 64.19562371
+	Radius 144.423
+	Distance 3641.695
+}
+
+OpenCluster "UBC 415"
+{
+	RA 2.83393412
+	Dec 72.89683611
+	Radius 24.449
+	Distance 2843.242
+}
+
+OpenCluster "OC 0254"
+{
+	RA 2.83584288
+	Dec 62.09289445
+	Radius 145.659
+	Distance 16480.547
+}
+
+OpenCluster "HSC 2014"
+{
+	RA 2.8358455
+	Dec -41.19795038
+	Radius 42.535
+	Distance 6572.435
+}
+
+OpenCluster "HSC 1108"
+{
+	RA 2.83621623
+	Dec 62.41910683
+	Radius 55.139
+	Distance 16665.101
+}
+
+OpenCluster "Westerhout 5:IC 1848"
+{
+	RA 2.85273734
+	Dec 60.40803246
+	Radius 37.527
+	Distance 6713.233
+}
+
+OpenCluster "HSC 1113"
+{
+	RA 2.85608047
+	Dec 60.41332719
+	Radius 13.992
+	Distance 3226.455
+}
+
+OpenCluster "UBC 1242"
+{
+	RA 2.86562335
+	Dec 59.5341027
+	Radius 49.382
+	Distance 7198.369
+}
+
+OpenCluster "OCSN 46:Theia 123"
+{
+	RA 2.89126324
+	Dec 68.84017583
+	Radius 84.447
+	Distance 1411.48
+}
+
+OpenCluster "OC 0255"
+{
+	RA 2.90247084
+	Dec 60.65500051
+	Radius 16.144
+	Distance 6609.456
+}
+
+OpenCluster "HSC 1082"
+{
+	RA 2.95891102
+	Dec 70.98396899
+	Radius 64.746
+	Distance 2798.177
+}
+
+OpenCluster "HSC 1120"
+{
+	RA 2.96669231
+	Dec 60.25758083
+	Radius 27.681
+	Distance 8585.333
+}
+
+OpenCluster "FSR 0604:FSR 604:MWSC 604:UBC 1240"
+{
+	RA 2.97910368
+	Dec 63.57505829
+	Radius 149.103
+	Distance 16069.834
+}
+
+OpenCluster "HSC 1109"
+{
+	RA 2.99069448
+	Dec 64.27439058
+	Radius 67.014
+	Distance 15719.925
+}
+
+OpenCluster "Westerhout 5 Cr 34:Collinder 34:SAI 24"
+{
+	RA 2.99131046
+	Dec 60.56536939
+	Radius 35.98
+	Distance 6670.412
+}
+
+OpenCluster "Theia 311"
+{
+	RA 2.99257931
+	Dec 61.20379651
+	Radius 96.031
+	Distance 1793.316
+}
+
+OpenCluster "HSC 1238"
+{
+	RA 3.00082599
+	Dec 24.69611486
+	Radius 55.29
+	Distance 598.63
+}
+
+OpenCluster "MWSC 250:OC 0259:SAI 25"
+{
+	RA 3.00473277
+	Dec 57.47902444
+	Radius 96.693
+	Distance 7345.759
+}
+
+OpenCluster "HSC 1131"
+{
+	RA 3.01201068
+	Dec 56.37018936
+	Radius 209.174
+	Distance 967.198
+}
+
+OpenCluster "COIN-Gaia 37:Theia 592"
+{
+	RA 3.01543863
+	Dec 58.86213481
+	Radius 72.515
+	Distance 3233.901
+}
+
+OpenCluster "CWNU 77"
+{
+	RA 3.02205787
+	Dec 71.07842454
+	Radius 170.003
+	Distance 2690.033
+}
+
+OpenCluster "CWNU 365:OC 0268:UBC 1246"
+{
+	RA 3.03466861
+	Dec 47.97422048
+	Radius 66.444
+	Distance 8638.567
+}
+
+OpenCluster "CWNU 474:UBC 1245"
+{
+	RA 3.03799646
+	Dec 56.58012047
+	Radius 79.677
+	Distance 7655.78
+}
+
+OpenCluster "HSC 1129"
+{
+	RA 3.06597725
+	Dec 57.77655403
+	Radius 43.232
+	Distance 9031.691
+}
+
+OpenCluster "Berkeley 66:FSR 624:MWSC 255:OCL 373"
+{
+	RA 3.06794901
+	Dec 58.74200287
+	Radius 164.046
+	Distance 13259.42
+}
+
+OpenCluster "CWNU 1154:OC 0257"
+{
+	RA 3.07730132
+	Dec 59.27040025
+	Radius 38.834
+	Distance 2703.973
+}
+
+OpenCluster "CWNU 1382"
+{
+	RA 3.08841652
+	Dec 55.89732465
+	Radius 49.33
+	Distance 7893.068
+}
+
+OpenCluster "NGC 1193:Collinder 35:FSR 649:MWSC 256:OCL 390"
+{
+	RA 3.09908731
+	Dec 44.38170655
+	Radius 301.027
+	Distance 16939.092
+}
+
+OpenCluster "HSC 1115"
+{
+	RA 3.13205784
+	Dec 62.95285827
+	Radius 72.879
+	Distance 2457.432
+}
+
+OpenCluster "HSC 1128"
+{
+	RA 3.14650987
+	Dec 59.19079237
+	Radius 108.309
+	Distance 8652.861
+}
+
+OpenCluster "HSC 1130"
+{
+	RA 3.15225618
+	Dec 58.54687249
+	Radius 66.558
+	Distance 7269.251
+}
+
+OpenCluster "CWNU 119"
+{
+	RA 3.16335154
+	Dec 57.93365938
+	Radius 56.596
+	Distance 2354.236
+}
+
+OpenCluster "COIN-Gaia 9"
+{
+	RA 3.18095296
+	Dec 48.02966917
+	Radius 210.912
+	Distance 2832.929
+}
+
+OpenCluster "UBC 607"
+{
+	RA 3.18310806
+	Dec 50.27847005
+	Radius 132.095
+	Distance 12749.701
+}
+
+OpenCluster "CWNU 1484"
+{
+	RA 3.18443456
+	Dec 56.89217054
+	Radius 64.942
+	Distance 7541.396
+}
+
+OpenCluster "CWNU 1406"
+{
+	RA 3.18844437
+	Dec 55.20210376
+	Radius 72.526
+	Distance 7316.513
+}
+
+OpenCluster "NGC 1220:Collinder 37:MWSC 261:OCL 380"
+{
+	RA 3.19487687
+	Dec 53.34972789
+	Radius 95.664
+	Distance 8946.712
+}
+
+OpenCluster "HSC 1119"
+{
+	RA 3.1982492
+	Dec 63.21463548
+	Radius 27.696
+	Distance 1628.342
+}
+
+OpenCluster "Collinder 36:Harvard 1:MWSC 262:OCL 366:Theia 127:Trumpler 3"
+{
+	RA 3.20035033
+	Dec 63.2074044
+	Radius 209.941
+	Distance 2159.129
+}
+
+OpenCluster "HSC 1469"
+{
+	RA 3.21165022
+	Dec -4.3721897
+	Radius 101.48
+	Distance 584.79
+}
+
+OpenCluster "UBC 1243"
+{
+	RA 3.21689269
+	Dec 63.4876651
+	Radius 112.239
+	Distance 8904.048
+}
+
+OpenCluster "UBC 423"
+{
+	RA 3.21804536
+	Dec 58.92869251
+	Radius 58.599
+	Distance 7693.234
+}
+
+OpenCluster "Theia 638"
+{
+	RA 3.22650147
+	Dec 59.26104627
+	Radius 201.862
+	Distance 1711.929
+}
+
+OpenCluster "HSC 2127"
+{
+	RA 3.24114813
+	Dec -50.91495483
+	Radius 77.559
+	Distance 967.684
+}
+
+OpenCluster "FSR 639:King 5:MWSC 265:OCL 384"
+{
+	RA 3.2451483
+	Dec 52.70312699
+	Radius 56.361
+	Distance 7417.336
+}
+
+OpenCluster "NGC 1245:Melotte 18:Collinder 38:FSR 648:MWSC 264:OCL 389:Theia 5374"
+{
+	RA 3.24742313
+	Dec 47.23507987
+	Radius 185.492
+	Distance 9815.713
+}
+
+OpenCluster "HSC 1127"
+{
+	RA 3.24851107
+	Dec 61.1667084
+	Radius 46.715
+	Distance 3195.805
+}
+
+OpenCluster "Theia 2482"
+{
+	RA 3.25394467
+	Dec 56.5677441
+	Radius 74.289
+	Distance 3071.114
+}
+
+OpenCluster "CWNU 1029"
+{
+	RA 3.26218179
+	Dec 59.64338326
+	Radius 30.291
+	Distance 3491.923
+}
+
+OpenCluster "HSC 1125"
+{
+	RA 3.274526
+	Dec 61.77123739
+	Radius 56.894
+	Distance 2441.058
+}
+
+OpenCluster "OC 0260:Stock 23"
+{
+	RA 3.27893119
+	Dec 60.07144352
+	Radius 57.378
+	Distance 1950.91
+}
+
+OpenCluster "CWNU 1799"
+{
+	RA 3.28338443
+	Dec 58.52076191
+	Radius 34.101
+	Distance 6952.487
+}
+
+OpenCluster "Czernik 14:MWSC 267:OCL 376:OC 0261"
+{
+	RA 3.28451297
+	Dec 58.61254037
+	Radius 75.639
+	Distance 9841.181
+}
+
+OpenCluster "CWNU 1130:Theia 1740"
+{
+	RA 3.28748249
+	Dec 60.52598564
+	Radius 70.416
+	Distance 3354.81
+}
+
+OpenCluster "CWNU 133"
+{
+	RA 3.3281914
+	Dec 52.68680779
+	Radius 113.089
+	Distance 8723.441
+}
+
+OpenCluster "HSC 1117"
+{
+	RA 3.34049856
+	Dec 65.05495991
+	Radius 139.345
+	Distance 17591.781
+}
+
+OpenCluster "HSC 1588"
+{
+	RA 3.34668842
+	Dec -14.32278543
+	Radius 56.706
+	Distance 431.965
+}
+
+OpenCluster "CWNU 1131:OC 0262:Theia 1713"
+{
+	RA 3.34898403
+	Dec 58.87010893
+	Radius 52.912
+	Distance 3456.167
+}
+
+OpenCluster "CWNU 481:CWNU 489"
+{
+	RA 3.3509158
+	Dec 60.10050122
+	Radius 50.817
+	Distance 8403.991
+}
+
+OpenCluster "UBC 1248"
+{
+	RA 3.37838229
+	Dec 52.04512192
+	Radius 79.557
+	Distance 10208.078
+}
+
+OpenCluster "CWNU 1080:Teutsch 175:Teutsch J0323.1+4445"
+{
+	RA 3.38631391
+	Dec 44.75659446
+	Radius 23.005
+	Distance 3606.877
+}
+
+OpenCluster "Czernik 15:FSR 644:MWSC 271:OCL 386"
+{
+	RA 3.38785978
+	Dec 52.21760379
+	Radius 136.998
+	Distance 8689.361
+}
+
+OpenCluster "HSC 1134"
+{
+	RA 3.39171608
+	Dec 59.00096713
+	Radius 28.879
+	Distance 3222.404
+}
+
+OpenCluster "CWNU 1715"
+{
+	RA 3.39570171
+	Dec 67.34771779
+	Radius 102.599
+	Distance 14706.508
+}
+
+OpenCluster "UBC 424"
+{
+	RA 3.39723229
+	Dec 51.23802329
+	Radius 38.17
+	Distance 6766.789
+}
+
+OpenCluster "HSC 1136"
+{
+	RA 3.39881378
+	Dec 58.94595037
+	Radius 68.052
+	Distance 11922.167
+}
+
+OpenCluster "HSC 1168"
+{
+	RA 3.40519877
+	Dec 51.37258052
+	Radius 49.902
+	Distance 14081.198
+}
+
+OpenCluster "CWNU 405"
+{
+	RA 3.4123268
+	Dec 40.76431617
+	Radius 103.302
+	Distance 3672.39
+}
+
+OpenCluster "CWNU 483:OC 0266"
+{
+	RA 3.4137827
+	Dec 54.94157728
+	Radius 64.086
+	Distance 7001.146
+}
+
+OpenCluster "HSC 1146"
+{
+	RA 3.42165449
+	Dec 56.20620566
+	Radius 20.89
+	Distance 2394.318
+}
+
+OpenCluster "Alpha Persei Cluster:Melotte 20:Collinder 39"
+{
+	RA 3.42212923
+	Dec 49.11865853
+	Radius 114.33
+	Distance 566.146
+}
+
+OpenCluster "HSC 1250"
+{
+	RA 3.42534188
+	Dec 30.97032363
+	Radius 58.059
+	Distance 948.157
+}
+
+OpenCluster "UBC 1251"
+{
+	RA 3.43063744
+	Dec 49.08145391
+	Radius 47.942
+	Distance 7911.135
+}
+
+OpenCluster "COIN-Gaia 38:Theia 3727"
+{
+	RA 3.4313702
+	Dec 51.07592898
+	Radius 102.704
+	Distance 3747.931
+}
+
+OpenCluster "ASCC 10:AT 9:Alessi-Teutsch 9:Alessi Teutsch 9:MWSC 275:Theia 557"
+{
+	RA 3.45751791
+	Dec 34.88647655
+	Radius 194.195
+	Distance 2113.594
+}
+
+OpenCluster "HSC 1150"
+{
+	RA 3.46191849
+	Dec 55.34277297
+	Radius 25.513
+	Distance 5418.619
+}
+
+OpenCluster "Alessi 13:Chi For Group:Harrington 2:MWSC 278:Ramakers 26:Slotegraaf 3"
+{
+	RA 3.46619613
+	Dec -35.77331776
+	Radius 137.201
+	Distance 340.003
+}
+
+OpenCluster "Gulliver 25:Theia 152:Theia 3689"
+{
+	RA 3.46634768
+	Dec 45.1793841
+	Radius 166.637
+	Distance 4206.93
+}
+
+OpenCluster "King 6:Theia 864"
+{
+	RA 3.46681735
+	Dec 56.44921032
+	Radius 80.89
+	Distance 2304.368
+}
+
+OpenCluster "NGC 1333"
+{
+	RA 3.48854892
+	Dec 31.35815328
+	Radius 14.534
+	Distance 946.846
+}
+
+OpenCluster "HSC 1163"
+{
+	RA 3.49088668
+	Dec 53.26383692
+	Radius 127.245
+	Distance 10035.458
+}
+
+OpenCluster "HSC 1152"
+{
+	RA 3.50048477
+	Dec 55.58915104
+	Radius 39.619
+	Distance 189.126
+}
+
+OpenCluster "Czernik 16:FSR 645:MWSC 282:OCL 387:OC 0270"
+{
+	RA 3.51770925
+	Dec 52.61101288
+	Radius 81.157
+	Distance 7840.873
+}
+
+OpenCluster "CWNU 1070:Theia 1722"
+{
+	RA 3.52886352
+	Dec 60.13297621
+	Radius 153.447
+	Distance 3485.902
+}
+
+OpenCluster "NGC 1342:Melotte 21:Collinder 40:FSR 679:MWSC 283:OCL 401:Theia 853"
+{
+	RA 3.53018583
+	Dec 37.3869023
+	Radius 80.06
+	Distance 2090.334
+}
+
+OpenCluster "Theia 2135"
+{
+	RA 3.53169972
+	Dec 54.68126672
+	Radius 138.81
+	Distance 8181.158
+}
+
+OpenCluster "FSR 0632:FSR 632:MWSC 285"
+{
+	RA 3.53420727
+	Dec 59.13251523
+	Radius 50.439
+	Distance 2800.892
+}
+
+OpenCluster "ASCC 11:MWSC 284:Teutsch J0332.2+4450:Theia 152"
+{
+	RA 3.53669493
+	Dec 44.84076681
+	Radius 35.746
+	Distance 2693.841
+}
+
+OpenCluster "CWNU 1804"
+{
+	RA 3.53725813
+	Dec 55.03194406
+	Radius 64.106
+	Distance 9205.464
+}
+
+OpenCluster "HSC 1173"
+{
+	RA 3.54407546
+	Dec 51.83671477
+	Radius 91.133
+	Distance 9807.354
+}
+
+OpenCluster "Berkeley 9:FSR 646:MWSC 286:OCL 388"
+{
+	RA 3.54492612
+	Dec 52.65192139
+	Radius 38.483
+	Distance 5512.514
+}
+
+OpenCluster "HSC 1177"
+{
+	RA 3.54959829
+	Dec 51.56057084
+	Radius 35.693
+	Distance 8813.024
+}
+
+OpenCluster "HSC 1185"
+{
+	RA 3.55258985
+	Dec 49.57008243
+	Radius 120.946
+	Distance 3265.931
+}
+
+OpenCluster "UBC 1250"
+{
+	RA 3.55504595
+	Dec 51.25917121
+	Radius 168.843
+	Distance 8640.284
+}
+
+OpenCluster "Theia 729"
+{
+	RA 3.55567236
+	Dec 80.76862674
+	Radius 79.934
+	Distance 1599.151
+}
+
+OpenCluster "HSC 1179"
+{
+	RA 3.5656335
+	Dec 51.28758087
+	Radius 203.496
+	Distance 1891.661
+}
+
+OpenCluster "NGC 1348:FSR 650:MWSC 289:OCL 391:Theia 2975"
+{
+	RA 3.56968377
+	Dec 51.40024747
+	Radius 48.819
+	Distance 6729.217
+}
+
+OpenCluster "CWNU 2079"
+{
+	RA 3.62568313
+	Dec 52.47940777
+	Radius 43.504
+	Distance 5947.491
+}
+
+OpenCluster "UPK 307"
+{
+	RA 3.63286595
+	Dec 55.18028065
+	Radius 71.006
+	Distance 2866.283
+}
+
+OpenCluster "HSC 1231"
+{
+	RA 3.64206627
+	Dec 37.2239011
+	Radius 131.612
+	Distance 14665.679
+}
+
+OpenCluster "UBC 1252"
+{
+	RA 3.64650073
+	Dec 51.8776552
+	Radius 105.774
+	Distance 7926.548
+}
+
+OpenCluster "HSC 1189"
+{
+	RA 3.65884662
+	Dec 48.8195733
+	Radius 76.577
+	Distance 8430.195
+}
+
+OpenCluster "Berkeley 10:FSR 623:MWSC 290:OCL 370"
+{
+	RA 3.65898499
+	Dec 66.48904483
+	Radius 73.423
+	Distance 7687.806
+}
+
+OpenCluster "CWNU 364"
+{
+	RA 3.66723998
+	Dec 43.20436743
+	Radius 32.777
+	Distance 3031.235
+}
+
+OpenCluster "FSR 0634:FSR 634:MWSC 292:SAI 29"
+{
+	RA 3.67244421
+	Dec 59.41689548
+	Radius 43.779
+	Distance 10507.504
+}
+
+OpenCluster "UPK 287"
+{
+	RA 3.67669567
+	Dec 71.11305369
+	Radius 143.85
+	Distance 2122.149
+}
+
+OpenCluster "HSC 1178"
+{
+	RA 3.7059664
+	Dec 53.50330262
+	Radius 49.762
+	Distance 7032.237
+}
+
+OpenCluster "HSC 1245"
+{
+	RA 3.70822945
+	Dec 36.54754599
+	Radius 48.648
+	Distance 9633.924
+}
+
+OpenCluster "CWNU 2161"
+{
+	RA 3.723016
+	Dec 60.72136967
+	Radius 58.884
+	Distance 12220.151
+}
+
+OpenCluster "CWNU 1519"
+{
+	RA 3.72996133
+	Dec 51.40628013
+	Radius 35.218
+	Distance 8712.848
+}
+
+OpenCluster "IC 348:Theia 17"
+{
+	RA 3.74248424
+	Dec 32.1771281
+	Radius 70.01
+	Distance 1020.735
+}
+
+OpenCluster "CWNU 17:OC 0274:UBC 1254"
+{
+	RA 3.75393314
+	Dec 50.75222407
+	Radius 65.092
+	Distance 8539.279
+}
+
+OpenCluster "Alessi-Teutsch 10:Alessi Teutsch 10:OC 0278:UBC 19"
+{
+	RA 3.75537551
+	Dec 29.74158911
+	Radius 57.221
+	Distance 1280.485
+}
+
+OpenCluster "HSC 1257"
+{
+	RA 3.76266416
+	Dec 34.91731353
+	Radius 56.186
+	Distance 1210.773
+}
+
+OpenCluster "HSC 1426"
+{
+	RA 3.76521908
+	Dec 5.94313429
+	Radius 92.436
+	Distance 601.634
+}
+
+OpenCluster "Theia 932:UPK 292"
+{
+	RA 3.77446244
+	Dec 64.60486845
+	Radius 58.282
+	Distance 1418.842
+}
+
+OpenCluster "HSC 1162"
+{
+	RA 3.77698197
+	Dec 56.82781791
+	Radius 69.907
+	Distance 10656.223
+}
+
+OpenCluster "Pleiades:Seven Sisters:Subaru:M 45:Melotte 22:Collinder 42:Escorial 1:MWSC 305:OCL 421:Theia 369"
+{
+	RA 3.77865221
+	Dec 24.10845447
+	Radius 116.04
+	Distance 439.794
+}
+
+OpenCluster "DSH J0347.3+5354:FSR 651:Juchert 11:MWSC 304"
+{
+	RA 3.78931651
+	Dec 53.90832247
+	Radius 41.209
+	Distance 9155.106
+}
+
+OpenCluster "HSC 1153"
+{
+	RA 3.79437576
+	Dec 58.54120499
+	Radius 61.706
+	Distance 13339.091
+}
+
+OpenCluster "FSR 641:MWSC 306:OCL 385:Theia 3121:Tombaugh 5"
+{
+	RA 3.79829555
+	Dec 59.07554097
+	Radius 103.173
+	Distance 5336.8
+}
+
+OpenCluster "HSC 1133"
+{
+	RA 3.81615616
+	Dec 63.8795882
+	Radius 51.744
+	Distance 10689.452
+}
+
+OpenCluster "CWNU 2112"
+{
+	RA 3.82150614
+	Dec 50.2382354
+	Radius 45.144
+	Distance 5232.037
+}
+
+OpenCluster "NGC 1444:Collinder 43:MWSC 308:OCL 394:Theia 1686"
+{
+	RA 3.82388328
+	Dec 52.65541821
+	Radius 42.547
+	Distance 3596.935
+}
+
+OpenCluster "HSC 1239"
+{
+	RA 3.82672616
+	Dec 38.95658954
+	Radius 88.406
+	Distance 1383.254
+}
+
+OpenCluster "UBC 1247"
+{
+	RA 3.82708144
+	Dec 58.21862236
+	Radius 73.868
+	Distance 10447.241
+}
+
+OpenCluster "Theia 4652:UPK 300"
+{
+	RA 3.82717535
+	Dec 60.14630448
+	Radius 58.226
+	Distance 2990.672
+}
+
+OpenCluster "HSC 1165"
+{
+	RA 3.82923812
+	Dec 57.10130174
+	Radius 131.541
+	Distance 559.765
+}
+
+OpenCluster "HSC 1170"
+{
+	RA 3.83041901
+	Dec 56.40295186
+	Radius 59.447
+	Distance 15882.863
+}
+
+OpenCluster "CWNU 438:Theia 652"
+{
+	RA 3.83312794
+	Dec 68.71305269
+	Radius 86.001
+	Distance 2436.86
+}
+
+OpenCluster "HSC 1262"
+{
+	RA 3.84290469
+	Dec 35.07487137
+	Radius 44.298
+	Distance 1260.092
+}
+
+OpenCluster "CWNU 149:OC 0264:Theia 85"
+{
+	RA 3.84562436
+	Dec 60.20206607
+	Radius 79.828
+	Distance 2020.253
+}
+
+OpenCluster "HSC 1437"
+{
+	RA 3.86103165
+	Dec 6.55510094
+	Radius 51.561
+	Distance 737.21
+}
+
+OpenCluster "CWNU 1346"
+{
+	RA 3.86451207
+	Dec 52.01261656
+	Radius 70.122
+	Distance 7327.725
+}
+
+OpenCluster "UBC 1257"
+{
+	RA 3.86557135
+	Dec 48.39740331
+	Radius 29.12
+	Distance 4933.777
+}
+
+OpenCluster "CWNU 1899"
+{
+	RA 3.86937667
+	Dec 54.49429774
+	Radius 51.621
+	Distance 11857.23
+}
+
+OpenCluster "CWNU 1486:Teutsch 194"
+{
+	RA 3.86963774
+	Dec 52.4836528
+	Radius 32.338
+	Distance 6954.079
+}
+
+OpenCluster "Czernik 17:MWSC 311:OCL 378"
+{
+	RA 3.87169206
+	Dec 61.97230294
+	Radius 128.481
+	Distance 17946.246
+}
+
+OpenCluster "CWNU 2071"
+{
+	RA 3.8761873
+	Dec 55.81696158
+	Radius 37.228
+	Distance 7612.901
+}
+
+OpenCluster "Ferrero 53:Teutsch 176:Teutsch J0352+4558:Theia 297:UBC 88:UPK 322"
+{
+	RA 3.8806912
+	Dec 45.97510802
+	Radius 41.061
+	Distance 3060.376
+}
+
+OpenCluster "CWNU 1042"
+{
+	RA 3.89745228
+	Dec 53.20702547
+	Radius 29.834
+	Distance 3667.362
+}
+
+OpenCluster "HSC 1234"
+{
+	RA 3.89998765
+	Dec 40.44010176
+	Radius 56.436
+	Distance 1265.046
+}
+
+OpenCluster "OC 0279:Theia 17:Theia 21"
+{
+	RA 3.90313648
+	Dec 31.9230373
+	Radius 48.458
+	Distance 915.38
+}
+
+OpenCluster "HSC 1369"
+{
+	RA 3.90563143
+	Dec 15.18680834
+	Radius 58.307
+	Distance 715.399
+}
+
+OpenCluster "DSH J0355.3+5823:Juchert 9:MWSC 313"
+{
+	RA 3.92319476
+	Dec 58.39202121
+	Radius 111.65
+	Distance 14447.496
+}
+
+OpenCluster "CWNU 105"
+{
+	RA 3.93046501
+	Dec 38.46600896
+	Radius 49.974
+	Distance 5713.986
+}
+
+OpenCluster "CWNU 2703:Theia 2488"
+{
+	RA 3.93184472
+	Dec 57.18767027
+	Radius 106.192
+	Distance 10370.886
+}
+
+OpenCluster "CWNU 2490"
+{
+	RA 3.93280538
+	Dec 55.33526544
+	Radius 38.727
+	Distance 9675.194
+}
+
+OpenCluster "UBC 1259"
+{
+	RA 3.93342488
+	Dec 47.43258673
+	Radius 73.967
+	Distance 8775.767
+}
+
+OpenCluster "UBC 425"
+{
+	RA 3.94709201
+	Dec 48.64800785
+	Radius 63.306
+	Distance 8773.344
+}
+
+OpenCluster "HSC 1184"
+{
+	RA 3.9480206
+	Dec 54.38809516
+	Radius 147.963
+	Distance 19685.23
+}
+
+OpenCluster "HSC 1188"
+{
+	RA 3.95392517
+	Dec 53.09113464
+	Radius 28.397
+	Distance 6649.144
+}
+
+OpenCluster "HSC 1197"
+{
+	RA 3.96828632
+	Dec 50.49839705
+	Radius 18.749
+	Distance 3204.784
+}
+
+OpenCluster "HSC 1230"
+{
+	RA 3.97256958
+	Dec 42.19353717
+	Radius 126.161
+	Distance 1615.672
+}
+
+OpenCluster "UBC 51"
+{
+	RA 3.98458111
+	Dec 52.64234894
+	Radius 37.678
+	Distance 3430.98
 }
 
 OpenCluster "King 7"
 {
-	RA 3.983333
-	Dec 51.800000
-	Distance 7175
-	Radius 7.3
+	RA 3.98574314
+	Dec 51.78726644
+	Radius 127.203
+	Distance 9330.769
+}
+
+OpenCluster "Alicante 1:FSR 0647:Theia 3619:UBC 1249"
+{
+	RA 3.98706578
+	Dec 57.23547182
+	Radius 215.134
+	Distance 12342.359
+}
+
+OpenCluster "DSH J0359.3+4723:Teutsch 56:Theia 2353:Theia 3090:UBC 53"
+{
+	RA 3.98809391
+	Dec 47.38406131
+	Radius 34.938
+	Distance 4953.642
+}
+
+OpenCluster "HSC 1196"
+{
+	RA 3.99396719
+	Dec 51.01802415
+	Radius 56.732
+	Distance 1683.381
+}
+
+OpenCluster "HSC 1193"
+{
+	RA 3.99756713
+	Dec 51.59393408
+	Radius 12.383
+	Distance 3398.728
+}
+
+OpenCluster "HSC 1457"
+{
+	RA 4.00833323
+	Dec 6.04309664
+	Radius 77.727
+	Distance 1720.731
+}
+
+OpenCluster "HSC 1273"
+{
+	RA 4.0135507
+	Dec 34.72190363
+	Radius 43.644
+	Distance 7764.984
+}
+
+OpenCluster "LISC 3058:OC 0269:UBC 49"
+{
+	RA 4.01463911
+	Dec 59.19649605
+	Radius 70.352
+	Distance 7807.263
+}
+
+OpenCluster "HSC 1438"
+{
+	RA 4.01770787
+	Dec 8.33913373
+	Radius 84.302
+	Distance 481.474
+}
+
+OpenCluster "HSC 1149"
+{
+	RA 4.01970056
+	Dec 61.60645631
+	Radius 167.955
+	Distance 1890.861
+}
+
+OpenCluster "OC 0280:Theia 21:Theia 77:UBC 31"
+{
+	RA 4.03473289
+	Dec 32.17810404
+	Radius 50.198
+	Distance 1200.307
+}
+
+OpenCluster "HSC 1175"
+{
+	RA 4.03600706
+	Dec 57.08275677
+	Radius 33.677
+	Distance 9357.405
+}
+
+OpenCluster "UBC 87"
+{
+	RA 4.03640504
+	Dec 56.4322323
+	Radius 68.317
+	Distance 7559.64
+}
+
+OpenCluster "Juchert 19"
+{
+	RA 4.03882742
+	Dec 52.44388502
+	Radius 147.196
+	Distance 17107.242
+}
+
+OpenCluster "Theia 733:UBC 4"
+{
+	RA 4.04387995
+	Dec 35.56115498
+	Radius 174.752
+	Distance 1901.786
 }
 
 OpenCluster "NGC 1496"
 {
-	RA 4.075556
-	Dec 52.661667
-	Distance 4011
-	Radius 2.3
+	RA 4.07459808
+	Dec 52.65940822
+	Radius 35.585
+	Distance 5050.042
 }
 
-OpenCluster "NGC 1502"
+OpenCluster "HSC 1710"
 {
-	RA 4.130556
-	Dec 62.331667
-	Distance 3522
-	Radius 4.1
+	RA 4.07608052
+	Dec -21.44897106
+	Radius 96.217
+	Distance 447.333
 }
 
-OpenCluster "NGC 1513"
+OpenCluster "HSC 1194"
 {
-	RA 4.165833
-	Dec 49.515000
-	Distance 4305
-	Radius 6.3
+	RA 4.08076726
+	Dec 52.38871385
+	Radius 35.825
+	Distance 2701.28
 }
 
-OpenCluster "NGC 1528"
+OpenCluster "FSR 0665:UBC 1256"
 {
-	RA 4.256389
-	Dec 51.215000
-	Distance 3555
-	Radius 8.3
+	RA 4.08673557
+	Dec 51.51508231
+	Radius 95.748
+	Distance 8954.955
 }
 
-OpenCluster "Waterloo 1"
+OpenCluster "HSC 1340"
 {
-	RA 4.310000
-	Dec 52.858333
-	Distance 14351
-	Radius 10.4
+	RA 4.08690637
+	Dec 21.98531728
+	Radius 165.389
+	Distance 391.681
 }
 
-OpenCluster "IC 361"
+OpenCluster "UBC 608"
 {
-	RA 4.316667
-	Dec 58.300000
-	Distance 3489
-	Radius 3.0
+	RA 4.08937454
+	Dec 55.9253069
+	Radius 100.137
+	Distance 16493.518
 }
 
-OpenCluster "Berkeley 11"
+OpenCluster "CWNU 1479"
 {
-	RA 4.343333
-	Dec 44.916667
-	Distance 7175
-	Radius 5.2
+	RA 4.09661135
+	Dec 51.80033639
+	Radius 37.211
+	Distance 6915.979
 }
 
-OpenCluster "NGC 1545"
+OpenCluster "HSC 1202"
 {
-	RA 4.349167
-	Dec 50.253333
-	Distance 2319
-	Radius 6.1
+	RA 4.0996996
+	Dec 50.93389442
+	Radius 22.381
+	Distance 3443.995
 }
 
-OpenCluster "Hyades:Melotte 25"
+OpenCluster "HSC 1204"
 {
-	RA 4.448333
-	Dec 15.866667
-	Distance 146
-	Radius 7.0
+	RA 4.10218755
+	Dec 50.30700853
+	Radius 24.575
+	Distance 4251.03
 }
 
-OpenCluster "NGC 1582"
+OpenCluster "HSC 1172"
 {
-	RA 4.527500
-	Dec 43.743333
-	Distance 3587
-	Radius 12.5
+	RA 4.10382865
+	Dec 58.44066975
+	Radius 74.328
+	Distance 13082.203
 }
 
-OpenCluster "NGC 1605"
+OpenCluster "CWNU 1278"
 {
-	RA 4.581389
-	Dec 45.270000
-	Distance 8346
-	Radius 7.3
+	RA 4.11265017
+	Dec 53.42880782
+	Radius 107.64
+	Distance 9759.822
 }
 
-OpenCluster "Berkeley 67"
+OpenCluster "Theia 981:UPK 333"
 {
-	RA 4.635000
-	Dec 50.750000
-	Distance 7991
-	Radius 11.6
+	RA 4.112652
+	Dec 44.18942964
+	Radius 82.18
+	Distance 2282.321
 }
 
-OpenCluster "Platais 3"
+OpenCluster "CWNU 1381:Theia 2493"
 {
-	RA 4.693611
-	Dec 71.236667
-	Distance 525
-	Radius 16.5
+	RA 4.11368686
+	Dec 48.84165231
+	Radius 89.185
+	Distance 7316.393
 }
 
-OpenCluster "Berkeley 68"
+OpenCluster "FSR 0667:FSR 667:MWSC 341:Patchick 16"
 {
-	RA 4.741667
-	Dec 42.066667
-	Distance 5473
-	Radius 9.6
+	RA 4.11846247
+	Dec 51.14963997
+	Radius 47.276
+	Distance 3658.041
 }
 
-OpenCluster "Berkeley 12"
+OpenCluster "HSC 1186"
 {
-	RA 4.743333
-	Dec 42.683333
-	Distance 10313
-	Radius 6.0
+	RA 4.12009662
+	Dec 55.08443769
+	Radius 86.482
+	Distance 15560.491
 }
 
-OpenCluster "NGC 1647"
+OpenCluster "Theia 869:UPK 294"
 {
-	RA 4.765278
-	Dec 19.115000
-	Distance 1761
-	Radius 10.2
+	RA 4.12636785
+	Dec 65.49220116
+	Radius 92.535
+	Distance 2385.52
 }
 
-OpenCluster "Alessi 2"
+OpenCluster "NGC 1502:Theia 1701"
 {
-	RA 4.767222
-	Dec 55.206667
-	Distance 1634
-	Radius 7.1
+	RA 4.13073178
+	Dec 62.32567278
+	Radius 57.107
+	Distance 3339.402
 }
 
-OpenCluster "Ruprecht 148"
+OpenCluster "CWNU 2049"
 {
-	RA 4.775000
-	Dec 44.733333
-	Distance 9876
-	Radius 5.7
+	RA 4.1315368
+	Dec 53.10643756
+	Radius 49.123
+	Distance 9556.428
 }
 
-OpenCluster "NGC 1662"
+OpenCluster "HSC 2283"
 {
-	RA 4.807500
-	Dec 10.936667
-	Distance 1425
-	Radius 4.1
+	RA 4.14967316
+	Dec -67.28660654
+	Radius 219.947
+	Distance 343.219
 }
 
-OpenCluster "NGC 1663"
+OpenCluster "HSC 1222"
 {
-	RA 4.816111
-	Dec 13.148333
-	Distance 2283
-	Radius 4.0
+	RA 4.15653362
+	Dec 46.53342312
+	Radius 52.377
+	Distance 7601.137
 }
 
-OpenCluster "ASCC 12"
+OpenCluster "OCSN 50"
 {
-	RA 4.831944
-	Dec 41.730000
-	Distance 1630
-	Radius 7.1
+	RA 4.15733507
+	Dec 21.42042292
+	Radius 65.467
+	Distance 638.864
 }
 
-OpenCluster "NGC 1664"
+OpenCluster "PHOC 23:Theia 2192"
 {
-	RA 4.851667
-	Dec 43.675000
-	Distance 3910
-	Radius 5.1
+	RA 4.16031584
+	Dec 51.86906535
+	Radius 31.504
+	Distance 5202.553
 }
 
-OpenCluster "Berkeley 13"
+OpenCluster "UBC 1258"
 {
-	RA 4.931111
-	Dec 52.800000
-	Distance 8056
-	Radius 10.3
+	RA 4.16188004
+	Dec 50.35180203
+	Radius 64.393
+	Distance 7308.507
 }
 
-OpenCluster "Czernik 19"
+OpenCluster "NGC 1513:Theia 2248"
 {
-	RA 4.952500
-	Dec 28.779722
-	Distance 8154
-	Radius 9.5
+	RA 4.16477013
+	Dec 49.50155413
+	Radius 95.243
+	Distance 4561.996
 }
 
-OpenCluster "Skiff J0458+43.0"
+OpenCluster "HSC 1228"
 {
-	RA 4.970556
-	Dec 43.013333
-	Distance 6931
-	Radius 5.0
+	RA 4.16735259
+	Dec 44.64913878
+	Radius 47.727
+	Distance 2212.447
 }
 
-OpenCluster "Berkeley 14"
+OpenCluster "Theia 2248:UBC 426"
 {
-	RA 5.003333
-	Dec 43.466667
-	Distance 17939
-	Radius 13.0
+	RA 4.16848394
+	Dec 50.06704878
+	Radius 63.988
+	Distance 8193.048
+}
+
+OpenCluster "HSC 1217"
+{
+	RA 4.17013947
+	Dec 47.84570859
+	Radius 53.025
+	Distance 12564.763
+}
+
+OpenCluster "HSC 1260"
+{
+	RA 4.17082053
+	Dec 39.54145004
+	Radius 38.032
+	Distance 4086.692
+}
+
+OpenCluster "CWNU 1542"
+{
+	RA 4.1744112
+	Dec 52.0919569
+	Radius 41.025
+	Distance 7220.868
+}
+
+OpenCluster "HXHWL 73:Theia 7938"
+{
+	RA 4.17893263
+	Dec 57.14813495
+	Radius 51.098
+	Distance 4467.668
+}
+
+OpenCluster "HSC 1495"
+{
+	RA 4.17977602
+	Dec 3.86595862
+	Radius 62.582
+	Distance 786.277
+}
+
+OpenCluster "DSH J0410.8+4652:FSR 676:Juchert 20:MWSC 348:SAI 35"
+{
+	RA 4.18020172
+	Dec 46.8736752
+	Radius 111.195
+	Distance 9009.325
+}
+
+OpenCluster "CWNU 1422"
+{
+	RA 4.18929115
+	Dec 51.21738
+	Radius 42.496
+	Distance 8987.104
+}
+
+OpenCluster "HSC 1346"
+{
+	RA 4.18980325
+	Dec 21.86379821
+	Radius 31.469
+	Distance 2297.162
+}
+
+OpenCluster "CWNU 429"
+{
+	RA 4.19298854
+	Dec 68.02149859
+	Radius 22.507
+	Distance 2825.108
+}
+
+OpenCluster "HSC 1190"
+{
+	RA 4.19682255
+	Dec 54.31569297
+	Radius 109.414
+	Distance 16311.363
+}
+
+OpenCluster "UBC 1255"
+{
+	RA 4.19819486
+	Dec 53.00516726
+	Radius 60.078
+	Distance 11763.35
+}
+
+OpenCluster "UBC 57"
+{
+	RA 4.19841099
+	Dec 42.72050143
+	Radius 44.117
+	Distance 5748.49
+}
+
+OpenCluster "Cmg 878:FSR 0674:FSR 674:MWSC 350"
+{
+	RA 4.20705297
+	Dec 48.72616638
+	Radius 84.127
+	Distance 8948.956
+}
+
+OpenCluster "HSC 1248"
+{
+	RA 4.21622311
+	Dec 43.05280965
+	Radius 37.021
+	Distance 5575.423
+}
+
+OpenCluster "HSC 1271"
+{
+	RA 4.21951989
+	Dec 37.69505035
+	Radius 39.996
+	Distance 3218.719
+}
+
+OpenCluster "HSC 1213"
+{
+	RA 4.22622334
+	Dec 49.50668729
+	Radius 103.714
+	Distance 1902.557
+}
+
+OpenCluster "CWNU 2842"
+{
+	RA 4.24511943
+	Dec 50.36754975
+	Radius 75.135
+	Distance 9890.463
+}
+
+OpenCluster "HSC 1139"
+{
+	RA 4.2486019
+	Dec 65.50885446
+	Radius 91.478
+	Distance 1378.384
+}
+
+OpenCluster "HSC 1293"
+{
+	RA 4.25360371
+	Dec 32.29627877
+	Radius 179.399
+	Distance 14273.495
+}
+
+OpenCluster "HSC 1240"
+{
+	RA 4.254117
+	Dec 44.31243264
+	Radius 69.773
+	Distance 2375.247
+}
+
+OpenCluster "NGC 1528:Melotte 23:Collinder 47:MWSC 353:OCL 397:Theia 5062:Theia 5528:Theia 593:Theia 7064"
+{
+	RA 4.26037132
+	Dec 51.19496113
+	Radius 68.424
+	Distance 3247.676
+}
+
+OpenCluster "NGC 1528:Melotte 23:Collinder 47:MWSC 353:OCL 397:Theia 47"
+{
+	RA 4.26592413
+	Dec 51.5978805
+	Radius 153.593
+	Distance 2474.623
+}
+
+OpenCluster "HSC 1205"
+{
+	RA 4.26595948
+	Dec 51.59806781
+	Radius 50.489
+	Distance 2454.481
+}
+
+OpenCluster "UBC 1253"
+{
+	RA 4.2683601
+	Dec 56.24016373
+	Radius 104.897
+	Distance 11726.1
+}
+
+OpenCluster "HSC 1220"
+{
+	RA 4.27806509
+	Dec 48.52852983
+	Radius 45.036
+	Distance 8233.414
+}
+
+OpenCluster "HSC 1180"
+{
+	RA 4.2803418
+	Dec 58.05696122
+	Radius 140.552
+	Distance 12906.016
+}
+
+OpenCluster "NGC 1528:Melotte 23:Collinder 47:CWNU 1140:MWSC 353:OCL 397:Theia 5062:Theia 593:Theia 7064"
+{
+	RA 4.2831288
+	Dec 51.18439084
+	Radius 56.191
+	Distance 3862.003
+}
+
+OpenCluster "CWNU 361"
+{
+	RA 4.29027645
+	Dec 42.8088615
+	Radius 41.022
+	Distance 3124.257
+}
+
+OpenCluster "HSC 2047"
+{
+	RA 4.29714425
+	Dec -48.44545078
+	Radius 130.893
+	Distance 1101.442
+}
+
+OpenCluster "HSC 1318"
+{
+	RA 4.3043586
+	Dec 28.24950404
+	Radius 23.586
+	Distance 419.583
+}
+
+OpenCluster "CWNU 2684"
+{
+	RA 4.30854151
+	Dec 44.15468952
+	Radius 31.037
+	Distance 5155.065
+}
+
+OpenCluster "Theia 4050:UBC 609:Waterloo 1"
+{
+	RA 4.31019272
+	Dec 52.86356299
+	Radius 129.072
+	Distance 12102.395
+}
+
+OpenCluster "HSC 1235"
+{
+	RA 4.3114674
+	Dec 45.36496369
+	Radius 29.465
+	Distance 9250.148
+}
+
+OpenCluster "Theia 2574:UBC 54"
+{
+	RA 4.31498166
+	Dec 46.41453511
+	Radius 76.854
+	Distance 3436.658
+}
+
+OpenCluster "IC 361:Melotte 24:Collinder 48:FSR 652:MWSC 362:OCL 393:Theia 6039"
+{
+	RA 4.31551064
+	Dec 58.25086946
+	Radius 83.262
+	Distance 11588.051
+}
+
+OpenCluster "UBC 52"
+{
+	RA 4.31951536
+	Dec 52.33153503
+	Radius 53.644
+	Distance 7078.599
+}
+
+OpenCluster "CWNU 2124"
+{
+	RA 4.32727526
+	Dec 54.05362703
+	Radius 53.593
+	Distance 9599.38
+}
+
+OpenCluster "Theia 230"
+{
+	RA 4.33345248
+	Dec 12.41818305
+	Radius 128.02
+	Distance 1052.005
+}
+
+OpenCluster "Berkeley 11:MWSC 368:OCL 404"
+{
+	RA 4.34138472
+	Dec 44.92386325
+	Radius 117.976
+	Distance 8579.446
+}
+
+OpenCluster "NGC 1545:Collinder 49:MWSC 369:OCL 399:Theia 749"
+{
+	RA 4.35180447
+	Dec 50.24750704
+	Radius 62.518
+	Distance 2270.988
+}
+
+OpenCluster "HSC 1201"
+{
+	RA 4.35935208
+	Dec 53.66777278
+	Radius 51.056
+	Distance 12137.378
+}
+
+OpenCluster "HSC 1203"
+{
+	RA 4.36258683
+	Dec 53.37565093
+	Radius 47.994
+	Distance 12563.781
+}
+
+OpenCluster "CWNU 2580"
+{
+	RA 4.36767089
+	Dec 45.48564387
+	Radius 137.97
+	Distance 8327.51
+}
+
+OpenCluster "CWNU 1242"
+{
+	RA 4.37449689
+	Dec 15.25119497
+	Radius 51.948
+	Distance 948.061
+}
+
+OpenCluster "HSC 1232"
+{
+	RA 4.37840264
+	Dec 46.52215076
+	Radius 60.654
+	Distance 8972.445
+}
+
+OpenCluster "HSC 1390"
+{
+	RA 4.39139379
+	Dec 18.63070352
+	Radius 43.589
+	Distance 725.198
+}
+
+OpenCluster "UBC 1263"
+{
+	RA 4.41483914
+	Dec 44.30905679
+	Radius 132.188
+	Distance 9256.931
+}
+
+OpenCluster "HSC 1210"
+{
+	RA 4.41677104
+	Dec 51.78447153
+	Radius 30.908
+	Distance 2451.569
+}
+
+OpenCluster "HSC 1225"
+{
+	RA 4.42222844
+	Dec 48.02327022
+	Radius 62.844
+	Distance 8859.576
+}
+
+OpenCluster "Theia 868:UPK 325"
+{
+	RA 4.42464661
+	Dec 50.49512697
+	Radius 76.802
+	Distance 2414.722
+}
+
+OpenCluster "FSR 0686:Theia 204:UBC 55"
+{
+	RA 4.42644757
+	Dec 46.13096786
+	Radius 32.7
+	Distance 2867.793
+}
+
+OpenCluster "CWNU 1760"
+{
+	RA 4.4321156
+	Dec 48.76210071
+	Radius 26.521
+	Distance 5900.433
+}
+
+OpenCluster "HSC 1268"
+{
+	RA 4.43606532
+	Dec 40.93144853
+	Radius 55.722
+	Distance 2233.487
+}
+
+OpenCluster "Hyades:Taurus Moving Cluster:Melotte 25:Collinder 50:MWSC 379:OCL 456"
+{
+	RA 4.44724306
+	Dec 16.0807978
+	Radius 179.574
+	Distance 153.915
+}
+
+OpenCluster "HSC 1258"
+{
+	RA 4.447327
+	Dec 43.22140658
+	Radius 59.163
+	Distance 9552.544
+}
+
+OpenCluster "UBC 428"
+{
+	RA 4.45193691
+	Dec 44.7080515
+	Radius 50.889
+	Distance 8800.139
+}
+
+OpenCluster "CWNU 1137"
+{
+	RA 4.45538152
+	Dec 58.35694511
+	Radius 119.385
+	Distance 2171.797
+}
+
+OpenCluster "HSC 1219"
+{
+	RA 4.4616424
+	Dec 50.35419812
+	Radius 133.747
+	Distance 14298.106
+}
+
+OpenCluster "Czernik 18:MWSC 381:OCL 426"
+{
+	RA 4.46375596
+	Dec 30.93368795
+	Radius 53.541
+	Distance 4155.202
+}
+
+OpenCluster "HSC 1640"
+{
+	RA 4.4758158
+	Dec -12.15719233
+	Radius 126.859
+	Distance 761.456
+}
+
+OpenCluster "UBC 199"
+{
+	RA 4.4957739
+	Dec 25.41886171
+	Radius 32.456
+	Distance 3713.658
+}
+
+OpenCluster "FSR 0728:FSR 728:MWSC 384"
+{
+	RA 4.49746629
+	Dec 38.49824905
+	Radius 48.078
+	Distance 5630.944
+}
+
+OpenCluster "NGC 1579"
+{
+	RA 4.50153076
+	Dec 35.28214524
+	Radius 73.702
+	Distance 1699.938
+}
+
+OpenCluster "CWNU 1508"
+{
+	RA 4.50491627
+	Dec 45.54141831
+	Radius 51.194
+	Distance 8099.748
+}
+
+OpenCluster "CWNU 1086"
+{
+	RA 4.50936848
+	Dec 53.95937593
+	Radius 47.305
+	Distance 2418.505
+}
+
+OpenCluster "CWNU 1178"
+{
+	RA 4.50959447
+	Dec -43.18513801
+	Radius 90.089
+	Distance 448.438
+}
+
+OpenCluster "HSC 1266"
+{
+	RA 4.51217906
+	Dec 42.10401531
+	Radius 111.461
+	Distance 21197.997
+}
+
+OpenCluster "FoF 2139:Theia 2461:UBC 195"
+{
+	RA 4.5127111
+	Dec 46.31636571
+	Radius 95.517
+	Distance 3463.215
+}
+
+OpenCluster "HSC 1544"
+{
+	RA 4.51861518
+	Dec 0.10743303
+	Radius 96.232
+	Distance 1876.945
+}
+
+OpenCluster "Theia 2581:UBC 1264"
+{
+	RA 4.52377455
+	Dec 44.39843249
+	Radius 190.842
+	Distance 8965.19
+}
+
+OpenCluster "CWNU 1505"
+{
+	RA 4.52408929
+	Dec 46.01303
+	Radius 53.314
+	Distance 6155.55
+}
+
+OpenCluster "HSC 1270"
+{
+	RA 4.5264753
+	Dec 41.22844614
+	Radius 128.895
+	Distance 1747.011
+}
+
+OpenCluster "NGC 1582:Collinder 51:MWSC 388:OCL 407:Theia 2581:Theia 364"
+{
+	RA 4.52740136
+	Dec 43.80078054
+	Radius 57.639
+	Distance 3096.18
+}
+
+OpenCluster "NGC 1582:Collinder 51:Gulliver 11:MWSC 388:OCL 407:Theia 591"
+{
+	RA 4.53396397
+	Dec 43.61268083
+	Radius 70.215
+	Distance 3025.197
+}
+
+OpenCluster "Theia 3803:UPK 312"
+{
+	RA 4.53697619
+	Dec 56.05039826
+	Radius 82.111
+	Distance 2243.311
+}
+
+OpenCluster "OCSN 53:Theia 66"
+{
+	RA 4.54293014
+	Dec 18.10314319
+	Radius 38.268
+	Distance 468.473
+}
+
+OpenCluster "COIN-Gaia 11:Theia 963"
+{
+	RA 4.54331403
+	Dec 39.53324453
+	Radius 235.24
+	Distance 2096.317
+}
+
+OpenCluster "Theia 1086"
+{
+	RA 4.54781132
+	Dec 55.74381381
+	Radius 133.039
+	Distance 3029.311
+}
+
+OpenCluster "HSC 1256"
+{
+	RA 4.54848008
+	Dec 44.60059998
+	Radius 45.473
+	Distance 3001.977
+}
+
+OpenCluster "OCSN 52:Theia 7"
+{
+	RA 4.55358017
+	Dec 24.38984604
+	Radius 26.15
+	Distance 422.928
+}
+
+OpenCluster "HSC 1254"
+{
+	RA 4.55472765
+	Dec 45.13632778
+	Radius 47.321
+	Distance 375.55
+}
+
+OpenCluster "HSC 1166"
+{
+	RA 4.55477371
+	Dec 62.76881906
+	Radius 36.244
+	Distance 3001.688
+}
+
+OpenCluster "HSC 1253"
+{
+	RA 4.55889282
+	Dec 45.27009568
+	Radius 82.377
+	Distance 1789.217
+}
+
+OpenCluster "HIP 21974 Group:MWSC 395:Platais 3:Theia 787"
+{
+	RA 4.56037421
+	Dec 71.48936129
+	Radius 124.828
+	Distance 577.985
+}
+
+OpenCluster "COIN-Gaia 10"
+{
+	RA 4.56389519
+	Dec 40.49964235
+	Radius 42.208
+	Distance 3283.373
+}
+
+OpenCluster "CWNU 1607:Can-BattlÃ³ 1"
+{
+	RA 4.57039029
+	Dec 45.4569126
+	Radius 64.558
+	Distance 9375.652
+}
+
+OpenCluster "Theia 71"
+{
+	RA 4.57213522
+	Dec 20.46681432
+	Radius 26.329
+	Distance 609.217
+}
+
+OpenCluster "CWNU 1018"
+{
+	RA 4.57473431
+	Dec -8.43139141
+	Radius 91.094
+	Distance 543.237
+}
+
+OpenCluster "CWNU 390:UBC 1272"
+{
+	RA 4.58134167
+	Dec 38.39283146
+	Radius 59.606
+	Distance 5322.695
+}
+
+OpenCluster "NGC 1605:Collinder 52:FSR 694:MWSC 394:OCL 406"
+{
+	RA 4.58354039
+	Dec 45.27094832
+	Radius 66.232
+	Distance 8921.116
+}
+
+OpenCluster "CWNU 1129"
+{
+	RA 4.58475977
+	Dec 22.80022375
+	Radius 70.764
+	Distance 519.306
+}
+
+OpenCluster "HSC 1242"
+{
+	RA 4.58562359
+	Dec 47.27706069
+	Radius 28.652
+	Distance 20260.429
+}
+
+OpenCluster "CWNU 1814"
+{
+	RA 4.59683948
+	Dec 44.27110152
+	Radius 33.607
+	Distance 8759.918
+}
+
+OpenCluster "HSC 1246"
+{
+	RA 4.59740782
+	Dec 47.13690537
+	Radius 58.55
+	Distance 9183.136
+}
+
+OpenCluster "CWNU 409"
+{
+	RA 4.60045961
+	Dec 59.73485413
+	Radius 54.711
+	Distance 3208.642
+}
+
+OpenCluster "CWNU 1010"
+{
+	RA 4.60640047
+	Dec -8.3552535
+	Radius 56.442
+	Distance 526.743
+}
+
+OpenCluster "Theia 1083"
+{
+	RA 4.61683761
+	Dec 48.52447488
+	Radius 56.002
+	Distance 2403.593
+}
+
+OpenCluster "CWNU 1190"
+{
+	RA 4.6228252
+	Dec 45.39515969
+	Radius 22.216
+	Distance 3747.987
+}
+
+OpenCluster "Theia 1040"
+{
+	RA 4.6295085
+	Dec 56.51411714
+	Radius 113.552
+	Distance 2024.677
+}
+
+OpenCluster "Berkeley 67:FSR 677:MWSC 404:OCL 400:Theia 5855"
+{
+	RA 4.63060056
+	Dec 50.77596673
+	Radius 60.561
+	Distance 6549.032
+}
+
+OpenCluster "COIN-Gaia 39"
+{
+	RA 4.63870638
+	Dec 42.97025309
+	Radius 23.794
+	Distance 3261.284
+}
+
+OpenCluster "DSH J0438.2+4317:Teutsch 4:UBC 1265"
+{
+	RA 4.63886639
+	Dec 43.29914887
+	Radius 54.762
+	Distance 12296.933
+}
+
+OpenCluster "FSR 0687:FSR 687:MWSC 406:SAI 37"
+{
+	RA 4.65552834
+	Dec 48.20684584
+	Radius 39.911
+	Distance 13008.867
+}
+
+OpenCluster "FoF 2230:Theia 1083:UBC 56"
+{
+	RA 4.65789387
+	Dec 47.5638096
+	Radius 45.747
+	Distance 2763.388
+}
+
+OpenCluster "CWNU 368"
+{
+	RA 4.66270277
+	Dec 50.29801118
+	Radius 38.077
+	Distance 7853.344
+}
+
+OpenCluster "HSC 1255"
+{
+	RA 4.66551115
+	Dec 46.11216608
+	Radius 69.868
+	Distance 3338.787
+}
+
+OpenCluster "NGC 1624"
+{
+	RA 4.67745034
+	Dec 50.45807369
+	Radius 60.371
+	Distance 13898.04
+}
+
+OpenCluster "CWNU 461:UBC 1262"
+{
+	RA 4.67971369
+	Dec 47.68885173
+	Radius 95.351
+	Distance 7648.423
+}
+
+OpenCluster "HSC 1272"
+{
+	RA 4.67983942
+	Dec 42.61452148
+	Radius 48.496
+	Distance 9127.302
+}
+
+OpenCluster "CWNU 1317"
+{
+	RA 4.70076129
+	Dec 33.05266346
+	Radius 43.334
+	Distance 7785.302
+}
+
+OpenCluster "UBC 1578"
+{
+	RA 4.70544243
+	Dec 49.21692
+	Radius 75.494
+	Distance 4731.538
+}
+
+OpenCluster "HSC 1580"
+{
+	RA 4.70586686
+	Dec -2.33156146
+	Radius 149.071
+	Distance 279.35
+}
+
+OpenCluster "HSC 1394"
+{
+	RA 4.71608283
+	Dec 21.92462908
+	Radius 33.163
+	Distance 1269.81
+}
+
+OpenCluster "CWNU 1497"
+{
+	RA 4.71986178
+	Dec 54.9128194
+	Radius 65.246
+	Distance 12359.038
+}
+
+OpenCluster "Berkeley 68:FSR 713:MWSC 412:OCL 413:OC 0277"
+{
+	RA 4.73663312
+	Dec 42.1612288
+	Radius 89.994
+	Distance 9910.664
+}
+
+OpenCluster "Berkeley 12:FSR 710:MWSC 413:OCL 412"
+{
+	RA 4.73972298
+	Dec 42.69143768
+	Radius 80.594
+	Distance 12155.837
+}
+
+OpenCluster "HSC 1291"
+{
+	RA 4.74826685
+	Dec 38.33826348
+	Radius 56.629
+	Distance 2070.457
+}
+
+OpenCluster "CWNU 1392"
+{
+	RA 4.74855559
+	Dec 47.91222803
+	Radius 62.487
+	Distance 8435.204
+}
+
+OpenCluster "FSR 0723:FSR 723:MWSC 414:UBC 430"
+{
+	RA 4.74889374
+	Dec 41.51933626
+	Radius 86.018
+	Distance 9678.47
+}
+
+OpenCluster "NGC 1647:Melotte 26:Collinder 54:MWSC 416:OCL 457:Theia 740"
+{
+	RA 4.76586351
+	Dec 19.16254322
+	Radius 162.925
+	Distance 1881.537
+}
+
+OpenCluster "FSR 0717"
+{
+	RA 4.76694335
+	Dec 42.15820156
+	Radius 24.808
+	Distance 11260.704
+}
+
+OpenCluster "GCL 7:MWSC 418:Pal 2:Palomar 2"
+{
+	RA 4.76839671
+	Dec 31.3813961
+	Radius 259.747
+	Distance 35651.587
+}
+
+OpenCluster "Alessi 2:LeDrew 4:MWSC 419"
+{
+	RA 4.77046987
+	Dec 55.18407081
+	Radius 113.75
+	Distance 1970.425
+}
+
+OpenCluster "Basel 9:MWSC 421:OCL 408:Ruprecht 148"
+{
+	RA 4.77520048
+	Dec 44.71466014
+	Radius 110.441
+	Distance 10203.065
+}
+
+OpenCluster "CWWL 3078"
+{
+	RA 4.78464719
+	Dec 60.85881384
+	Radius 185.119
+	Distance 12628.146
+}
+
+OpenCluster "UBC 1261"
+{
+	RA 4.78545831
+	Dec 49.81157732
+	Radius 50.77
+	Distance 12484.666
+}
+
+OpenCluster "OC 0275:UBC 427"
+{
+	RA 4.78631388
+	Dec 49.02706776
+	Radius 47.455
+	Distance 8841.523
+}
+
+OpenCluster "HXHWL 35:UBC 1266"
+{
+	RA 4.80094927
+	Dec 43.96728021
+	Radius 37.198
+	Distance 6064.48
+}
+
+OpenCluster "NGC 1662:Collinder 55:MWSC 425:OCL 470:Theia 1018"
+{
+	RA 4.80759988
+	Dec 10.90376029
+	Radius 303.695
+	Distance 1319.625
+}
+
+OpenCluster "CWNU 52"
+{
+	RA 4.82258886
+	Dec 26.18538988
+	Radius 69.401
+	Distance 1969.698
+}
+
+OpenCluster "Theia 569"
+{
+	RA 4.82680413
+	Dec 44.8329008
+	Radius 77.178
+	Distance 2365.574
+}
+
+OpenCluster "NGC 1664:Melotte 27:Collinder 56:MWSC 430:OCL 411:Theia 933"
+{
+	RA 4.82695948
+	Dec 43.61252043
+	Radius 57.732
+	Distance 931.285
+}
+
+OpenCluster "ASCC 12:MWSC 427"
+{
+	RA 4.82803983
+	Dec 41.71429711
+	Radius 82.414
+	Distance 3308.914
+}
+
+OpenCluster "HSC 1274"
+{
+	RA 4.83656081
+	Dec 43.7957454
+	Radius 172.689
+	Distance 16222.696
+}
+
+OpenCluster "CWNU 381:UBC 1267"
+{
+	RA 4.83799713
+	Dec 43.54469998
+	Radius 24.736
+	Distance 6882.3
+}
+
+OpenCluster "CWNU 1191:TRSG 9:Teutsch J0450.9+5209"
+{
+	RA 4.83801295
+	Dec 52.26422336
+	Radius 74.09
+	Distance 971.12
+}
+
+OpenCluster "UBC 429"
+{
+	RA 4.83811039
+	Dec 44.76290302
+	Radius 46.689
+	Distance 8140.706
+}
+
+OpenCluster "HSC 1226"
+{
+	RA 4.83921037
+	Dec 51.37368571
+	Radius 46.345
+	Distance 2411.003
+}
+
+OpenCluster "NGC 1664:Melotte 27:Collinder 56:MWSC 430:OCL 411"
+{
+	RA 4.85109876
+	Dec 43.67478182
+	Radius 115.017
+	Distance 4200.188
+}
+
+OpenCluster "HSC 1229"
+{
+	RA 4.8604418
+	Dec 51.17016289
+	Radius 76.718
+	Distance 8747.794
+}
+
+OpenCluster "CWNU 1688:FSR 0702"
+{
+	RA 4.86129569
+	Dec 45.77618584
+	Radius 51.004
+	Distance 13351.439
+}
+
+OpenCluster "CWNU 358"
+{
+	RA 4.86517169
+	Dec 49.07117827
+	Radius 28.172
+	Distance 5477.44
+}
+
+OpenCluster "HSC 1223"
+{
+	RA 4.87492553
+	Dec 52.76543939
+	Radius 45.057
+	Distance 8488.93
+}
+
+OpenCluster "CWNU 1262"
+{
+	RA 4.87712647
+	Dec -10.5497878
+	Radius 45.882
+	Distance 901.529
+}
+
+OpenCluster "HSC 1233"
+{
+	RA 4.88814671
+	Dec 50.89570789
+	Radius 31.087
+	Distance 6612.742
+}
+
+OpenCluster "HSC 1409"
+{
+	RA 4.89029462
+	Dec 22.25751905
+	Radius 35.416
+	Distance 5471.651
+}
+
+OpenCluster "FSR 0735:FSR 735:MWSC 433"
+{
+	RA 4.89809784
+	Dec 40.85799805
+	Radius 37.371
+	Distance 9371.133
+}
+
+OpenCluster "CWNU 449:Theia 560"
+{
+	RA 4.90632565
+	Dec 45.86919145
+	Radius 109.845
+	Distance 2088.563
+}
+
+OpenCluster "HSC 1283"
+{
+	RA 4.90698208
+	Dec 41.60952878
+	Radius 75.992
+	Distance 5161.316
+}
+
+OpenCluster "CWNU 386:UBC 1607"
+{
+	RA 4.91072965
+	Dec 45.58779028
+	Radius 65.78
+	Distance 8585.842
+}
+
+OpenCluster "Theia 818"
+{
+	RA 4.91705245
+	Dec 13.68701567
+	Radius 107.605
+	Distance 1308.529
+}
+
+OpenCluster "HSC 1400"
+{
+	RA 4.91778787
+	Dec 23.16919822
+	Radius 59.262
+	Distance 4106.276
+}
+
+OpenCluster "HSC 1206"
+{
+	RA 4.92858068
+	Dec 56.65408312
+	Radius 80.629
+	Distance 1133.308
+}
+
+OpenCluster "DSH J0455.7+3646:FSR 747:MWSC 438:OC 0284:OC 0285:Teutsch 5"
+{
+	RA 4.92938995
+	Dec 36.78324381
+	Radius 33.526
+	Distance 6552.283
+}
+
+OpenCluster "Berkeley 13:MWSC 439:OCL 402"
+{
+	RA 4.93018441
+	Dec 52.81025872
+	Radius 61.447
+	Distance 12355.848
+}
+
+OpenCluster "Theia 54"
+{
+	RA 4.93329081
+	Dec 30.41623858
+	Radius 44.298
+	Distance 507.174
+}
+
+OpenCluster "UBC 1276"
+{
+	RA 4.93778661
+	Dec 38.1870572
+	Radius 52.572
+	Distance 9816.307
+}
+
+OpenCluster "Czernik 19:FSR 792:MWSC 441:OCL 443"
+{
+	RA 4.95159148
+	Dec 28.77003198
+	Radius 166.127
+	Distance 7459.676
+}
+
+OpenCluster "HXHWL 18"
+{
+	RA 4.95443474
+	Dec 39.79568797
+	Radius 38.873
+	Distance 3279.247
+}
+
+OpenCluster "HSC 1527"
+{
+	RA 4.9553298
+	Dec 6.37795634
+	Radius 108.886
+	Distance 1070.667
+}
+
+OpenCluster "CWNU 424:OC 0289:Theia 4058"
+{
+	RA 4.95618769
+	Dec 32.75738804
+	Radius 74.477
+	Distance 4259.979
+}
+
+OpenCluster "CWNU 518"
+{
+	RA 4.96063306
+	Dec 42.23841566
+	Radius 82.088
+	Distance 3119.547
+}
+
+OpenCluster "HSC 1314"
+{
+	RA 4.96145901
+	Dec 35.93111566
+	Radius 240.18
+	Distance 1129.555
+}
+
+OpenCluster "MWSC 442:Skiff 2:Skiff J0458+43.0"
+{
+	RA 4.96963125
+	Dec 43.01047587
+	Radius 53.434
+	Distance 8424.872
+}
+
+OpenCluster "CWNU 1773"
+{
+	RA 4.97614451
+	Dec 44.56181512
+	Radius 58.552
+	Distance 6743.614
+}
+
+OpenCluster "CWNU 1068:FSR 0744:FSR 744:MWSC 447"
+{
+	RA 4.99003044
+	Dec 37.97873421
+	Radius 57.896
+	Distance 3462.32
+}
+
+OpenCluster "Berkeley 14:Berkeley 14A:FSR 726:MWSC 448:MWSC 449:OCL 416"
+{
+	RA 4.99555013
+	Dec 43.48151676
+	Radius 115.415
+	Distance 14278.224
+}
+
+OpenCluster "UBC 1273"
+{
+	RA 4.99570338
+	Dec 40.82116432
+	Radius 39.668
+	Distance 11450.179
+}
+
+OpenCluster "CWNU 210:OC 0282"
+{
+	RA 4.99968221
+	Dec 38.68785644
+	Radius 19.185
+	Distance 5554.662
+}
+
+OpenCluster "CWNU 2206"
+{
+	RA 5.00234742
+	Dec 34.37897923
+	Radius 42.46
+	Distance 12305.368
+}
+
+OpenCluster "Berkeley 14A:MWSC 449"
+{
+	RA 5.00303491
+	Dec 43.67924222
+	Radius 43.964
+	Distance 3550.473
+}
+
+OpenCluster "Theia 3625:UBC 61"
+{
+	RA 5.00547033
+	Dec 36.22267933
+	Radius 52.734
+	Distance 4101.38
+}
+
+OpenCluster "HSC 2314"
+{
+	RA 5.01064751
+	Dec -71.16420471
+	Radius 111.931
+	Distance 2913.09
+}
+
+OpenCluster "HSC 1311"
+{
+	RA 5.01117908
+	Dec 37.03435788
+	Radius 45.787
+	Distance 15143.73
+}
+
+OpenCluster "Theia 480"
+{
+	RA 5.01136782
+	Dec 41.4359999
+	Radius 70.191
+	Distance 2277.221
+}
+
+OpenCluster "HD 277249 Group:SAI 40:Teutsch 196:UBC 431"
+{
+	RA 5.01409888
+	Dec 41.22490612
+	Radius 92.767
+	Distance 13451.995
+}
+
+OpenCluster "HSC 1299"
+{
+	RA 5.02237217
+	Dec 38.81430876
+	Radius 100.239
+	Distance 11109.583
+}
+
+OpenCluster "CWNU 344:OC 0290"
+{
+	RA 5.02898342
+	Dec 30.75945734
+	Radius 56.057
+	Distance 5249.271
+}
+
+OpenCluster "Alessi 96:RSG 1:TRSG 1:Theia 380"
+{
+	RA 5.03234476
+	Dec 37.4875441
+	Radius 255.377
+	Distance 1051.798
 }
 
 OpenCluster "Berkeley 15"
 {
-	RA 5.034722
-	Dec 44.500000
-	Distance 3920
-	Radius 4.6
+	RA 5.03492021
+	Dec 44.50728146
+	Radius 57.952
+	Distance 8378.819
 }
 
-OpenCluster "NGC 1708"
+OpenCluster "CWNU 1142"
 {
-	RA 5.057500
-	Dec 52.833333
-	Distance 1957
-	Radius 5.7
+	RA 5.0351031
+	Dec 2.83666657
+	Radius 103.098
+	Distance 941.346
 }
 
-OpenCluster "NGC 1746"
+OpenCluster "CWNU 33:OC 0298"
 {
-	RA 5.063889
-	Dec 23.770000
-	Distance 1369
-	Radius 8.4
+	RA 5.04080254
+	Dec 19.69044849
+	Radius 25.828
+	Distance 4192.814
 }
 
-OpenCluster "NGC 1750"
+OpenCluster "UBC 1270"
 {
-	RA 5.065278
-	Dec 23.658333
-	Distance 2054
-	Radius 6.0
+	RA 5.04207444
+	Dec 43.65425891
+	Radius 72.968
+	Distance 9486.646
 }
 
-OpenCluster "NGC 1758"
+OpenCluster "FSR 0732:FSR 732:MWSC 732:Theia 501"
 {
-	RA 5.076389
-	Dec 23.798333
-	Distance 2478
-	Radius 3.2
+	RA 5.04207502
+	Dec 42.54514167
+	Radius 102.226
+	Distance 3769.333
 }
 
-OpenCluster "Bica 6"
+OpenCluster "HSC 1294"
 {
-	RA 5.105556
-	Dec 39.163889
-	Distance 5544
-	Radius 5.6
+	RA 5.04266113
+	Dec 40.57183823
+	Radius 53.469
+	Distance 11977.296
 }
 
-OpenCluster "Platais 4"
+OpenCluster "HSC 1347"
 {
-	RA 5.122778
-	Dec 22.278333
-	Distance 900
-	Radius 26.7
+	RA 5.04516016
+	Dec 31.34232309
+	Radius 139.113
+	Distance 277.998
 }
 
-OpenCluster "NGC 1778"
+OpenCluster "CWNU 522:LISC-III 3611"
 {
-	RA 5.134444
-	Dec 37.023333
-	Distance 4791
-	Radius 5.6
+	RA 5.0452002
+	Dec 8.08101379
+	Radius 96.562
+	Distance 1242.931
 }
 
-OpenCluster "NGC 1802"
+OpenCluster "HSC 1403"
 {
-	RA 5.170556
-	Dec 24.108333
-	Distance 1304
-	Radius 4.7
+	RA 5.04621108
+	Dec 24.30051458
+	Radius 101.616
+	Distance 1582.49
 }
 
-OpenCluster "NGC 1798"
+OpenCluster "Theia 30:UPK 385"
 {
-	RA 5.194167
-	Dec 47.691667
-	Distance 14909
-	Radius 10.8
+	RA 5.04675485
+	Dec 12.94782013
+	Radius 34.432
+	Distance 1018.803
 }
 
-OpenCluster "NGC 1817"
+OpenCluster "CWNU 1145"
 {
-	RA 5.204167
-	Dec 16.690000
-	Distance 6432
-	Radius 15.0
+	RA 5.04843276
+	Dec 39.94646513
+	Radius 58.344
+	Distance 3437.887
 }
 
-OpenCluster "ASCC 13"
+OpenCluster "HSC 1252"
 {
-	RA 5.221944
-	Dec 44.580000
-	Distance 2609
-	Radius 31.9
+	RA 5.05365761
+	Dec 49.64564367
+	Radius 49.782
+	Distance 3844.762
 }
 
-OpenCluster "NGC 1901"
+OpenCluster "HSC 1460"
 {
-	RA 5.303056
-	Dec -67.550000
-	Distance 1500
-	Radius 2.2
+	RA 5.05376971
+	Dec 17.18575287
+	Radius 20.048
+	Distance 384.33
 }
 
-OpenCluster "ASCC 14"
+OpenCluster "OC 0281:Theia 5736"
 {
-	RA 5.341944
-	Dec 35.220000
-	Distance 3587
-	Radius 13.8
+	RA 5.05504849
+	Dec 40.59088241
+	Radius 73.206
+	Distance 5563.315
 }
 
-OpenCluster "Czernik 20"
+OpenCluster "NGC 1724:MWSC 459:OCL 405"
 {
-	RA 5.342222
-	Dec 39.547222
-	Distance 10991
-	Radius 57.6
+	RA 5.0552296
+	Dec 49.50474121
+	Radius 73.254
+	Distance 11585.644
 }
 
-OpenCluster "Berkeley 17"
+OpenCluster "UBC 1274"
 {
-	RA 5.343333
-	Dec 30.600000
-	Distance 8806
-	Radius 9.0
+	RA 5.05566474
+	Dec 40.97425812
+	Radius 104.87
+	Distance 12050.041
 }
 
-OpenCluster "Berkeley 18"
+OpenCluster "CWNU 1098:Theia 2901:Theia 3145"
 {
-	RA 5.370000
-	Dec 45.400000
-	Distance 18917
-	Radius 33.0
+	RA 5.05567743
+	Dec 42.08877953
+	Radius 62.583
+	Distance 3652.348
 }
 
-OpenCluster "ASCC 15"
+OpenCluster "FSR 0734"
 {
-	RA 5.376944
-	Dec 36.550000
-	Distance 4566
-	Radius 15.9
+	RA 5.05664224
+	Dec 42.39104129
+	Radius 196.957
+	Distance 16513.915
 }
 
-OpenCluster "NGC 1893"
+OpenCluster "NGC 1708:MWSC 458"
 {
-	RA 5.378889
-	Dec 33.411667
-	Distance 19570
-	Radius 71.2
+	RA 5.05899806
+	Dec 52.92246107
+	Radius 72.739
+	Distance 2988.297
 }
 
-OpenCluster "Berkeley 19"
+OpenCluster "FSR 0771:FSR 771:MWSC 460:Theia 4058"
 {
-	RA 5.401667
-	Dec 29.600000
-	Distance 15757
-	Radius 9.2
+	RA 5.06140355
+	Dec 32.14532596
+	Radius 68.886
+	Distance 5040.745
 }
 
-OpenCluster "Briceno 1"
+OpenCluster "NGC 1746:NGC 1750:Melotte 28:Collinder 57:FSR 822:MWSC 461:MWSC 462:OCL 452:OCL 454:Theia 3947:Theia 754"
 {
-	RA 5.410000
-	Dec 1.800000
-	Distance 1500
-	Radius 16.2
+	RA 5.06448596
+	Dec 23.67444095
+	Radius 278.734
+	Distance 2288.774
 }
 
-OpenCluster "Berkeley 69"
+OpenCluster "HSC 1279"
 {
-	RA 5.410000
-	Dec 32.650000
-	Distance 9328
-	Radius 4.1
+	RA 5.06685938
+	Dec 44.95503345
+	Radius 46.658
+	Distance 560.321
 }
 
-OpenCluster "ASCC 17"
+OpenCluster "COIN-Gaia 15:Theia 2491"
 {
-	RA 5.420000
-	Dec 30.170000
-	Distance 6523
-	Radius 28.5
+	RA 5.07354834
+	Dec 35.80107117
+	Radius 112.754
+	Distance 3792.049
 }
 
-OpenCluster "NGC 1896"
+OpenCluster "NGC 1746:NGC 1758:Melotte 28:Collinder 57:FSR 822:MWSC 461:MWSC 463:OCL 452:OCL 453:Theia 897"
 {
-	RA 5.428333
-	Dec 29.328333
-	Distance 2674
-	Radius 7.8
+	RA 5.07832645
+	Dec 23.81255872
+	Radius 35.809
+	Distance 2797.327
 }
 
-OpenCluster "Berkeley 70"
+OpenCluster "CWNU 2255"
 {
-	RA 5.428333
-	Dec 41.900000
-	Distance 13594
-	Radius 11.9
+	RA 5.09511342
+	Dec 55.76612196
+	Radius 111.178
+	Distance 10391.145
 }
 
-OpenCluster "NGC 1883"
+OpenCluster "CWNU 350"
 {
-	RA 5.431667
-	Dec 46.490000
-	Distance 15656
-	Radius 6.8
+	RA 5.09771104
+	Dec 45.96860614
+	Radius 41.496
+	Distance 3454.024
 }
 
-OpenCluster "Collinder 65"
+OpenCluster "HSC 1297"
 {
-	RA 5.435000
-	Dec 16.700278
-	Distance 1011
-	Radius 32.4
+	RA 5.09856985
+	Dec 39.9458654
+	Radius 73.793
+	Distance 11277.276
 }
 
-OpenCluster "ASCC 18"
+OpenCluster "HSC 1308"
 {
-	RA 5.436111
-	Dec 0.820000
-	Distance 1630
-	Radius 17.6
+	RA 5.10083486
+	Dec 38.4704472
+	Radius 55.6
+	Distance 3278.49
 }
 
-OpenCluster "Czernik 21"
+OpenCluster "CWNU 1015"
 {
-	RA 5.444722
-	Dec 36.013611
-	Distance 7501
-	Radius 7.6
+	RA 5.10291013
+	Dec -3.33828939
+	Radius 125.772
+	Distance 561.123
+}
+
+OpenCluster "FSR 0841:FSR 841:MWSC 464:OC 0296"
+{
+	RA 5.10550809
+	Dec 21.52540343
+	Radius 82.074
+	Distance 5975.132
+}
+
+OpenCluster "Skiff J0507+30.8"
+{
+	RA 5.11623126
+	Dec 30.87202674
+	Radius 84.603
+	Distance 15090.589
+}
+
+OpenCluster "LISC-III 3613:OCSN 59"
+{
+	RA 5.12293597
+	Dec -3.33567837
+	Radius 48.869
+	Distance 1241.799
+}
+
+OpenCluster "HSC 1331"
+{
+	RA 5.12310593
+	Dec 35.20963738
+	Radius 26.434
+	Distance 3000
+}
+
+OpenCluster "DSH J0507.6+1734:FSR 854:Juchert 23:SAI 42:UBC 200"
+{
+	RA 5.12820123
+	Dec 17.58888636
+	Radius 150.523
+	Distance 7865.43
+}
+
+OpenCluster "CWNU 186:UBC 1608"
+{
+	RA 5.12996275
+	Dec 40.54847
+	Radius 83.726
+	Distance 4129.869
+}
+
+OpenCluster "NGC 1778:Collinder 58:MWSC 472:OCL 429:Theia 2031"
+{
+	RA 5.13506196
+	Dec 37.01842045
+	Radius 61.955
+	Distance 5183.027
+}
+
+OpenCluster "UPK 347"
+{
+	RA 5.13671865
+	Dec 40.76470472
+	Radius 67.35
+	Distance 2956.46
+}
+
+OpenCluster "HSC 1286"
+{
+	RA 5.13792361
+	Dec 42.7472243
+	Radius 65.673
+	Distance 14852.399
+}
+
+OpenCluster "Kronberger 26:MWSC 473:SAI 43:Teutsch 36"
+{
+	RA 5.13814482
+	Dec 49.86534795
+	Radius 66.657
+	Distance 14374.753
+}
+
+OpenCluster "King 17:MWSC 474:OCL 424"
+{
+	RA 5.13962431
+	Dec 39.07115194
+	Radius 43.603
+	Distance 11596.456
+}
+
+OpenCluster "FSR 0683:FSR 683:MWSC 475"
+{
+	RA 5.14491747
+	Dec 53.21340314
+	Radius 91.958
+	Distance 9595.848
+}
+
+OpenCluster "Ferrero 17"
+{
+	RA 5.1457455
+	Dec 17.98686198
+	Radius 75.564
+	Distance 14323.702
+}
+
+OpenCluster "HSC 1509"
+{
+	RA 5.14997714
+	Dec 10.66877857
+	Radius 325.207
+	Distance 19767.06
+}
+
+OpenCluster "HSC 1648"
+{
+	RA 5.15165365
+	Dec -8.81562736
+	Radius 81.367
+	Distance 936.669
+}
+
+OpenCluster "CWNU 1807"
+{
+	RA 5.15191063
+	Dec 40.50452566
+	Radius 41.329
+	Distance 8056.359
+}
+
+OpenCluster "HSC 1306"
+{
+	RA 5.15291511
+	Dec 39.01850573
+	Radius 42.148
+	Distance 14726.72
+}
+
+OpenCluster "OCSN 54"
+{
+	RA 5.17480619
+	Dec 17.43095
+	Radius 61.616
+	Distance 1410.767
+}
+
+OpenCluster "COIN-Gaia 14"
+{
+	RA 5.17956938
+	Dec 39.20290629
+	Radius 61.648
+	Distance 3103.604
+}
+
+OpenCluster "HXHWL 49:UBC 1277"
+{
+	RA 5.18017777
+	Dec 36.36497771
+	Radius 42.856
+	Distance 4783.391
+}
+
+OpenCluster "HSC 1714"
+{
+	RA 5.18138385
+	Dec -16.0059992
+	Radius 86.797
+	Distance 692.17
+}
+
+OpenCluster "UBC 1269"
+{
+	RA 5.18338832
+	Dec 45.2042826
+	Radius 83.82
+	Distance 13110.418
+}
+
+OpenCluster "FSR 0716:FSR 716:MWSC 482:SAI 44"
+{
+	RA 5.18621271
+	Dec 45.72307987
+	Radius 69.494
+	Distance 11087.011
+}
+
+OpenCluster "CWNU 1421"
+{
+	RA 5.18790572
+	Dec 34.19071469
+	Radius 29.876
+	Distance 8947.229
+}
+
+OpenCluster "Theia 3980"
+{
+	RA 5.19370137
+	Dec 36.24575191
+	Radius 66.752
+	Distance 2330.837
+}
+
+OpenCluster "NGC 1798:Berkeley 16:Dolidze 48:FSR 705:MWSC 483:OCL 410"
+{
+	RA 5.19385956
+	Dec 47.68911136
+	Radius 122.37
+	Distance 13591.03
+}
+
+OpenCluster "CWNU 154"
+{
+	RA 5.19616531
+	Dec 38.10519611
+	Radius 84.74
+	Distance 3420.465
+}
+
+OpenCluster "CWNU 2689"
+{
+	RA 5.19855141
+	Dec 37.92235585
+	Radius 35.505
+	Distance 6418.287
+}
+
+OpenCluster "CWNU 2307"
+{
+	RA 5.20596335
+	Dec 38.44549258
+	Radius 41.197
+	Distance 9392.518
+}
+
+OpenCluster "NGC 1817:Collinder 60:MWSC 484:OCL 463:Theia 4898"
+{
+	RA 5.20940197
+	Dec 16.69318417
+	Radius 67.278
+	Distance 5337.403
+}
+
+OpenCluster "HSC 1192"
+{
+	RA 5.21289061
+	Dec 61.19596359
+	Radius 35.054
+	Distance 1374.34
+}
+
+OpenCluster "ASCC 13:MWSC 486:Theia 2043"
+{
+	RA 5.21471131
+	Dec 44.36502692
+	Radius 71.324
+	Distance 3509.94
+}
+
+OpenCluster "HSC 1292"
+{
+	RA 5.21870145
+	Dec 42.28202182
+	Radius 57.671
+	Distance 3497.999
+}
+
+OpenCluster "HSC 1304"
+{
+	RA 5.22268192
+	Dec 39.88802922
+	Radius 39.838
+	Distance 6324.843
+}
+
+OpenCluster "IRAS 05100+3723"
+{
+	RA 5.22387117
+	Dec 37.44056992
+	Radius 101.313
+	Distance 10434.416
+}
+
+OpenCluster "HSC 1587"
+{
+	RA 5.22558154
+	Dec 1.04555149
+	Radius 125.12
+	Distance 23874.664
+}
+
+OpenCluster "COIN-Gaia 18"
+{
+	RA 5.22689872
+	Dec 35.48011987
+	Radius 27.015
+	Distance 3217.917
+}
+
+OpenCluster "HSC 1481"
+{
+	RA 5.23009958
+	Dec 15.82813302
+	Radius 187.513
+	Distance 682.197
+}
+
+OpenCluster "OCSN 64"
+{
+	RA 5.23115796
+	Dec -4.84942197
+	Radius 108.592
+	Distance 1057.146
+}
+
+OpenCluster "CWNU 1937"
+{
+	RA 5.23288137
+	Dec 42.43866884
+	Radius 106.135
+	Distance 6685.143
+}
+
+OpenCluster "HSC 1315"
+{
+	RA 5.23290342
+	Dec 38.24868778
+	Radius 42.482
+	Distance 9368.872
+}
+
+OpenCluster "Dolidze 16"
+{
+	RA 5.23954174
+	Dec 32.76971765
+	Radius 40.621
+	Distance 3960.431
+}
+
+OpenCluster "COIN-Gaia 20:Theia 2419"
+{
+	RA 5.24239791
+	Dec 31.72005005
+	Radius 68.057
+	Distance 3354.796
+}
+
+OpenCluster "HSC 1535"
+{
+	RA 5.24821812
+	Dec 8.34302187
+	Radius 55.541
+	Distance 2672.473
+}
+
+OpenCluster "HSC 1259"
+{
+	RA 5.25401474
+	Dec 49.66428727
+	Radius 110.92
+	Distance 16116.386
+}
+
+OpenCluster "Theia 271:Theia 3968:UBC 202:UPK 394"
+{
+	RA 5.2544196
+	Dec 6.24164063
+	Radius 75.237
+	Distance 2555.736
+}
+
+OpenCluster "HSC 1310"
+{
+	RA 5.26182086
+	Dec 39.64158252
+	Radius 79.966
+	Distance 12447.478
+}
+
+OpenCluster "HSC 1243"
+{
+	RA 5.261979
+	Dec 52.48759271
+	Radius 108.471
+	Distance 10443.908
+}
+
+OpenCluster "HSC 1343"
+{
+	RA 5.26416733
+	Dec 34.19407443
+	Radius 22.392
+	Distance 2989.375
+}
+
+OpenCluster "HSC 1523"
+{
+	RA 5.26760488
+	Dec 10.03606634
+	Radius 33.639
+	Distance 896.474
+}
+
+OpenCluster "UBC 432"
+{
+	RA 5.27041878
+	Dec 39.53653555
+	Radius 63.605
+	Distance 8760.654
+}
+
+OpenCluster "DSH J0516.4+4535:FSR 727:MWSC 495:Patchick 3:SAI 45:Theia 4635"
+{
+	RA 5.27473956
+	Dec 45.58206403
+	Radius 45.06
+	Distance 5249.884
+}
+
+OpenCluster "Theia 387"
+{
+	RA 5.27686936
+	Dec 37.19914221
+	Radius 237.846
+	Distance 1716.174
+}
+
+OpenCluster "CWNU 1007:LISC-III 3645"
+{
+	RA 5.28051789
+	Dec 18.47774548
+	Radius 130.55
+	Distance 1168.99
+}
+
+OpenCluster "HSC 1321"
+{
+	RA 5.28320699
+	Dec 38.16124395
+	Radius 16.212
+	Distance 5006.051
+}
+
+OpenCluster "NGC 1901:AFF 5:Bok 1:MWSC 500:OCL 791.1"
+{
+	RA 5.28589125
+	Dec -68.44091363
+	Radius 150.161
+	Distance 1357.915
+}
+
+OpenCluster "Melotte 31:UBC 1282"
+{
+	RA 5.28903236
+	Dec 33.20316834
+	Radius 38.28
+	Distance 8769.853
+}
+
+OpenCluster "HSC 1323"
+{
+	RA 5.28987347
+	Dec 37.89246017
+	Radius 40.387
+	Distance 4873.422
+}
+
+OpenCluster "HSC 1653"
+{
+	RA 5.29068392
+	Dec -8.50414237
+	Radius 40.663
+	Distance 1008.672
+}
+
+OpenCluster "HSC 1644"
+{
+	RA 5.29346024
+	Dec -6.82555383
+	Radius 35.644
+	Distance 560.61
+}
+
+OpenCluster "CWNU 216:OC 0322"
+{
+	RA 5.29451279
+	Dec 7.16412271
+	Radius 45.203
+	Distance 1260.047
+}
+
+OpenCluster "COIN-Gaia 12:LISC 3479:Theia 675"
+{
+	RA 5.29467226
+	Dec 41.67985831
+	Radius 90.848
+	Distance 3083.943
+}
+
+OpenCluster "PHOC 9"
+{
+	RA 5.3057957
+	Dec 41.93518849
+	Radius 197.477
+	Distance 14033.554
+}
+
+OpenCluster "HSC 1361"
+{
+	RA 5.3063496
+	Dec 32.25795019
+	Radius 60.558
+	Distance 2003.016
+}
+
+OpenCluster "HSC 1320"
+{
+	RA 5.31542848
+	Dec 38.45112556
+	Radius 62.998
+	Distance 12371.296
+}
+
+OpenCluster "HSC 1401"
+{
+	RA 5.32158133
+	Dec 27.03325261
+	Radius 35.361
+	Distance 3201.589
+}
+
+OpenCluster "CWWL 2942:UBC 612"
+{
+	RA 5.321708
+	Dec 40.14068777
+	Radius 103.995
+	Distance 14764.421
+}
+
+OpenCluster "HSC 1353"
+{
+	RA 5.32389837
+	Dec 33.64142447
+	Radius 27.409
+	Distance 13488.7
+}
+
+OpenCluster "HSC 1449"
+{
+	RA 5.32700947
+	Dec 20.62023712
+	Radius 26.655
+	Distance 4741.097
+}
+
+OpenCluster "UBC 613"
+{
+	RA 5.32995503
+	Dec 38.9821308
+	Radius 125.168
+	Distance 14346.478
+}
+
+OpenCluster "ASCC 14:MWSC 507"
+{
+	RA 5.33359053
+	Dec 35.22905658
+	Radius 52.88
+	Distance 3275.428
+}
+
+OpenCluster "NGC 1857:Melotte 32:Collinder 61:FSR 755:MWSC 505:OCL 428:Theia 2630"
+{
+	RA 5.33524993
+	Dec 39.32883536
+	Radius 32.672
+	Distance 8828.886
+}
+
+OpenCluster "UBC 614"
+{
+	RA 5.34127169
+	Dec 30.23444752
+	Radius 45.453
+	Distance 5900.083
+}
+
+OpenCluster "Czernik 20:DSH J0520.5+3932:MWSC 508:OCL 427:Teutsch 88"
+{
+	RA 5.34222125
+	Dec 39.54351931
+	Radius 20.138
+	Distance 10089.998
+}
+
+OpenCluster "Berkeley 17:FSR 800:MWSC 509:OCL 447"
+{
+	RA 5.34276479
+	Dec 30.57427186
+	Radius 100.21
+	Distance 9620.947
+}
+
+OpenCluster "COIN-Gaia 16"
+{
+	RA 5.34465191
+	Dec 37.44458742
+	Radius 15.498
+	Distance 4986.49
+}
+
+OpenCluster "HSC 1341"
+{
+	RA 5.35039143
+	Dec 35.32565575
+	Radius 39.02
+	Distance 3240.709
+}
+
+OpenCluster "UBC 1281"
+{
+	RA 5.36539501
+	Dec 34.75508175
+	Radius 119.34
+	Distance 9452.041
+}
+
+OpenCluster "CWNU 1720"
+{
+	RA 5.36559381
+	Dec 37.74186943
+	Radius 59.054
+	Distance 10667.219
+}
+
+OpenCluster "Berkeley 18:FSR 731:King 22:MWSC 512:OCL 419:OCL 420"
+{
+	RA 5.37024472
+	Dec 45.46785151
+	Radius 142.344
+	Distance 15940.212
+}
+
+OpenCluster "Gulliver 8:HXWHB 6:HXWHB 8:Melotte 31:Theia 504"
+{
+	RA 5.37150402
+	Dec 33.78284555
+	Radius 88.944
+	Distance 3501.946
+}
+
+OpenCluster "HSC 1566"
+{
+	RA 5.37685314
+	Dec 5.33797407
+	Radius 87.702
+	Distance 235.967
+}
+
+OpenCluster "UBC 1275"
+{
+	RA 5.37859717
+	Dec 43.40958735
+	Radius 36.262
+	Distance 7710.239
+}
+
+OpenCluster "Gulliver 26"
+{
+	RA 5.37921314
+	Dec 35.27439393
+	Radius 69.238
+	Distance 8033.728
+}
+
+OpenCluster "NGC 1893:OC 0293"
+{
+	RA 5.380123
+	Dec 33.42627927
+	Radius 53.502
+	Distance 9309.844
+}
+
+OpenCluster "HSC 1633"
+{
+	RA 5.38354224
+	Dec -4.58072071
+	Radius 28.635
+	Distance 1221.162
+}
+
+OpenCluster "HSC 1334"
+{
+	RA 5.3846653
+	Dec 37.01561478
+	Radius 91.664
+	Distance 2984.431
+}
+
+OpenCluster "Theia 93"
+{
+	RA 5.38500212
+	Dec 24.62370534
+	Radius 74.556
+	Distance 568.872
+}
+
+OpenCluster "CWNU 1057"
+{
+	RA 5.39224811
+	Dec -8.30208011
+	Radius 108.055
+	Distance 469.41
+}
+
+OpenCluster "UPK 317"
+{
+	RA 5.39454245
+	Dec 60.13894616
+	Radius 56.621
+	Distance 2803.041
+}
+
+OpenCluster "HSC 1470"
+{
+	RA 5.39760243
+	Dec 19.35127465
+	Radius 56.002
+	Distance 236.971
+}
+
+OpenCluster "MWSC 526:SAI 47"
+{
+	RA 5.39978309
+	Dec 42.31605739
+	Radius 67.394
+	Distance 13730.321
+}
+
+OpenCluster "Gulliver 53"
+{
+	RA 5.40057415
+	Dec 34.04995412
+	Radius 36.162
+	Distance 7676.534
+}
+
+OpenCluster "Berkeley 19:MWSC 527:OCL 450"
+{
+	RA 5.40088236
+	Dec 29.57177077
+	Radius 127.606
+	Distance 17128.551
+}
+
+OpenCluster "CWNU 1667"
+{
+	RA 5.40091644
+	Dec 46.90865113
+	Radius 26.005
+	Distance 9279.975
+}
+
+OpenCluster "HSC 1471"
+{
+	RA 5.40225088
+	Dec 19.01939563
+	Radius 66.161
+	Distance 2330.893
+}
+
+OpenCluster "HSC 1667"
+{
+	RA 5.40228705
+	Dec -8.66702283
+	Radius 45.05
+	Distance 504.902
+}
+
+OpenCluster "CWNU 168"
+{
+	RA 5.40447714
+	Dec 20.72325039
+	Radius 45.233
+	Distance 2604.926
+}
+
+OpenCluster "ASCC 16:Briceno 1"
+{
+	RA 5.40555754
+	Dec 1.69561227
+	Radius 24.809
+	Distance 1115.777
+}
+
+OpenCluster "Berkeley 69:FSR 793:MWSC 532:OCL 444:OC 0294"
+{
+	RA 5.40605907
+	Dec 32.60815438
+	Radius 98.027
+	Distance 10370.163
+}
+
+OpenCluster "HSC 1442"
+{
+	RA 5.40922598
+	Dec 22.6977841
+	Radius 45.035
+	Distance 4178.229
+}
+
+OpenCluster "CWNU 1732:Theia 1424"
+{
+	RA 5.4103082
+	Dec 38.24580285
+	Radius 96.187
+	Distance 4445.785
+}
+
+OpenCluster "HSC 1446"
+{
+	RA 5.41081619
+	Dec 22.05204746
+	Radius 53.37
+	Distance 3891.787
+}
+
+OpenCluster "HSC 1900"
+{
+	RA 5.41351335
+	Dec -33.86333072
+	Radius 51.222
+	Distance 188.474
+}
+
+OpenCluster "COIN-Gaia 17:Saloranta 10:Theia 2667"
+{
+	RA 5.41430423
+	Dec 37.56609641
+	Radius 58.41
+	Distance 3479.986
+}
+
+OpenCluster "Gulliver 54"
+{
+	RA 5.41813168
+	Dec 33.67777218
+	Radius 71.589
+	Distance 3907.268
+}
+
+OpenCluster "HSC 1309"
+{
+	RA 5.41874252
+	Dec 40.96763326
+	Radius 148.597
+	Distance 13852.494
+}
+
+OpenCluster "HSC 1312"
+{
+	RA 5.4203106
+	Dec 40.24620988
+	Radius 54.18
+	Distance 12659.809
+}
+
+OpenCluster "ASCC 18:MWSC 541:OCSN 58"
+{
+	RA 5.42201679
+	Dec 0.36762755
+	Radius 52.745
+	Distance 1341.593
+}
+
+OpenCluster "HSC 1427"
+{
+	RA 5.42282901
+	Dec 24.34207229
+	Radius 31.565
+	Distance 2368.007
+}
+
+OpenCluster "HSC 1358"
+{
+	RA 5.42677972
+	Dec 33.89646669
+	Radius 30.99
+	Distance 6352.853
+}
+
+OpenCluster "Berkeley 70:FSR 743:MWSC 538:OCL 422"
+{
+	RA 5.43029053
+	Dec 41.95006707
+	Radius 47.606
+	Distance 13028.676
+}
+
+OpenCluster "MWSC 537:NGC 1896"
+{
+	RA 5.43165462
+	Dec 29.22797273
+	Radius 76.68
+	Distance 2643.802
+}
+
+OpenCluster "NGC 1883:Collinder 64:FSR 729:MWSC 539:OCL 417"
+{
+	RA 5.43171245
+	Dec 46.48879723
+	Radius 159.884
+	Distance 13981.422
 }
 
 OpenCluster "Mamajek 3"
 {
-	RA 5.453056
-	Dec 6.266667
-	Distance 300
-	Radius 10.9
+	RA 5.43679444
+	Dec 6.73643939
+	Radius 29.616
+	Distance 327.267
+}
+
+OpenCluster "CWNU 1104:Theia 780"
+{
+	RA 5.44392389
+	Dec 30.31970522
+	Radius 121.88
+	Distance 3020.949
+}
+
+OpenCluster "HSC 1300"
+{
+	RA 5.44413845
+	Dec 42.2274545
+	Radius 163.645
+	Distance 13339.168
+}
+
+OpenCluster "Czernik 21"
+{
+	RA 5.44503911
+	Dec 36.01833301
+	Radius 106.225
+	Distance 10767.5
+}
+
+OpenCluster "HSC 1387"
+{
+	RA 5.45427585
+	Dec 29.73823201
+	Radius 33.952
+	Distance 4122.728
+}
+
+OpenCluster "HSC 1356"
+{
+	RA 5.4577696
+	Dec 34.37328279
+	Radius 25.933
+	Distance 6580.665
+}
+
+OpenCluster "COIN-Gaia 40"
+{
+	RA 5.4594419
+	Dec 33.51469479
+	Radius 46.226
+	Distance 6585.504
+}
+
+OpenCluster "HXWHB 10:UBC 1283"
+{
+	RA 5.46202429
+	Dec 33.28342013
+	Radius 76.32
+	Distance 7510.825
+}
+
+OpenCluster "HXHWL 53"
+{
+	RA 5.4635934
+	Dec 32.6618485
+	Radius 17.126
+	Distance 4955.87
 }
 
 OpenCluster "ASCC 19"
 {
-	RA 5.463056
-	Dec -0.020000
-	Distance 1141
-	Radius 15.9
+	RA 5.46520866
+	Dec -1.8560224
+	Radius 17.784
+	Distance 1148.329
 }
 
-OpenCluster "Waterloo 2"
+OpenCluster "HSC 1408"
 {
-	RA 5.466944
-	Dec 40.371667
-	Distance 1859
-	Radius 1.1
+	RA 5.4660111
+	Dec 27.82978531
+	Radius 41.859
+	Distance 13693.144
 }
 
-OpenCluster "NGC 1907"
+OpenCluster "Stock 8:Theia 1658"
 {
-	RA 5.468056
-	Dec 35.325000
-	Distance 5871
-	Radius 6.0
+	RA 5.4685784
+	Dec 34.42083239
+	Radius 70.817
+	Distance 6390.845
 }
 
-OpenCluster "Stock 8"
+OpenCluster "CWNU 1567"
 {
-	RA 5.468611
-	Dec 34.423333
-	Distance 6539
-	Radius 11.4
+	RA 5.46858375
+	Dec 56.38657992
+	Radius 70.16
+	Distance 8239.82
 }
 
-OpenCluster "Kronberger 1"
+OpenCluster "NGC 1907:Melotte 35:Collinder 66:FSR 774:MWSC 552:OCL 434:Theia 3773"
 {
-	RA 5.472500
-	Dec 34.775000
-	Distance 6197
-	Radius 1.4
+	RA 5.46860013
+	Dec 35.32409105
+	Radius 63.041
+	Distance 4902.951
 }
 
-OpenCluster "NGC 1912"
+OpenCluster "HSC 1322"
 {
-	RA 5.477778
-	Dec 35.848333
-	Distance 4566
-	Radius 13.3
+	RA 5.46965415
+	Dec 39.51587048
+	Radius 124.387
+	Distance 14511.589
 }
 
-OpenCluster "ASCC 20"
+OpenCluster "UBC 198"
 {
-	RA 5.478889
-	Dec 1.630000
-	Distance 1467
-	Radius 19.2
+	RA 5.47284737
+	Dec 35.8062562
+	Radius 67.574
+	Distance 5971.711
+}
+
+OpenCluster "HSC 1351"
+{
+	RA 5.47455186
+	Dec 35.05577054
+	Radius 19.831
+	Distance 6422.931
+}
+
+OpenCluster "HSC 1463"
+{
+	RA 5.47524033
+	Dec 21.08066554
+	Radius 108.736
+	Distance 1768.757
+}
+
+OpenCluster "Starfish Cluster:M 38:NGC 1912:Melotte 36:Collinder 67:MWSC 557:OCL 433:Theia 2549"
+{
+	RA 5.47778288
+	Dec 35.82082347
+	Radius 71.68
+	Distance 3540.285
+}
+
+OpenCluster "COIN-Gaia 19:Stock 8:Theia 3889"
+{
+	RA 5.47942374
+	Dec 34.3361242
+	Radius 116.412
+	Distance 3984.998
+}
+
+OpenCluster "ASCC 20:OCSN 57"
+{
+	RA 5.47957028
+	Dec 1.72130405
+	Radius 33.549
+	Distance 1178.102
+}
+
+OpenCluster "HSC 1414"
+{
+	RA 5.48023738
+	Dec 27.36253614
+	Radius 47.958
+	Distance 12670.148
 }
 
 OpenCluster "ASCC 21"
 {
-	RA 5.483056
-	Dec 3.650000
-	Distance 1630
-	Radius 22.8
+	RA 5.48080269
+	Dec 3.60658547
+	Radius 34.676
+	Distance 1111.327
+}
+
+OpenCluster "OC 0276:UBC 59"
+{
+	RA 5.48221153
+	Dec 48.00973718
+	Radius 34.876
+	Distance 7050.643
+}
+
+OpenCluster "HSC 1333"
+{
+	RA 5.48369971
+	Dec 37.95283186
+	Radius 75.705
+	Distance 3579.45
+}
+
+OpenCluster "HSC 1398"
+{
+	RA 5.49053235
+	Dec 28.96925138
+	Radius 112.129
+	Distance 17533.739
+}
+
+OpenCluster "HSC 1517"
+{
+	RA 5.49218975
+	Dec 12.76375745
+	Radius 85.504
+	Distance 4482.993
+}
+
+OpenCluster "HSC 1389"
+{
+	RA 5.49401821
+	Dec 30.03825247
+	Radius 53.804
+	Distance 12279.978
+}
+
+OpenCluster "HSC 1329"
+{
+	RA 5.49745686
+	Dec 38.46163759
+	Radius 124.179
+	Distance 12538.683
+}
+
+OpenCluster "ASCC 19:Theia 139"
+{
+	RA 5.50069051
+	Dec -2.11038248
+	Radius 101.498
+	Distance 1048.7
+}
+
+OpenCluster "HSC 1348"
+{
+	RA 5.5041132
+	Dec 35.36995533
+	Radius 47.82
+	Distance 2987.553
+}
+
+OpenCluster "DSH J0530.4+2706:Teutsch 90"
+{
+	RA 5.50699271
+	Dec 27.09933246
+	Radius 45.401
+	Distance 12481.836
+}
+
+OpenCluster "HSC 1328"
+{
+	RA 5.51298374
+	Dec 38.59966115
+	Radius 79.168
+	Distance 15383.207
 }
 
 OpenCluster "NGC 1931"
 {
-	RA 5.523611
-	Dec 34.245000
-	Distance 10065
-	Radius 7.3
+	RA 5.52349194
+	Dec 34.22435327
+	Radius 29.954
+	Distance 6895.303
 }
 
-OpenCluster "Berkeley 20"
+OpenCluster "HSC 1402"
 {
-	RA 5.543611
-	Dec 0.188333
-	Distance 27398
-	Radius 8.0
+	RA 5.52535518
+	Dec 28.83979038
+	Radius 41.786
+	Distance 2992.787
 }
 
-OpenCluster "Collinder 69"
+OpenCluster "FSR 1017:MWSC 567"
 {
-	RA 5.585000
-	Dec 9.933333
-	Distance 1304
-	Radius 13.3
+	RA 5.53125277
+	Dec -3.03508934
+	Radius 57.827
+	Distance 101.698
 }
 
-OpenCluster "NGC 1981"
+OpenCluster "CWNU 195"
 {
-	RA 5.585833
-	Dec -3.568333
-	Distance 1304
-	Radius 5.3
+	RA 5.53142293
+	Dec 29.07123266
+	Radius 73.662
+	Distance 6010.436
 }
 
-OpenCluster "NGC 1977"
+OpenCluster "Mamajek 3:Theia 224"
 {
-	RA 5.587778
-	Dec -3.180000
-	Distance 1552
-	Radius 4.5
+	RA 5.53587053
+	Dec 5.14998636
+	Radius 128.405
+	Distance 958.519
 }
 
-OpenCluster "NGC 1976"
+OpenCluster "OC 0339"
 {
-	RA 5.587778
-	Dec -4.610000
-	Distance 1350
-	Radius 9.2
+	RA 5.54126103
+	Dec -0.41880692
+	Radius 16.005
+	Distance 1162.562
 }
 
-OpenCluster "NGC 1980"
+OpenCluster "Collinder 70:Gulliver 6:Theia 13:UBC 17b"
 {
-	RA 5.590000
-	Dec -4.085000
-	Distance 1630
-	Radius 4.7
+	RA 5.54216202
+	Dec -1.75276594
+	Radius 31.72
+	Distance 1333.478
 }
 
-OpenCluster "Collinder 70"
+OpenCluster "Theia 415"
 {
-	RA 5.591667
-	Dec -0.900000
-	Distance 1262
-	Radius 25.7
+	RA 5.54223281
+	Dec 38.33123665
+	Radius 28.38
+	Distance 2674.077
 }
 
-OpenCluster "NGC 1960"
+OpenCluster "CWNU 2180"
 {
-	RA 5.605000
-	Dec 34.140000
-	Distance 4338
-	Radius 6.3
+	RA 5.54335293
+	Dec 30.60186352
+	Radius 47.339
+	Distance 4078.789
 }
 
-OpenCluster "Koposov 36"
+OpenCluster "Berkeley 20:MWSC 572:OCL 497"
 {
-	RA 5.614167
-	Dec 31.210833
-	Distance 4892
-	Radius 6.4
+	RA 5.54362511
+	Dec 0.18844258
+	Radius 218.032
+	Distance 25416.007
 }
 
-OpenCluster "NGC 1996"
+OpenCluster "CWNU 1810"
 {
-	RA 5.636111
-	Dec 25.816667
-	Distance 4566
-	Radius 14.6
+	RA 5.54602583
+	Dec 40.78032198
+	Radius 104.235
+	Distance 12989.565
 }
 
-OpenCluster "Sigma Orionis"
+OpenCluster "HSC 1692"
 {
-	RA 5.645000
-	Dec -1.400000
-	Distance 1301
-	Radius 1.9
+	RA 5.54786212
+	Dec -11.28942072
+	Radius 53.376
+	Distance 846.952
 }
 
-OpenCluster "Stock 10"
+OpenCluster "HSC 1388"
 {
-	RA 5.650000
-	Dec 37.933333
-	Distance 1239
-	Radius 4.5
+	RA 5.55166093
+	Dec 30.56895434
+	Radius 44.534
+	Distance 9492.035
 }
 
-OpenCluster "Koposov 27"
+OpenCluster "FSR 0761:UBC 197"
 {
-	RA 5.658333
-	Dec 33.350000
-	Distance 11742
-	Radius 5.1
+	RA 5.55554034
+	Dec 39.83449368
+	Radius 46.551
+	Distance 8822.74
 }
 
-OpenCluster "Berkeley 71"
+OpenCluster "CWNU 2145"
 {
-	RA 5.681944
-	Dec 32.277778
-	Distance 10633
-	Radius 9.6
+	RA 5.56084005
+	Dec 36.46520452
+	Radius 66.282
+	Distance 5221.446
 }
 
-OpenCluster "Koposov 77"
+OpenCluster "HSC 1392"
 {
-	RA 5.731111
-	Dec 21.710278
-	Distance 5707
-	Radius 4.2
+	RA 5.56255298
+	Dec 30.25840725
+	Radius 31.987
+	Distance 5417.445
 }
 
-OpenCluster "Teutsch 10"
+OpenCluster "UPK 369"
 {
-	RA 5.739444
-	Dec 28.820278
-	Distance 8480
-	Radius 7.4
+	RA 5.56698489
+	Dec 30.35148128
+	Radius 48.313
+	Distance 2356.301
 }
 
-OpenCluster "Koposov 10"
+OpenCluster "OCSN 56"
 {
-	RA 5.791389
-	Dec 35.432222
-	Distance 6523
-	Radius 3.8
+	RA 5.57187968
+	Dec 2.62920327
+	Radius 68.756
+	Distance 1344.152
 }
 
-OpenCluster "Basel 4"
+OpenCluster "CWNU 465:UBC 1280"
 {
-	RA 5.808333
-	Dec 30.216667
-	Distance 9785
-	Radius 5.1
+	RA 5.57441088
+	Dec 37.24567019
+	Radius 59.602
+	Distance 7201.856
 }
 
-OpenCluster "Collinder 74"
+OpenCluster "UBC 1279"
 {
-	RA 5.811111
-	Dec 7.358333
-	Distance 8186
-	Radius 7.1
+	RA 5.57532277
+	Dec 39.01141565
+	Radius 27.755
+	Distance 6312.524
 }
 
-OpenCluster "King 8"
+OpenCluster "HSC 1404"
 {
-	RA 5.823333
-	Dec 33.633333
-	Distance 20884
-	Radius 12.2
+	RA 5.58324436
+	Dec 29.24512359
+	Radius 29.452
+	Distance 2954.199
 }
 
-OpenCluster "Czernik 23"
+OpenCluster "Collinder 70:OCSN 65:Theia 13"
 {
-	RA 5.834444
-	Dec 28.894722
-	Distance 8154
-	Radius 5.9
+	RA 5.58428051
+	Dec -2.15505865
+	Radius 38.498
+	Distance 1358.93
 }
 
-OpenCluster "Berkeley 72"
+OpenCluster "COIN-Gaia 26:LISC 0988:Theia 2486"
 {
-	RA 5.838333
-	Dec 22.200000
-	Distance 11415
-	Radius 3.3
+	RA 5.58489584
+	Dec 15.70671447
+	Radius 36.706
+	Distance 4336.102
 }
 
-OpenCluster "Berkeley 21"
+OpenCluster "Lower Sword:The Lost Jewel of Orion:NGC 1980:UBC 208:Collinder 72"
 {
-	RA 5.861667
-	Dec 21.783333
-	Distance 16308
-	Radius 11.9
+	RA 5.58670777
+	Dec -5.92125053
+	Radius 32.119
+	Distance 1233.791
 }
 
-OpenCluster "Koposov 43"
+OpenCluster "HSC 1416"
 {
-	RA 5.870833
-	Dec 29.919167
-	Distance 9132
-	Radius 10.6
+	RA 5.58693765
+	Dec 28.07262327
+	Radius 45.001
+	Distance 13266.38
 }
 
-OpenCluster "NGC 2099"
+OpenCluster "Lambda Orionis Cluster:Collinder 69:FSR 0934:FSR 934:MWSC 585"
 {
-	RA 5.871667
-	Dec 32.553333
-	Distance 4510
-	Radius 9.2
+	RA 5.58761175
+	Dec 9.88805505
+	Radius 93.932
+	Distance 1284.323
 }
 
-OpenCluster "NGC 2112"
+OpenCluster "HSC 1350"
 {
-	RA 5.895833
-	Dec 0.410000
-	Distance 3065
-	Radius 8.0
+	RA 5.58992011
+	Dec 35.99317225
+	Radius 69.576
+	Distance 3550.409
 }
 
-OpenCluster "Teutsch 51"
+OpenCluster "CWNU 1158:Kronberger 92"
 {
-	RA 5.897778
-	Dec 26.829722
-	Distance 10763
-	Radius 5.6
+	RA 5.59012986
+	Dec 44.19483723
+	Radius 43.064
+	Distance 3879.224
 }
 
-OpenCluster "Czernik 24"
+OpenCluster "Pinwheel Cluster:M 36:NGC 1960:CWNU 2673:XDOCC 2"
 {
-	RA 5.923611
-	Dec 20.886389
-	Distance 15003
-	Radius 10.9
+	RA 5.60219706
+	Dec 34.29120538
+	Radius 20.289
+	Distance 4068.181
 }
 
-OpenCluster "Basel 11b"
+OpenCluster "HSC 1418"
 {
-	RA 5.970000
-	Dec 21.966667
-	Distance 5871
-	Radius 6.0
+	RA 5.60397614
+	Dec 27.6560472
+	Radius 50.199
+	Distance 7076.678
 }
 
-OpenCluster "Berkeley 22"
+OpenCluster "Collinder 70:OCSN 61"
 {
-	RA 5.974167
-	Dec 7.756667
-	Distance 19570
-	Radius 4.3
+	RA 5.60557675
+	Dec -0.40216642
+	Radius 32.474
+	Distance 1231.648
 }
 
-OpenCluster "Koposov 12"
+OpenCluster "Theia 2010"
 {
-	RA 6.015556
-	Dec 35.276667
-	Distance 6686
-	Radius 8.8
+	RA 5.60568784
+	Dec 34.13422525
+	Radius 75.691
+	Distance 3668.675
+}
+
+OpenCluster "CWNU 1379"
+{
+	RA 5.60683069
+	Dec 24.7857659
+	Radius 45.836
+	Distance 4556.814
+}
+
+OpenCluster "HSC 1456"
+{
+	RA 5.60879241
+	Dec 22.85226655
+	Radius 47.127
+	Distance 929.281
+}
+
+OpenCluster "Theia 7082"
+{
+	RA 5.61179394
+	Dec 40.01584539
+	Radius 91.525
+	Distance 4276.079
+}
+
+OpenCluster "FSR 0814:FSR 814:Koposov 36:MWSC 600:MWSC 601:Teutsch J0536.8+3112"
+{
+	RA 5.61392338
+	Dec 31.20805451
+	Radius 54.477
+	Distance 5364.207
+}
+
+OpenCluster "Theia 65"
+{
+	RA 5.61723985
+	Dec 23.51630851
+	Radius 61.453
+	Distance 351.213
+}
+
+OpenCluster "HSC 1419"
+{
+	RA 5.62183112
+	Dec 27.59059467
+	Radius 96.38
+	Distance 18313.231
+}
+
+OpenCluster "HSC 1332"
+{
+	RA 5.62427409
+	Dec 39.03248449
+	Radius 33.589
+	Distance 9314.838
+}
+
+OpenCluster "Theia 3582:Theia 412"
+{
+	RA 5.62951651
+	Dec 31.00259066
+	Radius 132.959
+	Distance 2109.039
+}
+
+OpenCluster "HSC 1379"
+{
+	RA 5.63090347
+	Dec 31.98334744
+	Radius 96.912
+	Distance 5198.281
+}
+
+OpenCluster "CWNU 2636"
+{
+	RA 5.63157977
+	Dec 37.20983743
+	Radius 103.873
+	Distance 11447.544
+}
+
+OpenCluster "OCSN 68"
+{
+	RA 5.63271475
+	Dec -4.9107565
+	Radius 49.923
+	Distance 1364.346
+}
+
+OpenCluster "LISC-III 3517:Renou 23:Theia 938:UBC 8"
+{
+	RA 5.6350757
+	Dec 57.10841925
+	Radius 144.731
+	Distance 1539.796
+}
+
+OpenCluster "CWNU 2078:FSR 0812"
+{
+	RA 5.63650846
+	Dec 31.73407198
+	Radius 138.331
+	Distance 9567.865
+}
+
+OpenCluster "HSC 1439"
+{
+	RA 5.64179053
+	Dec 25.20719817
+	Radius 66.776
+	Distance 17510.4
+}
+
+OpenCluster "Sigma Orionis:UBC 205"
+{
+	RA 5.64732426
+	Dec -2.6097557
+	Radius 29.071
+	Distance 1291.841
+}
+
+OpenCluster "HSC 1289"
+{
+	RA 5.64743721
+	Dec 46.15789216
+	Radius 74.865
+	Distance 8538.423
+}
+
+OpenCluster "Stock 10:Theia 609"
+{
+	RA 5.64943982
+	Dec 37.80836692
+	Radius 104.436
+	Distance 1153.09
+}
+
+OpenCluster "COIN-Gaia 21"
+{
+	RA 5.65030482
+	Dec 28.43665702
+	Radius 37.237
+	Distance 4331.992
+}
+
+OpenCluster "Theia 13:UBC 17a"
+{
+	RA 5.65171834
+	Dec -1.93244115
+	Radius 36.548
+	Distance 1163.611
+}
+
+OpenCluster "CWNU 1718"
+{
+	RA 5.65366796
+	Dec 32.6086218
+	Radius 42.632
+	Distance 6497.127
+}
+
+OpenCluster "HSC 1428"
+{
+	RA 5.65413742
+	Dec 26.34826079
+	Radius 41.351
+	Distance 2407.558
+}
+
+OpenCluster "Gulliver 22:Theia 761"
+{
+	RA 5.65494605
+	Dec 26.34502001
+	Radius 132.383
+	Distance 2391.191
+}
+
+OpenCluster "CWNU 1571:FSR 0817"
+{
+	RA 5.65732819
+	Dec 30.89024937
+	Radius 47.784
+	Distance 4409.85
+}
+
+OpenCluster "DSH J0539.4+3320:Koposov 27:MWSC 624:MWSC 625:Teutsch 1"
+{
+	RA 5.65818076
+	Dec 33.34476732
+	Radius 71.078
+	Distance 12014.249
+}
+
+OpenCluster "HSC 1608"
+{
+	RA 5.66015938
+	Dec 0.822691
+	Radius 146.236
+	Distance 2334.366
+}
+
+OpenCluster "CWNU 525:Stock 10:Theia 2077"
+{
+	RA 5.66171011
+	Dec 37.50061863
+	Radius 75.808
+	Distance 3642.655
+}
+
+OpenCluster "HSC 1489"
+{
+	RA 5.66550209
+	Dec 19.20491449
+	Radius 84.725
+	Distance 14190.285
+}
+
+OpenCluster "HSC 1421"
+{
+	RA 5.67060923
+	Dec 27.45419967
+	Radius 43.88
+	Distance 4937.816
+}
+
+OpenCluster "CWNU 1111"
+{
+	RA 5.67356547
+	Dec 13.70720141
+	Radius 46.796
+	Distance 869.757
+}
+
+OpenCluster "CWNU 1464"
+{
+	RA 5.67616284
+	Dec 31.84111481
+	Radius 107.832
+	Distance 4161.303
+}
+
+OpenCluster "HSC 1385"
+{
+	RA 5.67811355
+	Dec 31.79878326
+	Radius 71.9
+	Distance 2409.187
+}
+
+OpenCluster "CWNU 2446"
+{
+	RA 5.67821277
+	Dec 32.56661453
+	Radius 62.128
+	Distance 6351.296
+}
+
+OpenCluster "HSC 1490"
+{
+	RA 5.67980451
+	Dec 19.23931548
+	Radius 65.845
+	Distance 24121.089
+}
+
+OpenCluster "Berkeley 71:FSR 810:MWSC 634:OCL 449:Theia 1857"
+{
+	RA 5.6827883
+	Dec 32.27269948
+	Radius 95.823
+	Distance 11420.48
+}
+
+OpenCluster "OCSN 70:OC 0356"
+{
+	RA 5.68289898
+	Dec -9.28738374
+	Radius 11.226
+	Distance 1388.871
+}
+
+OpenCluster "FSR 0874:Theia 2220"
+{
+	RA 5.68568001
+	Dec 20.32335601
+	Radius 37.934
+	Distance 4682.592
+}
+
+OpenCluster "OCSN 70:OC 0356"
+{
+	RA 5.68571005
+	Dec -9.52376611
+	Radius 14.517
+	Distance 1440.067
+}
+
+OpenCluster "Teutsch 2"
+{
+	RA 5.68952804
+	Dec 39.23814261
+	Radius 195.392
+	Distance 13753.384
+}
+
+OpenCluster "CWNU 1684"
+{
+	RA 5.69061441
+	Dec 28.19651017
+	Radius 56.927
+	Distance 4926.802
+}
+
+OpenCluster "Theia 345"
+{
+	RA 5.69371362
+	Dec 19.19284421
+	Radius 80.349
+	Distance 1619.384
+}
+
+OpenCluster "Theia 176"
+{
+	RA 5.69490999
+	Dec -15.0461653
+	Radius 53.757
+	Distance 1839.006
+}
+
+OpenCluster "CWNU 127:Theia 1806"
+{
+	RA 5.69555989
+	Dec 27.50033313
+	Radius 33.736
+	Distance 4194.323
+}
+
+OpenCluster "HSC 1377"
+{
+	RA 5.69646774
+	Dec 32.63512478
+	Radius 43.129
+	Distance 11701.323
+}
+
+OpenCluster "CWNU 194:UBC 1289"
+{
+	RA 5.69896805
+	Dec 29.40152209
+	Radius 56.291
+	Distance 6623.072
+}
+
+OpenCluster "CWNU 126:Theia 1798"
+{
+	RA 5.6998857
+	Dec 30.2264279
+	Radius 108.092
+	Distance 5651.445
+}
+
+OpenCluster "CWNU 300:UBC 1297"
+{
+	RA 5.70652737
+	Dec 25.74238918
+	Radius 81.975
+	Distance 3997.213
+}
+
+OpenCluster "CWNU 2332"
+{
+	RA 5.70807684
+	Dec 29.80006149
+	Radius 74.61
+	Distance 8181.617
+}
+
+OpenCluster "L 1641S"
+{
+	RA 5.70942048
+	Dec -8.1379881
+	Radius 17.828
+	Distance 1362.296
+}
+
+OpenCluster "HSC 1441"
+{
+	RA 5.70953463
+	Dec 25.71355527
+	Radius 59.335
+	Distance 2493.801
+}
+
+OpenCluster "OC 0292"
+{
+	RA 5.71011291
+	Dec 36.18970454
+	Radius 88.741
+	Distance 5250.07
+}
+
+OpenCluster "HSC 1443"
+{
+	RA 5.7128882
+	Dec 25.28532874
+	Radius 62.214
+	Distance 13464.531
+}
+
+OpenCluster "HSC 1684"
+{
+	RA 5.71383792
+	Dec -9.37612039
+	Radius 26.965
+	Distance 285.859
+}
+
+OpenCluster "FSR 0826"
+{
+	RA 5.71508761
+	Dec 28.94980104
+	Radius 142.775
+	Distance 9803.756
+}
+
+OpenCluster "COIN-Gaia 27:Streicher 52:Theia 3018"
+{
+	RA 5.7193764
+	Dec 13.70859469
+	Radius 40.271
+	Distance 3385.645
+}
+
+OpenCluster "CWNU 1088"
+{
+	RA 5.72706214
+	Dec -1.59277638
+	Radius 58.358
+	Distance 1482.532
+}
+
+OpenCluster "HSC 1375"
+{
+	RA 5.73013515
+	Dec 33.28753696
+	Radius 55.157
+	Distance 4959.015
+}
+
+OpenCluster "HSC 1766"
+{
+	RA 5.73025391
+	Dec -20.14580738
+	Radius 38.939
+	Distance 366.817
+}
+
+OpenCluster "Theia 36:UPK 398"
+{
+	RA 5.73039851
+	Dec 7.05923289
+	Radius 91.629
+	Distance 1424.143
+}
+
+OpenCluster "HSC 1342"
+{
+	RA 5.73077323
+	Dec 38.22429327
+	Radius 62.871
+	Distance 12634.668
+}
+
+OpenCluster "PHOC 34"
+{
+	RA 5.73080714
+	Dec 30.09063059
+	Radius 36.304
+	Distance 5568.43
+}
+
+OpenCluster "HSC 1381"
+{
+	RA 5.7338092
+	Dec 32.64097821
+	Radius 114.883
+	Distance 11908.333
+}
+
+OpenCluster "DSH J0544.3+2848:FSR 829:Koposov 49:MWSC 661:Teutsch 10"
+{
+	RA 5.73984725
+	Dec 28.81664099
+	Radius 43.636
+	Distance 9544.756
+}
+
+OpenCluster "HSC 1432"
+{
+	RA 5.74202396
+	Dec 26.87588302
+	Radius 44.801
+	Distance 8208.794
+}
+
+OpenCluster "HSC 1472"
+{
+	RA 5.74307034
+	Dec 21.8471866
+	Radius 26.699
+	Distance 4207.339
+}
+
+OpenCluster "CWNU 176:UBC 1295"
+{
+	RA 5.74780664
+	Dec 26.89645223
+	Radius 67.169
+	Distance 5552.733
+}
+
+OpenCluster "FSR 0850:OC 0299:Theia 2104:Theia 2865"
+{
+	RA 5.74938482
+	Dec 24.745201
+	Radius 47.869
+	Distance 6705.554
+}
+
+OpenCluster "HSC 1362"
+{
+	RA 5.75127393
+	Dec 35.48750563
+	Radius 35.969
+	Distance 9635.348
+}
+
+OpenCluster "HSC 1411"
+{
+	RA 5.75648893
+	Dec 30.08500799
+	Radius 33.149
+	Distance 4133.303
+}
+
+OpenCluster "FSR 0850:OC 0300"
+{
+	RA 5.75885339
+	Dec 24.78440147
+	Radius 46.627
+	Distance 5017.601
+}
+
+OpenCluster "CWNU 255"
+{
+	RA 5.76081423
+	Dec 33.77651142
+	Radius 55.048
+	Distance 4328.938
+}
+
+OpenCluster "HSC 1496"
+{
+	RA 5.76237334
+	Dec 19.04306494
+	Radius 68.006
+	Distance 18782.096
+}
+
+OpenCluster "HSC 1282"
+{
+	RA 5.76906554
+	Dec 48.34535889
+	Radius 120.144
+	Distance 12399.497
+}
+
+OpenCluster "Theia 567:Theia 648"
+{
+	RA 5.77185317
+	Dec 25.96468797
+	Radius 64.023
+	Distance 1836.244
+}
+
+OpenCluster "HSC 1366"
+{
+	RA 5.77499726
+	Dec 35.15353702
+	Radius 45.453
+	Distance 8702.979
+}
+
+OpenCluster "HSC 1330"
+{
+	RA 5.77634151
+	Dec 40.40513146
+	Radius 344.514
+	Distance 1985.625
+}
+
+OpenCluster "NGC 2068:OCSN 62:OC 0341"
+{
+	RA 5.77724757
+	Dec 0.138454
+	Radius 40.568
+	Distance 1318.329
+}
+
+OpenCluster "CWNU 2063"
+{
+	RA 5.77957043
+	Dec 24.74573873
+	Radius 43.816
+	Distance 11478.677
+}
+
+OpenCluster "UBC 1285"
+{
+	RA 5.78198336
+	Dec 32.15994348
+	Radius 82.74
+	Distance 7815.431
+}
+
+OpenCluster "HSC 1468"
+{
+	RA 5.78979895
+	Dec 23.20475679
+	Radius 26.831
+	Distance 7021.332
+}
+
+OpenCluster "FSR 0795:FSR 795:Koposov 10:MWSC 668:MWSC 669"
+{
+	RA 5.79097315
+	Dec 35.4213628
+	Radius 50.277
+	Distance 8802.132
+}
+
+OpenCluster "DSH J0548.0+2529:Teutsch 57"
+{
+	RA 5.799731
+	Dec 25.5004684
+	Radius 179.142
+	Distance 15394.192
+}
+
+OpenCluster "CWNU 173:Theia 856"
+{
+	RA 5.80281091
+	Dec 39.26275871
+	Radius 27.645
+	Distance 2753.484
+}
+
+OpenCluster "OCSN 75:Theia 807"
+{
+	RA 5.80454293
+	Dec -18.71405135
+	Radius 129.663
+	Distance 1081.913
+}
+
+OpenCluster "Collinder 74:FSR 973:MWSC 673:OCL 489"
+{
+	RA 5.81123186
+	Dec 7.36764591
+	Radius 99.27
+	Distance 8041.42
+}
+
+OpenCluster "HSC 1462"
+{
+	RA 5.811542
+	Dec 23.99181455
+	Radius 37.265
+	Distance 2677.21
+}
+
+OpenCluster "CWNU 1072"
+{
+	RA 5.81350113
+	Dec -5.45588011
+	Radius 49.834
+	Distance 1435.904
+}
+
+OpenCluster "HSC 1298"
+{
+	RA 5.81555845
+	Dec 45.01497326
+	Radius 88.81
+	Distance 16240.105
+}
+
+OpenCluster "UBC 1278"
+{
+	RA 5.81617156
+	Dec 40.78283423
+	Radius 78.499
+	Distance 9716.867
+}
+
+OpenCluster "Basel 4:Czernik 22:FSR 825:MWSC 672:OCL 455:OC 0295"
+{
+	RA 5.81620778
+	Dec 30.19188752
+	Radius 84.738
+	Distance 9673.833
+}
+
+OpenCluster "CWNU 1423"
+{
+	RA 5.8206
+	Dec 17.94559666
+	Radius 34.197
+	Distance 6321.337
+}
+
+OpenCluster "UBC 1300"
+{
+	RA 5.82096608
+	Dec 25.06954048
+	Radius 64.994
+	Distance 11004.826
+}
+
+OpenCluster "CWNU 2749"
+{
+	RA 5.82109389
+	Dec 33.4063901
+	Radius 43.248
+	Distance 11343.39
+}
+
+OpenCluster "King 8:MWSC 675:OCL 448"
+{
+	RA 5.82179559
+	Dec 33.6346266
+	Radius 52.237
+	Distance 15615.637
+}
+
+OpenCluster "HSC 1531"
+{
+	RA 5.82186947
+	Dec 13.83637319
+	Radius 67.087
+	Distance 892.054
+}
+
+OpenCluster "HSC 1417"
+{
+	RA 5.8231032
+	Dec 29.71092963
+	Radius 58.597
+	Distance 4084.344
+}
+
+OpenCluster "Alessi 135:CWNU 2105:Majaess 65"
+{
+	RA 5.82350582
+	Dec 27.04115896
+	Radius 25.727
+	Distance 4796.793
+}
+
+OpenCluster "HSC 1431"
+{
+	RA 5.82471442
+	Dec 27.61042107
+	Radius 49.729
+	Distance 13522.15
+}
+
+OpenCluster "Alessi 135:COIN-Gaia 23:Majaess 65:Theia 497"
+{
+	RA 5.82868615
+	Dec 27.01323423
+	Radius 53.981
+	Distance 2986.538
+}
+
+OpenCluster "Theia 856"
+{
+	RA 5.83145359
+	Dec 38.82232872
+	Radius 92.14
+	Distance 2562.175
+}
+
+OpenCluster "HXHWL 38:Theia 3796"
+{
+	RA 5.83399168
+	Dec 31.67816851
+	Radius 17.864
+	Distance 4264.477
+}
+
+OpenCluster "UPK 402"
+{
+	RA 5.83432889
+	Dec 2.90025226
+	Radius 30.871
+	Distance 1290.092
+}
+
+OpenCluster "CWNU 15:Theia 648"
+{
+	RA 5.83507814
+	Dec 26.13658603
+	Radius 98.117
+	Distance 3604.558
+}
+
+OpenCluster "Czernik 23:FSR 834:MWSC 677:OCL 458"
+{
+	RA 5.83517128
+	Dec 28.89828294
+	Radius 48.363
+	Distance 9897.666
+}
+
+OpenCluster "Berkeley 72:MWSC 679:OCL 464"
+{
+	RA 5.83704267
+	Dec 22.24914464
+	Radius 79.24
+	Distance 16558.307
+}
+
+OpenCluster "CWNU 146:UBC 1290"
+{
+	RA 5.83741812
+	Dec 30.3975565
+	Radius 135.793
+	Distance 9963.875
+}
+
+OpenCluster "Theia 874"
+{
+	RA 5.83816292
+	Dec 34.22783551
+	Radius 148.504
+	Distance 2325.691
+}
+
+OpenCluster "CWNU 1106"
+{
+	RA 5.83914372
+	Dec 8.23060015
+	Radius 23.837
+	Distance 1302.862
+}
+
+OpenCluster "Theia 497"
+{
+	RA 5.8444947
+	Dec 27.11634949
+	Radius 133.86
+	Distance 8261.158
+}
+
+OpenCluster "UBC 433"
+{
+	RA 5.8462818
+	Dec 28.74143322
+	Radius 67.069
+	Distance 12321.3
+}
+
+OpenCluster "Berkeley 21:FSR 875:MWSC 682:OCL 469:Theia 4235"
+{
+	RA 5.8632658
+	Dec 21.81077389
+	Radius 66.728
+	Distance 17268.825
+}
+
+OpenCluster "UPK 422"
+{
+	RA 5.86425607
+	Dec -7.39008228
+	Radius 152.478
+	Distance 951.559
+}
+
+OpenCluster "CWNU 75:UBC 1299"
+{
+	RA 5.86841613
+	Dec 25.83979636
+	Radius 68.316
+	Distance 8436.347
+}
+
+OpenCluster "Salt and Pepper Cluster:M 37:NGC 2099:Melotte 38:Collinder 75:FSR 818:MWSC 689:OCL 451:Theia 3542:Theia 874"
+{
+	RA 5.87200548
+	Dec 32.54084466
+	Radius 145.606
+	Distance 4571.321
+}
+
+OpenCluster "UBC 1284"
+{
+	RA 5.87208742
+	Dec 33.75836981
+	Radius 60.22
+	Distance 12067.384
+}
+
+OpenCluster "FSR 0828:FSR 828:Koposov 43:MWSC 687:MWSC 688"
+{
+	RA 5.87275843
+	Dec 29.91155206
+	Radius 93.314
+	Distance 12625.772
+}
+
+OpenCluster "HSC 1365"
+{
+	RA 5.88596807
+	Dec 36.12393188
+	Radius 53.437
+	Distance 12917.253
+}
+
+OpenCluster "FSR 0852:FSR 852:MWSC 691:SAI 56"
+{
+	RA 5.88899733
+	Dec 25.03318882
+	Radius 136.264
+	Distance 11007.098
+}
+
+OpenCluster "FSR 0852:FSR 852:MWSC 691:OC 0301:SAI 56"
+{
+	RA 5.89188617
+	Dec 25.18337436
+	Radius 126.457
+	Distance 9114.931
+}
+
+OpenCluster "Cmg 119"
+{
+	RA 5.89432408
+	Dec -10.39355701
+	Radius 22.476
+	Distance 2375.022
+}
+
+OpenCluster "NGC 2112:Collinder 76:FSR 1007:LLA 1:MWSC 692:OCL 509:Theia 1633"
+{
+	RA 5.89570122
+	Dec 0.40209988
+	Radius 89.019
+	Distance 3440.934
+}
+
+OpenCluster "DSH J0553.8+2649:FSR 0847:FSR 847:Koposov 52:MWSC 693:Teutsch 51"
+{
+	RA 5.89760663
+	Dec 26.82958964
+	Radius 55.283
+	Distance 12337.252
+}
+
+OpenCluster "Theia 4372:UBC 1293"
+{
+	RA 5.90347403
+	Dec 28.52618411
+	Radius 81.672
+	Distance 7125.742
+}
+
+OpenCluster "HSC 1395"
+{
+	RA 5.90806184
+	Dec 32.47151759
+	Radius 116.36
+	Distance 1644.571
+}
+
+OpenCluster "CWNU 197:UBC 1580"
+{
+	RA 5.90942239
+	Dec 31.16658966
+	Radius 67.438
+	Distance 5468.763
+}
+
+OpenCluster "CWNU 2644"
+{
+	RA 5.91155206
+	Dec 11.30596762
+	Radius 86.869
+	Distance 6528.701
+}
+
+OpenCluster "HSC 1550"
+{
+	RA 5.91262372
+	Dec 11.74948354
+	Radius 135.578
+	Distance 21645.003
+}
+
+OpenCluster "OC 0302"
+{
+	RA 5.91410935
+	Dec 25.09328658
+	Radius 41.328
+	Distance 5813.744
+}
+
+OpenCluster "Czernik 24:FSR 881:MWSC 695:OCL 472"
+{
+	RA 5.92349441
+	Dec 20.87710887
+	Radius 62.432
+	Distance 12141.914
+}
+
+OpenCluster "Theia 1993:UBC 76"
+{
+	RA 5.92580358
+	Dec 17.26464815
+	Radius 49.677
+	Distance 5315.769
+}
+
+OpenCluster "HSC 1435"
+{
+	RA 5.9299178
+	Dec 28.07258881
+	Radius 75.657
+	Distance 12988.605
+}
+
+OpenCluster "UBC 1304"
+{
+	RA 5.93239789
+	Dec 20.12218037
+	Radius 58.549
+	Distance 9835.795
+}
+
+OpenCluster "HSC 1450"
+{
+	RA 5.93302351
+	Dec 25.7158109
+	Radius 121.449
+	Distance 14100.535
+}
+
+OpenCluster "CWNU 1372"
+{
+	RA 5.93358859
+	Dec 32.74320099
+	Radius 82.706
+	Distance 10672.323
+}
+
+OpenCluster "HSC 1324"
+{
+	RA 5.93370546
+	Dec 42.02294512
+	Radius 46.313
+	Distance 7398.935
+}
+
+OpenCluster "HSC 1440"
+{
+	RA 5.94283903
+	Dec 27.65124955
+	Radius 55.173
+	Distance 4780.992
+}
+
+OpenCluster "Theia 1993:UBC 77"
+{
+	RA 5.94572358
+	Dec 16.99679593
+	Radius 67.491
+	Distance 5359.246
+}
+
+OpenCluster "UBC 1286"
+{
+	RA 5.94924759
+	Dec 32.44916828
+	Radius 77.797
+	Distance 12870.134
+}
+
+OpenCluster "CWNU 1617"
+{
+	RA 5.95001049
+	Dec 21.26550254
+	Radius 40.605
+	Distance 6789.819
+}
+
+OpenCluster "HSC 1378"
+{
+	RA 5.95053774
+	Dec 34.42277683
+	Radius 53.766
+	Distance 3343.599
+}
+
+OpenCluster "HSC 1765"
+{
+	RA 5.9507201
+	Dec -18.75180718
+	Radius 59.988
+	Distance 619.736
+}
+
+OpenCluster "HSC 1399"
+{
+	RA 5.95576417
+	Dec 32.65964463
+	Radius 59.362
+	Distance 2442.52
+}
+
+OpenCluster "CWNU 2652"
+{
+	RA 5.95579435
+	Dec 11.33153334
+	Radius 168.23
+	Distance 16066.133
+}
+
+OpenCluster "HSC 1630"
+{
+	RA 5.95686813
+	Dec 0.10471111
+	Radius 293.689
+	Distance 437.944
+}
+
+OpenCluster "CWNU 334:Theia 3187"
+{
+	RA 5.96013797
+	Dec 19.26483579
+	Radius 59.369
+	Distance 3559.048
+}
+
+OpenCluster "CWNU 18:OC 0367"
+{
+	RA 5.963401
+	Dec -14.11430558
+	Radius 73.336
+	Distance 2122.684
+}
+
+OpenCluster "HSC 1473"
+{
+	RA 5.96593848
+	Dec 23.55394738
+	Radius 85.48
+	Distance 11320.916
+}
+
+OpenCluster "CWNU 299"
+{
+	RA 5.96697426
+	Dec 29.57888974
+	Radius 74.854
+	Distance 5037.734
+}
+
+OpenCluster "Basel 11B:Basel 11b:FSR 877:MWSC 696:OCL 469.1:UBC 437"
+{
+	RA 5.96821577
+	Dec 22.09183471
+	Radius 54.54
+	Distance 6026.98
+}
+
+OpenCluster "UBC 1317"
+{
+	RA 5.96935754
+	Dec 9.60205187
+	Radius 62.019
+	Distance 12566.445
+}
+
+OpenCluster "Basel 11B:Basel 11b:FSR 877:MWSC 696:OCL 469.1"
+{
+	RA 5.9700061
+	Dec 21.9736243
+	Radius 33.647
+	Distance 5528.056
+}
+
+OpenCluster "HSC 2437"
+{
+	RA 5.97104189
+	Dec -81.6003461
+	Radius 99.849
+	Distance 816.783
+}
+
+OpenCluster "HSC 1586"
+{
+	RA 5.97366481
+	Dec 7.78533795
+	Radius 21.824
+	Distance 7117.24
+}
+
+OpenCluster "Berkeley 22:MWSC 698:OCL 490"
+{
+	RA 5.97433624
+	Dec 7.75885126
+	Radius 209.572
+	Distance 17398.366
+}
+
+OpenCluster "CWNU 1654"
+{
+	RA 5.97526433
+	Dec 16.2080493
+	Radius 36.697
+	Distance 4260.826
+}
+
+OpenCluster "HSC 1486"
+{
+	RA 5.97801919
+	Dec 22.02218883
+	Radius 162.24
+	Distance 12644.152
+}
+
+OpenCluster "CWNU 1054"
+{
+	RA 5.98186826
+	Dec 0.95361945
+	Radius 61.638
+	Distance 1352.851
+}
+
+OpenCluster "CWNU 1971"
+{
+	RA 5.98337717
+	Dec 23.43380863
+	Radius 103.507
+	Distance 7797.541
+}
+
+OpenCluster "HSC 1386"
+{
+	RA 5.98792947
+	Dec 33.94001582
+	Radius 86.401
+	Distance 14019.638
+}
+
+OpenCluster "COIN-Gaia 41:Theia 3187"
+{
+	RA 5.98849453
+	Dec 18.98747919
+	Radius 96.779
+	Distance 5654.058
+}
+
+OpenCluster "HSC 1601"
+{
+	RA 5.98880803
+	Dec 5.45889314
+	Radius 38.431
+	Distance 4824.672
+}
+
+OpenCluster "Theia 1802"
+{
+	RA 5.9908545
+	Dec 20.71586521
+	Radius 127.912
+	Distance 9822.398
+}
+
+OpenCluster "CWNU 1704"
+{
+	RA 5.99706192
+	Dec 26.13131773
+	Radius 28.769
+	Distance 7874.77
+}
+
+OpenCluster "HSC 1476"
+{
+	RA 5.99764305
+	Dec 23.64617229
+	Radius 136.793
+	Distance 12162.346
+}
+
+OpenCluster "HSC 1407"
+{
+	RA 5.999671
+	Dec 32.10835879
+	Radius 19.635
+	Distance 3236.47
+}
+
+OpenCluster "HSC 1581"
+{
+	RA 6.00437576
+	Dec 8.56570378
+	Radius 43.281
+	Distance 5894.737
+}
+
+OpenCluster "CWNU 1451"
+{
+	RA 6.00448028
+	Dec 24.40575196
+	Radius 50.891
+	Distance 5903.296
+}
+
+OpenCluster "CWNU 2637"
+{
+	RA 6.00483398
+	Dec 21.48643224
+	Radius 91.959
+	Distance 10438.64
+}
+
+OpenCluster "CWNU 516:Theia 2231"
+{
+	RA 6.00899018
+	Dec 27.6856494
+	Radius 36.192
+	Distance 5229.514
+}
+
+OpenCluster "UBC 1294"
+{
+	RA 6.00976057
+	Dec 29.31504895
+	Radius 47.367
+	Distance 9829.817
+}
+
+OpenCluster "HSC 1413"
+{
+	RA 6.01637216
+	Dec 32.00629904
+	Radius 76.344
+	Distance 14970.279
+}
+
+OpenCluster "Alessi J0601.6+35b:FSR 802:Koposov 12:MWSC 701:MWSC 702:Theia 2614:Theia 3400"
+{
+	RA 6.01643645
+	Dec 35.26562511
+	Radius 42.899
+	Distance 7462.455
+}
+
+OpenCluster "OCSN 81:Theia 229"
+{
+	RA 6.01683703
+	Dec -27.85041429
+	Radius 202.831
+	Distance 994.718
 }
 
 OpenCluster "NGC 2129"
 {
-	RA 6.018611
-	Dec 23.322222
-	Distance 7175
-	Radius 5.2
+	RA 6.01850039
+	Dec 23.32464592
+	Radius 91.278
+	Distance 6054.363
 }
 
-OpenCluster "NGC 2126"
+OpenCluster "HSC 1464"
 {
-	RA 6.041389
-	Dec 49.917778
-	Distance 3555
-	Radius 3.3
+	RA 6.01901536
+	Dec 25.593595
+	Radius 159.081
+	Distance 15002.877
 }
 
-OpenCluster "NGC 2141"
+OpenCluster "CWNU 1471"
 {
-	RA 6.048611
-	Dec 10.446667
-	Distance 13154
-	Radius 19.1
+	RA 6.01903892
+	Dec 25.95080041
+	Radius 26.217
+	Distance 6125.588
 }
 
-OpenCluster "NGC 2143"
+OpenCluster "HSC 1522"
 {
-	RA 6.051944
-	Dec 5.728333
-	Distance 2609
-	Radius 4.2
+	RA 6.01987028
+	Dec 16.67975752
+	Radius 68.186
+	Distance 19709.482
 }
 
-OpenCluster "IC 2157"
+OpenCluster "CWNU 257:Theia 3428:UBC 1325"
 {
-	RA 6.080556
-	Dec 24.055833
-	Distance 6653
-	Radius 4.8
+	RA 6.02006839
+	Dec 4.60233354
+	Radius 63.17
+	Distance 4309.129
 }
 
-OpenCluster "ESO 425-06"
+OpenCluster "HSC 1445"
 {
-	RA 6.080556
-	Dec -28.816944
-	Distance 3587
-	Radius 2.6
+	RA 6.02167655
+	Dec 27.21160817
+	Radius 101.407
+	Distance 5898.962
 }
 
-OpenCluster "NGC 2158"
+OpenCluster "CWNU 2142"
 {
-	RA 6.123611
-	Dec 24.096667
-	Distance 16539
-	Radius 12.0
+	RA 6.02397186
+	Dec 27.63324081
+	Radius 27.411
+	Distance 11524.104
 }
 
-OpenCluster "NGC 2169"
+OpenCluster "HSC 1360"
 {
-	RA 6.140000
-	Dec 13.965000
-	Distance 3431
-	Radius 2.5
+	RA 6.02508679
+	Dec 37.82061043
+	Radius 62.698
+	Distance 11504.246
 }
 
-OpenCluster "Kharchenko 1"
+OpenCluster "Alessi J0601.6+3531:Alessi J0601.6+3531a:Theia 3400:UBC 1579"
 {
-	RA 6.146667
-	Dec 24.331667
-	Distance 8219
-	Radius 8.4
+	RA 6.02649627
+	Dec 35.52551595
+	Radius 18.863
+	Distance 5222.367
 }
 
-OpenCluster "NGC 2168"
+OpenCluster "OC 0361"
 {
-	RA 6.148333
-	Dec 24.333333
-	Distance 2974
-	Radius 17.3
+	RA 6.03430598
+	Dec -9.97238119
+	Radius 7.395
+	Distance 2606.323
 }
 
-OpenCluster "Koposov 53"
+OpenCluster "HSC 1941"
 {
-	RA 6.148889
-	Dec 26.263611
-	Distance 11252
-	Radius 8.2
+	RA 6.03590765
+	Dec -35.80474521
+	Radius 42.009
+	Distance 885.664
 }
 
-OpenCluster "DC 8"
+OpenCluster "UBC 1298"
 {
-	RA 6.155833
-	Dec 31.231667
-	Distance 6849
-	Radius 0.8
+	RA 6.03659918
+	Dec 28.23757481
+	Radius 68.253
+	Distance 9740.996
 }
 
-OpenCluster "Platais 5"
+OpenCluster "DSH J0602.2+2608:Teutsch 92:UBC 1301"
 {
-	RA 6.160000
-	Dec -21.848333
-	Distance 887
-	Radius 38.7
+	RA 6.03727458
+	Dec 26.15094088
+	Radius 55.632
+	Distance 10965.969
 }
 
-OpenCluster "NGC 2175"
+OpenCluster "HSC 1482"
 {
-	RA 6.160833
-	Dec 20.486667
-	Distance 5306
-	Radius 17.0
+	RA 6.04154379
+	Dec 22.87242768
+	Radius 73.979
+	Distance 13573.139
 }
 
-OpenCluster "NGC 2180"
+OpenCluster "NGC 2126:Melotte 39:Collinder 78:FSR 730:MWSC 708:OCL 418:Theia 6270:UBC 196"
 {
-	RA 6.163333
-	Dec 4.807222
-	Distance 2968
-	Radius 4.3
+	RA 6.04330061
+	Dec 49.87188942
+	Radius 56.996
+	Distance 4071.025
 }
 
-OpenCluster "Koposov 63"
+OpenCluster "HSC 1539"
 {
-	RA 6.167222
-	Dec 24.560556
-	Distance 9785
-	Radius 7.1
+	RA 6.04608076
+	Dec 14.59394357
+	Radius 59.163
+	Distance 2725.675
+}
+
+OpenCluster "COIN-Gaia 24"
+{
+	RA 6.04824407
+	Dec 23.16394984
+	Radius 44.039
+	Distance 3152.988
+}
+
+OpenCluster "NGC 2141:Collinder 79:FSR 971:MWSC 710:OCL 487"
+{
+	RA 6.04963039
+	Dec 10.45550656
+	Radius 81.618
+	Distance 13216.577
+}
+
+OpenCluster "HSC 1380"
+{
+	RA 6.05112049
+	Dec 35.01151499
+	Radius 211.051
+	Distance 13263.928
+}
+
+OpenCluster "Juchert J0603.1+3102:UBC 1292"
+{
+	RA 6.05185825
+	Dec 31.03880529
+	Radius 85.464
+	Distance 11468.039
+}
+
+OpenCluster "CWNU 1092"
+{
+	RA 6.05539282
+	Dec 8.55893056
+	Radius 36.597
+	Distance 1341.652
+}
+
+OpenCluster "OC 0362:Theia 15"
+{
+	RA 6.05878925
+	Dec -9.74189379
+	Radius 16.585
+	Distance 2686.118
+}
+
+OpenCluster "CWNU 11"
+{
+	RA 6.0610016
+	Dec 18.27017806
+	Radius 48.884
+	Distance 2904.797
+}
+
+OpenCluster "HSC 2119"
+{
+	RA 6.06340329
+	Dec -55.05819323
+	Radius 67.217
+	Distance 1449.211
+}
+
+OpenCluster "FoF 2143:Theia 4318:UBC 72"
+{
+	RA 6.0656801
+	Dec 26.62945014
+	Radius 36.034
+	Distance 5715.225
+}
+
+OpenCluster "HSC 1436"
+{
+	RA 6.06609461
+	Dec 29.07193774
+	Radius 60.328
+	Distance 3077.202
+}
+
+OpenCluster "HSC 1433"
+{
+	RA 6.06735381
+	Dec 29.26966262
+	Radius 46.64
+	Distance 11222.643
+}
+
+OpenCluster "FoF 1375:UBC 434"
+{
+	RA 6.06917322
+	Dec 28.04728341
+	Radius 197.201
+	Distance 14026.438
+}
+
+OpenCluster "UBC 1318"
+{
+	RA 6.07155884
+	Dec 9.18352844
+	Radius 84.579
+	Distance 14466.992
+}
+
+OpenCluster "COIN-Gaia 22:FSR 0827:FSR 827:Kronberger 6:Teutsch J0604.2+3136"
+{
+	RA 6.07163517
+	Dec 31.60716532
+	Radius 68.058
+	Distance 5958.005
+}
+
+OpenCluster "FSR 0883:FSR 883:MWSC 717"
+{
+	RA 6.07208213
+	Dec 22.03061425
+	Radius 51.312
+	Distance 9036.643
+}
+
+OpenCluster "Theia 2361:UPK 416"
+{
+	RA 6.0724371
+	Dec -4.25602694
+	Radius 35.366
+	Distance 2838.531
+}
+
+OpenCluster "FSR 0932:FSR 932:MWSC 719:SAI 57"
+{
+	RA 6.07293929
+	Dec 14.57549077
+	Radius 40.823
+	Distance 6532.395
+}
+
+OpenCluster "CWNU 2440:FSR 0894:FSR 894:MWSC 714"
+{
+	RA 6.07558288
+	Dec 20.28154672
+	Radius 104.029
+	Distance 10185.098
+}
+
+OpenCluster "UBC 68"
+{
+	RA 6.07899523
+	Dec 36.7943235
+	Radius 51.326
+	Distance 6659.659
+}
+
+OpenCluster "IC 2157:Collinder 80:FSR 867:MWSC 722:OCL 465:OC 0305:Trumpler 4"
+{
+	RA 6.08005332
+	Dec 24.08679145
+	Radius 36.952
+	Distance 6312.992
+}
+
+OpenCluster "IC 2156:IC 2157:Collinder 80:FSR 867:MWSC 722:MWSC 723:OCL 465:Trumpler 4:UBC 1302"
+{
+	RA 6.08183679
+	Dec 24.14583746
+	Radius 30.278
+	Distance 8020.706
+}
+
+OpenCluster "FSR 0921:FSR 921:MWSC 727:SAI 58"
+{
+	RA 6.08620138
+	Dec 16.68821448
+	Radius 89.304
+	Distance 7624.471
+}
+
+OpenCluster "HSC 1479"
+{
+	RA 6.08622153
+	Dec 23.62906359
+	Radius 36.57
+	Distance 9472.878
+}
+
+OpenCluster "FSR 0833"
+{
+	RA 6.08763612
+	Dec 30.80259992
+	Radius 49.641
+	Distance 13787.266
+}
+
+OpenCluster "HSC 1410"
+{
+	RA 6.09061706
+	Dec 32.60715473
+	Radius 38.645
+	Distance 10301.71
+}
+
+OpenCluster "HSC 1364"
+{
+	RA 6.09073869
+	Dec 37.60445262
+	Radius 33.04
+	Distance 9570.928
+}
+
+OpenCluster "UBC 1610"
+{
+	RA 6.09293928
+	Dec 28.70272631
+	Radius 42.444
+	Distance 7828.457
+}
+
+OpenCluster "CWNU 2503"
+{
+	RA 6.09302573
+	Dec 11.95256073
+	Radius 53.6
+	Distance 15156.627
+}
+
+OpenCluster "CWNU 406"
+{
+	RA 6.09324747
+	Dec 20.81403142
+	Radius 51.094
+	Distance 3200.837
+}
+
+OpenCluster "HSC 1480"
+{
+	RA 6.09523726
+	Dec 23.51086596
+	Radius 79.706
+	Distance 14673.697
+}
+
+OpenCluster "FSR 0942:FSR 942:MWSC 729:SAI 59"
+{
+	RA 6.10040235
+	Dec 13.66999942
+	Radius 64.06
+	Distance 9391.316
+}
+
+OpenCluster "HSC 1367"
+{
+	RA 6.10171639
+	Dec 37.37933645
+	Radius 33.192
+	Distance 4150.633
+}
+
+OpenCluster "HSC 1507"
+{
+	RA 6.10558159
+	Dec 19.59148447
+	Radius 38.768
+	Distance 3295.869
+}
+
+OpenCluster "UBC 80"
+{
+	RA 6.10730086
+	Dec 8.77492553
+	Radius 91.093
+	Distance 6794.946
+}
+
+OpenCluster "Theia 669"
+{
+	RA 6.10751694
+	Dec 38.92027658
+	Radius 28.355
+	Distance 2738.815
+}
+
+OpenCluster "DSH J0606.6+1557:FSR 926:SAI 60:Teutsch 58"
+{
+	RA 6.11062009
+	Dec 15.94867124
+	Radius 110.878
+	Distance 12944.606
+}
+
+OpenCluster "COIN-Gaia 25:Theia 991"
+{
+	RA 6.1107665
+	Dec 20.45690363
+	Radius 61.499
+	Distance 2573.411
+}
+
+OpenCluster "NGC 2184:MWSC 784:Theia 1408"
+{
+	RA 6.11340709
+	Dec -2.0424517
+	Radius 60.292
+	Distance 1838.927
+}
+
+OpenCluster "CWNU 1801"
+{
+	RA 6.11646262
+	Dec 32.17208497
+	Radius 63.117
+	Distance 3923.644
+}
+
+OpenCluster "FSR 0904:OC 0317:Theia 1862"
+{
+	RA 6.11797703
+	Dec 19.01366792
+	Radius 23.111
+	Distance 6462.386
+}
+
+OpenCluster "HSC 1698"
+{
+	RA 6.11945579
+	Dec -8.52838682
+	Radius 36.655
+	Distance 2579.056
+}
+
+OpenCluster "NGC 2158:Melotte 40:Collinder 81:FSR 872:MWSC 733:OCL 468"
+{
+	RA 6.12396566
+	Dec 24.09770927
+	Radius 139.309
+	Distance 12088.447
+}
+
+OpenCluster "FSR 0903:FSR 0904:FSR 903:MWSC 735"
+{
+	RA 6.12494865
+	Dec 19.09309465
+	Radius 18.437
+	Distance 7292.549
+}
+
+OpenCluster "CWNU 2157"
+{
+	RA 6.12774141
+	Dec 21.02476188
+	Radius 55.728
+	Distance 5508.659
+}
+
+OpenCluster "UBC 1296"
+{
+	RA 6.12876779
+	Dec 29.03722125
+	Radius 76.556
+	Distance 12916.913
+}
+
+OpenCluster "OC 0357"
+{
+	RA 6.12879789
+	Dec -6.39588144
+	Radius 34.476
+	Distance 2697.137
+}
+
+OpenCluster "HSC 1510"
+{
+	RA 6.12886223
+	Dec 19.16903446
+	Radius 12.777
+	Distance 6156.502
+}
+
+OpenCluster "CWNU 436:UBC 1303"
+{
+	RA 6.13286788
+	Dec 21.9146076
+	Radius 49.939
+	Distance 5927.617
+}
+
+OpenCluster "FSR 1115"
+{
+	RA 6.1370999
+	Dec -9.57963333
+	Radius 48.706
+	Distance 2696.668
+}
+
+OpenCluster "CWNU 1295"
+{
+	RA 6.13882394
+	Dec 28.07333139
+	Radius 174.866
+	Distance 11345.829
+}
+
+OpenCluster "37 Cluster:NGC 2169:Collinder 38/83:OC 0323"
+{
+	RA 6.14118166
+	Dec 13.9666308
+	Radius 33.878
+	Distance 3050.722
+}
+
+OpenCluster "Kharchenko 1:MWSC 747"
+{
+	RA 6.14653647
+	Dec 24.28646601
+	Radius 32.707
+	Distance 7840.734
+}
+
+OpenCluster "HSC 1548"
+{
+	RA 6.14736617
+	Dec 13.8973107
+	Radius 121.621
+	Distance 14771.974
+}
+
+OpenCluster "HSC 1861"
+{
+	RA 6.14837332
+	Dec -28.24237706
+	Radius 59.991
+	Distance 17977.884
+}
+
+OpenCluster "FSR 0856:FSR 856:Koposov 53:MWSC 750:MWSC 751:Teutsch 9"
+{
+	RA 6.14868548
+	Dec 26.26040014
+	Radius 203.841
+	Distance 13780.654
+}
+
+OpenCluster "HSC 1455"
+{
+	RA 6.15057016
+	Dec 27.19856954
+	Radius 66.406
+	Distance 4734.132
+}
+
+OpenCluster "HSC 2256"
+{
+	RA 6.15111589
+	Dec -67.54715639
+	Radius 185.59
+	Distance 2724.694
+}
+
+OpenCluster "CWNU 2717"
+{
+	RA 6.15146912
+	Dec 19.5073978
+	Radius 79.516
+	Distance 6462.419
+}
+
+OpenCluster "Dias 2:MWSC 756:Theia 1972:UBC 1327"
+{
+	RA 6.15181206
+	Dec 4.6904498
+	Radius 118.105
+	Distance 6855.743
+}
+
+OpenCluster "Shoe-Buckle Cluster:M 35:NGC 2168:Melotte 41:Collinder 82:MWSC 754:OCL 466:Theia 203"
+{
+	RA 6.15225387
+	Dec 24.32621761
+	Radius 107.521
+	Distance 2734.931
+}
+
+OpenCluster "Dias 2:MWSC 756"
+{
+	RA 6.15256775
+	Dec 4.57143207
+	Radius 59.47
+	Distance 12710.642
+}
+
+OpenCluster "DC 8:MWSC 758:Teutsch J0609.3+3113"
+{
+	RA 6.15596378
+	Dec 31.22556973
+	Radius 142.11
+	Distance 12982.602
+}
+
+OpenCluster "CWNU 232"
+{
+	RA 6.1564226
+	Dec -2.99419091
+	Radius 101.656
+	Distance 1580.287
+}
+
+OpenCluster "NGC 2175:Sh2 252C"
+{
+	RA 6.1566085
+	Dec 20.63568386
+	Radius 56.147
+	Distance 5769.404
+}
+
+OpenCluster "Theia 83:UBC 446:UPK 445"
+{
+	RA 6.15691496
+	Dec -15.03935511
+	Radius 67.043
+	Distance 2157.827
+}
+
+OpenCluster "FSR 0869:FSR 869:Koposov 63:MWSC 772:MWSC 773:Teutsch J0610.0+2434"
+{
+	RA 6.16806565
+	Dec 24.56541744
+	Radius 95.324
+	Distance 12765.76
+}
+
+OpenCluster "CWNU 2471"
+{
+	RA 6.17050229
+	Dec 12.83076517
+	Radius 140.752
+	Distance 11062.371
+}
+
+OpenCluster "HSC 1658"
+{
+	RA 6.17073777
+	Dec -2.07921495
+	Radius 82.431
+	Distance 1194.43
+}
+
+OpenCluster "HSC 1477"
+{
+	RA 6.17598732
+	Dec 25.00906825
+	Radius 58.586
+	Distance 6866.809
+}
+
+OpenCluster "FSR 0923:FSR 923:MWSC 777:MWSC 778:Theia 2789"
+{
+	RA 6.17649701
+	Dec 16.97365299
+	Radius 41.155
+	Distance 5268.065
+}
+
+OpenCluster "NGC 2183:Theia 130"
+{
+	RA 6.17995721
+	Dec -6.21850563
+	Radius 57.613
+	Distance 2673.498
 }
 
 OpenCluster "Pismis 27"
 {
-	RA 6.181667
-	Dec 20.607222
-	Distance 3261
-	Radius 2.4
+	RA 6.18174001
+	Dec 20.62006896
+	Radius 26.214
+	Distance 5908.993
 }
 
-OpenCluster "NGC 2184"
+OpenCluster "CWNU 2236:FSR 0939:FSR 939:MWSC 781"
 {
-	RA 6.183333
-	Dec -2.516667
-	Distance 2087
-	Radius 10.6
+	RA 6.18238812
+	Dec 14.39662336
+	Radius 26.555
+	Distance 9561.326
 }
 
-OpenCluster "NGC 2186"
+OpenCluster "CWNU 39"
 {
-	RA 6.201944
-	Dec 5.458333
-	Distance 4713
-	Radius 3.4
+	RA 6.18267995
+	Dec 23.43399518
+	Radius 39.572
+	Distance 6042.171
 }
 
-OpenCluster "NGC 2194"
+OpenCluster "HSC 1571"
 {
-	RA 6.229167
-	Dec 12.806667
-	Distance 12332
-	Radius 16.1
+	RA 6.18548177
+	Dec 11.77364244
+	Radius 93.585
+	Distance 13321.902
 }
 
-OpenCluster "Ferrero 11"
+OpenCluster "HSC 1511"
 {
-	RA 6.242500
-	Dec 0.641667
-	Distance 4892
-	Radius 15.4
+	RA 6.1880241
+	Dec 19.58656753
+	Radius 40.726
+	Distance 6058.617
 }
 
-OpenCluster "ESO 425-15"
+OpenCluster "HXHWL 12"
 {
-	RA 6.243056
-	Dec -28.625000
-	Distance 3229
-	Radius 2.8
+	RA 6.18853554
+	Dec 6.58380234
+	Radius 71.049
+	Distance 3485.437
 }
 
-OpenCluster "Skiff J0614+12.9"
+OpenCluster "FSR 0968:FSR 968:MWSC 785"
 {
-	RA 6.246389
-	Dec 12.870833
-	Distance 10274
-	Radius 4.5
+	RA 6.18900713
+	Dec 11.86911063
+	Radius 56.981
+	Distance 7744.89
 }
 
-OpenCluster "NGC 2192"
+OpenCluster "HSC 1487"
 {
-	RA 6.254722
-	Dec 39.855000
-	Distance 11843
-	Radius 8.6
+	RA 6.18972138
+	Dec 23.64888575
+	Radius 112.91
+	Distance 12404.825
 }
 
-OpenCluster "Platais 6"
+OpenCluster "NGC 2184:MWSC 784"
 {
-	RA 6.257222
-	Dec 3.845000
-	Distance 1135
-	Radius 41.6
+	RA 6.19012694
+	Dec -3.37202671
+	Radius 69.778
+	Distance 2067.25
 }
 
-OpenCluster "NGC 2204"
+OpenCluster "HSC 1524"
 {
-	RA 6.259167
-	Dec -17.335000
-	Distance 8574
-	Radius 12.5
+	RA 6.19097101
+	Dec 17.44074742
+	Radius 234.119
+	Distance 15677.097
 }
 
-OpenCluster "NGC 2202"
+OpenCluster "HSC 1925"
 {
-	RA 6.280556
-	Dec 5.996667
-	Distance 2935
-	Radius 3.0
+	RA 6.19321688
+	Dec -34.03442114
+	Radius 35.331
+	Distance 788.185
+}
+
+OpenCluster "FSR 0985:FSR 985:MWSC 786:SAI 62"
+{
+	RA 6.19681214
+	Dec 7.02082097
+	Radius 52.394
+	Distance 6589.638
+}
+
+OpenCluster "CWNU 35"
+{
+	RA 6.19792755
+	Dec -16.52451555
+	Radius 47.377
+	Distance 1944.179
+}
+
+OpenCluster "HSC 1551"
+{
+	RA 6.19973285
+	Dec 14.07259942
+	Radius 54.256
+	Distance 3012.063
+}
+
+OpenCluster "HSC 1553"
+{
+	RA 6.20084964
+	Dec 13.98187736
+	Radius 111.392
+	Distance 691.029
+}
+
+OpenCluster "HSC 1538"
+{
+	RA 6.20117936
+	Dec 16.22386998
+	Radius 86.879
+	Distance 5867.412
+}
+
+OpenCluster "NGC 2186:Collinder 85:MWSC 787:OCL 498:OC 0338:Theia 2871"
+{
+	RA 6.20188943
+	Dec 5.4506244
+	Radius 52.871
+	Distance 6973.319
+}
+
+OpenCluster "HSC 1557"
+{
+	RA 6.20394135
+	Dec 13.67353977
+	Radius 24.164
+	Distance 3870.676
+}
+
+OpenCluster "CWNU 1523"
+{
+	RA 6.20513309
+	Dec 17.49565199
+	Radius 32.092
+	Distance 6535.177
+}
+
+OpenCluster "CWNU 1787"
+{
+	RA 6.20586328
+	Dec 14.53457317
+	Radius 29.475
+	Distance 7295.403
+}
+
+OpenCluster "HSC 1709"
+{
+	RA 6.20597535
+	Dec -8.81093316
+	Radius 67.013
+	Distance 680.025
+}
+
+OpenCluster "HSC 1585"
+{
+	RA 6.20911162
+	Dec 9.80334481
+	Radius 80.234
+	Distance 7851.362
+}
+
+OpenCluster "HSC 1503"
+{
+	RA 6.21028979
+	Dec 21.58287983
+	Radius 68.46
+	Distance 8562.993
+}
+
+OpenCluster "HSC 1465"
+{
+	RA 6.21210414
+	Dec 26.93027988
+	Radius 74.68
+	Distance 1196.259
+}
+
+OpenCluster "OC 0307:Theia 3475"
+{
+	RA 6.2132221
+	Dec 24.11243766
+	Radius 91.503
+	Distance 5882.851
+}
+
+OpenCluster "HSC 1467"
+{
+	RA 6.2160814
+	Dec 26.56503283
+	Radius 70.929
+	Distance 2883.849
+}
+
+OpenCluster "HSC 1958"
+{
+	RA 6.2211504
+	Dec -36.68339592
+	Radius 44.29
+	Distance 1905.246
+}
+
+OpenCluster "UBC 206"
+{
+	RA 6.2228701
+	Dec 1.4439005
+	Radius 54.605
+	Distance 5673.118
+}
+
+OpenCluster "UBC 1320"
+{
+	RA 6.22302126
+	Dec 9.53816184
+	Radius 50.737
+	Distance 7716.831
+}
+
+OpenCluster "CWNU 2595"
+{
+	RA 6.22427598
+	Dec 14.23676004
+	Radius 122.067
+	Distance 11406.923
+}
+
+OpenCluster "HSC 1530"
+{
+	RA 6.22474976
+	Dec 17.20197844
+	Radius 30.608
+	Distance 7058.921
+}
+
+OpenCluster "FSR 0931:FSR 931:MWSC 796:UBC 201"
+{
+	RA 6.22524905
+	Dec 15.9404654
+	Radius 42.757
+	Distance 5342.586
+}
+
+OpenCluster "HSC 1573"
+{
+	RA 6.22567816
+	Dec 11.90390808
+	Radius 54.464
+	Distance 4065.849
+}
+
+OpenCluster "FSR 0893:FSR 893:MWSC 802:OC 0313"
+{
+	RA 6.22658201
+	Dec 21.60188631
+	Radius 93.37
+	Distance 6823.147
+}
+
+OpenCluster "FSR 0937:FSR 937:MWSC 800"
+{
+	RA 6.22792956
+	Dec 14.99690331
+	Radius 162.102
+	Distance 14317.775
+}
+
+OpenCluster "NGC 2194:Melotte 43:Collinder 87:FSR 961:MWSC 803:OCL 485"
+{
+	RA 6.22868031
+	Dec 12.80969402
+	Radius 61.911
+	Distance 10143.57
+}
+
+OpenCluster "Czernik 25:FSR 987:MWSC 795:MWSC 804:OCL 493:SAI 63:Theia 4424"
+{
+	RA 6.2287487
+	Dec 6.95111114
+	Radius 54.13
+	Distance 6729.147
+}
+
+OpenCluster "HSC 1567"
+{
+	RA 6.23146682
+	Dec 12.50520098
+	Radius 24.336
+	Distance 4863.509
+}
+
+OpenCluster "HSC 1466"
+{
+	RA 6.2321219
+	Dec 26.80313567
+	Radius 77.823
+	Distance 9076.634
+}
+
+OpenCluster "HSC 1504"
+{
+	RA 6.23801068
+	Dec 21.09553026
+	Radius 75.117
+	Distance 5992.646
+}
+
+OpenCluster "CWNU 2448"
+{
+	RA 6.23804477
+	Dec 20.73935065
+	Radius 50.461
+	Distance 8629.623
+}
+
+OpenCluster "CWNU 205"
+{
+	RA 6.24051289
+	Dec 2.84589874
+	Radius 56.057
+	Distance 4619.946
+}
+
+OpenCluster "OCSN 69"
+{
+	RA 6.24316103
+	Dec -4.61708713
+	Radius 41.158
+	Distance 1145.908
+}
+
+OpenCluster "ASCC 22:Ferrero 11:MWSC 813:Theia 488"
+{
+	RA 6.24392381
+	Dec 0.65220041
+	Radius 147.989
+	Distance 2553.824
+}
+
+OpenCluster "Theia 399"
+{
+	RA 6.24474821
+	Dec 17.39762279
+	Radius 108.486
+	Distance 1932.546
+}
+
+OpenCluster "FSR 963:Luginbuhl-Skiff 1:MWSC 817:MWSC 818:Skiff J0614+12.9"
+{
+	RA 6.24649704
+	Dec 12.8689697
+	Radius 49.065
+	Distance 10720.091
+}
+
+OpenCluster "HSC 1249"
+{
+	RA 6.24658624
+	Dec 56.89653556
+	Radius 73.209
+	Distance 842.653
+}
+
+OpenCluster "IRAS 06117+1901:OC 0318"
+{
+	RA 6.24677726
+	Dec 19.00585146
+	Radius 74.958
+	Distance 6236.977
+}
+
+OpenCluster "HSC 1560"
+{
+	RA 6.24769987
+	Dec 13.5620555
+	Radius 62.192
+	Distance 10680.255
+}
+
+OpenCluster "HSC 1542"
+{
+	RA 6.24781736
+	Dec 15.55179117
+	Radius 172.592
+	Distance 498.965
+}
+
+OpenCluster "BDSB 82"
+{
+	RA 6.2489103
+	Dec 12.34906477
+	Radius 152.202
+	Distance 11861.081
+}
+
+OpenCluster "HSC 1430"
+{
+	RA 6.24922067
+	Dec 30.76168032
+	Radius 162.104
+	Distance 1934.142
+}
+
+OpenCluster "NGC 2192:Melotte 42:Collinder 86:MWSC 820:OCL 437:OC 0291"
+{
+	RA 6.25483103
+	Dec 39.84275513
+	Radius 123.75
+	Distance 12357.561
+}
+
+OpenCluster "HSC 1558"
+{
+	RA 6.25492237
+	Dec 13.82807042
+	Radius 24.172
+	Distance 6339.938
+}
+
+OpenCluster "OC 0310"
+{
+	RA 6.25520181
+	Dec 22.26774381
+	Radius 44.102
+	Distance 5798.468
+}
+
+OpenCluster "CWNU 26"
+{
+	RA 6.25783991
+	Dec 13.78485959
+	Radius 27.71
+	Distance 6934.931
+}
+
+OpenCluster "NGC 2204:Melotte 44:Collinder 88:ESO 556-7:FSR 1201:MWSC 2204:OCL 572:Theia 6191"
+{
+	RA 6.25901532
+	Dec -18.67148567
+	Radius 216.804
+	Distance 13416.325
+}
+
+OpenCluster "UBC 1305"
+{
+	RA 6.26262421
+	Dec 22.58806823
+	Radius 49.242
+	Distance 5865.509
+}
+
+OpenCluster "CWNU 80"
+{
+	RA 6.26398992
+	Dec 11.89108758
+	Radius 161.819
+	Distance 2443.367
+}
+
+OpenCluster "FSR 0811:FSR 811:MWSC 826"
+{
+	RA 6.27420309
+	Dec 36.36430182
+	Radius 38.933
+	Distance 8473.406
+}
+
+OpenCluster "FSR 1117:MWSC 827"
+{
+	RA 6.27728561
+	Dec -8.96830265
+	Radius 55.784
+	Distance 2774.95
+}
+
+OpenCluster "HSC 1989"
+{
+	RA 6.28011558
+	Dec -39.62914009
+	Radius 126.042
+	Distance 557.464
+}
+
+OpenCluster "Theia 760:UPK 379"
+{
+	RA 6.28128783
+	Dec 30.74434502
+	Radius 133.843
+	Distance 2444.6
+}
+
+OpenCluster "CWNU 1666"
+{
+	RA 6.28756081
+	Dec 5.01323051
+	Radius 38.217
+	Distance 6925.207
+}
+
+OpenCluster "CWNU 24:Theia 2249"
+{
+	RA 6.29164039
+	Dec 14.59395097
+	Radius 43.779
+	Distance 6939.489
+}
+
+OpenCluster "CWNU 1824"
+{
+	RA 6.29767594
+	Dec 4.36228767
+	Radius 39.086
+	Distance 4162.189
+}
+
+OpenCluster "CWNU 1550:Theia 4212"
+{
+	RA 6.29800572
+	Dec 9.67956604
+	Radius 90.407
+	Distance 9439.312
+}
+
+OpenCluster "UBC 439"
+{
+	RA 6.29801983
+	Dec 10.7526146
+	Radius 100.602
+	Distance 9253.597
+}
+
+OpenCluster "HSC 1716"
+{
+	RA 6.29815642
+	Dec -8.93817611
+	Radius 70.992
+	Distance 18445.912
+}
+
+OpenCluster "HSC 1502"
+{
+	RA 6.29823318
+	Dec 22.63198499
+	Radius 18.835
+	Distance 5713.134
+}
+
+OpenCluster "HSC 1579"
+{
+	RA 6.29919809
+	Dec 11.49055454
+	Radius 42.939
+	Distance 8717.582
+}
+
+OpenCluster "HSC 1576"
+{
+	RA 6.30169267
+	Dec 11.94377377
+	Radius 126.697
+	Distance 17133.322
+}
+
+OpenCluster "HSC 1675"
+{
+	RA 6.30204436
+	Dec -3.3407916
+	Radius 131.339
+	Distance 16588.871
+}
+
+OpenCluster "HSC 1484"
+{
+	RA 6.30428797
+	Dec 24.82861879
+	Radius 72.182
+	Distance 15186.414
+}
+
+OpenCluster "HSC 1613"
+{
+	RA 6.30510307
+	Dec 4.62195695
+	Radius 135.057
+	Distance 10061.708
+}
+
+OpenCluster "CWNU 82:UBC 1315"
+{
+	RA 6.30511538
+	Dec 14.89050432
+	Radius 58.59
+	Distance 7815.527
+}
+
+OpenCluster "FSR 0902:FSR 902:MWSC 832:UBC 1308"
+{
+	RA 6.30517532
+	Dec 20.56213963
+	Radius 37.887
+	Distance 5894.271
+}
+
+OpenCluster "CWNU 1227"
+{
+	RA 6.30761725
+	Dec -7.78077533
+	Radius 94.734
+	Distance 1315.072
+}
+
+OpenCluster "CWNU 1510"
+{
+	RA 6.30811116
+	Dec 4.92330099
+	Radius 65.161
+	Distance 5064.309
+}
+
+OpenCluster "HSC 1547"
+{
+	RA 6.31238635
+	Dec 15.28905945
+	Radius 100.417
+	Distance 21215.492
+}
+
+OpenCluster "UBC 438"
+{
+	RA 6.31244507
+	Dec 15.2844404
+	Radius 73.133
+	Distance 12868.058
+}
+
+OpenCluster "Theia 2335"
+{
+	RA 6.31295259
+	Dec 29.81621653
+	Radius 49.985
+	Distance 4584.392
 }
 
 OpenCluster "Collinder 89"
 {
-	RA 6.300000
-	Dec 23.633333
-	Distance 2175
-	Radius 19.0
+	RA 6.31349032
+	Dec 23.16961561
+	Radius 23.353
+	Distance 5901.439
 }
 
-OpenCluster "Koposov 62"
+OpenCluster "HSC 1572"
 {
-	RA 6.300556
-	Dec 24.710556
-	Distance 9132
-	Radius 8.0
+	RA 6.31497236
+	Dec 12.6228093
+	Radius 92.21
+	Distance 994.136
 }
 
-OpenCluster "ASCC 23"
+OpenCluster "UBC 1316"
 {
-	RA 6.338889
-	Dec 46.670000
-	Distance 1957
-	Radius 12.3
+	RA 6.3154864
+	Dec 14.64526062
+	Radius 116.074
+	Distance 10069.113
 }
 
-OpenCluster "NGC 2215"
+OpenCluster "FSR 0953:FSR 953:MWSC 835"
 {
-	RA 6.346944
-	Dec -6.716667
-	Distance 4217
-	Radius 4.3
+	RA 6.317296
+	Dec 14.1459915
+	Radius 48.412
+	Distance 8511.555
 }
 
-OpenCluster "Berkeley 73"
+OpenCluster "HSC 1570"
 {
-	RA 6.366667
-	Dec -5.650000
-	Distance 31964
-	Radius 9.3
+	RA 6.31766098
+	Dec 12.87594408
+	Radius 165.996
+	Distance 16089.813
 }
 
-OpenCluster "Bochum 1"
+OpenCluster "UBC 617"
 {
-	RA 6.423611
-	Dec 19.766667
-	Distance 9142
-	Radius 34.6
+	RA 6.31810991
+	Dec 10.1222302
+	Radius 55.627
+	Distance 6959.598
 }
 
-OpenCluster "NGC 2225"
+OpenCluster "Skiff J0619+18.5:Theia 2067"
 {
-	RA 6.443333
-	Dec -8.361667
-	Distance 10437
-	Radius 4.3
+	RA 6.32209295
+	Dec 18.53383631
+	Radius 32.813
+	Distance 4844.684
 }
 
-OpenCluster "NGC 2232"
+OpenCluster "UBC 436"
 {
-	RA 6.454167
-	Dec -3.241667
-	Distance 1170
-	Radius 9.0
+	RA 6.325921
+	Dec 26.2281763
+	Radius 84.587
+	Distance 9998.51
 }
 
-OpenCluster "ASCC 24"
+OpenCluster "HIP 29713 Group:MWSC 821:Platais 6"
 {
-	RA 6.478889
-	Dec -6.980000
-	Distance 1304
-	Radius 8.0
+	RA 6.32639869
+	Dec 5.3012761
+	Radius 133.813
+	Distance 732.315
 }
 
-OpenCluster "NGC 2243"
+OpenCluster "OC 0315"
 {
-	RA 6.492778
-	Dec -30.716667
-	Distance 14540
-	Radius 10.6
+	RA 6.32905903
+	Dec 22.11473418
+	Radius 31.946
+	Distance 5516.79
 }
 
-OpenCluster "NGC 2236"
+OpenCluster "HSC 1500"
 {
-	RA 6.494167
-	Dec 6.830000
-	Distance 9556
-	Radius 9.7
+	RA 6.33040401
+	Dec 23.14307081
+	Radius 91.125
+	Distance 4227.885
 }
 
-OpenCluster "Collinder 96"
+OpenCluster "HSC 1516"
 {
-	RA 6.505000
-	Dec 2.866667
-	Distance 3137
-	Radius 5.5
+	RA 6.33220846
+	Dec 19.84525186
+	Radius 45.101
+	Distance 2979.911
+}
+
+OpenCluster "CWNU 1313"
+{
+	RA 6.33315035
+	Dec 1.92262205
+	Radius 129.191
+	Distance 7454.984
+}
+
+OpenCluster "HSC 1545"
+{
+	RA 6.33413715
+	Dec 15.86786392
+	Radius 22.555
+	Distance 12757.163
+}
+
+OpenCluster "ASCC 23:FSR 746:Ferrero 16:MWSC 839:Theia 552"
+{
+	RA 6.33532189
+	Dec 46.68569526
+	Radius 54.337
+	Distance 1968.917
+}
+
+OpenCluster "CWNU 189"
+{
+	RA 6.33691689
+	Dec -6.44156545
+	Radius 38.434
+	Distance 6019.206
+}
+
+OpenCluster "NGC 2215:Melotte 45:Collinder 90:MWSC 843:OCL 550:Theia 1087"
+{
+	RA 6.34815937
+	Dec -7.27415968
+	Radius 43.462
+	Distance 3016.86
+}
+
+OpenCluster "NGC 2220:ESO 255-4:MWSC 841"
+{
+	RA 6.3485906
+	Dec -44.7448138
+	Radius 33.931
+	Distance 1618.894
+}
+
+OpenCluster "HSC 1370"
+{
+	RA 6.35000382
+	Dec 38.4933065
+	Radius 33.699
+	Distance 3372.199
+}
+
+OpenCluster "OC 0316"
+{
+	RA 6.35100476
+	Dec 22.17063969
+	Radius 35.941
+	Distance 5577.374
+}
+
+OpenCluster "PHOC 25"
+{
+	RA 6.35121594
+	Dec 7.33579074
+	Radius 59.944
+	Distance 5888.147
+}
+
+OpenCluster "Theia 859:UPK 381"
+{
+	RA 6.35132241
+	Dec 29.51714393
+	Radius 84.755
+	Distance 2284.182
+}
+
+OpenCluster "FoF 658:Theia 3904:Theia 4142:UBC 211"
+{
+	RA 6.35144067
+	Dec -3.46812959
+	Radius 47.858
+	Distance 4577.11
+}
+
+OpenCluster "CWNU 10"
+{
+	RA 6.35450396
+	Dec 18.82700081
+	Radius 82.804
+	Distance 3152.117
+}
+
+OpenCluster "CWNU 201"
+{
+	RA 6.35851337
+	Dec -10.28274183
+	Radius 68.954
+	Distance 3116.195
+}
+
+OpenCluster "FoF 2383"
+{
+	RA 6.35867355
+	Dec -16.096699
+	Radius 61.037
+	Distance 1190.419
+}
+
+OpenCluster "HSC 1518"
+{
+	RA 6.35911762
+	Dec 19.83985621
+	Radius 51.743
+	Distance 9836.996
+}
+
+OpenCluster "Gulliver 56:OC 0304:UBC 73"
+{
+	RA 6.35948918
+	Dec 26.90073437
+	Radius 40.243
+	Distance 6732.774
+}
+
+OpenCluster "HSC 1532"
+{
+	RA 6.3611393
+	Dec 18.06935003
+	Radius 111.832
+	Distance 10436.54
+}
+
+OpenCluster "FSR 0941:FSR 941:MWSC 846"
+{
+	RA 6.36212158
+	Dec 15.76656872
+	Radius 62.961
+	Distance 13147.393
+}
+
+OpenCluster "FoF 1973:UBC 74"
+{
+	RA 6.36345292
+	Dec 22.4133391
+	Radius 56.804
+	Distance 8047.729
+}
+
+OpenCluster "CWNU 385"
+{
+	RA 6.36664182
+	Dec 9.64260953
+	Radius 30.33
+	Distance 6707.042
+}
+
+OpenCluster "Alessi 50:DSH J0622.0+2104:FSR 901:UBC 1307"
+{
+	RA 6.36786415
+	Dec 21.07346545
+	Radius 65.093
+	Distance 9692.104
+}
+
+OpenCluster "Berkeley 73:MWSC 847:OCL 546"
+{
+	RA 6.36800363
+	Dec -6.31894792
+	Radius 198.908
+	Distance 21193.012
+}
+
+OpenCluster "FSR 0951:FSR 951:MWSC 849:Theia 2489"
+{
+	RA 6.36957366
+	Dec 14.65764314
+	Radius 46.365
+	Distance 5353.113
+}
+
+OpenCluster "OC 0321"
+{
+	RA 6.36967286
+	Dec 19.00428186
+	Radius 34.321
+	Distance 5960.447
+}
+
+OpenCluster "HSC 1561"
+{
+	RA 6.37011425
+	Dec 14.40128268
+	Radius 45.319
+	Distance 3064.906
+}
+
+OpenCluster "HSC 1459"
+{
+	RA 6.37019281
+	Dec 28.49911675
+	Radius 52.832
+	Distance 6459.997
+}
+
+OpenCluster "Alessi J0622.4+2114:CWNU 1404"
+{
+	RA 6.37288058
+	Dec 21.24941095
+	Radius 23.46
+	Distance 9463.047
+}
+
+OpenCluster "OC 0312"
+{
+	RA 6.38430871
+	Dec 22.93630792
+	Radius 21.902
+	Distance 5275.956
+}
+
+OpenCluster "Theia 3309"
+{
+	RA 6.38919544
+	Dec 10.75079904
+	Radius 44.026
+	Distance 3487.803
+}
+
+OpenCluster "HSC 1582"
+{
+	RA 6.38958464
+	Dec 11.58577397
+	Radius 138.589
+	Distance 17296.587
+}
+
+OpenCluster "Theia 3715"
+{
+	RA 6.39134948
+	Dec 7.80770667
+	Radius 44.38
+	Distance 3514.673
+}
+
+OpenCluster "UBC 82"
+{
+	RA 6.39196702
+	Dec 8.36294435
+	Radius 48.836
+	Distance 6909.527
+}
+
+OpenCluster "Theia 558:Theia 838"
+{
+	RA 6.39365235
+	Dec 3.6703087
+	Radius 197.223
+	Distance 2226.382
+}
+
+OpenCluster "UBC 1319"
+{
+	RA 6.394396
+	Dec 11.54759847
+	Radius 111.729
+	Distance 6807.162
+}
+
+OpenCluster "CWNU 104:UBC 1611"
+{
+	RA 6.39938747
+	Dec 20.50679972
+	Radius 52.634
+	Distance 6733.521
+}
+
+OpenCluster "CWNU 1274"
+{
+	RA 6.40090633
+	Dec 16.08361964
+	Radius 39.034
+	Distance 9431.521
+}
+
+OpenCluster "Theia 925"
+{
+	RA 6.40211972
+	Dec 35.74199135
+	Radius 123.505
+	Distance 1337.598
+}
+
+OpenCluster "CWNU 1355"
+{
+	RA 6.40394758
+	Dec 21.09814998
+	Radius 44.629
+	Distance 4952.775
+}
+
+OpenCluster "HXHWL 50:PHOC 26"
+{
+	RA 6.40493287
+	Dec 7.50273973
+	Radius 24.188
+	Distance 6132.015
+}
+
+OpenCluster "CWNU 410"
+{
+	RA 6.40837297
+	Dec -12.95687147
+	Radius 72.23
+	Distance 1389.185
+}
+
+OpenCluster "CWNU 250:OC 0351"
+{
+	RA 6.40957253
+	Dec -1.34857132
+	Radius 49.966
+	Distance 5884.967
+}
+
+OpenCluster "HSC 1575"
+{
+	RA 6.40964064
+	Dec 13.07652286
+	Radius 145.476
+	Distance 1878.072
+}
+
+OpenCluster "CWNU 1305"
+{
+	RA 6.41110204
+	Dec 12.47989565
+	Radius 49.793
+	Distance 9492.356
+}
+
+OpenCluster "UBC 618"
+{
+	RA 6.41584987
+	Dec 7.61774307
+	Radius 63.864
+	Distance 17904.827
+}
+
+OpenCluster "BBD 7:Bochum 1:FSR 0911:FSR 911:UBC 1309"
+{
+	RA 6.41711013
+	Dec 19.84623012
+	Radius 128.069
+	Distance 12536.354
+}
+
+OpenCluster "HSC 1751"
+{
+	RA 6.41838149
+	Dec -13.46859637
+	Radius 58.727
+	Distance 1157.256
+}
+
+OpenCluster "BDSB91:BDSB 91"
+{
+	RA 6.42103478
+	Dec -10.55788755
+	Radius 37.184
+	Distance 2862.95
+}
+
+OpenCluster "COIN-Gaia 28"
+{
+	RA 6.4220597
+	Dec 11.1632653
+	Radius 30.365
+	Distance 5041.255
+}
+
+OpenCluster "CWNU 418"
+{
+	RA 6.42388295
+	Dec 8.38190941
+	Radius 106.948
+	Distance 2870.491
+}
+
+OpenCluster "FSR 0929:FSR 929:MWSC 865:UBC 1310"
+{
+	RA 6.42622833
+	Dec 17.70880708
+	Radius 101.124
+	Distance 10279.56
+}
+
+OpenCluster "DSH J0625.6+1336:MWSC 866:Teutsch 12"
+{
+	RA 6.42782573
+	Dec 13.60844976
+	Radius 32.925
+	Distance 11208.898
+}
+
+OpenCluster "FSR 0948:FSR 948:MWSC 867:SAI 64"
+{
+	RA 6.4322112
+	Dec 15.85541557
+	Radius 78.387
+	Distance 12284.135
+}
+
+OpenCluster "HSC 1619"
+{
+	RA 6.43450867
+	Dec 4.71512175
+	Radius 60.356
+	Distance 6925.152
+}
+
+OpenCluster "HSC 1715"
+{
+	RA 6.43638914
+	Dec -7.547451
+	Radius 51.312
+	Distance 378.063
+}
+
+OpenCluster "HSC 1961"
+{
+	RA 6.43695839
+	Dec -36.06005484
+	Radius 154.742
+	Distance 2204.1
+}
+
+OpenCluster "CWNU 1835:Theia 2615"
+{
+	RA 6.44051461
+	Dec 8.22307701
+	Radius 47.158
+	Distance 10614.495
+}
+
+OpenCluster "CWNU 1516"
+{
+	RA 6.4424466
+	Dec 4.50591627
+	Radius 92.895
+	Distance 9491.87
+}
+
+OpenCluster "HSC 1732"
+{
+	RA 6.44245064
+	Dec -10.02468722
+	Radius 77.678
+	Distance 2384.654
+}
+
+OpenCluster "CWNU 143:CWNU 472"
+{
+	RA 6.44248363
+	Dec -8.29639748
+	Radius 67.498
+	Distance 4899.323
+}
+
+OpenCluster "Theia 834"
+{
+	RA 6.44250688
+	Dec 29.88653953
+	Radius 193.747
+	Distance 1517.789
+}
+
+OpenCluster "NGC 2225:FSR 1135:MWSC 868"
+{
+	RA 6.44360576
+	Dec -9.64231529
+	Radius 70.77
+	Distance 9952.428
+}
+
+OpenCluster "UBC 1332"
+{
+	RA 6.4439806
+	Dec 1.23175153
+	Radius 58.726
+	Distance 8238.697
+}
+
+OpenCluster "CWNU 520:Theia 2728"
+{
+	RA 6.44449404
+	Dec 15.19180965
+	Radius 49.922
+	Distance 3792.34
+}
+
+OpenCluster "HSC 1521"
+{
+	RA 6.44623762
+	Dec 20.08424745
+	Radius 33.093
+	Distance 10609.206
+}
+
+OpenCluster "HSC 1656"
+{
+	RA 6.45122863
+	Dec 0.18211893
+	Radius 117.654
+	Distance 1082.33
+}
+
+OpenCluster "HSC 1540"
+{
+	RA 6.4519298
+	Dec 17.73562651
+	Radius 161.795
+	Distance 12717.041
+}
+
+OpenCluster "UBC 1326"
+{
+	RA 6.45236048
+	Dec 7.8172328
+	Radius 40.094
+	Distance 12979.895
+}
+
+OpenCluster "UBC 1324"
+{
+	RA 6.45454831
+	Dec 8.53232522
+	Radius 49.995
+	Distance 14263.419
+}
+
+OpenCluster "UBC 1313"
+{
+	RA 6.45948666
+	Dec 17.18895534
+	Radius 123.389
+	Distance 13907.622
+}
+
+OpenCluster "CWNU 200:Theia 3747"
+{
+	RA 6.46241435
+	Dec 36.05470024
+	Radius 37.259
+	Distance 3803.412
+}
+
+OpenCluster "UBC 1612"
+{
+	RA 6.46293649
+	Dec 17.53113407
+	Radius 37.38
+	Distance 8480.019
+}
+
+OpenCluster "NGC 2232:Collinder 93:Escorial 8:MWSC 871:OCL 545"
+{
+	RA 6.46516966
+	Dec -4.77170078
+	Radius 57.497
+	Distance 1037.295
+}
+
+OpenCluster "HSC 1458"
+{
+	RA 6.46736434
+	Dec 29.24625762
+	Radius 22.565
+	Distance 3386.253
+}
+
+OpenCluster "HSC 1687"
+{
+	RA 6.46857884
+	Dec -4.14585763
+	Radius 66.907
+	Distance 1250.782
+}
+
+OpenCluster "CWNU 159:UBC 1328"
+{
+	RA 6.46955217
+	Dec 6.85458951
+	Radius 62.742
+	Distance 7518.583
+}
+
+OpenCluster "HSC 1631"
+{
+	RA 6.46972998
+	Dec 4.10311673
+	Radius 103.979
+	Distance 6951.237
+}
+
+OpenCluster "DSH J0628.8+1455:Teutsch 20:UBC 90"
+{
+	RA 6.48015385
+	Dec 14.9205217
+	Radius 40.172
+	Distance 8527.443
+}
+
+OpenCluster "ASCC 24:Alessi 47:MWSC 875"
+{
+	RA 6.48405927
+	Dec -7.03519235
+	Radius 44.38
+	Distance 684.162
+}
+
+OpenCluster "CWNU 416"
+{
+	RA 6.48903571
+	Dec 13.47146131
+	Radius 49.822
+	Distance 4207.915
+}
+
+OpenCluster "Alessi 53:DC 7:DSH J0629.4+0910:FSR 986:MWSC 879"
+{
+	RA 6.49013116
+	Dec 9.17805141
+	Radius 183.58
+	Distance 15831.981
+}
+
+OpenCluster "HSC 1719"
+{
+	RA 6.49024202
+	Dec -8.08065341
+	Radius 71.086
+	Distance 1200.366
+}
+
+OpenCluster "NGC 2243:Melotte 46:Collinder 98:ESO 426-16:FSR 1296:MWSC 880:OCL 644"
+{
+	RA 6.49309628
+	Dec -31.28344316
+	Radius 116.788
+	Distance 12812.164
+}
+
+OpenCluster "PHOC 24"
+{
+	RA 6.49361788
+	Dec 7.99138198
+	Radius 49.746
+	Distance 5303.373
+}
+
+OpenCluster "NGC 2236:Collinder 94:FSR 1002:MWSC 881:OCL 501:Theia 3041"
+{
+	RA 6.49408071
+	Dec 6.8314648
+	Radius 48.172
+	Distance 8304.516
+}
+
+OpenCluster "Theia 3041:UBC 83"
+{
+	RA 6.50035954
+	Dec 7.3203113
+	Radius 42.668
+	Distance 6231.239
+}
+
+OpenCluster "CWNU 1755:Collinder 95"
+{
+	RA 6.5052733
+	Dec 10.0096034
+	Radius 114.29
+	Distance 9447.267
+}
+
+OpenCluster "CWNU 1003:OC 0343:Theia 838"
+{
+	RA 6.50877645
+	Dec 4.35729786
+	Radius 65.317
+	Distance 2095.16
+}
+
+OpenCluster "Theia 1256"
+{
+	RA 6.51063743
+	Dec -21.31785135
+	Radius 37.999
+	Distance 3058.412
+}
+
+OpenCluster "UBC 210"
+{
+	RA 6.51217317
+	Dec -1.40045521
+	Radius 43.36
+	Distance 7099.502
+}
+
+OpenCluster "vdBergh 80"
+{
+	RA 6.51537079
+	Dec -9.63276704
+	Radius 58.407
+	Distance 3117.955
+}
+
+OpenCluster "Czernik 26:MWSC 886:OCL 544"
+{
+	RA 6.51640431
+	Dec -4.17767756
+	Radius 174.179
+	Distance 22683.388
 }
 
 OpenCluster "Collinder 95"
 {
-	RA 6.514167
-	Dec 9.943611
-	Distance 1813
-	Radius 7.1
+	RA 6.51889535
+	Dec 9.83902432
+	Radius 38.897
+	Distance 2123.368
 }
 
-OpenCluster "Collinder 97"
+OpenCluster "Theia 189"
 {
-	RA 6.521667
-	Dec 5.916667
-	Distance 2054
-	Radius 7.5
+	RA 6.51911305
+	Dec 5.43145307
+	Radius 189.537
+	Distance 2924.678
 }
 
-OpenCluster "NGC 2244"
+OpenCluster "OC 0326:UBC 203"
 {
-	RA 6.531944
-	Dec 4.941667
-	Distance 4713
-	Radius 19.9
+	RA 6.52073175
+	Dec 15.06441815
+	Radius 82.066
+	Distance 9030.162
 }
 
-OpenCluster "NGC 2240"
+OpenCluster "FSR 0979:FSR 979:MWSC 891:OC 0333:SAI 65"
 {
-	RA 6.552778
-	Dec 35.250000
-	Distance 1467
-	Radius 2.3
+	RA 6.52151656
+	Dec 11.08208048
+	Radius 47.354
+	Distance 8462.993
 }
 
-OpenCluster "Berkeley 23"
+OpenCluster "UPK 442"
 {
-	RA 6.558333
-	Dec 20.550000
-	Distance 22564
-	Radius 13.1
+	RA 6.52348235
+	Dec -12.55732944
+	Radius 75.915
+	Distance 2051.575
 }
 
-OpenCluster "Basel 8"
+OpenCluster "Collinder 97:DSH J0631.6+0552:Teutsch 137"
 {
-	RA 6.570000
-	Dec 8.083333
-	Distance 4331
-	Radius 18.3
+	RA 6.52801485
+	Dec 5.88407765
+	Radius 163.678
+	Distance 16803.976
 }
 
-OpenCluster "NGC 2251"
+OpenCluster "LISC-III 1682:Theia 1775:UBC 620"
 {
-	RA 6.577222
-	Dec 8.366667
-	Distance 4334
-	Radius 6.3
+	RA 6.52929027
+	Dec 2.45430145
+	Radius 25.409
+	Distance 4614.222
 }
 
-OpenCluster "NGC 2252"
+OpenCluster "FSR 0977:FSR 977:MWSC 895:Riddle 1:Teutsch J0631.9+1151"
 {
-	RA 6.578333
-	Dec 5.366667
-	Distance 2935
-	Radius 7.7
+	RA 6.53119181
+	Dec 11.86795422
+	Radius 76.429
+	Distance 6598.581
 }
 
-OpenCluster "NGC 2254"
+OpenCluster "Satellite Cluster:NGC 2244:Melotte 47:Collinder 99:Caldwell 50"
 {
-	RA 6.596944
-	Dec 7.673333
-	Distance 7710
-	Radius 5.6
+	RA 6.5323534
+	Dec 4.92671252
+	Radius 36.32
+	Distance 4615.88
 }
 
-OpenCluster "ESO 426-26"
+OpenCluster "HXHWL 19:Theia 2356"
 {
-	RA 6.605000
-	Dec -29.141667
-	Distance 4044
-	Radius 2.9
+	RA 6.53366958
+	Dec 0.47612093
+	Radius 31.371
+	Distance 3887.204
 }
 
-OpenCluster "Ruprecht 1"
+OpenCluster "Teutsch 198"
 {
-	RA 6.606667
-	Dec -13.816667
-	Distance 3261
-	Radius 2.4
+	RA 6.5341339
+	Dec 16.0964602
+	Radius 136.107
+	Distance 16829.337
 }
 
-OpenCluster "Basel 7"
+OpenCluster "CWNU 1473"
 {
-	RA 6.610000
-	Dec 8.350000
-	Distance 5492
-	Radius 4.0
+	RA 6.539112
+	Dec 9.6024488
+	Radius 84.142
+	Distance 6391.628
 }
 
-OpenCluster "Trumpler 5"
+OpenCluster "HSC 1699"
 {
-	RA 6.611667
-	Dec 9.433333
-	Distance 7828
-	Radius 17.5
+	RA 6.53938064
+	Dec -5.44934329
+	Radius 26.436
+	Distance 7209.18
 }
 
-OpenCluster "vdBergh 1"
+OpenCluster "FSR 0974:FSR 974:MWSC 897:MWSC 898:OC 0328"
 {
-	RA 6.616667
-	Dec 3.066667
-	Distance 5502
-	Radius 4.0
+	RA 6.54335542
+	Dec 12.55628031
+	Radius 41.143
+	Distance 9494.21
 }
 
-OpenCluster "Collinder 106"
+OpenCluster "HSC 1623"
 {
-	RA 6.618333
-	Dec 5.950000
-	Distance 2508
-	Radius 12.8
+	RA 6.54586366
+	Dec 5.41778023
+	Radius 50.84
+	Distance 11956.271
+}
+
+OpenCluster "HSC 1920"
+{
+	RA 6.54828033
+	Dec -32.05816843
+	Radius 130.636
+	Distance 2074.017
+}
+
+OpenCluster "CWNU 239:LISC-III 1682:Theia 1671:UBC 1330"
+{
+	RA 6.55197233
+	Dec 2.44583542
+	Radius 104.664
+	Distance 4929.143
+}
+
+OpenCluster "CWNU 2535:Theia 2133"
+{
+	RA 6.55249227
+	Dec 12.43808073
+	Radius 95.712
+	Distance 6211.466
+}
+
+OpenCluster "HSC 1625"
+{
+	RA 6.55394752
+	Dec 5.37454147
+	Radius 69.172
+	Distance 13108.101
+}
+
+OpenCluster "Berkeley 23:FSR 917:MWSC 902:OCL 478"
+{
+	RA 6.55433728
+	Dec 20.53468901
+	Radius 115.389
+	Distance 15971.202
+}
+
+OpenCluster "HSC 1615"
+{
+	RA 6.55678046
+	Dec 6.2263722
+	Radius 44.352
+	Distance 8456.236
+}
+
+OpenCluster "Gulliver 32"
+{
+	RA 6.5589079
+	Dec 7.46585503
+	Radius 143.271
+	Distance 5418.881
+}
+
+OpenCluster "FSR 0905:FSR 905:MWSC 904:Theia 3923"
+{
+	RA 6.56206403
+	Dec 22.31307514
+	Radius 48.742
+	Distance 4712.483
+}
+
+OpenCluster "HSC 1512"
+{
+	RA 6.56240964
+	Dec 22.22325356
+	Radius 52.558
+	Distance 2217.889
+}
+
+OpenCluster "CWNU 288:OC 0354"
+{
+	RA 6.56454699
+	Dec -1.6934597
+	Radius 66.551
+	Distance 6453.388
+}
+
+OpenCluster "UBC 1312"
+{
+	RA 6.5655786
+	Dec 18.34457576
+	Radius 128.121
+	Distance 12793.501
+}
+
+OpenCluster "CWNU 238:OC 0353"
+{
+	RA 6.57087825
+	Dec -0.89594296
+	Radius 34.083
+	Distance 2509.517
+}
+
+OpenCluster "Basel 8:MWSC 907:OCL 499.1"
+{
+	RA 6.57174113
+	Dec 7.8608743
+	Radius 49.582
+	Distance 4697.489
+}
+
+OpenCluster "UBC 443"
+{
+	RA 6.57622942
+	Dec -6.83413858
+	Radius 58.047
+	Distance 9535.436
+}
+
+OpenCluster "HSC 1731"
+{
+	RA 6.57695572
+	Dec -8.86538172
+	Radius 117.392
+	Distance 24310.083
+}
+
+OpenCluster "FSR 1063:MWSC 917:SAI 66"
+{
+	RA 6.57700273
+	Dec -0.26745335
+	Radius 77.96
+	Distance 7172.697
+}
+
+OpenCluster "NGC 2251:Collinder 101:MWSC 916:OCL 499:Theia 2992"
+{
+	RA 6.57842007
+	Dec 8.34438476
+	Radius 51.208
+	Distance 4541.663
+}
+
+OpenCluster "FSR 0935:FSR 935:MWSC 948"
+{
+	RA 6.58560363
+	Dec 17.7364675
+	Radius 91.949
+	Distance 7879.745
+}
+
+OpenCluster "CWNU 451:OC 0330"
+{
+	RA 6.58628161
+	Dec 12.64683193
+	Radius 43.359
+	Distance 5617.242
+}
+
+OpenCluster "HSC 1977"
+{
+	RA 6.58808217
+	Dec -36.71643843
+	Radius 24.544
+	Distance 527.199
+}
+
+OpenCluster "HXHWL 58"
+{
+	RA 6.59657963
+	Dec 8.76570296
+	Radius 45.852
+	Distance 6109.339
+}
+
+OpenCluster "NGC 2254:Collinder 103:FSR 1001:MWSC 924:OCL 500"
+{
+	RA 6.59662042
+	Dec 7.67208068
+	Radius 72.829
+	Distance 7610.29
+}
+
+OpenCluster "OCSN 55:Theia 792"
+{
+	RA 6.60122693
+	Dec 19.61347762
+	Radius 106.936
+	Distance 680.284
+}
+
+OpenCluster "HSC 1629"
+{
+	RA 6.6012778
+	Dec 5.51484377
+	Radius 32.272
+	Distance 4651.987
+}
+
+OpenCluster "HSC 1598"
+{
+	RA 6.60339998
+	Dec 10.91479987
+	Radius 62.606
+	Distance 9887.884
+}
+
+OpenCluster "Theia 1797"
+{
+	RA 6.60474395
+	Dec 9.83258774
+	Radius 110.659
+	Distance 3575.327
+}
+
+OpenCluster "FSR 1032:MWSC 927"
+{
+	RA 6.60481048
+	Dec 4.01065891
+	Radius 38.293
+	Distance 6839.203
+}
+
+OpenCluster "FSR 1179:MWSC 929:MWSC 931:OCL 563:Ruprecht 1:Theia 3569"
+{
+	RA 6.60659621
+	Dec -14.1666642
+	Radius 52.35
+	Distance 4766.856
+}
+
+OpenCluster "HSC 1912"
+{
+	RA 6.60808556
+	Dec -30.43608874
+	Radius 35.929
+	Distance 2844.052
+}
+
+OpenCluster "Collinder 105:FSR 989:MWSC 933:OCL 494:Theia 5805:Trumpler 5"
+{
+	RA 6.60847051
+	Dec 9.45854713
+	Radius 121.794
+	Distance 9474.608
+}
+
+OpenCluster "HSC 1552"
+{
+	RA 6.60948791
+	Dec 17.16456487
+	Radius 156.053
+	Distance 12347.576
+}
+
+OpenCluster "HSC 1649"
+{
+	RA 6.61060577
+	Dec 2.26522216
+	Radius 38.915
+	Distance 4576.004
+}
+
+OpenCluster "HSC 2032"
+{
+	RA 6.61177473
+	Dec -44.43196147
+	Radius 80.41
+	Distance 1869.704
+}
+
+OpenCluster "Collinder 104:Collinder 107"
+{
+	RA 6.61247043
+	Dec 4.71024285
+	Radius 44.985
+	Distance 4932.53
+}
+
+OpenCluster "HSC 1590"
+{
+	RA 6.61512642
+	Dec 12.18436891
+	Radius 76.786
+	Distance 3474.367
+}
+
+OpenCluster "CV Mon:FSR 1042:MWSC 934:OCL 527:vdB 1:vdBergh 1"
+{
+	RA 6.61819788
+	Dec 3.07917934
+	Radius 26.33
+	Distance 5560.835
+}
+
+OpenCluster "HSC 1651"
+{
+	RA 6.61822135
+	Dec 2.0669028
+	Radius 37.388
+	Distance 10802.93
+}
+
+OpenCluster "Collinder 106:FSR 1008"
+{
+	RA 6.61968371
+	Dec 6.05024065
+	Radius 31.242
+	Distance 4661.222
+}
+
+OpenCluster "HSC 1577"
+{
+	RA 6.6200802
+	Dec 14.22316063
+	Radius 43.436
+	Distance 10294.481
+}
+
+OpenCluster "HSC 1583"
+{
+	RA 6.62705251
+	Dec 13.30547471
+	Radius 128.108
+	Distance 13622.759
+}
+
+OpenCluster "Berkeley 24:FSR 1070:MWSC 937:OCL 539"
+{
+	RA 6.62967026
+	Dec -0.87700037
+	Radius 80.924
+	Distance 14555.438
+}
+
+OpenCluster "HSC 2037"
+{
+	RA 6.62996649
+	Dec -44.92239099
+	Radius 67.213
+	Distance 1015.693
+}
+
+OpenCluster "HSC 1665"
+{
+	RA 6.6374453
+	Dec 0.73476031
+	Radius 120.465
+	Distance 18636.356
+}
+
+OpenCluster "HSC 1622"
+{
+	RA 6.63780292
+	Dec 6.16082742
+	Radius 50.166
+	Distance 3989.23
+}
+
+OpenCluster "HSC 1641"
+{
+	RA 6.64002461
+	Dec 4.20555213
+	Radius 38.832
+	Distance 4705.549
+}
+
+OpenCluster "Theia 177"
+{
+	RA 6.64057784
+	Dec -45.13446349
+	Radius 84.032
+	Distance 1759.856
 }
 
 OpenCluster "Collinder 107"
 {
-	RA 6.628333
-	Dec 4.733333
-	Distance 5668
-	Radius 23.9
+	RA 6.64144021
+	Dec 4.63508593
+	Radius 106.023
+	Distance 4590.232
 }
 
-OpenCluster "Berkeley 24"
+OpenCluster "CWNU 1291"
 {
-	RA 6.629722
-	Dec 0.871944
-	Distance 15329
-	Radius 15.6
+	RA 6.64203155
+	Dec -3.76882291
+	Radius 178.361
+	Distance 6489.158
 }
 
-OpenCluster "NGC 2259"
+OpenCluster "OCSN 76"
 {
-	RA 6.639167
-	Dec 10.883333
-	Distance 10799
-	Radius 4.7
+	RA 6.64253919
+	Dec -16.76476224
+	Radius 146.305
+	Distance 1483.436
 }
 
-OpenCluster "Collinder 110"
+OpenCluster "NGC 2259:Melotte 48:Collinder 108:FSR 972:MWSC 940:OCL 492:OC 0334"
 {
-	RA 6.640000
-	Dec 2.016667
-	Distance 6360
-	Radius 16.7
+	RA 6.64260484
+	Dec 10.88076025
+	Radius 44.982
+	Distance 8991.067
 }
 
-OpenCluster "NGC 2262"
+OpenCluster "Collinder 110:FSR 1049:MWSC 941:OCL 530:Theia 4536"
 {
-	RA 6.660556
-	Dec 1.143333
-	Distance 11742
-	Radius 8.5
+	RA 6.64649051
+	Dec 2.07287901
+	Radius 97.651
+	Distance 6852.561
 }
 
-OpenCluster "NGC 2264"
+OpenCluster "HSC 1655"
 {
-	RA 6.682778
-	Dec 9.895000
-	Distance 2175
-	Radius 12.3
+	RA 6.65289151
+	Dec 1.77333919
+	Radius 48.661
+	Distance 11518.968
 }
 
-OpenCluster "Berkeley 25"
+OpenCluster "HSC 1636"
 {
-	RA 6.683333
-	Dec -15.483333
-	Distance 37183
-	Radius 27.0
+	RA 6.65928885
+	Dec 4.88723937
+	Radius 27.57
+	Distance 4833.296
 }
 
-OpenCluster "Ruprecht 3"
+OpenCluster "NGC 2262:Collinder 109:FSR 1055:MWSC 946:OCL 531:OC 0348:OC 0349"
 {
-	RA 6.701944
-	Dec -28.545833
-	Distance 3587
-	Radius 2.1
+	RA 6.66052406
+	Dec 1.14347853
+	Radius 51.48
+	Distance 10786.12
 }
 
-OpenCluster "Dolidze 23"
+OpenCluster "CWNU 2683"
 {
-	RA 6.715278
-	Dec 0.046111
-	Distance 2038
-	Radius 3.8
+	RA 6.66087355
+	Dec 7.33268693
+	Radius 49.029
+	Distance 7137.292
 }
 
-OpenCluster "NGC 2269"
+OpenCluster "CWNU 158"
 {
-	RA 6.721389
-	Dec 4.625000
-	Distance 5502
-	Radius 2.4
+	RA 6.66227373
+	Dec 5.23329825
+	Radius 92.129
+	Distance 4849.991
 }
 
-OpenCluster "NGC 2266"
+OpenCluster "Desvoivres 2"
 {
-	RA 6.721944
-	Dec 26.970000
-	Distance 11089
-	Radius 8.1
+	RA 6.66530539
+	Dec 6.03698268
+	Radius 32.962
+	Distance 4660.815
 }
 
-OpenCluster "NGC 2270"
+OpenCluster "vdBergh 83"
 {
-	RA 6.732500
-	Dec 3.478333
-	Distance 4566
-	Radius 9.3
+	RA 6.6661162
+	Dec -27.18196104
+	Radius 45.22
+	Distance 2947.445
+}
+
+OpenCluster "FSR 0975:FSR 975:MWSC 948"
+{
+	RA 6.66705889
+	Dec 13.31110374
+	Radius 117.244
+	Distance 14232.023
+}
+
+OpenCluster "HSC 1871"
+{
+	RA 6.6676038
+	Dec -26.10701949
+	Radius 46.14
+	Distance 1077.253
+}
+
+OpenCluster "LISC 3106:UBC 441"
+{
+	RA 6.66811693
+	Dec -3.61774856
+	Radius 49.124
+	Distance 6235.335
+}
+
+OpenCluster "CWNU 1121"
+{
+	RA 6.66996244
+	Dec -50.54326832
+	Radius 196.731
+	Distance 1541.577
+}
+
+OpenCluster "HSC 1528"
+{
+	RA 6.67701569
+	Dec 20.61720621
+	Radius 184.536
+	Distance 2180.028
+}
+
+OpenCluster "HSC 1677"
+{
+	RA 6.67711001
+	Dec -0.68565928
+	Radius 60.025
+	Distance 1825.56
+}
+
+OpenCluster "HSC 1863"
+{
+	RA 6.68148374
+	Dec -25.51945136
+	Radius 117.366
+	Distance 24315.958
+}
+
+OpenCluster "Theia 41"
+{
+	RA 6.68180464
+	Dec 9.87543655
+	Radius 19.757
+	Distance 2284.339
+}
+
+OpenCluster "CWNU 1436"
+{
+	RA 6.68180688
+	Dec 13.16165376
+	Radius 45.039
+	Distance 11215.903
+}
+
+OpenCluster "Christmas Tree Cluster:Mon OB1-D:NGC 2264"
+{
+	RA 6.68490425
+	Dec 9.57258837
+	Radius 12.424
+	Distance 2304.164
+}
+
+OpenCluster "Berkeley 25:MWSC 955:OCL 576"
+{
+	RA 6.68748646
+	Dec -16.48689544
+	Radius 117.292
+	Distance 23195.562
+}
+
+OpenCluster "UPK 436"
+{
+	RA 6.68853688
+	Dec -7.99848563
+	Radius 59.454
+	Distance 2654.247
+}
+
+OpenCluster "HSC 1678"
+{
+	RA 6.68986262
+	Dec -1.25269076
+	Radius 52.524
+	Distance 16558.717
+}
+
+OpenCluster "Theia 555:UPK 448"
+{
+	RA 6.69185509
+	Dec -12.04773488
+	Radius 88.32
+	Distance 2905.854
+}
+
+OpenCluster "LISC-III 3344:Teutsch 177:Theia 2851:UBC 216"
+{
+	RA 6.69290083
+	Dec -5.8078888
+	Radius 44.117
+	Distance 3697.47
+}
+
+OpenCluster "HSC 1492"
+{
+	RA 6.69524796
+	Dec 26.7455501
+	Radius 36.655
+	Distance 4425.143
+}
+
+OpenCluster "Alessi 170:Theia 3522:UBC 215"
+{
+	RA 6.6970971
+	Dec -5.23928191
+	Radius 129.029
+	Distance 4418.62
+}
+
+OpenCluster "FSR 1077:MWSC 960:UBC 1339"
+{
+	RA 6.69804627
+	Dec -0.88924263
+	Radius 110.615
+	Distance 14204.169
+}
+
+OpenCluster "CWNU 2076"
+{
+	RA 6.70046154
+	Dec -6.44107519
+	Radius 80.389
+	Distance 8171.032
+}
+
+OpenCluster "HSC 1757"
+{
+	RA 6.70078601
+	Dec -12.9542413
+	Radius 50.65
+	Distance 18298.657
+}
+
+OpenCluster "UBC 1334"
+{
+	RA 6.70224701
+	Dec 3.00724947
+	Radius 81.444
+	Distance 6433.428
+}
+
+OpenCluster "HSC 1600"
+{
+	RA 6.70419709
+	Dec 11.40481035
+	Radius 131.155
+	Distance 14107.717
+}
+
+OpenCluster "CWNU 1334"
+{
+	RA 6.70540569
+	Dec 16.43326842
+	Radius 36.618
+	Distance 8021.397
+}
+
+OpenCluster "UBC 442"
+{
+	RA 6.70558936
+	Dec -4.60498778
+	Radius 133.627
+	Distance 12394.169
+}
+
+OpenCluster "CWNU 1714"
+{
+	RA 6.70633932
+	Dec -1.51528475
+	Radius 257.921
+	Distance 17277.125
+}
+
+OpenCluster "UBC 1321"
+{
+	RA 6.70817231
+	Dec 12.86175083
+	Radius 49.008
+	Distance 8462.956
+}
+
+OpenCluster "CWNU 1281"
+{
+	RA 6.70969653
+	Dec 4.72764022
+	Radius 40.864
+	Distance 4767.829
+}
+
+OpenCluster "UBC 451"
+{
+	RA 6.71591484
+	Dec -23.74103537
+	Radius 64.127
+	Distance 5568.969
+}
+
+OpenCluster "HSC 1595"
+{
+	RA 6.71624507
+	Dec 12.51085182
+	Radius 85.917
+	Distance 13050.851
+}
+
+OpenCluster "HSC 1679"
+{
+	RA 6.71821504
+	Dec -1.26822314
+	Radius 77.96
+	Distance 5677.628
+}
+
+OpenCluster "HSC 1645"
+{
+	RA 6.72007025
+	Dec 3.97580438
+	Radius 47.606
+	Distance 5389.808
+}
+
+OpenCluster "HSC 1659"
+{
+	RA 6.72126182
+	Dec 2.13014702
+	Radius 18.058
+	Distance 9054.221
+}
+
+OpenCluster "NGC 2269:Collinder 114:FSR 1037:MWSC 966:OCL 524"
+{
+	RA 6.72149027
+	Dec 4.62291179
+	Radius 38.726
+	Distance 6952.928
+}
+
+OpenCluster "HSC 1708"
+{
+	RA 6.72164704
+	Dec -4.85597235
+	Radius 73.162
+	Distance 24706.329
+}
+
+OpenCluster "NGC 2266:Melotte 50:Collinder 113:FSR 879:MWSC 967:OCL 471"
+{
+	RA 6.72205415
+	Dec 26.97836982
+	Radius 109.644
+	Distance 10940.028
+}
+
+OpenCluster "HSC 1654"
+{
+	RA 6.72253539
+	Dec 2.37569516
+	Radius 91.888
+	Distance 13202.994
+}
+
+OpenCluster "HSC 1840"
+{
+	RA 6.72704722
+	Dec -22.90165549
+	Radius 71.618
+	Distance 891.117
+}
+
+OpenCluster "HSC 1771"
+{
+	RA 6.72862579
+	Dec -14.160122
+	Radius 54.885
+	Distance 15420.034
+}
+
+OpenCluster "FSR 0999:FSR 999:MWSC 970"
+{
+	RA 6.73012437
+	Dec 9.4757988
+	Radius 53.123
+	Distance 9563.373
+}
+
+OpenCluster "UBC 212"
+{
+	RA 6.73135704
+	Dec -0.88381268
+	Radius 41.308
+	Distance 8707.347
+}
+
+OpenCluster "DSH J0643.9+0124:FSR 1060:MWSC 969:Teutsch 13"
+{
+	RA 6.73175891
+	Dec 1.4065859
+	Radius 159.092
+	Distance 15360.392
+}
+
+OpenCluster "HSC 1565"
+{
+	RA 6.73389519
+	Dec 16.77865697
+	Radius 66.999
+	Distance 7103.693
+}
+
+OpenCluster "Theia 319"
+{
+	RA 6.73655007
+	Dec -15.44403576
+	Radius 129.485
+	Distance 1407.813
+}
+
+OpenCluster "CWNU 527:UBC 1346"
+{
+	RA 6.73844074
+	Dec -3.56798548
+	Radius 101.369
+	Distance 7067.817
+}
+
+OpenCluster "HSC 1620"
+{
+	RA 6.73924574
+	Dec 6.97838573
+	Radius 125.999
+	Distance 13086.781
+}
+
+OpenCluster "UPK 438"
+{
+	RA 6.74301808
+	Dec -9.20192704
+	Radius 51.74
+	Distance 1370.911
+}
+
+OpenCluster "CWNU 130:UBC 1345"
+{
+	RA 6.74330553
+	Dec -2.79851347
+	Radius 95.642
+	Distance 6788.509
+}
+
+OpenCluster "DSH J0644.7-0031:MWSC 974:Patchick 90:SAI 68"
+{
+	RA 6.74542202
+	Dec -0.52430228
+	Radius 46.013
+	Distance 15758.007
+}
+
+OpenCluster "CWNU 1169"
+{
+	RA 6.74625214
+	Dec -36.4789835
+	Radius 28.553
+	Distance 741.041
+}
+
+OpenCluster "Juchert J0644.8+0925:Juchert J0644.8-0925"
+{
+	RA 6.74725747
+	Dec -9.42984752
+	Radius 69.132
+	Distance 22387.663
+}
+
+OpenCluster "UBC 1350"
+{
+	RA 6.74892633
+	Dec -5.71483189
+	Radius 93.188
+	Distance 14318.596
+}
+
+OpenCluster "CWNU 2558"
+{
+	RA 6.74994508
+	Dec 0.86440239
+	Radius 61.16
+	Distance 4580.208
+}
+
+OpenCluster "HXHWL 69:Theia 3740"
+{
+	RA 6.75021034
+	Dec -24.26364966
+	Radius 77.821
+	Distance 3262.53
 }
 
 OpenCluster "Dolidze 25"
 {
-	RA 6.751667
-	Dec 0.300000
-	Distance 22179
-	Radius 64.5
+	RA 6.75115346
+	Dec 0.22784927
+	Radius 131.942
+	Distance 13382.664
 }
 
-OpenCluster "ASCC 25"
+OpenCluster "HSC 1534"
 {
-	RA 6.758889
-	Dec 24.600000
-	Distance 4566
-	Radius 16.7
+	RA 6.75693828
+	Dec 20.78991756
+	Radius 147.849
+	Distance 2404.596
 }
 
-OpenCluster "NGC 2287"
+OpenCluster "HSC 1652"
 {
-	RA 6.766944
-	Dec -19.243333
-	Distance 2315
-	Radius 13.1
+	RA 6.76167941
+	Dec 2.99317499
+	Radius 105.488
+	Distance 12260.302
 }
 
-OpenCluster "NGC 2286"
+OpenCluster "HSC 1728"
 {
-	RA 6.794444
-	Dec -2.851667
-	Distance 8480
-	Radius 17.3
+	RA 6.7635731
+	Dec -7.31525124
+	Radius 197.119
+	Distance 22159.703
 }
 
-OpenCluster "NGC 2281"
+OpenCluster "UBC 1329"
 {
-	RA 6.804722
-	Dec 41.078333
-	Distance 1820
-	Radius 6.6
+	RA 6.76375294
+	Dec 7.66962228
+	Radius 115.734
+	Distance 15507.027
+}
+
+OpenCluster "Gaia 1:OC 0384:OC 0385:OC 0386:Siriusly"
+{
+	RA 6.76443582
+	Dec -16.73987206
+	Radius 330.676
+	Distance 15760.046
+}
+
+OpenCluster "HSC 1614"
+{
+	RA 6.76521488
+	Dec 7.98795847
+	Radius 46.202
+	Distance 2833.277
+}
+
+OpenCluster "HSC 1657"
+{
+	RA 6.76551735
+	Dec 2.51618225
+	Radius 57.262
+	Distance 4758.845
+}
+
+OpenCluster "Little Beehive Cluster:M 41:NGC 2287:Melotte 52:Collinder 118:ESO 557-14:MWSC 978:OCL 597:Theia 476"
+{
+	RA 6.76634266
+	Dec -20.70304973
+	Radius 80.712
+	Distance 2332.203
+}
+
+OpenCluster "HSC 1689"
+{
+	RA 6.76687878
+	Dec -1.95126686
+	Radius 64.843
+	Distance 19167.709
+}
+
+OpenCluster "HSC 1344"
+{
+	RA 6.76914618
+	Dec 43.57294547
+	Radius 81.938
+	Distance 1931.332
+}
+
+OpenCluster "OC 0346:Theia 1734"
+{
+	RA 6.76948455
+	Dec 3.3800726
+	Radius 123.291
+	Distance 4558.502
+}
+
+OpenCluster "UBC 1322"
+{
+	RA 6.76962489
+	Dec 12.05255653
+	Radius 240.381
+	Distance 13732.246
+}
+
+OpenCluster "HSC 1690"
+{
+	RA 6.77719739
+	Dec -2.09322739
+	Radius 64.145
+	Distance 13829.257
+}
+
+OpenCluster "Collinder 115:FSR 1059:MWSC 981:OCL 535:Theia 1988"
+{
+	RA 6.77735955
+	Dec 1.78301894
+	Radius 202.546
+	Distance 6121.13
+}
+
+OpenCluster "HSC 1756"
+{
+	RA 6.77944164
+	Dec -12.01554471
+	Radius 25.585
+	Distance 2329.087
+}
+
+OpenCluster "Theia 72"
+{
+	RA 6.78015714
+	Dec -9.78555471
+	Radius 101.781
+	Distance 914.033
+}
+
+OpenCluster "vdBergh 85"
+{
+	RA 6.78134227
+	Dec 1.32425587
+	Radius 38.823
+	Distance 5481.426
+}
+
+OpenCluster "Theia 2118"
+{
+	RA 6.78258746
+	Dec 7.38741064
+	Radius 156.516
+	Distance 4506.448
+}
+
+OpenCluster "Theia 826:UPK 350"
+{
+	RA 6.78316573
+	Dec 48.33213977
+	Radius 182.218
+	Distance 1397.365
+}
+
+OpenCluster "CWNU 2178"
+{
+	RA 6.78515302
+	Dec 4.70409558
+	Radius 128.14
+	Distance 14562.954
+}
+
+OpenCluster "CWNU 263"
+{
+	RA 6.78520351
+	Dec 0.7478931
+	Radius 51.794
+	Distance 6514.532
+}
+
+OpenCluster "HSC 1772"
+{
+	RA 6.78680691
+	Dec -13.8716288
+	Radius 101.159
+	Distance 4063.811
+}
+
+OpenCluster "HSC 1726"
+{
+	RA 6.79208059
+	Dec -6.38058484
+	Radius 163.65
+	Distance 23989.385
+}
+
+OpenCluster "HSC 1638"
+{
+	RA 6.79259179
+	Dec 5.63126909
+	Radius 104.237
+	Distance 11261.177
+}
+
+OpenCluster "NGC 2286:Collinder 117:FSR 1104:MWSC 987:OCL 548:Theia 3007"
+{
+	RA 6.79455596
+	Dec -3.15288228
+	Radius 100.156
+	Distance 7271.175
+}
+
+OpenCluster "UBC 1323"
+{
+	RA 6.7968888
+	Dec 11.40879646
+	Radius 126.769
+	Distance 12899.436
+}
+
+OpenCluster "CWNU 251:UBC 1614"
+{
+	RA 6.79756854
+	Dec -7.12337905
+	Radius 27.53
+	Distance 7329.159
+}
+
+OpenCluster "CWNU 1778:Theia 1769"
+{
+	RA 6.79791355
+	Dec -12.83589296
+	Radius 137.832
+	Distance 4343.353
+}
+
+OpenCluster "OC 0342:Theia 2812"
+{
+	RA 6.79916743
+	Dec 7.66373399
+	Radius 42.935
+	Distance 4429.227
+}
+
+OpenCluster "CWNU 222"
+{
+	RA 6.79956518
+	Dec -8.0188464
+	Radius 76.068
+	Distance 4987.469
+}
+
+OpenCluster "HSC 1564"
+{
+	RA 6.80075036
+	Dec 17.32562288
+	Radius 26.83
+	Distance 4014.813
+}
+
+OpenCluster "UBC 1340"
+{
+	RA 6.80449794
+	Dec -0.06972132
+	Radius 62.733
+	Distance 10386.144
+}
+
+OpenCluster "NGC 2281:Melotte 51:Collinder 116:MWSC 989:OCL 446:Theia 635"
+{
+	RA 6.80599663
+	Dec 41.09397082
+	Radius 154.957
+	Distance 1659.914
+}
+
+OpenCluster "CWNU 501"
+{
+	RA 6.80681641
+	Dec -16.88281913
+	Radius 47.551
+	Distance 3253.867
+}
+
+OpenCluster "UBC 1331"
+{
+	RA 6.80711979
+	Dec 4.00716115
+	Radius 66.866
+	Distance 11160.846
 }
 
 OpenCluster "Bochum 2"
 {
-	RA 6.815000
-	Dec 0.383333
-	Distance 8679
-	Radius 1.9
+	RA 6.81380839
+	Dec 0.37711184
+	Radius 109.674
+	Distance 14460.954
 }
 
-OpenCluster "Ruprecht 4"
+OpenCluster "Berkeley 74:FSR 1165:MWSC 990:OCL 560:OC 0371:Ruprecht 4"
 {
-	RA 6.815000
-	Dec -9.466667
-	Distance 15329
-	Radius 6.7
+	RA 6.81634296
+	Dec -10.52952636
+	Radius 68.548
+	Distance 12757.687
 }
 
-OpenCluster "Berkeley 75"
+OpenCluster "Berkeley 75:ES0490SC50:MWSC 993:OCL 614"
 {
-	RA 6.816944
-	Dec -22.003333
-	Distance 29681
-	Radius 17.3
+	RA 6.81659979
+	Dec -23.9959872
+	Radius 174.514
+	Distance 22275.172
 }
 
-OpenCluster "ASCC 26"
+OpenCluster "CWNU 1181:Theia 69"
 {
-	RA 6.840000
-	Dec 7.250000
-	Distance 2609
-	Radius 7.7
+	RA 6.81881595
+	Dec -15.09564806
+	Radius 35.899
+	Distance 554.86
 }
 
-OpenCluster "Berkeley 27"
+OpenCluster "HSC 1668"
 {
-	RA 6.855000
-	Dec 5.766667
-	Distance 16422
-	Radius 4.8
+	RA 6.82089717
+	Dec 2.00197783
+	Radius 129.106
+	Distance 15916.876
 }
 
-OpenCluster "NGC 2301"
+OpenCluster "CWNU 266:UBC 1333"
 {
-	RA 6.862500
-	Dec 0.460000
-	Distance 2837
-	Radius 5.8
+	RA 6.82178777
+	Dec 3.98645844
+	Radius 66.64
+	Distance 11143.067
 }
 
-OpenCluster "NGC 2302"
+OpenCluster "HSC 1635"
 {
-	RA 6.865278
-	Dec -6.916667
-	Distance 4892
-	Radius 3.6
+	RA 6.82190631
+	Dec 6.31100301
+	Radius 80.028
+	Distance 2877.453
 }
 
-OpenCluster "Berkeley 28"
+OpenCluster "CWNU 1041:Theia 2449"
 {
-	RA 6.870000
-	Dec 2.933333
-	Distance 8340
-	Radius 3.6
+	RA 6.82364164
+	Dec -3.7314149
+	Radius 71.627
+	Distance 3572.693
 }
 
-OpenCluster "Berkeley 29"
+OpenCluster "Juchert J0649.4+1202:UBC 204"
 {
-	RA 6.888333
-	Dec 16.916667
-	Distance 48504
-	Radius 42.3
+	RA 6.82462712
+	Dec 12.04228448
+	Radius 133.222
+	Distance 13129.208
 }
 
-OpenCluster "ASCC 27"
+OpenCluster "HSC 1700"
 {
-	RA 6.898056
-	Dec -3.610000
-	Distance 3914
-	Radius 13.7
+	RA 6.82792999
+	Dec -3.41416071
+	Radius 43.177
+	Distance 5383.407
 }
 
-OpenCluster "ASCC 28"
+OpenCluster "CWNU 2012"
 {
-	RA 6.901111
-	Dec 0.170000
-	Distance 2609
-	Radius 13.7
+	RA 6.83066201
+	Dec -0.17417965
+	Radius 126.275
+	Distance 15018.857
 }
 
-OpenCluster "ASCC 29"
+OpenCluster "OC 0364:Theia 1885"
 {
-	RA 6.905000
-	Dec -0.350000
-	Distance 2446
-	Radius 9.4
+	RA 6.83549461
+	Dec -5.3379557
+	Radius 36.13
+	Distance 4256.743
 }
 
-OpenCluster "NGC 2306"
+OpenCluster "CWNU 240"
 {
-	RA 6.908056
-	Dec -6.796667
-	Distance 3914
-	Radius 6.8
+	RA 6.8358775
+	Dec 0.9565583
+	Radius 24.846
+	Distance 3963.167
 }
 
-OpenCluster "NGC 2304"
+OpenCluster "FSR 1125:MWSC 996:SAI 70"
 {
-	RA 6.919722
-	Dec 17.988333
-	Distance 13017
-	Radius 5.7
+	RA 6.8411235
+	Dec -5.44172419
+	Radius 105.305
+	Distance 14961.087
 }
 
-OpenCluster "NGC 2309"
+OpenCluster "Theia 373"
 {
-	RA 6.934167
-	Dec -6.825000
-	Distance 8190
-	Radius 6.0
+	RA 6.84117185
+	Dec -27.956077
+	Radius 75.463
+	Distance 661.533
 }
 
-OpenCluster "Collinder 121"
+OpenCluster "HSC 1680"
 {
-	RA 6.938889
-	Dec -23.270556
-	Distance 3587
-	Radius 31.3
+	RA 6.84126292
+	Dec -0.32533339
+	Radius 77.525
+	Distance 13407.041
 }
 
-OpenCluster "ASCC 30"
+OpenCluster "UBC 1355"
 {
-	RA 6.950000
-	Dec -5.790000
-	Distance 2609
-	Radius 11.8
+	RA 6.84152614
+	Dec -10.12009914
+	Radius 64.83
+	Distance 14639.611
 }
 
-OpenCluster "Berkeley 31"
+OpenCluster "CWNU 1503"
 {
-	RA 6.960000
-	Dec 8.266667
-	Distance 26980
-	Radius 19.6
+	RA 6.84617222
+	Dec -6.09603517
+	Radius 32.286
+	Distance 3902.208
 }
 
-OpenCluster "Berkeley 30"
+OpenCluster "HSC 1706"
 {
-	RA 6.961667
-	Dec 3.216667
-	Distance 15623
-	Radius 6.8
+	RA 6.84673435
+	Dec -3.61143024
+	Radius 70.821
+	Distance 14745.22
+}
+
+OpenCluster "DSH J0650.8+0131:Teutsch 93"
+{
+	RA 6.84768481
+	Dec 1.52641578
+	Radius 134.145
+	Distance 13549.595
+}
+
+OpenCluster "HXHWL 61:Theia 2266:UBC 1354"
+{
+	RA 6.84803473
+	Dec -10.01523864
+	Radius 36.139
+	Distance 6314.759
+}
+
+OpenCluster "HSC 1660"
+{
+	RA 6.8503089
+	Dec 2.9775909
+	Radius 96.911
+	Distance 10485.265
+}
+
+OpenCluster "HSC 1827"
+{
+	RA 6.85049723
+	Dec -20.15392197
+	Radius 34.677
+	Distance 1273.147
+}
+
+OpenCluster "Berkeley 27:Biurakan 11:MWSC 999:OCL 521:OC 0344"
+{
+	RA 6.85582857
+	Dec 5.76846219
+	Radius 78.199
+	Distance 12637.234
+}
+
+OpenCluster "DSH J0651.4-0148:FSR 1101:FoF 930:Teutsch 60:Theia 5786:UBC 213"
+{
+	RA 6.85657991
+	Dec -1.80242438
+	Radius 71.61
+	Distance 7393.683
+}
+
+OpenCluster "CWNU 1438"
+{
+	RA 6.8594778
+	Dec -10.50339335
+	Radius 68.01
+	Distance 7420.9
+}
+
+OpenCluster "HSC 1605"
+{
+	RA 6.86105077
+	Dec 10.60903392
+	Radius 23.187
+	Distance 3167.837
+}
+
+OpenCluster "NGC 2301:Melotte 54:Collinder 119:MWSC 1000:OCL 540"
+{
+	RA 6.86249715
+	Dec 0.46206923
+	Radius 52.632
+	Distance 2738.426
+}
+
+OpenCluster "Theia 2782"
+{
+	RA 6.86474715
+	Dec 9.23574735
+	Radius 95.048
+	Distance 4569.358
+}
+
+OpenCluster "NGC 2302:MWSC 1001:OCL 554"
+{
+	RA 6.86539385
+	Dec -7.08133097
+	Radius 28.07
+	Distance 3814.933
+}
+
+OpenCluster "CWNU 310:OC 0352"
+{
+	RA 6.86821341
+	Dec 1.91607105
+	Radius 52.038
+	Distance 4920.535
+}
+
+OpenCluster "HSC 1998"
+{
+	RA 6.86845347
+	Dec -38.48802021
+	Radius 110.314
+	Distance 584.837
+}
+
+OpenCluster "Berkeley 28:Biurakan 10:MWSC 1002:OCL 532"
+{
+	RA 6.86861982
+	Dec 2.91875935
+	Radius 87.736
+	Distance 12572.531
+}
+
+OpenCluster "FSR 1051:MWSC 1003"
+{
+	RA 6.86989682
+	Dec 3.65257465
+	Radius 46.666
+	Distance 7521.084
+}
+
+OpenCluster "HSC 1671"
+{
+	RA 6.87226668
+	Dec 1.54962423
+	Radius 133.545
+	Distance 11543.889
+}
+
+OpenCluster "HSC 1704"
+{
+	RA 6.87226935
+	Dec -3.31424823
+	Radius 87.899
+	Distance 15060.768
+}
+
+OpenCluster "HSC 1618"
+{
+	RA 6.8759518
+	Dec 8.33290803
+	Radius 42.496
+	Distance 4941.808
+}
+
+OpenCluster "HSC 1603"
+{
+	RA 6.87923432
+	Dec 10.94543844
+	Radius 81.45
+	Distance 3838.661
+}
+
+OpenCluster "CWNU 2103"
+{
+	RA 6.88001747
+	Dec 3.94914964
+	Radius 114.478
+	Distance 4393.063
+}
+
+OpenCluster "HSC 1643"
+{
+	RA 6.88113044
+	Dec 5.43804045
+	Radius 64.945
+	Distance 14264.461
+}
+
+OpenCluster "HSC 2028"
+{
+	RA 6.88121087
+	Dec -43.04600873
+	Radius 49.022
+	Distance 952.502
+}
+
+OpenCluster "Berkeley 29:MWSC 1008:OCL 486"
+{
+	RA 6.88439307
+	Dec 16.92587374
+	Radius 207.92
+	Distance 36774.783
+}
+
+OpenCluster "HSC 1894"
+{
+	RA 6.88449438
+	Dec -26.97451378
+	Radius 50.841
+	Distance 2616.651
+}
+
+OpenCluster "ASCC 28:FSR 1085:MWSC 1007:MWSC 1011:SAI 71"
+{
+	RA 6.88641854
+	Dec -0.19729689
+	Radius 34.318
+	Distance 5008.779
+}
+
+OpenCluster "HSC 1685"
+{
+	RA 6.88703638
+	Dec -0.6567833
+	Radius 80.994
+	Distance 14297.806
+}
+
+OpenCluster "Teutsch 201:Theia 194:UPK 433"
+{
+	RA 6.88717901
+	Dec -5.64136684
+	Radius 81.478
+	Distance 2502.402
+}
+
+OpenCluster "HSC 1513"
+{
+	RA 6.89228438
+	Dec 24.09524065
+	Radius 144.926
+	Distance 2417.128
+}
+
+OpenCluster "ASCC 28:MWSC 1011"
+{
+	RA 6.89686068
+	Dec -0.1287823
+	Radius 57.036
+	Distance 3391.174
+}
+
+OpenCluster "CWNU 1526"
+{
+	RA 6.89720788
+	Dec -1.03040528
+	Radius 102.791
+	Distance 15233.965
+}
+
+OpenCluster "HSC 1750"
+{
+	RA 6.89910901
+	Dec -9.94498503
+	Radius 118.529
+	Distance 9131.086
+}
+
+OpenCluster "ASCC 27:MWSC 1009"
+{
+	RA 6.90080265
+	Dec -4.51159597
+	Radius 54.31
+	Distance 10088.032
+}
+
+OpenCluster "CWNU 2728"
+{
+	RA 6.90097836
+	Dec -7.90625982
+	Radius 79.457
+	Distance 7263.495
+}
+
+OpenCluster "CWNU 1973"
+{
+	RA 6.90108703
+	Dec -7.75448579
+	Radius 136.595
+	Distance 14718.944
+}
+
+OpenCluster "HSC 1676"
+{
+	RA 6.90335537
+	Dec 1.14907268
+	Radius 62.851
+	Distance 3827.659
+}
+
+OpenCluster "HSC 1599"
+{
+	RA 6.90512362
+	Dec 12.89239267
+	Radius 46.405
+	Distance 6420.856
+}
+
+OpenCluster "ASCC 29:MWSC 1013:Theia 2521"
+{
+	RA 6.90596886
+	Dec -1.66867729
+	Radius 30.03
+	Distance 3240.189
+}
+
+OpenCluster "FSR 1197:MWSC 1015"
+{
+	RA 6.90604066
+	Dec -13.74757623
+	Radius 71.008
+	Distance 2700.586
+}
+
+OpenCluster "HSC 1865"
+{
+	RA 6.91088406
+	Dec -24.23355373
+	Radius 56.661
+	Distance 2810.933
+}
+
+OpenCluster "HSC 1826"
+{
+	RA 6.91094398
+	Dec -19.60279283
+	Radius 108.581
+	Distance 8501.692
+}
+
+OpenCluster "Theia 249"
+{
+	RA 6.91567192
+	Dec -37.5363259
+	Radius 123.258
+	Distance 1373.871
+}
+
+OpenCluster "LISC 2014:UBC 1341"
+{
+	RA 6.91714543
+	Dec 0.63190252
+	Radius 46.938
+	Distance 8904.813
+}
+
+OpenCluster "NGC 2304:Melotte 55:Collinder 120:FSR 959:MWSC 1019:OCL 484"
+{
+	RA 6.9202025
+	Dec 17.98461602
+	Radius 91.105
+	Distance 11791.672
+}
+
+OpenCluster "CWNU 279"
+{
+	RA 6.92177849
+	Dec -2.13190579
+	Radius 71.179
+	Distance 5600.244
+}
+
+OpenCluster "FSR 0866:FSR 866:MWSC 1022:Theia 6736"
+{
+	RA 6.92237783
+	Dec 29.74097459
+	Radius 61.786
+	Distance 3853.321
+}
+
+OpenCluster "HXHWL 74:UBC 1349"
+{
+	RA 6.92403817
+	Dec -3.77700366
+	Radius 43.429
+	Distance 7184.202
+}
+
+OpenCluster "CWNU 2477"
+{
+	RA 6.9243122
+	Dec 0.80245287
+	Radius 36.98
+	Distance 7506.008
+}
+
+OpenCluster "HSC 1556"
+{
+	RA 6.92488656
+	Dec 19.1570063
+	Radius 94.841
+	Distance 10575.544
+}
+
+OpenCluster "HSC 1701"
+{
+	RA 6.92521678
+	Dec -2.68314164
+	Radius 39.712
+	Distance 6562.608
+}
+
+OpenCluster "FSR 1172"
+{
+	RA 6.92692584
+	Dec -11.03133446
+	Radius 26.513
+	Distance 7474.304
+}
+
+OpenCluster "Theia 2233:UPK 447"
+{
+	RA 6.9270721
+	Dec -10.26451816
+	Radius 83.404
+	Distance 3145.976
+}
+
+OpenCluster "CWNU 2902:Theia 2782"
+{
+	RA 6.92883411
+	Dec 9.5333709
+	Radius 57.767
+	Distance 4551.009
+}
+
+OpenCluster "HSC 1775"
+{
+	RA 6.92909137
+	Dec -13.48312223
+	Radius 106
+	Distance 13303.138
+}
+
+OpenCluster "CWNU 2293"
+{
+	RA 6.92919649
+	Dec -3.76858773
+	Radius 142.721
+	Distance 8758.109
+}
+
+OpenCluster "FoF 2439:ZHBJZ 1"
+{
+	RA 6.92977383
+	Dec -5.79122298
+	Radius 68.917
+	Distance 925.161
+}
+
+OpenCluster "CWNU 362"
+{
+	RA 6.93074897
+	Dec -13.06996343
+	Radius 86.964
+	Distance 6781.57
+}
+
+OpenCluster "HSC 1760"
+{
+	RA 6.93137002
+	Dec -11.37237249
+	Radius 47.53
+	Distance 10255.336
+}
+
+OpenCluster "HSC 1697"
+{
+	RA 6.9330053
+	Dec -2.27242204
+	Radius 81.557
+	Distance 10017.493
+}
+
+OpenCluster "NGC 2309:Melotte 56:Collinder 122:FSR 1148:MWSC 1026:OCL 557:Theia 2098"
+{
+	RA 6.93471271
+	Dec -7.1773391
+	Radius 80.506
+	Distance 7811.117
+}
+
+OpenCluster "Theia 398"
+{
+	RA 6.94230145
+	Dec -19.92205391
+	Radius 157.788
+	Distance 2174.001
+}
+
+OpenCluster "CWNU 1966"
+{
+	RA 6.94533236
+	Dec 0.4721518
+	Radius 90.497
+	Distance 11980.451
+}
+
+OpenCluster "UBC 1365"
+{
+	RA 6.94890364
+	Dec -15.62422137
+	Radius 49.304
+	Distance 8010.105
+}
+
+OpenCluster "ASCC 30:Alessi 35:MWSC 1028"
+{
+	RA 6.94915284
+	Dec -6.21213759
+	Radius 61.041
+	Distance 3458.51
+}
+
+OpenCluster "HSC 1860"
+{
+	RA 6.95226008
+	Dec -23.57344116
+	Radius 218.634
+	Distance 20994.606
+}
+
+OpenCluster "CWNU 1024"
+{
+	RA 6.95236747
+	Dec -27.39179106
+	Radius 199.29
+	Distance 1288.008
+}
+
+OpenCluster "BDSB93:BDSB 93"
+{
+	RA 6.95301005
+	Dec -8.19506888
+	Radius 56.238
+	Distance 4185.473
+}
+
+OpenCluster "FSR 1144:MWSC 1031:Theia 2002"
+{
+	RA 6.95348125
+	Dec -6.6262967
+	Radius 32.875
+	Distance 6114.981
+}
+
+OpenCluster "CWNU 1791"
+{
+	RA 6.95364366
+	Dec -1.09797296
+	Radius 33.654
+	Distance 9518.696
+}
+
+OpenCluster "CWNU 1706"
+{
+	RA 6.95735117
+	Dec -9.79183395
+	Radius 50.818
+	Distance 7192.8
+}
+
+OpenCluster "CWNU 91:LISC 3392:OC 0395"
+{
+	RA 6.95792912
+	Dec -21.35340156
+	Radius 69.273
+	Distance 2596.616
+}
+
+OpenCluster "Berkeley 31:Biurakan 7:FSR 1012:MWSC 1032:OCL 513"
+{
+	RA 6.96044798
+	Dec 8.28813294
+	Radius 157.234
+	Distance 19128.467
+}
+
+OpenCluster "HSC 2247"
+{
+	RA 6.96081759
+	Dec -66.26147027
+	Radius 104.903
+	Distance 1348.306
+}
+
+OpenCluster "Berkeley 30:Biurakan 9:FSR 1058:MWSC 1034:OCL 534:OC 0350"
+{
+	RA 6.96245683
+	Dec 3.22755948
+	Radius 175.697
+	Distance 14554.241
+}
+
+OpenCluster "HSC 1693"
+{
+	RA 6.96258091
+	Dec -1.1432781
+	Radius 44.664
+	Distance 3011.418
+}
+
+OpenCluster "NGC 2311:Collinder 123:FSR 1127:MWSC 1035:OCL 553:OC 0365"
+{
+	RA 6.96311025
+	Dec -4.6130476
+	Radius 27.841
+	Distance 6590.983
 }
 
 OpenCluster "Berkeley 33"
 {
-	RA 6.961667
-	Dec -12.783333
-	Distance 19570
-	Radius 8.5
+	RA 6.96415855
+	Dec -13.22613936
+	Radius 60.805
+	Distance 15417.482
 }
 
-OpenCluster "NGC 2311"
+OpenCluster "UPK 457"
 {
-	RA 6.963056
-	Dec -3.388333
-	Distance 7469
-	Radius 6.5
+	RA 6.96558644
+	Dec -18.66520688
+	Radius 73.313
+	Distance 3101.144
 }
 
-OpenCluster "Berkeley 32"
+OpenCluster "Berkeley 32:Biurakan 8:MWSC 1037:OCL 522:Theia 4440"
 {
-	RA 6.968333
-	Dec 6.433333
-	Distance 10111
-	Radius 8.8
+	RA 6.96873604
+	Dec 6.43326437
+	Radius 83.693
+	Distance 10266.945
+}
+
+OpenCluster "HSC 1722"
+{
+	RA 6.96941318
+	Dec -4.75430452
+	Radius 30.345
+	Distance 6839.552
+}
+
+OpenCluster "CWNU 1013"
+{
+	RA 6.97012762
+	Dec -33.05843603
+	Radius 43.543
+	Distance 754.002
+}
+
+OpenCluster "Gulliver 45"
+{
+	RA 6.97471735
+	Dec 3.09045429
+	Radius 164.404
+	Distance 10252.404
+}
+
+OpenCluster "CWNU 302"
+{
+	RA 6.97525201
+	Dec -3.02885571
+	Radius 47.589
+	Distance 6748.278
+}
+
+OpenCluster "OC 0401"
+{
+	RA 6.97905626
+	Dec -23.32588835
+	Radius 43.078
+	Distance 2653.581
+}
+
+OpenCluster "FSR 1129"
+{
+	RA 6.98079282
+	Dec -4.85301218
+	Radius 57.192
+	Distance 4310.753
+}
+
+OpenCluster "CWNU 2895"
+{
+	RA 6.98135731
+	Dec -10.99877033
+	Radius 109.154
+	Distance 9344.754
+}
+
+OpenCluster "HSC 1666"
+{
+	RA 6.98346192
+	Dec 3.31727967
+	Radius 299.614
+	Distance 1996.646
+}
+
+OpenCluster "HSC 1755"
+{
+	RA 6.98547784
+	Dec -10.43883333
+	Radius 35.014
+	Distance 1606.544
+}
+
+OpenCluster "FSR 1163"
+{
+	RA 6.98734653
+	Dec -9.08420944
+	Radius 44.32
+	Distance 7190.341
+}
+
+OpenCluster "Theia 458:UPK 456"
+{
+	RA 6.988156
+	Dec -16.77150847
+	Radius 43.235
+	Distance 1601.248
+}
+
+OpenCluster "HSC 1723"
+{
+	RA 6.98917078
+	Dec -4.70276103
+	Radius 19.301
+	Distance 6786.638
+}
+
+OpenCluster "CWNU 1203:FSR 1185"
+{
+	RA 6.99126118
+	Dec -11.98162586
+	Radius 38.004
+	Distance 3416.24
+}
+
+OpenCluster "NGC 2318:MWSC 1050:Theia 3278"
+{
+	RA 6.99153057
+	Dec -13.75886779
+	Radius 54.367
+	Distance 4301.171
+}
+
+OpenCluster "Gulliver 13"
+{
+	RA 6.99183035
+	Dec -13.24935955
+	Radius 103.089
+	Distance 4829.587
+}
+
+OpenCluster "UBC 1353"
+{
+	RA 6.99319984
+	Dec -8.79899966
+	Radius 82.128
+	Distance 11579.411
+}
+
+OpenCluster "HSC 1740"
+{
+	RA 6.99488173
+	Dec -7.80089825
+	Radius 24.918
+	Distance 4136.45
+}
+
+OpenCluster "HSC 1721"
+{
+	RA 6.99887542
+	Dec -4.50101782
+	Radius 17.111
+	Distance 6685.211
+}
+
+OpenCluster "CWNU 1512"
+{
+	RA 7.00079217
+	Dec -3.97206813
+	Radius 139.705
+	Distance 8140.996
+}
+
+OpenCluster "FSR 1171"
+{
+	RA 7.00406958
+	Dec -10.32154527
+	Radius 102.158
+	Distance 11310.13
 }
 
 OpenCluster "Berkeley 34"
 {
-	RA 7.006667
-	Dec 0.250000
-	Distance 23744
-	Radius 6.9
+	RA 7.00629922
+	Dec -0.23681353
+	Radius 98.241
+	Distance 16475.541
 }
 
-OpenCluster "Tombaugh 1"
+OpenCluster "ESO 558-4:FSR 1246:Haffner 1:MWSC 1060:OCL 603:Theia 5222:Tombaugh 1"
 {
-	RA 7.008056
-	Dec -19.433333
-	Distance 9785
-	Radius 7.1
+	RA 7.00812828
+	Dec -20.5757899
+	Radius 112.723
+	Distance 7579.535
 }
 
-OpenCluster "NGC 2319"
+OpenCluster "HSC 1991"
 {
-	RA 7.008889
-	Dec 3.041667
-	Distance 3587
-	Radius 9.4
+	RA 7.00850561
+	Dec -36.58553913
+	Radius 51.339
+	Distance 485.389
 }
 
-OpenCluster "ASCC 31"
+OpenCluster "HSC 1749"
 {
-	RA 7.015000
-	Dec 3.500000
-	Distance 1957
-	Radius 5.8
+	RA 7.0093825
+	Dec -9.02664579
+	Radius 91.757
+	Distance 8051.116
 }
 
-OpenCluster "Alessi 33"
+OpenCluster "HSC 1612"
 {
-	RA 7.033056
-	Dec -25.496667
-	Distance 2446
-	Radius 21.3
+	RA 7.01006971
+	Dec 10.11814076
+	Radius 32.34
+	Distance 2955.617
 }
 
-OpenCluster "NGC 2323"
+OpenCluster "CWNU 2627"
 {
-	RA 7.045000
-	Dec -7.616667
-	Distance 3098
-	Radius 6.3
+	RA 7.01068065
+	Dec -2.88051484
+	Radius 77.681
+	Distance 5735.907
 }
 
-OpenCluster "Tombaugh 2"
+OpenCluster "CWNU 190:OC 0381"
 {
-	RA 7.051389
-	Dec -19.183333
-	Distance 19830
-	Radius 8.7
+	RA 7.01109616
+	Dec -14.39721318
+	Radius 28.34
+	Distance 4855.611
 }
 
-OpenCluster "ASCC 33"
+OpenCluster "Theia 146:UPK 524"
 {
-	RA 7.053056
-	Dec -24.950000
-	Distance 2609
-	Radius 41.0
+	RA 7.01217974
+	Dec -55.24245711
+	Radius 132.604
+	Distance 1778.426
 }
 
-OpenCluster "Bochum 3"
+OpenCluster "HSC 1611"
 {
-	RA 7.056667
-	Dec -4.950000
-	Distance 5747
-	Radius 3.3
+	RA 7.01733932
+	Dec 10.38485418
+	Radius 68.687
+	Distance 20465.362
+}
+
+OpenCluster "HXHWL 72"
+{
+	RA 7.01974411
+	Dec -3.73774196
+	Radius 79.284
+	Distance 5364.404
+}
+
+OpenCluster "HSC 1798"
+{
+	RA 7.01983489
+	Dec -15.61680103
+	Radius 95.57
+	Distance 16485.624
+}
+
+OpenCluster "HSC 1536"
+{
+	RA 7.02023659
+	Dec 22.36255466
+	Radius 49.743
+	Distance 2981.708
+}
+
+OpenCluster "Theia 2471:Theia 2836:UBC 444"
+{
+	RA 7.02036526
+	Dec -6.85240017
+	Radius 55.156
+	Distance 3463.746
+}
+
+OpenCluster "HSC 1794"
+{
+	RA 7.02098693
+	Dec -15.1602453
+	Radius 87.751
+	Distance 25218.627
+}
+
+OpenCluster "CWNU 2501:Theia 1925:Wit 2"
+{
+	RA 7.02345338
+	Dec -3.09825337
+	Radius 67.048
+	Distance 6761.434
+}
+
+OpenCluster "UBC 1335"
+{
+	RA 7.02468281
+	Dec 5.25031265
+	Radius 98.847
+	Distance 9769.435
+}
+
+OpenCluster "MWSC 1068:OCL 573:Ruprecht 8:Theia 3278:UBC 219"
+{
+	RA 7.02868498
+	Dec -13.53862592
+	Radius 117.742
+	Distance 6817.023
+}
+
+OpenCluster "HSC 1754"
+{
+	RA 7.02947453
+	Dec -10.05504384
+	Radius 37.3
+	Distance 7989.572
+}
+
+OpenCluster "ASCC 33:MWSC 1077:Theia 239"
+{
+	RA 7.03029644
+	Dec -24.43701314
+	Radius 69.855
+	Distance 1359.119
+}
+
+OpenCluster "HSC 1702"
+{
+	RA 7.03909403
+	Dec -1.8509488
+	Radius 179.671
+	Distance 10891.006
+}
+
+OpenCluster "CWNU 1445"
+{
+	RA 7.03947387
+	Dec -7.19300095
+	Radius 19.654
+	Distance 7743.696
+}
+
+OpenCluster "HSC 1761"
+{
+	RA 7.04050235
+	Dec -10.61925707
+	Radius 68.645
+	Distance 2027.775
+}
+
+OpenCluster "Alessi 60:Alessi J0702.4-0108:DSH J0702.4-0108:MWSC 1071"
+{
+	RA 7.04131626
+	Dec -1.11998444
+	Radius 100.863
+	Distance 8609.579
+}
+
+OpenCluster "HSC 1971"
+{
+	RA 7.04200225
+	Dec -33.89065587
+	Radius 59.509
+	Distance 3561.815
+}
+
+OpenCluster "CWNU 536"
+{
+	RA 7.04410722
+	Dec -45.67984051
+	Radius 44.177
+	Distance 817.235
+}
+
+OpenCluster "CMa 2:HXHWL 32:Theia 2471"
+{
+	RA 7.04547063
+	Dec -7.75662131
+	Radius 50.969
+	Distance 3531.624
+}
+
+OpenCluster "UBC 214"
+{
+	RA 7.04653013
+	Dec -2.10418753
+	Radius 59.577
+	Distance 8359.559
+}
+
+OpenCluster "HSC 1672"
+{
+	RA 7.04684265
+	Dec 2.81787886
+	Radius 32.528
+	Distance 4161.487
+}
+
+OpenCluster "Heart-Shaped Cluster:M 50:NGC 2323:Collinder 124"
+{
+	RA 7.04696923
+	Dec -8.35467926
+	Radius 36.518
+	Distance 3119.694
+}
+
+OpenCluster "ASCC 32:Alessi 33:MWSC 1069:Theia 87"
+{
+	RA 7.04732542
+	Dec -26.36541844
+	Radius 45.961
+	Distance 2539.412
+}
+
+OpenCluster "HSC 1688"
+{
+	RA 7.04849249
+	Dec 0.27999546
+	Radius 91.05
+	Distance 5965.589
+}
+
+OpenCluster "CWNU 2496"
+{
+	RA 7.04911424
+	Dec -12.17623189
+	Radius 47.899
+	Distance 8685.491
+}
+
+OpenCluster "ESO 558-7:FSR 1250:Haffner 2:MWSC 1076:OCL 605:Tombaugh 2"
+{
+	RA 7.05183143
+	Dec -20.81703303
+	Radius 140.649
+	Distance 23009.132
+}
+
+OpenCluster "CWNU 401:OC 0369"
+{
+	RA 7.05232998
+	Dec -6.9184699
+	Radius 43.24
+	Distance 7087.264
+}
+
+OpenCluster "CWNU 332:OC 0376"
+{
+	RA 7.05511704
+	Dec -12.64543728
+	Radius 30.204
+	Distance 4040.101
+}
+
+OpenCluster "Czernik 27:MWSC 1078:OCL 526"
+{
+	RA 7.05554619
+	Dec 6.3832117
+	Radius 76.535
+	Distance 13032.999
+}
+
+OpenCluster "CWNU 2918"
+{
+	RA 7.05609344
+	Dec -6.95651799
+	Radius 32.534
+	Distance 7862.438
+}
+
+OpenCluster "Bochum 3:MWSC 1079"
+{
+	RA 7.05762013
+	Dec -5.01132854
+	Radius 76.123
+	Distance 7519.72
+}
+
+OpenCluster "Theia 267"
+{
+	RA 7.05779572
+	Dec -8.01687484
+	Radius 82.42
+	Distance 2205.966
+}
+
+OpenCluster "PHOC 5"
+{
+	RA 7.05916192
+	Dec -7.83527254
+	Radius 32.001
+	Distance 3881.852
+}
+
+OpenCluster "OC 0373"
+{
+	RA 7.06070748
+	Dec -9.44502985
+	Radius 100.417
+	Distance 8401.501
+}
+
+OpenCluster "HSC 1673"
+{
+	RA 7.06250533
+	Dec 2.62975772
+	Radius 27.944
+	Distance 9826.561
+}
+
+OpenCluster "CWNU 1410"
+{
+	RA 7.06361112
+	Dec -4.01607286
+	Radius 45.087
+	Distance 6594.358
+}
+
+OpenCluster "CWNU 131:UBC 1342"
+{
+	RA 7.06380206
+	Dec 0.26019879
+	Radius 43.796
+	Distance 6442.392
+}
+
+OpenCluster "CWNU 274"
+{
+	RA 7.06643333
+	Dec -16.88416465
+	Radius 18.557
+	Distance 3792.449
+}
+
+OpenCluster "CWNU 1447"
+{
+	RA 7.0678964
+	Dec -5.3849878
+	Radius 70.069
+	Distance 7150.852
+}
+
+OpenCluster "Haffner 3:MWSC 1081:OCL 556"
+{
+	RA 7.06806837
+	Dec -6.14009199
+	Radius 55.986
+	Distance 7986.637
+}
+
+OpenCluster "NGC 2324:Melotte 59:Collinder 125:FSR 1089:MWSC 1084:OCL 542:OC 0355:Theia 3592"
+{
+	RA 7.06900932
+	Dec 1.04721752
+	Radius 117.1
+	Distance 12711.948
 }
 
 OpenCluster "vdBergh 92"
 {
-	RA 7.065000
-	Dec -10.466667
-	Distance 4660
-	Radius 2.0
+	RA 7.06910015
+	Dec -11.44233764
+	Radius 30.243
+	Distance 3604.55
 }
 
-OpenCluster "NGC 2324"
+OpenCluster "CWNU 281"
 {
-	RA 7.068611
-	Dec 1.045000
-	Distance 12394
-	Radius 19.1
+	RA 7.0692601
+	Dec -16.35181209
+	Radius 27.138
+	Distance 4210.906
 }
 
-OpenCluster "Auner 1"
+OpenCluster "Auner 1:ESO 558-8:MWSC 1087"
 {
-	RA 7.071111
-	Dec -18.250000
-	Distance 29028
-	Radius 25.3
+	RA 7.07090101
+	Dec -19.7468929
+	Radius 61.027
+	Distance 22297.782
 }
 
-OpenCluster "NGC 2335"
+OpenCluster "HSC 1664"
 {
-	RA 7.113611
-	Dec -9.971667
-	Distance 4621
-	Radius 4.0
+	RA 7.07108542
+	Dec 4.1292157
+	Radius 31.114
+	Distance 2590.691
 }
 
-OpenCluster "Ruprecht 12"
+OpenCluster "CWNU 2711:FSR 1149:MWSC 1083"
 {
-	RA 7.119444
-	Dec -27.800000
-	Distance 2508
-	Radius 1.8
+	RA 7.07110875
+	Dec -6.44575963
+	Radius 47.751
+	Distance 7027.326
 }
 
-OpenCluster "NGC 2343"
+OpenCluster "HSC 1674"
 {
-	RA 7.135000
-	Dec -9.383333
-	Distance 3444
-	Radius 2.5
+	RA 7.07134435
+	Dec 2.61066548
+	Radius 29.77
+	Distance 4117.717
 }
 
-OpenCluster "NGC 2345"
+OpenCluster "HSC 1691"
 {
-	RA 7.138333
-	Dec -12.806667
-	Distance 7342
-	Radius 12.8
+	RA 7.07181761
+	Dec 0.03466733
+	Radius 32.096
+	Distance 3874.286
 }
 
-OpenCluster "Haffner 23"
+OpenCluster "UBC 1361"
 {
-	RA 7.156667
-	Dec -15.050000
-	Distance 1917
-	Radius 3.1
+	RA 7.07582626
+	Dec -11.2517459
+	Radius 75.773
+	Distance 17975.861
 }
 
-OpenCluster "Berkeley 35"
+OpenCluster "FSR 1150:MWSC 1089:SAI 74"
 {
-	RA 7.165556
-	Dec 2.733611
-	Distance 14351
-	Radius 12.5
+	RA 7.07673131
+	Dec -6.61578649
+	Radius 85.289
+	Distance 11970.546
 }
 
-OpenCluster "ASCC 34"
+OpenCluster "HSC 1785"
 {
-	RA 7.175000
-	Dec 6.070000
-	Distance 1793
-	Radius 9.4
+	RA 7.07692386
+	Dec -13.71038106
+	Radius 50.647
+	Distance 9181.09
+}
+
+OpenCluster "HSC 1770"
+{
+	RA 7.07746365
+	Dec -11.58468075
+	Radius 133.567
+	Distance 8674.15
+}
+
+OpenCluster "HSC 2125"
+{
+	RA 7.07811913
+	Dec -53.58781431
+	Radius 80.283
+	Distance 1716.691
+}
+
+OpenCluster "HSC 1720"
+{
+	RA 7.07904571
+	Dec -3.84043625
+	Radius 118.637
+	Distance 6129.018
+}
+
+OpenCluster "NGC 2324:Melotte 59:Collinder 125:CWNU 1845:FSR 1089:MWSC 1084:OCL 542"
+{
+	RA 7.08063712
+	Dec 0.95233996
+	Radius 32.929
+	Distance 5917.299
+}
+
+OpenCluster "Theia 458"
+{
+	RA 7.08264038
+	Dec -16.82736423
+	Radius 66.99
+	Distance 1899.533
+}
+
+OpenCluster "Theia 1654"
+{
+	RA 7.083914
+	Dec -10.38152816
+	Radius 112.896
+	Distance 3844.272
+}
+
+OpenCluster "HSC 1913"
+{
+	RA 7.08443148
+	Dec -27.7960425
+	Radius 26.839
+	Distance 2647.603
+}
+
+OpenCluster "CWNU 1611"
+{
+	RA 7.08791575
+	Dec -14.06882729
+	Radius 73.049
+	Distance 8158.883
+}
+
+OpenCluster "HSC 1769"
+{
+	RA 7.08844602
+	Dec -11.30952506
+	Radius 70.263
+	Distance 9494.884
+}
+
+OpenCluster "BDSB96:BDSB 96:Theia 1654"
+{
+	RA 7.08877476
+	Dec -12.32451056
+	Radius 59.535
+	Distance 3609.953
+}
+
+OpenCluster "HSC 1725"
+{
+	RA 7.08878709
+	Dec -4.04205793
+	Radius 184.799
+	Distance 16287.603
+}
+
+OpenCluster "UBC 1347"
+{
+	RA 7.08996364
+	Dec -1.00081309
+	Radius 71.53
+	Distance 11273.846
+}
+
+OpenCluster "FSR 1178"
+{
+	RA 7.09095681
+	Dec -10.68654623
+	Radius 23.817
+	Distance 3618.034
+}
+
+OpenCluster "UBC 447"
+{
+	RA 7.09215017
+	Dec -9.04648919
+	Radius 31.552
+	Distance 7690.188
+}
+
+OpenCluster "CWNU 1144"
+{
+	RA 7.09474997
+	Dec -52.6636272
+	Radius 154.917
+	Distance 630.792
+}
+
+OpenCluster "BDSB96:BDSB 96:UBC 1362"
+{
+	RA 7.09494452
+	Dec -12.27085429
+	Radius 25.368
+	Distance 6722.069
+}
+
+OpenCluster "HSC 1745"
+{
+	RA 7.09500462
+	Dec -8.0119821
+	Radius 101.638
+	Distance 8812.048
+}
+
+OpenCluster "HSC 1686"
+{
+	RA 7.0955674
+	Dec 0.91717748
+	Radius 81.924
+	Distance 6495.923
+}
+
+OpenCluster "HSC 2033"
+{
+	RA 7.09610925
+	Dec -42.50630455
+	Radius 26.322
+	Distance 490.256
+}
+
+OpenCluster "UBC 626"
+{
+	RA 7.09639344
+	Dec -2.29873423
+	Radius 150.123
+	Distance 14042.643
+}
+
+OpenCluster "CWNU 1401"
+{
+	RA 7.10056
+	Dec -7.5366272
+	Radius 109.125
+	Distance 6486.422
+}
+
+OpenCluster "Haffner 4:MWSC 1094:OCL 583:OC 0389"
+{
+	RA 7.10099659
+	Dec -15.00527408
+	Radius 49.903
+	Distance 13198.994
+}
+
+OpenCluster "Alessi 72:CWNU 1157:Theia 2063"
+{
+	RA 7.10243529
+	Dec -16.06804913
+	Radius 66.806
+	Distance 4069.575
+}
+
+OpenCluster "CWNU 1712"
+{
+	RA 7.10339371
+	Dec -6.36028496
+	Radius 43.936
+	Distance 4191.131
+}
+
+OpenCluster "CWNU 2770"
+{
+	RA 7.10381628
+	Dec -13.17873977
+	Radius 353.195
+	Distance 26928.582
+}
+
+OpenCluster "Alessi 36:FoF 2385:UBC 7"
+{
+	RA 7.10434176
+	Dec -37.59593941
+	Radius 32.048
+	Distance 897.939
+}
+
+OpenCluster "ESO 558-10:MWSC 1098:OCL 604:Ruprecht 10"
+{
+	RA 7.10790518
+	Dec -20.12340476
+	Radius 46.541
+	Distance 6916.371
+}
+
+OpenCluster "HSC 1744"
+{
+	RA 7.10807636
+	Dec -7.88271332
+	Radius 40.978
+	Distance 7514.214
+}
+
+OpenCluster "UBC 225"
+{
+	RA 7.10961779
+	Dec -23.50108355
+	Radius 132.278
+	Distance 8548.709
+}
+
+OpenCluster "Berkeley 76:MWSC 1099:OCL 568"
+{
+	RA 7.11062427
+	Dec -11.72358075
+	Radius 131.451
+	Distance 16763.631
+}
+
+OpenCluster "NGC 2335:Theia 1977"
+{
+	RA 7.11486233
+	Dec -10.04133312
+	Radius 43.973
+	Distance 5212.375
+}
+
+OpenCluster "Collinder 465"
+{
+	RA 7.11488706
+	Dec -10.46563249
+	Radius 49.624
+	Distance 9684.294
+}
+
+OpenCluster "CMa 23:Theia 2289:UBC 1363"
+{
+	RA 7.11489944
+	Dec -12.25122831
+	Radius 58.859
+	Distance 4998.274
+}
+
+OpenCluster "OC 0375:Theia 1774"
+{
+	RA 7.11571573
+	Dec -9.17272561
+	Radius 20.551
+	Distance 7970.421
+}
+
+OpenCluster "CWNU 340"
+{
+	RA 7.11832626
+	Dec -26.39799789
+	Radius 34.877
+	Distance 2996.036
+}
+
+OpenCluster "FSR 1209:MWSC 1105"
+{
+	RA 7.11921704
+	Dec -13.82527965
+	Radius 48.459
+	Distance 13829.827
+}
+
+OpenCluster "CWNU 330"
+{
+	RA 7.12073136
+	Dec -11.96398864
+	Radius 36.063
+	Distance 7703.998
+}
+
+OpenCluster "HXHWL 52"
+{
+	RA 7.12185682
+	Dec -6.29720423
+	Radius 75.023
+	Distance 5154.346
+}
+
+OpenCluster "HXHWL 60:UBC 1337"
+{
+	RA 7.1227358
+	Dec 4.29752088
+	Radius 55.582
+	Distance 6219.681
+}
+
+OpenCluster "CWNU 1859:Theia 5254"
+{
+	RA 7.12401421
+	Dec -18.48649204
+	Radius 147.655
+	Distance 9612.844
+}
+
+OpenCluster "FSR 1170"
+{
+	RA 7.12480181
+	Dec -8.87166815
+	Radius 38.422
+	Distance 8384.061
+}
+
+OpenCluster "FSR 1207:MWSC 1112:Theia 2879"
+{
+	RA 7.12514333
+	Dec -13.32879571
+	Radius 31.555
+	Distance 7830.019
+}
+
+OpenCluster "CMa 1:HXHWL 54:PHOC 4:Theia 2649"
+{
+	RA 7.12560226
+	Dec -7.66498252
+	Radius 109.263
+	Distance 3380.095
+}
+
+OpenCluster "Gulliver 21:Teutsch 205:Theia 469"
+{
+	RA 7.12582495
+	Dec -25.50922818
+	Radius 78.986
+	Distance 2074.941
+}
+
+OpenCluster "FSR 1202:MWSC 1110"
+{
+	RA 7.12751761
+	Dec -12.81753541
+	Radius 78.315
+	Distance 8847.504
+}
+
+OpenCluster "FSR 1212:MWSC 1115"
+{
+	RA 7.1295925
+	Dec -14.15059161
+	Radius 161.038
+	Distance 20773.121
+}
+
+OpenCluster "UBC 616"
+{
+	RA 7.13185443
+	Dec 19.93396366
+	Radius 50.788
+	Distance 8996.536
+}
+
+OpenCluster "HSC 1835"
+{
+	RA 7.13215838
+	Dec -18.9281546
+	Radius 58.5
+	Distance 22563.043
+}
+
+OpenCluster "HSC 1739"
+{
+	RA 7.13269932
+	Dec -6.64056609
+	Radius 34.327
+	Distance 8545.12
+}
+
+OpenCluster "UBC 1336"
+{
+	RA 7.13445701
+	Dec 4.8475861
+	Radius 114.551
+	Distance 12012.537
+}
+
+OpenCluster "NGC 2343:Theia 2557"
+{
+	RA 7.13510243
+	Dec -10.61731475
+	Radius 27.452
+	Distance 3431.492
+}
+
+OpenCluster "NGC 2345:Theia 2051"
+{
+	RA 7.13855808
+	Dec -13.18976094
+	Radius 95.481
+	Distance 8252.477
+}
+
+OpenCluster "HSC 1647"
+{
+	RA 7.14017464
+	Dec 6.54151963
+	Radius 27.289
+	Distance 3597.712
+}
+
+OpenCluster "OC 0368"
+{
+	RA 7.1412931
+	Dec -5.90702911
+	Radius 22.977
+	Distance 5962.056
+}
+
+OpenCluster "UBC 628"
+{
+	RA 7.14276848
+	Dec -6.21213577
+	Radius 258.931
+	Distance 16046.767
+}
+
+OpenCluster "CWNU 329:FSR 1173:UBC 1358"
+{
+	RA 7.14589924
+	Dec -9.42220483
+	Radius 32.33
+	Distance 8459.363
+}
+
+OpenCluster "HSC 1790"
+{
+	RA 7.14749149
+	Dec -13.73911322
+	Radius 76.601
+	Distance 7193.244
+}
+
+OpenCluster "HSC 1949"
+{
+	RA 7.14789968
+	Dec -31.5675624
+	Radius 77.296
+	Distance 1023.421
+}
+
+OpenCluster "HSC 1806"
+{
+	RA 7.1486324
+	Dec -15.68266686
+	Radius 69.711
+	Distance 5173.191
+}
+
+OpenCluster "Theia 361"
+{
+	RA 7.15062879
+	Dec -7.25171308
+	Radius 22.388
+	Distance 2278.016
+}
+
+OpenCluster "OC 0370:Theia 361"
+{
+	RA 7.15070653
+	Dec -7.20169586
+	Radius 33.938
+	Distance 2780.231
+}
+
+OpenCluster "HSC 1767"
+{
+	RA 7.15120187
+	Dec -10.69328118
+	Radius 33.344
+	Distance 3744.061
+}
+
+OpenCluster "FSR 1113:MWSC 1126"
+{
+	RA 7.15303238
+	Dec -1.50548544
+	Radius 59.502
+	Distance 12996.693
+}
+
+OpenCluster "CWNU 192:UBC 1344"
+{
+	RA 7.15646007
+	Dec 0.53260777
+	Radius 62.724
+	Distance 9708.737
+}
+
+OpenCluster "CWNU 1204:OC 0407:Teutsch 205"
+{
+	RA 7.1580106
+	Dec -25.20081826
+	Radius 43.909
+	Distance 1972.672
+}
+
+OpenCluster "Haffner 23:MWSC 1127:MWSC 26:OCL 590:Theia 3588"
+{
+	RA 7.15905225
+	Dec -16.85164264
+	Radius 85.327
+	Distance 6631.459
+}
+
+OpenCluster "HSC 1801"
+{
+	RA 7.15935755
+	Dec -15.00434445
+	Radius 48.508
+	Distance 8958.395
+}
+
+OpenCluster "CMa 8:OC 0377:Theia 1654:Theia 265"
+{
+	RA 7.16087362
+	Dec -12.04917162
+	Radius 65.442
+	Distance 3653.886
+}
+
+OpenCluster "HSC 1169"
+{
+	RA 7.16130204
+	Dec 69.67828046
+	Radius 72.495
+	Distance 725.177
+}
+
+OpenCluster "HSC 1830"
+{
+	RA 7.16181438
+	Dec -18.28405099
+	Radius 34.068
+	Distance 4348.586
+}
+
+OpenCluster "HSC 1759"
+{
+	RA 7.16189235
+	Dec -9.60615396
+	Radius 24.714
+	Distance 8811.734
+}
+
+OpenCluster "Berkeley 35:FSR 1075:MWSC 1129:MWSC 1130:OCL 541"
+{
+	RA 7.16534455
+	Dec 2.73106662
+	Radius 119.66
+	Distance 15189.948
+}
+
+OpenCluster "FoF 2198:Theia 4633:UBC 209"
+{
+	RA 7.16649002
+	Dec 4.65038827
+	Radius 40.438
+	Distance 3813.754
+}
+
+OpenCluster "HSC 1808"
+{
+	RA 7.16897375
+	Dec -15.68667152
+	Radius 22.778
+	Distance 3997.747
+}
+
+OpenCluster "DBSB 3"
+{
+	RA 7.17000124
+	Dec -18.43840003
+	Radius 48.909
+	Distance 10841.373
+}
+
+OpenCluster "CWNU 2794"
+{
+	RA 7.17013045
+	Dec -10.36706529
+	Radius 65.201
+	Distance 10088.143
 }
 
 OpenCluster "Alessi 21"
 {
-	RA 7.179722
-	Dec -8.663333
-	Distance 1630
-	Radius 10.0
+	RA 7.17278746
+	Dec -9.31830449
+	Radius 82.308
+	Distance 1828.937
 }
 
-OpenCluster "ASCC 35"
+OpenCluster "CWNU 531"
 {
-	RA 7.211111
-	Dec 2.120000
-	Distance 2609
-	Radius 18.2
+	RA 7.17286483
+	Dec -44.28672789
+	Radius 72.707
+	Distance 2369.039
 }
 
-OpenCluster "NGC 2354"
+OpenCluster "OCSN 80:Theia 35"
 {
-	RA 7.236111
-	Dec -24.310000
-	Distance 13323
-	Radius 34.9
+	RA 7.17315435
+	Dec -19.41426695
+	Radius 150.305
+	Distance 1321.865
 }
 
-OpenCluster "NGC 2353"
+OpenCluster "Alessi 21:UBC 1359"
 {
-	RA 7.241667
-	Dec -9.733333
-	Distance 3649
-	Radius 9.6
+	RA 7.17334991
+	Dec -9.43822026
+	Radius 44.941
+	Distance 10686.891
 }
 
-OpenCluster "ASCC 36"
+OpenCluster "OC 0393:Theia 366"
 {
-	RA 7.241944
-	Dec -20.880000
-	Distance 2446
-	Radius 7.7
+	RA 7.17615459
+	Dec -18.66014533
+	Radius 64.057
+	Distance 3020.164
 }
 
-OpenCluster "Collinder 132"
+OpenCluster "HXHWL 2:UBC 1348"
 {
-	RA 7.255556
-	Dec -29.316667
-	Distance 1539
-	Radius 17.9
+	RA 7.17714882
+	Dec -0.42971269
+	Radius 40.806
+	Distance 5791.734
 }
 
-OpenCluster "Berkeley 36"
+OpenCluster "UBC 1351"
 {
-	RA 7.268333
-	Dec -12.900000
-	Distance 20026
-	Radius 14.6
+	RA 7.18171464
+	Dec -3.4290655
+	Radius 55.455
+	Distance 12247.752
 }
 
-OpenCluster "Alessi 3"
+OpenCluster "HSC 1791"
 {
-	RA 7.274722
-	Dec -45.315000
-	Distance 939
-	Radius 9.8
+	RA 7.18252891
+	Dec -13.54984019
+	Radius 77.919
+	Distance 2112.875
 }
 
-OpenCluster "NGC 2358"
+OpenCluster "HSC 1825"
 {
-	RA 7.282222
-	Dec -16.883333
-	Distance 2054
-	Radius 6.0
+	RA 7.18489422
+	Dec -17.60577712
+	Radius 249.422
+	Distance 23369.503
 }
 
-OpenCluster "NGC 2355"
+OpenCluster "HSC 1752"
 {
-	RA 7.283056
-	Dec 13.750000
-	Distance 7175
-	Radius 7.3
+	RA 7.18896684
+	Dec -8.40908253
+	Radius 45.973
+	Distance 8151.4
 }
 
-OpenCluster "Basel 11a"
+OpenCluster "Alessi 21:CWNU 1554"
 {
-	RA 7.285000
-	Dec -12.033333
-	Distance 4957
-	Radius 3.6
+	RA 7.19149947
+	Dec -9.19064607
+	Radius 133.046
+	Distance 9261.133
 }
 
-OpenCluster "Collinder 135"
+OpenCluster "Gulliver 47:Theia 3474"
 {
-	RA 7.288056
-	Dec -35.183333
-	Distance 1030
-	Radius 7.5
+	RA 7.19467246
+	Dec 0.80468239
+	Radius 50.001
+	Distance 6231.473
 }
 
-OpenCluster "NGC 2360"
+OpenCluster "CWNU 1431"
 {
-	RA 7.295278
-	Dec -14.358333
-	Distance 6154
-	Radius 11.6
+	RA 7.19806344
+	Dec -14.92743379
+	Radius 33.423
+	Distance 7451.138
 }
 
-OpenCluster "ASCC 37"
+OpenCluster "HSC 1762"
 {
-	RA 7.301111
-	Dec -23.520000
-	Distance 5218
-	Radius 14.6
+	RA 7.20199997
+	Dec -9.45142531
+	Radius 23.777
+	Distance 5002.374
 }
 
-OpenCluster "NGC 2362"
+OpenCluster "CWNU 45"
 {
-	RA 7.311389
-	Dec -23.045000
-	Distance 4827
-	Radius 3.5
+	RA 7.20662523
+	Dec -27.98383277
+	Radius 113.726
+	Distance 1957.918
 }
 
-OpenCluster "Bica 4"
+OpenCluster "HSC 1783"
 {
-	RA 7.318611
-	Dec -21.972222
-	Distance 12818
-	Radius 4.7
+	RA 7.20740451
+	Dec -12.58503195
+	Radius 101.346
+	Distance 9862.756
 }
 
-OpenCluster "Haffner 6"
+OpenCluster "CWNU 1064"
 {
-	RA 7.335000
-	Dec -12.866667
-	Distance 9961
-	Radius 8.7
+	RA 7.20834796
+	Dec -25.61113641
+	Radius 58.238
+	Distance 3931.261
+}
+
+OpenCluster "Theia 409:UPK 431"
+{
+	RA 7.20931474
+	Dec -2.56677562
+	Radius 71.919
+	Distance 2320.007
+}
+
+OpenCluster "HXHWL 62"
+{
+	RA 7.21052886
+	Dec -20.54139011
+	Radius 30.118
+	Distance 5881.798
+}
+
+OpenCluster "UBC 217"
+{
+	RA 7.21403299
+	Dec -4.69402063
+	Radius 41.884
+	Distance 7747.412
+}
+
+OpenCluster "HSC 1753"
+{
+	RA 7.21830014
+	Dec -8.32865938
+	Radius 35.176
+	Distance 7698.088
+}
+
+OpenCluster "HSC 1807"
+{
+	RA 7.22024831
+	Dec -15.15688766
+	Radius 96.909
+	Distance 2249.335
+}
+
+OpenCluster "Collinder 132:Theia 1765"
+{
+	RA 7.22307726
+	Dec -30.97053197
+	Radius 102.296
+	Distance 2079.132
+}
+
+OpenCluster "Theia 2398:UPK 470"
+{
+	RA 7.2234711
+	Dec -19.46935095
+	Radius 134.142
+	Distance 3207.934
+}
+
+OpenCluster "FSR 1183"
+{
+	RA 7.22359392
+	Dec -9.89106479
+	Radius 26.802
+	Distance 7000.709
+}
+
+OpenCluster "CWNU 2677"
+{
+	RA 7.22766021
+	Dec -14.88156834
+	Radius 52.766
+	Distance 7041.894
+}
+
+OpenCluster "NGC 2354:Collinder 131:ESO 492-6:FSR 1291:MWSC 1148:OCL 639:Theia 5939"
+{
+	RA 7.22953139
+	Dec -25.72396686
+	Radius 115.897
+	Distance 4007.582
+}
+
+OpenCluster "CWNU 2589:FSR 1183"
+{
+	RA 7.23039245
+	Dec -9.83848495
+	Radius 108.028
+	Distance 9661.952
+}
+
+OpenCluster "CWNU 1962"
+{
+	RA 7.23179979
+	Dec -10.51972651
+	Radius 21.609
+	Distance 9016.86
+}
+
+OpenCluster "UBC 445"
+{
+	RA 7.23423803
+	Dec -6.56824978
+	Radius 96.279
+	Distance 8199.782
+}
+
+OpenCluster "OCSN 82"
+{
+	RA 7.23542383
+	Dec -35.06059214
+	Radius 115.753
+	Distance 1337.294
+}
+
+OpenCluster "HSC 1515"
+{
+	RA 7.23682707
+	Dec 25.87082503
+	Radius 29.585
+	Distance 9174.663
+}
+
+OpenCluster "HSC 1764"
+{
+	RA 7.23685954
+	Dec -9.65489483
+	Radius 99.212
+	Distance 6932.325
+}
+
+OpenCluster "CWNU 1645"
+{
+	RA 7.23799328
+	Dec -7.79418431
+	Radius 38.551
+	Distance 8748.06
+}
+
+OpenCluster "FSR 1153:MWSC 1149"
+{
+	RA 7.23920692
+	Dec -5.66287573
+	Radius 194.659
+	Distance 9904.508
+}
+
+OpenCluster "HSC 1887"
+{
+	RA 7.23980085
+	Dec -24.30770304
+	Radius 74.732
+	Distance 21698.758
+}
+
+OpenCluster "ASCC 36:MWSC 1151"
+{
+	RA 7.24155728
+	Dec -21.10056525
+	Radius 56.24
+	Distance 3108.233
+}
+
+OpenCluster "NGC 2353:Theia 2363"
+{
+	RA 7.24274737
+	Dec -10.24974551
+	Radius 49.975
+	Distance 3715.322
+}
+
+OpenCluster "Theia 128"
+{
+	RA 7.24352052
+	Dec -7.69353997
+	Radius 53.841
+	Distance 1604.968
+}
+
+OpenCluster "OC 0413"
+{
+	RA 7.24630981
+	Dec -26.2472535
+	Radius 77.77
+	Distance 10762.062
+}
+
+OpenCluster "UBC 1376"
+{
+	RA 7.24930125
+	Dec -20.6240534
+	Radius 79.607
+	Distance 8941.102
+}
+
+OpenCluster "HSC 1797"
+{
+	RA 7.25192038
+	Dec -13.76794313
+	Radius 28.547
+	Distance 4447.928
+}
+
+OpenCluster "Alessi J0715.6+0722:Alessi J0715.6-0722:Alessi J0715.6-0727:DSH J0715.3-0726:Patchick 79:SAI 75:UBC 1357"
+{
+	RA 7.25626521
+	Dec -7.42897519
+	Radius 108.55
+	Distance 9360.03
+}
+
+OpenCluster "FSR 1180:Theia 4727"
+{
+	RA 7.26090612
+	Dec -9.44327981
+	Radius 80.552
+	Distance 8783.346
+}
+
+OpenCluster "CWNU 2211"
+{
+	RA 7.26202388
+	Dec -19.57610806
+	Radius 53.619
+	Distance 8946.075
+}
+
+OpenCluster "Theia 360:UPK 429"
+{
+	RA 7.26229717
+	Dec -0.82022902
+	Radius 33.864
+	Distance 2786.223
+}
+
+OpenCluster "CWNU 8:Theia 283"
+{
+	RA 7.26285802
+	Dec -18.57969376
+	Radius 102.909
+	Distance 3281.996
+}
+
+OpenCluster "FSR 1180:HXHWL 22"
+{
+	RA 7.26670599
+	Dec -9.37510032
+	Radius 43.194
+	Distance 3568.22
+}
+
+OpenCluster "CWNU 2575"
+{
+	RA 7.26794686
+	Dec -10.613583
+	Radius 73.15
+	Distance 9041.329
+}
+
+OpenCluster "HSC 1734"
+{
+	RA 7.27138123
+	Dec -4.42281751
+	Radius 65.469
+	Distance 8303.597
+}
+
+OpenCluster "Berkeley 36:FSR 1214:MWSC 1156:OCL 577:OC 0387"
+{
+	RA 7.27334902
+	Dec -13.19347297
+	Radius 107.517
+	Distance 12523.165
+}
+
+OpenCluster "HSC 1788"
+{
+	RA 7.27598507
+	Dec -12.55897547
+	Radius 43.621
+	Distance 9764.091
+}
+
+OpenCluster "CWNU 1803"
+{
+	RA 7.27683002
+	Dec -22.77692341
+	Radius 46.582
+	Distance 5787.122
+}
+
+OpenCluster "Alessi 3:MWSC 1157:Theia 1011"
+{
+	RA 7.27911351
+	Dec -46.6802815
+	Radius 66.827
+	Distance 902.081
+}
+
+OpenCluster "HSC 1707"
+{
+	RA 7.27997623
+	Dec -0.49543742
+	Radius 65.681
+	Distance 1487.826
+}
+
+OpenCluster "CWNU 172"
+{
+	RA 7.28146936
+	Dec -1.81070646
+	Radius 45.622
+	Distance 3203.056
+}
+
+OpenCluster "NGC 2355:Melotte 63:Collinder 133:FSR 995:MWSC 1160:OCL 496:Theia 5041"
+{
+	RA 7.28337584
+	Dec 13.76250143
+	Radius 72.065
+	Distance 5711.311
+}
+
+OpenCluster "CWNU 2038"
+{
+	RA 7.28351355
+	Dec -2.11049032
+	Radius 17.723
+	Distance 7543.833
+}
+
+OpenCluster "UBC 454"
+{
+	RA 7.28437873
+	Dec -20.66140904
+	Radius 59.799
+	Distance 10324.204
+}
+
+OpenCluster "NGC 2358:MWSC 1159:Theia 898"
+{
+	RA 7.28477477
+	Dec -17.17436074
+	Radius 44.081
+	Distance 2928.259
+}
+
+OpenCluster "HXHWL 17"
+{
+	RA 7.28511157
+	Dec -12.02933464
+	Radius 39.182
+	Distance 3456.097
+}
+
+OpenCluster "Basel 11A:Basel 11a:MWSC 1162:OCL 584.1"
+{
+	RA 7.28622362
+	Dec -13.9825289
+	Radius 30.501
+	Distance 4295.949
+}
+
+OpenCluster "CWNU 2284"
+{
+	RA 7.28981153
+	Dec -9.45442691
+	Radius 160.502
+	Distance 8371.496
+}
+
+OpenCluster "HSC 1973"
+{
+	RA 7.29033587
+	Dec -32.68237218
+	Radius 44.165
+	Distance 2302.836
+}
+
+OpenCluster "UBC 1373"
+{
+	RA 7.29139419
+	Dec -18.71404742
+	Radius 31.969
+	Distance 8662.134
+}
+
+OpenCluster "CWNU 1907"
+{
+	RA 7.29263844
+	Dec -11.13676983
+	Radius 33.421
+	Distance 7458.131
+}
+
+OpenCluster "Pi Puppis Cluster:Collinder 135"
+{
+	RA 7.2937026
+	Dec -36.92087657
+	Radius 46.023
+	Distance 964.988
+}
+
+OpenCluster "HSC 1836"
+{
+	RA 7.29456111
+	Dec -17.90273448
+	Radius 97.103
+	Distance 7937.785
+}
+
+OpenCluster "Caroline's Cluster:NGC 2360:Melotte 64:Collinder 134:FSR 1225:MWSC 1165:OCL 589:OC 0391:Theia 1473"
+{
+	RA 7.29604266
+	Dec -15.64439484
+	Radius 74.412
+	Distance 3397.347
+}
+
+OpenCluster "HSC 1817"
+{
+	RA 7.29915134
+	Dec -16.28795617
+	Radius 93.26
+	Distance 10937.194
+}
+
+OpenCluster "HSC 1847"
+{
+	RA 7.29931949
+	Dec -20.00997346
+	Radius 42.457
+	Distance 8989.956
+}
+
+OpenCluster "ESO 492-8:FSR 1272:Haffner 5:MWSC 1168:OCL 624:Theia 6194"
+{
+	RA 7.29951844
+	Dec -22.66254674
+	Radius 136.999
+	Distance 5276.417
+}
+
+OpenCluster "CWNU 2525"
+{
+	RA 7.29980682
+	Dec -15.10488105
+	Radius 39.211
+	Distance 8834.584
+}
+
+OpenCluster "HSC 1815"
+{
+	RA 7.30080435
+	Dec -15.9422349
+	Radius 40.434
+	Distance 2200.57
+}
+
+OpenCluster "CWNU 2027:Teutsch J0718.0+1642:Teutsch J0718.0-1642"
+{
+	RA 7.30095808
+	Dec -16.70932502
+	Radius 37.887
+	Distance 10337.528
+}
+
+OpenCluster "UBC 453"
+{
+	RA 7.30151574
+	Dec -20.28593721
+	Radius 52.36
+	Distance 12717.448
+}
+
+OpenCluster "CWNU 1383"
+{
+	RA 7.30365662
+	Dec -11.08497795
+	Radius 78.136
+	Distance 11939.199
+}
+
+OpenCluster "HSC 1848"
+{
+	RA 7.3050281
+	Dec -20.05773377
+	Radius 114.396
+	Distance 9098.493
+}
+
+OpenCluster "HSC 1849"
+{
+	RA 7.30512081
+	Dec -20.1959738
+	Radius 143.2
+	Distance 894.738
+}
+
+OpenCluster "DC 2:DSH J0718.4-1734:MWSC 1172:Teutsch 49"
+{
+	RA 7.30732109
+	Dec -17.57407274
+	Radius 53.551
+	Distance 10200.008
+}
+
+OpenCluster "HSC 1841"
+{
+	RA 7.30827205
+	Dec -18.9449988
+	Radius 16.185
+	Distance 8670.237
+}
+
+OpenCluster "Tau Canis Majoris Cluster:NGC 2362:Melotte 65:Collinder 136:Caldwell 64:Theia 2054"
+{
+	RA 7.31147755
+	Dec -24.95200664
+	Radius 43.132
+	Distance 4006.522
+}
+
+OpenCluster "Theia 3686"
+{
+	RA 7.31323607
+	Dec -7.92768172
+	Radius 137.916
+	Distance 6685.339
+}
+
+OpenCluster "CWNU 2286"
+{
+	RA 7.31475133
+	Dec -8.42419506
+	Radius 90.346
+	Distance 13580.271
+}
+
+OpenCluster "CWNU 2736"
+{
+	RA 7.3150396
+	Dec -10.32304785
+	Radius 71.862
+	Distance 8989.004
+}
+
+OpenCluster "HSC 1453"
+{
+	RA 7.31760918
+	Dec 34.12311173
+	Radius 76.419
+	Distance 22623.509
+}
+
+OpenCluster "HSC 1902"
+{
+	RA 7.32150449
+	Dec -24.97781016
+	Radius 86.413
+	Distance 2388.835
+}
+
+OpenCluster "CWNU 2115"
+{
+	RA 7.32217125
+	Dec -14.9083634
+	Radius 68.687
+	Distance 7809.416
+}
+
+OpenCluster "LISC 1024:UBC 457"
+{
+	RA 7.32300395
+	Dec -21.41750632
+	Radius 54.207
+	Distance 8581.978
+}
+
+OpenCluster "CWNU 1224"
+{
+	RA 7.32346518
+	Dec -47.45441407
+	Radius 69.362
+	Distance 1098.875
+}
+
+OpenCluster "HSC 1747"
+{
+	RA 7.32360678
+	Dec -6.44443015
+	Radius 96.297
+	Distance 8984.122
+}
+
+OpenCluster "HSC 1727"
+{
+	RA 7.32553644
+	Dec -2.58768913
+	Radius 58.431
+	Distance 16799.664
+}
+
+OpenCluster "CWNU 1540"
+{
+	RA 7.32693918
+	Dec -15.9364447
+	Radius 145.184
+	Distance 9208.32
+}
+
+OpenCluster "OC 0400:UBC 222"
+{
+	RA 7.32810935
+	Dec -20.8514373
+	Radius 31.033
+	Distance 6481.522
+}
+
+OpenCluster "UBC 634"
+{
+	RA 7.32938281
+	Dec -18.98814723
+	Radius 332.758
+	Distance 8929.585
+}
+
+OpenCluster "CWNU 1331"
+{
+	RA 7.3321886
+	Dec 3.20576763
+	Radius 72.447
+	Distance 6242.694
+}
+
+OpenCluster "Haffner 6:MWSC 1177:OCL 582"
+{
+	RA 7.33271977
+	Dec -13.15152991
+	Radius 190.808
+	Distance 14256.978
+}
+
+OpenCluster "FSR 1284"
+{
+	RA 7.33278436
+	Dec -24.53838059
+	Radius 48.082
+	Distance 7592.839
 }
 
 OpenCluster "NGC 2367"
 {
-	RA 7.335000
-	Dec -20.118333
-	Distance 4566
-	Radius 3.3
+	RA 7.33585076
+	Dec -21.88071388
+	Radius 42.36
+	Distance 7296.448
 }
 
-OpenCluster "Saurer 1"
+OpenCluster "Berkeley 37:FSR 1119:MWSC 1180:OCL 551"
 {
-	RA 7.348889
-	Dec 1.808056
-	Distance 43054
-	Radius 16.3
+	RA 7.33792827
+	Dec -0.99820522
+	Radius 98.419
+	Distance 14833.304
 }
 
-OpenCluster "Haffner 8"
+OpenCluster "HSC 1842"
 {
-	RA 7.390000
-	Dec -11.666667
-	Distance 3855
-	Radius 2.8
+	RA 7.33801887
+	Dec -18.90636072
+	Radius 27.984
+	Distance 6441.86
 }
 
-OpenCluster "Berkeley 78"
+OpenCluster "HSC 1789"
 {
-	RA 7.393889
-	Dec 5.370833
-	Distance 15656
-	Radius 13.7
+	RA 7.33882823
+	Dec -12.12864142
+	Radius 96.766
+	Distance 13919.219
 }
 
-OpenCluster "NGC 2374"
+OpenCluster "UBC 1360"
 {
-	RA 7.398889
-	Dec -12.736667
-	Distance 4788
-	Radius 8.4
+	RA 7.34142758
+	Dec -8.76490771
+	Radius 55.686
+	Distance 8854.784
+}
+
+OpenCluster "HSC 1724"
+{
+	RA 7.34362971
+	Dec -2.00526189
+	Radius 70.9
+	Distance 513.414
+}
+
+OpenCluster "Theia 2966"
+{
+	RA 7.34391507
+	Dec -14.03079071
+	Radius 58.233
+	Distance 5112.035
+}
+
+OpenCluster "CWNU 434"
+{
+	RA 7.34407571
+	Dec -7.30764757
+	Radius 80.54
+	Distance 10669.496
+}
+
+OpenCluster "CWNU 100:Theia 546"
+{
+	RA 7.34479308
+	Dec -4.3802574
+	Radius 67.551
+	Distance 1683.394
+}
+
+OpenCluster "CWNU 374:UBC 1372"
+{
+	RA 7.34567989
+	Dec -17.86962168
+	Radius 137.996
+	Distance 8238.844
+}
+
+OpenCluster "OC 0416"
+{
+	RA 7.3462343
+	Dec -27.38786838
+	Radius 62.623
+	Distance 22633.399
+}
+
+OpenCluster "CWNU 1033"
+{
+	RA 7.34777603
+	Dec -10.49023911
+	Radius 50.405
+	Distance 3940.337
+}
+
+OpenCluster "UBC 456"
+{
+	RA 7.34798481
+	Dec -20.77038219
+	Radius 134.557
+	Distance 10181.922
+}
+
+OpenCluster "HSC 1859"
+{
+	RA 7.34912376
+	Dec -20.77497636
+	Radius 18.214
+	Distance 8610.908
+}
+
+OpenCluster "HSC 1844"
+{
+	RA 7.35178548
+	Dec -19.43293897
+	Radius 43.83
+	Distance 5056.746
+}
+
+OpenCluster "CWNU 254:Theia 172:Tian 1"
+{
+	RA 7.35179339
+	Dec 4.081529
+	Radius 161.396
+	Distance 1515.309
+}
+
+OpenCluster "HSC 1816"
+{
+	RA 7.353267
+	Dec -15.80381729
+	Radius 39.702
+	Distance 9199.534
+}
+
+OpenCluster "HSC 1832"
+{
+	RA 7.35397655
+	Dec -17.17882371
+	Radius 69.39
+	Distance 9913.182
+}
+
+OpenCluster "UBC 1366"
+{
+	RA 7.35414236
+	Dec -12.60857019
+	Radius 41.664
+	Distance 8043.824
+}
+
+OpenCluster "OC 0382"
+{
+	RA 7.3549852
+	Dec -11.78547135
+	Radius 47.507
+	Distance 8741.648
+}
+
+OpenCluster "Berkeley 77:FSR 1138:MWSC 1188:MWSC 1189:OCL 555"
+{
+	RA 7.35724797
+	Dec -3.23881937
+	Radius 119.761
+	Distance 12542.407
+}
+
+OpenCluster "UPK 452"
+{
+	RA 7.35773272
+	Dec -11.7880401
+	Radius 27.854
+	Distance 1987.73
+}
+
+OpenCluster "PHOC 36"
+{
+	RA 7.36147371
+	Dec -12.97418477
+	Radius 49.127
+	Distance 10099.283
+}
+
+OpenCluster "Theia 3099"
+{
+	RA 7.36196024
+	Dec -24.92554094
+	Radius 39.033
+	Distance 4061.987
+}
+
+OpenCluster "UBC 1356"
+{
+	RA 7.36395688
+	Dec -6.54722829
+	Radius 126.481
+	Distance 11597.346
+}
+
+OpenCluster "UBC 1352"
+{
+	RA 7.36406589
+	Dec -5.43662912
+	Radius 115.934
+	Distance 12704.239
+}
+
+OpenCluster "HSC 1843"
+{
+	RA 7.36410994
+	Dec -18.94509939
+	Radius 90.512
+	Distance 3061.817
+}
+
+OpenCluster "King 23:OC 0363:Theia 2350"
+{
+	RA 7.36414477
+	Dec -0.98995596
+	Radius 48.789
+	Distance 10197.103
+}
+
+OpenCluster "HSC 1610"
+{
+	RA 7.36448429
+	Dec 13.25159454
+	Radius 58.201
+	Distance 9323.259
+}
+
+OpenCluster "HSC 2012"
+{
+	RA 7.36454517
+	Dec -37.45334633
+	Radius 83.175
+	Distance 1938.117
+}
+
+OpenCluster "HSC 1776"
+{
+	RA 7.3666697
+	Dec -10.68763152
+	Radius 35.336
+	Distance 10544.837
+}
+
+OpenCluster "Alessi 84:CWNU 1128:TRSG 2"
+{
+	RA 7.36733774
+	Dec 55.38448205
+	Radius 90.355
+	Distance 646.77
+}
+
+OpenCluster "FSR 1083:Kronberger 97:MWSC 1192"
+{
+	RA 7.36776523
+	Dec 3.5562762
+	Radius 113.939
+	Distance 14185.942
+}
+
+OpenCluster "HSC 1793"
+{
+	RA 7.36790198
+	Dec -12.44954957
+	Radius 174.707
+	Distance 7724.178
+}
+
+OpenCluster "HSC 1856"
+{
+	RA 7.36868796
+	Dec -20.26412139
+	Radius 72.692
+	Distance 1791.215
+}
+
+OpenCluster "HSC 2009"
+{
+	RA 7.36902273
+	Dec -36.85576211
+	Radius 58.291
+	Distance 5266.591
+}
+
+OpenCluster "CWNU 1460"
+{
+	RA 7.36983381
+	Dec -11.94494038
+	Radius 47.546
+	Distance 9658.755
+}
+
+OpenCluster "HSC 1892"
+{
+	RA 7.37556117
+	Dec -23.62720958
+	Radius 60.206
+	Distance 12449.86
+}
+
+OpenCluster "FSR 1252:MWSC 1195:OC 0396"
+{
+	RA 7.3767742
+	Dec -18.70120675
+	Radius 96.056
+	Distance 10454.432
+}
+
+OpenCluster "UBC 220"
+{
+	RA 7.37744687
+	Dec -17.1593647
+	Radius 64.262
+	Distance 9309.716
+}
+
+OpenCluster "HSC 1822"
+{
+	RA 7.38020224
+	Dec -16.08602235
+	Radius 58.027
+	Distance 13952.464
+}
+
+OpenCluster "HSC 1773"
+{
+	RA 7.38127435
+	Dec -9.66398124
+	Radius 55.663
+	Distance 7215.899
+}
+
+OpenCluster "HSC 1864"
+{
+	RA 7.38145955
+	Dec -20.88594629
+	Radius 40.867
+	Distance 8394.312
+}
+
+OpenCluster "BH 1:ESO 428-24:FSR 1311:Haffner 7:MWSC 1197:OCL 661"
+{
+	RA 7.38204783
+	Dec -29.49658386
+	Radius 63.095
+	Distance 13474.272
+}
+
+OpenCluster "Haffner 8:MWSC 1200:OCL 578"
+{
+	RA 7.38480592
+	Dec -12.30300076
+	Radius 38.68
+	Distance 8684.676
+}
+
+OpenCluster "ESO 559-7:MWSC 1198:OCL 612:Ruprecht 16:Theia 1951"
+{
+	RA 7.38627078
+	Dec -19.49875682
+	Radius 73.711
+	Distance 9221.066
+}
+
+OpenCluster "CWNU 2259"
+{
+	RA 7.38680541
+	Dec -18.63377863
+	Radius 110.858
+	Distance 9225.452
 }
 
 OpenCluster "Collinder 140"
 {
-	RA 7.407500
-	Dec -30.150000
-	Distance 1320
-	Radius 11.5
+	RA 7.38682677
+	Dec -32.01159004
+	Radius 54.239
+	Distance 1227.029
 }
 
-OpenCluster "Ruprecht 18"
+OpenCluster "ESO 492-11:MWSC 1202:OCL 627:Ruprecht 17"
 {
-	RA 7.410833
-	Dec -25.783333
-	Distance 3444
-	Radius 3.5
+	RA 7.38849503
+	Dec -23.24028091
+	Radius 173.936
+	Distance 3685.759
 }
 
-OpenCluster "NGC 2383"
+OpenCluster "HSC 1786"
 {
-	RA 7.411111
-	Dec -19.051667
-	Distance 11089
-	Radius 8.1
+	RA 7.39087817
+	Dec -11.52129083
+	Radius 134.679
+	Distance 8546.016
 }
 
-OpenCluster "Haffner 9"
+OpenCluster "HSC 1937"
 {
-	RA 7.411667
-	Dec -16.997222
-	Distance 6197
-	Radius 3.6
+	RA 7.39213503
+	Dec -28.60308401
+	Radius 57.152
+	Distance 15036.918
 }
 
-OpenCluster "NGC 2384"
+OpenCluster "CWNU 280:UBC 1364"
 {
-	RA 7.419444
-	Dec -20.978333
-	Distance 9458
-	Radius 6.9
+	RA 7.39343232
+	Dec -11.20644423
+	Radius 146.026
+	Distance 9509.769
 }
 
-OpenCluster "Waterloo 7"
+OpenCluster "Berkeley 78:FSR 1067:MWSC 1203:MWSC 1204:OCL 536"
 {
-	RA 7.435556
-	Dec -14.906667
-	Distance 9132
-	Radius 3.5
+	RA 7.39392101
+	Dec 5.37127535
+	Radius 147.366
+	Distance 14193.971
 }
 
-OpenCluster "Melotte 66"
+OpenCluster "HSC 1839"
 {
-	RA 7.439722
-	Dec -46.333333
-	Distance 14067
-	Radius 28.6
+	RA 7.39698086
+	Dec -18.1095419
+	Radius 69.084
+	Distance 8767.494
 }
 
-OpenCluster "Ruprecht 20"
+OpenCluster "FSR 1297:Majaess 88"
 {
-	RA 7.445278
-	Dec -27.183333
-	Distance 3940
-	Radius 2.9
+	RA 7.39922142
+	Dec -25.8868623
+	Radius 42.129
+	Distance 4007.934
 }
 
-OpenCluster "ASCC 38"
+OpenCluster "HSC 1838"
 {
-	RA 7.453056
-	Dec -4.450000
-	Distance 1630
-	Radius 7.4
+	RA 7.40095702
+	Dec -17.94495492
+	Radius 84.088
+	Distance 10508.069
 }
 
-OpenCluster "NGC 2395"
+OpenCluster "NGC 2374:Collinder 139:MWSC 1206:OCL 585:Theia 3491"
 {
-	RA 7.453333
-	Dec 13.608333
-	Distance 1669
-	Radius 3.4
+	RA 7.40171713
+	Dec -13.26772725
+	Radius 99.377
+	Distance 4032.964
 }
 
-OpenCluster "Trumpler 7"
+OpenCluster "Theia 2267"
 {
-	RA 7.456111
-	Dec -22.050000
-	Distance 4807
-	Radius 3.5
+	RA 7.40223234
+	Dec -26.46197723
+	Radius 124.947
+	Distance 3796.127
 }
 
-OpenCluster "NGC 2396"
+OpenCluster "HSC 1812"
 {
-	RA 7.466667
-	Dec -10.283333
-	Distance 1917
-	Radius 2.8
+	RA 7.40328213
+	Dec -14.42665039
+	Radius 62.207
+	Distance 11400.089
 }
 
-OpenCluster "Czernik 29"
+OpenCluster "PHOC 16"
 {
-	RA 7.471667
-	Dec -14.600000
-	Distance 13594
-	Radius 9.9
+	RA 7.40336292
+	Dec -20.20839055
+	Radius 43.889
+	Distance 8885.994
 }
 
-OpenCluster "Haffner 10"
+OpenCluster "Ivanov 6"
 {
-	RA 7.476667
-	Dec -14.616667
-	Distance 17117
-	Radius 7.5
+	RA 7.40341942
+	Dec -24.65003168
+	Radius 19.086
+	Distance 4195.295
 }
 
-OpenCluster "NGC 2401"
+OpenCluster "CWNU 341:UBC 1371"
 {
-	RA 7.490000
-	Dec -12.033333
-	Distance 19204
-	Radius 5.6
+	RA 7.40887818
+	Dec -17.19259658
+	Radius 99.6
+	Distance 8669.181
 }
 
-OpenCluster "Bochum 5"
+OpenCluster "UBC 1370"
 {
-	RA 7.516667
-	Dec -15.066667
-	Distance 2844
-	Radius 6.2
+	RA 7.40969815
+	Dec -16.38654935
+	Radius 87.693
+	Distance 8562.694
 }
 
-OpenCluster "Bochum 4"
+OpenCluster "Ruprecht 18:Theia 3297:Theia 6462"
 {
-	RA 7.526944
-	Dec -16.806667
-	Distance 7472
-	Radius 5.4
+	RA 7.41093332
+	Dec -26.2066973
+	Radius 93.177
+	Distance 7857.23
 }
 
-OpenCluster "Bochum 6"
+OpenCluster "HSC 1663"
 {
-	RA 7.533333
-	Dec -18.583333
-	Distance 12984
-	Radius 18.9
+	RA 7.41097339
+	Dec 6.9457303
+	Radius 39.774
+	Distance 5904.124
 }
 
-OpenCluster "ASCC 39"
+OpenCluster "LISC 1132:UBC 1375"
 {
-	RA 7.550000
-	Dec -21.050000
-	Distance 4892
-	Radius 25.6
+	RA 7.41135568
+	Dec -18.84398579
+	Radius 85.251
+	Distance 10319.996
 }
 
-OpenCluster "NGC 2413"
+OpenCluster "NGC 2383:NGC 2384:Collinder 141:Collinder 142:Collinder 143:ESO 559-8:ESO 559-9:MWSC 1213:MWSC 1216:OCL 616:OCL 618:Theia 3152"
 {
-	RA 7.551944
-	Dec -12.600000
-	Distance 1435
-	Radius 5.0
+	RA 7.41156632
+	Dec -20.94920581
+	Radius 76.939
+	Distance 10006.423
 }
 
-OpenCluster "NGC 2414"
+OpenCluster "FSR 1240:Haffner 9:MWSC 1214:OCL 600"
 {
-	RA 7.553333
-	Dec -14.546667
-	Distance 11269
-	Radius 8.2
+	RA 7.4120108
+	Dec -16.9973544
+	Radius 50.445
+	Distance 9343.698
 }
 
-OpenCluster "ESO 429-02"
+OpenCluster "CWNU 2456"
 {
-	RA 7.556667
-	Dec -27.812500
-	Distance 5446
-	Radius 2.4
+	RA 7.41297617
+	Dec 2.29552317
+	Radius 31.876
+	Distance 8748.585
 }
 
-OpenCluster "ASCC 40"
+OpenCluster "UBC 452"
 {
-	RA 7.560000
-	Dec -12.240000
-	Distance 2283
-	Radius 7.2
+	RA 7.41307438
+	Dec -19.25935688
+	Radius 50.43
+	Distance 10838.364
 }
 
-OpenCluster "Haffner 11"
+OpenCluster "CWNU 1337:Majaess 90:Theia 118"
 {
-	RA 7.591667
-	Dec -26.300278
-	Distance 16960
-	Radius 12.3
+	RA 7.41370456
+	Dec -24.50547336
+	Radius 38.515
+	Distance 4270.143
 }
 
-OpenCluster "NGC 2421"
+OpenCluster "CWNU 226"
 {
-	RA 7.603611
-	Dec -19.388333
-	Distance 7175
-	Radius 6.3
+	RA 7.4160629
+	Dec -4.92081679
+	Radius 60.336
+	Distance 4852.665
 }
 
-OpenCluster "NGC 2422"
+OpenCluster "HXHWL 5"
 {
-	RA 7.609722
-	Dec -13.516667
-	Distance 1598
-	Radius 5.8
+	RA 7.41885691
+	Dec -13.59335616
+	Radius 37.952
+	Distance 2683.436
 }
 
-OpenCluster "Czernik 31"
+OpenCluster "NGC 2384:Collinder 142:Collinder 143:ESO 559-9:MWSC 1216:OCL 618:UBC 224"
 {
-	RA 7.616389
-	Dec -19.490278
-	Distance 7175
-	Radius 5.2
+	RA 7.41916647
+	Dec -21.02152098
+	Radius 53.839
+	Distance 8525.951
 }
 
-OpenCluster "NGC 2423"
+OpenCluster "CWNU 2016"
 {
-	RA 7.618333
-	Dec -12.128333
-	Distance 2498
-	Radius 4.4
+	RA 7.41928923
+	Dec -8.04076101
+	Radius 83.829
+	Distance 6488.974
 }
 
-OpenCluster "Ruprecht 26"
+OpenCluster "HXHWL 21"
 {
-	RA 7.620000
-	Dec -14.350000
-	Distance 4077
-	Radius 2.4
+	RA 7.42217115
+	Dec -8.78335274
+	Radius 78.788
+	Distance 6570.848
 }
 
-OpenCluster "Melotte 71"
+OpenCluster "HSC 1936"
 {
-	RA 7.625000
-	Dec -11.933333
-	Distance 10287
-	Radius 10.5
+	RA 7.42306591
+	Dec -28.19082283
+	Radius 66.619
+	Distance 2349.25
 }
 
-OpenCluster "Ruprecht 27"
+OpenCluster "Theia 545"
 {
-	RA 7.626111
-	Dec -25.500000
-	Distance 4073
-	Radius 3.0
+	RA 7.42379684
+	Dec 14.54295617
+	Radius 79.699
+	Distance 1863.708
 }
 
-OpenCluster "NGC 2425"
+OpenCluster "HSC 1877"
 {
-	RA 7.638056
-	Dec -13.121667
-	Distance 11578
-	Radius 13.5
+	RA 7.42418753
+	Dec -21.88025478
+	Radius 95.165
+	Distance 20869.632
 }
 
-OpenCluster "NGC 2420"
+OpenCluster "HSC 1818"
 {
-	RA 7.639722
-	Dec 21.573333
-	Distance 8088
-	Radius 5.9
+	RA 7.42504295
+	Dec -15.58233551
+	Radius 51.743
+	Distance 9881.947
 }
 
-OpenCluster "Melotte 72"
+OpenCluster "UBC 1377"
 {
-	RA 7.640000
-	Dec -9.316667
-	Distance 2964
-	Radius 2.2
+	RA 7.42603258
+	Dec -19.72413333
+	Radius 55.44
+	Distance 11415.777
 }
 
-OpenCluster "Arp-Madore 2"
+OpenCluster "HSC 1922"
 {
-	RA 7.646111
-	Dec -32.156667
-	Distance 43513
-	Radius 12.7
+	RA 7.42647131
+	Dec -26.7982866
+	Radius 30.885
+	Distance 3013.195
 }
 
-OpenCluster "NGC 2428"
+OpenCluster "NGC 2384:Collinder 142:Collinder 143:ESO 559-9:MWSC 1216:OCL 618:Theia 3152"
 {
-	RA 7.655833
-	Dec -15.471667
-	Distance 6849
-	Radius 12.0
+	RA 7.43006868
+	Dec -20.97378438
+	Radius 88.276
+	Distance 9324.866
 }
 
-OpenCluster "NGC 2430"
+OpenCluster "ESO 559-10:MWSC 1218:OCL 622:Ruprecht 19:Theia 2230"
 {
-	RA 7.661389
-	Dec -15.703333
-	Distance 2120
-	Radius 4.6
+	RA 7.4332568
+	Dec -21.82974013
+	Radius 56.584
+	Distance 4486.75
 }
 
-OpenCluster "ESO 493-03"
+OpenCluster "Theia 2299"
 {
-	RA 7.662500
-	Dec -26.706667
-	Distance 4566
-	Radius 4.6
+	RA 7.43572879
+	Dec -9.05791891
+	Radius 99.061
+	Distance 4863.857
+}
+
+OpenCluster "MWSC 1220:Waterloo 7"
+{
+	RA 7.4358172
+	Dec -15.09189468
+	Radius 50.895
+	Distance 10632.717
+}
+
+OpenCluster "HSC 1869"
+{
+	RA 7.43790742
+	Dec -20.81077757
+	Radius 28.228
+	Distance 6652.722
+}
+
+OpenCluster "FSR 1253:MWSC 1221:SAI 76"
+{
+	RA 7.43794848
+	Dec -18.43650803
+	Radius 60.568
+	Distance 12055.598
+}
+
+OpenCluster "Melotte 66:Collinder 147:ESO 208-12:FSR 1396:MWSC 1222:OCL 739"
+{
+	RA 7.43889365
+	Dec -47.69344902
+	Radius 159.091
+	Distance 14729.1
+}
+
+OpenCluster "HSC 1831"
+{
+	RA 7.44407849
+	Dec -16.43255696
+	Radius 54.641
+	Distance 8217.673
+}
+
+OpenCluster "HSC 1845"
+{
+	RA 7.44527298
+	Dec -18.75470103
+	Radius 49.723
+	Distance 10420.105
+}
+
+OpenCluster "HSC 1634"
+{
+	RA 7.44592109
+	Dec 11.02363035
+	Radius 73.092
+	Distance 1381.504
+}
+
+OpenCluster "DC 3:MWSC 1226"
+{
+	RA 7.45038569
+	Dec -37.51793901
+	Radius 207.268
+	Distance 23685.059
+}
+
+OpenCluster "HSC 1809"
+{
+	RA 7.45156304
+	Dec -13.56348114
+	Radius 24.237
+	Distance 9828.47
+}
+
+OpenCluster "HSC 1927"
+{
+	RA 7.45355547
+	Dec -27.17921814
+	Radius 51.964
+	Distance 12574.263
+}
+
+OpenCluster "Theia 118"
+{
+	RA 7.45367442
+	Dec -25.39192896
+	Radius 62.388
+	Distance 828.703
+}
+
+OpenCluster "Collinder 146:ESO 492-16:FSR 1288:MWSC 1229:OCL 635:Theia 1904:Trumpler 7"
+{
+	RA 7.45625058
+	Dec -23.95121679
+	Radius 45.106
+	Distance 5282.664
+}
+
+OpenCluster "HSC 1782"
+{
+	RA 7.45765458
+	Dec -10.50324402
+	Radius 60.082
+	Distance 14422.973
+}
+
+OpenCluster "OC 0398"
+{
+	RA 7.45799994
+	Dec -18.48203166
+	Radius 53.293
+	Distance 8341.725
+}
+
+OpenCluster "HSC 1820"
+{
+	RA 7.46542139
+	Dec -15.3799786
+	Radius 40.793
+	Distance 15066.876
+}
+
+OpenCluster "HSC 1850"
+{
+	RA 7.46664964
+	Dec -19.00750524
+	Radius 79.849
+	Distance 1717.513
+}
+
+OpenCluster "NGC 2396:Collinder 148:MWSC 1232:OCL 579:Theia 2447"
+{
+	RA 7.46797668
+	Dec -11.65350773
+	Radius 49.087
+	Distance 4510.272
+}
+
+OpenCluster "FSR 1275:MWSC 1233:SAI 77"
+{
+	RA 7.46798275
+	Dec -21.77062733
+	Radius 37.65
+	Distance 7032.319
+}
+
+OpenCluster "HSC 1627"
+{
+	RA 7.46814155
+	Dec 12.02467837
+	Radius 85.35
+	Distance 8668.576
+}
+
+OpenCluster "HSC 1855"
+{
+	RA 7.46815831
+	Dec -19.49259185
+	Radius 58.556
+	Distance 18037.67
+}
+
+OpenCluster "FSR 1260"
+{
+	RA 7.47208811
+	Dec -19.67400213
+	Radius 40.939
+	Distance 8533.014
+}
+
+OpenCluster "Czernik 29:FSR 1231:Haffner 10:MWSC 1234:MWSC 1237:OCL 594:OCL 595"
+{
+	RA 7.47301567
+	Dec -15.39938773
+	Radius 33.357
+	Distance 11432.143
+}
+
+OpenCluster "OC 0392"
+{
+	RA 7.47487568
+	Dec -15.68172909
+	Radius 20.726
+	Distance 9436.655
+}
+
+OpenCluster "FoF 198:Theia 2318:UBC 223:UBC 635"
+{
+	RA 7.47530068
+	Dec -20.11684721
+	Radius 36.916
+	Distance 9439.261
+}
+
+OpenCluster "Czernik 29:FSR 1231:Haffner 10:MWSC 1234:MWSC 1237:OCL 594:OCL 595"
+{
+	RA 7.47654263
+	Dec -15.36453417
+	Radius 54.05
+	Distance 11264.295
+}
+
+OpenCluster "ESO 559-14:Haffner 24:MWSC 1239:OCL 608"
+{
+	RA 7.47772563
+	Dec -18.27021575
+	Radius 61.968
+	Distance 9901.234
+}
+
+OpenCluster "ESO 559-13:ESO 559 13:MWSC 1238"
+{
+	RA 7.47852454
+	Dec -20.80202052
+	Radius 62.309
+	Distance 7384.311
+}
+
+OpenCluster "HSC 1834"
+{
+	RA 7.48173894
+	Dec -16.28405493
+	Radius 69.505
+	Distance 9910.049
+}
+
+OpenCluster "CWNU 1112:Theia 3581"
+{
+	RA 7.48386308
+	Dec -14.15974069
+	Radius 77.637
+	Distance 3464.983
+}
+
+OpenCluster "HSC 1881"
+{
+	RA 7.48489023
+	Dec -22.03188825
+	Radius 51.749
+	Distance 9584.744
+}
+
+OpenCluster "Theia 759"
+{
+	RA 7.48830406
+	Dec -18.85954631
+	Radius 87.8
+	Distance 2329.653
+}
+
+OpenCluster "PHOC 15:Theia 759"
+{
+	RA 7.48916087
+	Dec -20.34272205
+	Radius 151.426
+	Distance 6470.393
+}
+
+OpenCluster "NGC 2401:Collinder 149:MWSC 1241:OCL 588"
+{
+	RA 7.49005204
+	Dec -13.96810776
+	Radius 48.719
+	Distance 13565.028
+}
+
+OpenCluster "HSC 1742"
+{
+	RA 7.49108327
+	Dec -4.12460499
+	Radius 38.072
+	Distance 5019.745
+}
+
+OpenCluster "DBSB 6"
+{
+	RA 7.49613266
+	Dec -19.19927179
+	Radius 63.852
+	Distance 4666.454
+}
+
+OpenCluster "HSC 1823"
+{
+	RA 7.49873745
+	Dec -15.17295681
+	Radius 41.233
+	Distance 3690.688
+}
+
+OpenCluster "HSC 1905"
+{
+	RA 7.50092708
+	Dec -23.94580097
+	Radius 38.761
+	Distance 3784.598
+}
+
+OpenCluster "DBSB 5:Mayer 3"
+{
+	RA 7.50165751
+	Dec -18.54626918
+	Radius 25.213
+	Distance 12319.227
+}
+
+OpenCluster "UBC 1367"
+{
+	RA 7.50519131
+	Dec -12.70631958
+	Radius 122.474
+	Distance 13906.665
+}
+
+OpenCluster "Alessi 144:UPK 418"
+{
+	RA 7.50611703
+	Dec 5.71678329
+	Radius 85.513
+	Distance 2700.14
+}
+
+OpenCluster "HSC 1852"
+{
+	RA 7.50643321
+	Dec -19.00833685
+	Radius 40.002
+	Distance 9574.146
+}
+
+OpenCluster "CWNU 2116"
+{
+	RA 7.50860542
+	Dec -23.0169595
+	Radius 23.057
+	Distance 4552.707
+}
+
+OpenCluster "HSC 1735"
+{
+	RA 7.50871762
+	Dec -2.60906616
+	Radius 28.013
+	Distance 6210.498
+}
+
+OpenCluster "ESO 492-17:FSR 1286:MWSC 1248:OCL 632:Ruprecht 23:Theia 2400"
+{
+	RA 7.51053454
+	Dec -23.38047793
+	Radius 41.64
+	Distance 8337.522
+}
+
+OpenCluster "OCSN 77"
+{
+	RA 7.51074369
+	Dec -12.53968097
+	Radius 70.288
+	Distance 1732.006
+}
+
+OpenCluster "HSC 1924"
+{
+	RA 7.51105674
+	Dec -26.38598106
+	Radius 51.887
+	Distance 10856.403
+}
+
+OpenCluster "HSC 2154"
+{
+	RA 7.51200644
+	Dec -54.92502222
+	Radius 97.351
+	Distance 2203.914
+}
+
+OpenCluster "CWNU 1592:Theia 2400"
+{
+	RA 7.51213526
+	Dec -23.14787103
+	Radius 25.352
+	Distance 9257.364
+}
+
+OpenCluster "HSC 1911"
+{
+	RA 7.51356079
+	Dec -24.40488671
+	Radius 156.556
+	Distance 2164.691
+}
+
+OpenCluster "HSC 1681"
+{
+	RA 7.51556599
+	Dec 4.6305934
+	Radius 35.058
+	Distance 13487.339
+}
+
+OpenCluster "HSC 1919"
+{
+	RA 7.51640906
+	Dec -25.87033214
+	Radius 103.801
+	Distance 10899.944
+}
+
+OpenCluster "HSC 1853"
+{
+	RA 7.51642972
+	Dec -18.93515071
+	Radius 62.082
+	Distance 11175.85
+}
+
+OpenCluster "Theia 3180:UBC 233"
+{
+	RA 7.51800335
+	Dec -28.38511088
+	Radius 96.465
+	Distance 7388.741
+}
+
+OpenCluster "OC 0390"
+{
+	RA 7.5180455
+	Dec -13.62593295
+	Radius 39.629
+	Distance 5671.855
+}
+
+OpenCluster "HSC 1857"
+{
+	RA 7.51831699
+	Dec -19.40203831
+	Radius 23.707
+	Distance 7797.225
+}
+
+OpenCluster "Theia 649"
+{
+	RA 7.51835705
+	Dec -51.32767345
+	Radius 110.028
+	Distance 2030.274
+}
+
+OpenCluster "FSR 1234:UBC 633"
+{
+	RA 7.51890986
+	Dec -15.43733392
+	Radius 32.612
+	Distance 14156.738
+}
+
+OpenCluster "Czernik 30:MWSC 1253:OCL 574"
+{
+	RA 7.51968865
+	Dec -9.94609074
+	Radius 132.108
+	Distance 19923.449
+}
+
+OpenCluster "MWSC 1257:OCL 586:Ruprecht 24:UBC 630"
+{
+	RA 7.52242243
+	Dec -12.78224488
+	Radius 65.387
+	Distance 6317.407
+}
+
+OpenCluster "Bochum 4:Theia 2951"
+{
+	RA 7.52645012
+	Dec -17.19866813
+	Radius 65.777
+	Distance 4081.619
+}
+
+OpenCluster "HSC 1858"
+{
+	RA 7.52682086
+	Dec -19.42197163
+	Radius 58.112
+	Distance 8420.604
+}
+
+OpenCluster "HSC 1729"
+{
+	RA 7.52829946
+	Dec -1.41280534
+	Radius 39.272
+	Distance 9211.73
+}
+
+OpenCluster "CWNU 2754"
+{
+	RA 7.52877146
+	Dec -14.45838998
+	Radius 42.592
+	Distance 8120.397
+}
+
+OpenCluster "HSC 2046"
+{
+	RA 7.53017468
+	Dec -42.84781453
+	Radius 67.408
+	Distance 1581.735
+}
+
+OpenCluster "Bochum 6:DBSB 9"
+{
+	RA 7.53044522
+	Dec -19.38083972
+	Radius 71.602
+	Distance 11196.087
+}
+
+OpenCluster "Theia 1147"
+{
+	RA 7.53100327
+	Dec -26.05417477
+	Radius 88.231
+	Distance 1966.819
+}
+
+OpenCluster "MWSC 1257:OCL 586:Ruprecht 24"
+{
+	RA 7.53122546
+	Dec -12.77345684
+	Radius 63.793
+	Distance 6118.086
+}
+
+OpenCluster "HSC 1799"
+{
+	RA 7.53126922
+	Dec -11.7471196
+	Radius 36.935
+	Distance 6296.26
+}
+
+OpenCluster "CWNU 324:OC 0394:Theia 2951"
+{
+	RA 7.53411281
+	Dec -16.93224554
+	Radius 57.887
+	Distance 5696.299
+}
+
+OpenCluster "HSC 1910"
+{
+	RA 7.53617516
+	Dec -24.20330339
+	Radius 73.941
+	Distance 10950.504
+}
+
+OpenCluster "HSC 1914"
+{
+	RA 7.53732534
+	Dec -24.7286531
+	Radius 83.826
+	Distance 21406.993
+}
+
+OpenCluster "CWNU 1087"
+{
+	RA 7.53817226
+	Dec -14.07237631
+	Radius 30.776
+	Distance 3174.735
+}
+
+OpenCluster "HSC 1906"
+{
+	RA 7.53871254
+	Dec -23.83534842
+	Radius 55.636
+	Distance 8146.065
+}
+
+OpenCluster "UBC 440"
+{
+	RA 7.54004655
+	Dec 5.99237247
+	Radius 30.793
+	Distance 9424.127
+}
+
+OpenCluster "HSC 1947"
+{
+	RA 7.54173853
+	Dec -28.63700805
+	Radius 31.481
+	Distance 7968.749
+}
+
+OpenCluster "HSC 1907"
+{
+	RA 7.54408071
+	Dec -24.05706061
+	Radius 28.137
+	Distance 7089.216
+}
+
+OpenCluster "OCSN 73:Theia 383"
+{
+	RA 7.54436107
+	Dec 0.32274703
+	Radius 135.584
+	Distance 1528.594
+}
+
+OpenCluster "UBC 1369"
+{
+	RA 7.55103756
+	Dec -14.50947452
+	Radius 50.322
+	Distance 11874.186
+}
+
+OpenCluster "CWNU 1265"
+{
+	RA 7.55256302
+	Dec -49.13834299
+	Radius 34.431
+	Distance 845.175
+}
+
+OpenCluster "NGC 2414:Theia 2343"
+{
+	RA 7.55288695
+	Dec -15.45232056
+	Radius 101.511
+	Distance 14747.797
+}
+
+OpenCluster "HSC 1921"
+{
+	RA 7.55337939
+	Dec -25.8679943
+	Radius 86.15
+	Distance 1760.092
+}
+
+OpenCluster "CWNU 321:OC 0403"
+{
+	RA 7.55394461
+	Dec -20.16022217
+	Radius 98.78
+	Distance 8684.19
+}
+
+OpenCluster "OC 0412"
+{
+	RA 7.55655706
+	Dec -23.96265337
+	Radius 268.283
+	Distance 20019.533
+}
+
+OpenCluster "ESO 429-02:ESO 429-2:ESO 429-429:ESO 429-5:ESO 429 02:MWSC 1264:MWSC 1482:Theia 5287:Theia 5578:Theia 5804:Theia 6804:UBC 464"
+{
+	RA 7.556886
+	Dec -28.18610877
+	Radius 230.864
+	Distance 8991.949
+}
+
+OpenCluster "HSC 2134"
+{
+	RA 7.55731318
+	Dec -52.9221589
+	Radius 205.654
+	Distance 32899.09
+}
+
+OpenCluster "CWNU 49:UBC 1374"
+{
+	RA 7.55802327
+	Dec -17.51786247
+	Radius 47.754
+	Distance 8432.035
+}
+
+OpenCluster "HSC 1974"
+{
+	RA 7.55904583
+	Dec -31.07129535
+	Radius 87.433
+	Distance 3924.174
+}
+
+OpenCluster "HSC 1875"
+{
+	RA 7.55939041
+	Dec -20.71957101
+	Radius 73.234
+	Distance 8717.322
+}
+
+OpenCluster "UBC 1428"
+{
+	RA 7.56057344
+	Dec -38.38459844
+	Radius 43.845
+	Distance 7009.995
+}
+
+OpenCluster "HXHWL 48"
+{
+	RA 7.56345928
+	Dec -8.2613759
+	Radius 21.772
+	Distance 3386.59
+}
+
+OpenCluster "HSC 1814"
+{
+	RA 7.56527607
+	Dec -13.55991213
+	Radius 121.49
+	Distance 14040.599
+}
+
+OpenCluster "CWNU 79:UBC 1378:UBC 1379"
+{
+	RA 7.56762951
+	Dec -19.17444401
+	Radius 63.98
+	Distance 8034.736
+}
+
+OpenCluster "UBC 448"
+{
+	RA 7.56782965
+	Dec -8.07335347
+	Radius 72.099
+	Distance 9623.493
+}
+
+OpenCluster "CWNU 2006"
+{
+	RA 7.57204556
+	Dec -17.18713261
+	Radius 73.923
+	Distance 4918.428
+}
+
+OpenCluster "DSH J0734.6-1947:FSR 1266:MWSC 1270:SAI 78:Teutsch 61"
+{
+	RA 7.57803857
+	Dec -19.79390824
+	Radius 29.009
+	Distance 8924.459
+}
+
+OpenCluster "CWNU 1034"
+{
+	RA 7.57910017
+	Dec -25.57206472
+	Radius 79.714
+	Distance 1487.859
+}
+
+OpenCluster "HSC 2216"
+{
+	RA 7.58416815
+	Dec -61.16115836
+	Radius 21.019
+	Distance 902.074
+}
+
+OpenCluster "CWNU 1515"
+{
+	RA 7.58759181
+	Dec -16.27044018
+	Radius 126.382
+	Distance 11400.989
+}
+
+OpenCluster "CWNU 283"
+{
+	RA 7.58876651
+	Dec -42.88950485
+	Radius 55.548
+	Distance 3609.279
+}
+
+OpenCluster "BH 3:ESO 429-3:FSR 1310:Haffner 11:MWSC 1273:OCL 657"
+{
+	RA 7.5894285
+	Dec -27.71357925
+	Radius 123.145
+	Distance 17272.084
+}
+
+OpenCluster "Theia 3849:UBC 460"
+{
+	RA 7.58949295
+	Dec -21.34924939
+	Radius 101.705
+	Distance 9207.985
+}
+
+OpenCluster "CWNU 1900"
+{
+	RA 7.58993516
+	Dec -26.03228797
+	Radius 44.628
+	Distance 9122.847
+}
+
+OpenCluster "Alessi 17:MWSC 1271"
+{
+	RA 7.59013236
+	Dec -15.09840827
+	Radius 49.281
+	Distance 12789.968
+}
+
+OpenCluster "DBSB 7:Theia 2110"
+{
+	RA 7.59095237
+	Dec -18.64242776
+	Radius 63.34
+	Distance 7471.93
+}
+
+OpenCluster "CWNU 371"
+{
+	RA 7.59144406
+	Dec -12.68765207
+	Radius 57.434
+	Distance 7711.965
+}
+
+OpenCluster "CWNU 110"
+{
+	RA 7.59161849
+	Dec -15.56153406
+	Radius 32.552
+	Distance 4212.818
+}
+
+OpenCluster "DBSB 7"
+{
+	RA 7.59277934
+	Dec -18.76650235
+	Radius 31.075
+	Distance 11593.787
+}
+
+OpenCluster "HSC 1979"
+{
+	RA 7.59604015
+	Dec -31.36914809
+	Radius 67.37
+	Distance 11401.307
+}
+
+OpenCluster "HSC 1851"
+{
+	RA 7.59869188
+	Dec -18.09104134
+	Radius 78.717
+	Distance 10724.886
+}
+
+OpenCluster "NGC 2421:Melotte 67:Collinder 151:ESO 56-2:FSR 1274:MWSC 1277:OCL 626:OC 0405:Theia 2102:Theia 2547"
+{
+	RA 7.60315232
+	Dec -20.62182722
+	Radius 130.667
+	Distance 8067.734
+}
+
+OpenCluster "CWNU 1443"
+{
+	RA 7.60793468
+	Dec -26.06297162
+	Radius 50.969
+	Distance 12003.535
+}
+
+OpenCluster "Theia 2000"
+{
+	RA 7.60882589
+	Dec -25.35598426
+	Radius 143.014
+	Distance 4143.272
+}
+
+OpenCluster "Theia 3849"
+{
+	RA 7.60930104
+	Dec -21.77938825
+	Radius 86.096
+	Distance 8465.574
+}
+
+OpenCluster "HSC 1916"
+{
+	RA 7.61039281
+	Dec -25.11836944
+	Radius 143.368
+	Distance 11477.648
+}
+
+OpenCluster "M 47:NGC 2422:Melotte 68:Collinder 152:Escorial 21:MWSC 1278:OCL 596:Theia 320"
+{
+	RA 7.61127246
+	Dec -14.49265462
+	Radius 84.462
+	Distance 1527.299
+}
+
+OpenCluster "ESO 493-1:MWSC 1280:OCL 641:Ruprecht 25"
+{
+	RA 7.613228
+	Dec -23.38599793
+	Radius 81.081
+	Distance 22826.282
+}
+
+OpenCluster "CWNU 2921"
+{
+	RA 7.61325043
+	Dec -33.57103753
+	Radius 123.748
+	Distance 6718.966
+}
+
+OpenCluster "HSC 1198"
+{
+	RA 7.61372037
+	Dec 65.56337885
+	Radius 230.049
+	Distance 15386.781
+}
+
+OpenCluster "UBC 1383"
+{
+	RA 7.61587884
+	Dec -21.87984852
+	Radius 86.895
+	Distance 10788.621
+}
+
+OpenCluster "CWNU 1733"
+{
+	RA 7.61600912
+	Dec -26.32058657
+	Radius 33.68
+	Distance 5626.887
+}
+
+OpenCluster "Czernik 31:ESO 560-3:MWSC 1281:OCL 625:OC 0404"
+{
+	RA 7.61609942
+	Dec -20.5220134
+	Radius 36.416
+	Distance 9650.307
+}
+
+OpenCluster "HSC 1828"
+{
+	RA 7.6164675
+	Dec -14.6243209
+	Radius 31.769
+	Distance 4271.276
+}
+
+OpenCluster "FSR 1244:MWSC 1285:OCL 602:Ruprecht 26:Theia 2348"
+{
+	RA 7.61691367
+	Dec -15.59093566
+	Radius 51.014
+	Distance 3469.247
+}
+
+OpenCluster "ESO 429-05:ESO 429-2:ESO 429-429:ESO 429-5:ESO 429 05:MWSC 1264:MWSC 1482"
+{
+	RA 7.61698445
+	Dec -32.20295427
+	Radius 69.249
+	Distance 26423.666
+}
+
+OpenCluster "FSR 1244:MWSC 1285:OCL 602:Ruprecht 26:UBC 221"
+{
+	RA 7.61999844
+	Dec -15.67703025
+	Radius 61.777
+	Distance 7499.221
+}
+
+OpenCluster "NGC 2423:Melotte 70:Collinder 153:MWSC 1283:OCL 592:Theia 1176"
+{
+	RA 7.62116063
+	Dec -13.86327647
+	Radius 87.235
+	Distance 2963.857
+}
+
+OpenCluster "HSC 1872"
+{
+	RA 7.62199817
+	Dec -19.73067499
+	Radius 94.565
+	Distance 9617.643
+}
+
+OpenCluster "CWNU 464"
+{
+	RA 7.62435128
+	Dec -19.41393112
+	Radius 96.388
+	Distance 7814.117
+}
+
+OpenCluster "Melotte 71:Collinder 155:FSR 1222:MWSC 1287:OCL 587:Theia 5059:Theia 5163"
+{
+	RA 7.62517143
+	Dec -12.05782944
+	Radius 91.466
+	Distance 6820.636
+}
+
+OpenCluster "HSC 1683"
+{
+	RA 7.62527274
+	Dec 5.11389742
+	Radius 71.038
+	Distance 14696.127
+}
+
+OpenCluster "HSC 1854"
+{
+	RA 7.62584835
+	Dec -18.14699004
+	Radius 35.924
+	Distance 8145.939
+}
+
+OpenCluster "CWNU 1974"
+{
+	RA 7.62644835
+	Dec -34.83434411
+	Radius 49.686
+	Distance 6950.351
+}
+
+OpenCluster "CWNU 1789"
+{
+	RA 7.62699519
+	Dec -18.68498142
+	Radius 58.266
+	Distance 11172.56
+}
+
+OpenCluster "CWNU 2197"
+{
+	RA 7.62702789
+	Dec -20.7873895
+	Radius 46.159
+	Distance 11757.132
+}
+
+OpenCluster "ESO 493-2:FSR 1305:MWSC 1286:OCL 654:Ruprecht 27:Theia 4800"
+{
+	RA 7.62778648
+	Dec -26.51320473
+	Radius 55.253
+	Distance 6204.563
+}
+
+OpenCluster "NGC 2451:NGC 2451A:Collinder 161:BH 9:ESO 311-8:Escorial 24:MWSC 1308:OCL 716:UPK 494"
+{
+	RA 7.63223705
+	Dec -38.13440445
+	Radius 94.231
+	Distance 2881.853
+}
+
+OpenCluster "HSC 1915"
+{
+	RA 7.6335763
+	Dec -24.60319475
+	Radius 42.592
+	Distance 4743.004
+}
+
+OpenCluster "Teutsch 210:Theia 2925:UBC 1382"
+{
+	RA 7.63541568
+	Dec -21.55469564
+	Radius 58.045
+	Distance 8980.469
+}
+
+OpenCluster "LISC 1145:UBC 230"
+{
+	RA 7.63661402
+	Dec -25.37028282
+	Radius 85.361
+	Distance 5990.875
+}
+
+OpenCluster "HSC 2056"
+{
+	RA 7.63695657
+	Dec -43.43646555
+	Radius 78.295
+	Distance 1414.575
+}
+
+OpenCluster "NGC 2425:FSR 1238:Haffner 12:MWSC 1291:OCL 599:Theia 4767"
+{
+	RA 7.63865638
+	Dec -14.8881251
+	Radius 157.151
+	Distance 10091.369
+}
+
+OpenCluster "NGC 2420:Melotte 69:Collinder 154:FSR 972:MWSC 1292:OCL 488:Theia 6042"
+{
+	RA 7.64013859
+	Dec 21.57406769
+	Radius 44.578
+	Distance 7538.839
+}
+
+OpenCluster "Melotte 72:Collinder 156:FSR 1215:MWSC 1293:OCL 581:Theia 6097"
+{
+	RA 7.64123518
+	Dec -10.69819864
+	Radius 71.483
+	Distance 7914.715
+}
+
+OpenCluster "CWNU 1449"
+{
+	RA 7.64182416
+	Dec -27.91423761
+	Radius 125.88
+	Distance 8625.978
+}
+
+OpenCluster "NGC 2420:Melotte 69:Collinder 154:FSR 972:MWSC 1292:OCL 488:Theia 6042"
+{
+	RA 7.64183818
+	Dec 21.54277454
+	Radius 10.988
+	Distance 4398.615
+}
+
+OpenCluster "Theia 3260"
+{
+	RA 7.65128725
+	Dec -17.09048185
+	Radius 95.923
+	Distance 3739.394
+}
+
+OpenCluster "HSC 1866"
+{
+	RA 7.65316516
+	Dec -18.94461646
+	Radius 84.518
+	Distance 11307.676
+}
+
+OpenCluster "CWNU 1487"
+{
+	RA 7.65416375
+	Dec -14.73025873
+	Radius 72.737
+	Distance 4848.523
+}
+
+OpenCluster "NGC 2428:MWSC 1297:Theia 4005"
+{
+	RA 7.65678395
+	Dec -16.53392219
+	Radius 62.562
+	Distance 4266.08
+}
+
+OpenCluster "ESO 429-7:FSR 1323:MWSC 1299:OCL 680:OC 0424:OC 0425:Ruprecht 28"
+{
+	RA 7.66029084
+	Dec -30.93492429
+	Radius 69.287
+	Distance 12906.025
+}
+
+OpenCluster "HSC 1942"
+{
+	RA 7.66072484
+	Dec -26.91264114
+	Radius 42.923
+	Distance 912.926
+}
+
+OpenCluster "HXHWL 59:UBC 1381"
+{
+	RA 7.66417179
+	Dec -18.91215599
+	Radius 25.906
+	Distance 7026.047
+}
+
+OpenCluster "UBC 1390"
+{
+	RA 7.66656584
+	Dec -25.54805412
+	Radius 50.996
+	Distance 9883.445
+}
+
+OpenCluster "HSC 1870"
+{
+	RA 7.66792524
+	Dec -19.09004442
+	Radius 50.6
+	Distance 9554.514
+}
+
+OpenCluster "CWNU 1273:Teutsch 211"
+{
+	RA 7.66992675
+	Dec -22.00456605
+	Radius 142.582
+	Distance 7984.929
+}
+
+OpenCluster "CWNU 2567"
+{
+	RA 7.67092229
+	Dec -28.02776979
+	Radius 58.624
+	Distance 10086.391
 }
 
 OpenCluster "Bochum 15"
 {
-	RA 7.668333
-	Dec -32.466667
-	Distance 9152
-	Radius 4.0
+	RA 7.67144889
+	Dec -33.55083729
+	Radius 135.934
+	Distance 11056.645
 }
 
-OpenCluster "Haffner 13"
+OpenCluster "UBC 459"
 {
-	RA 7.675000
-	Dec -29.916667
-	Distance 2328
-	Radius 4.7
+	RA 7.67237731
+	Dec -19.73403647
+	Radius 61.886
+	Distance 8166.033
 }
 
-OpenCluster "NGC 2439"
+OpenCluster "CWNU 2909"
 {
-	RA 7.679167
-	Dec -30.306667
-	Distance 4240
-	Radius 5.6
+	RA 7.67530055
+	Dec -20.77891319
+	Radius 26.483
+	Distance 10207.303
 }
 
-OpenCluster "NGC 2432"
+OpenCluster "BH 5:ESO 429-10:Haffner 13:MWSC 1305:OCL 678:Theia 106"
 {
-	RA 7.681389
-	Dec -18.923333
-	Distance 6197
-	Radius 5.4
+	RA 7.67593764
+	Dec -30.01790271
+	Radius 190.988
+	Distance 1801.989
 }
 
-OpenCluster "Ruprecht 151"
+OpenCluster "HSC 1897"
 {
-	RA 7.688333
-	Dec -15.750000
-	Distance 4077
-	Radius 4.2
+	RA 7.67656099
+	Dec -21.55324589
+	Radius 91.495
+	Distance 2077.358
 }
 
-OpenCluster "NGC 2437"
+OpenCluster "UBC 449"
 {
-	RA 7.696111
-	Dec -13.190000
-	Distance 4925
-	Radius 14.3
+	RA 7.68026554
+	Dec -12.89156795
+	Radius 35.089
+	Distance 10617.741
 }
 
-OpenCluster "Ruprecht 31"
+OpenCluster "NGC 2439:OC 0430"
 {
-	RA 7.716111
-	Dec -34.402778
-	Distance 3033
-	Radius 1.3
+	RA 7.68048738
+	Dec -31.69883537
+	Radius 162.292
+	Distance 10926.379
 }
 
-OpenCluster "NGC 2451A"
+OpenCluster "CWNU 2349"
 {
-	RA 7.720000
-	Dec -37.600000
-	Distance 616
-	Radius 10.8
+	RA 7.68072171
+	Dec -16.55877157
+	Radius 38.637
+	Distance 7816.223
 }
 
-OpenCluster "NGC 2451B"
+OpenCluster "HSC 1926"
 {
-	RA 7.740833
-	Dec -36.333333
-	Distance 985
-	Radius 15.5
+	RA 7.681151
+	Dec -25.33214513
+	Radius 119.213
+	Distance 13528.213
 }
 
-OpenCluster "NGC 2447"
+OpenCluster "NGC 2432:Melotte 73:Collinder 157:ESO 560-6:FSR 1267:MWSC 1310:OCL 620:Theia 4688"
 {
-	RA 7.741667
-	Dec -22.143333
-	Distance 3382
-	Radius 4.9
+	RA 7.6813442
+	Dec -19.07456323
+	Radius 41.519
+	Distance 5762.734
 }
 
-OpenCluster "NGC 2448"
+OpenCluster "ES493SC4:MWSC 1311:OCL 650:Ruprecht 29"
 {
-	RA 7.742778
-	Dec -23.320000
-	Distance 3392
-	Radius 9.9
+	RA 7.68293223
+	Dec -24.39822283
+	Radius 31.858
+	Distance 6815.329
 }
 
-OpenCluster "Ruprecht 32"
+OpenCluster "CWNU 1403:Theia 2399:Theia 4419"
 {
-	RA 7.752778
-	Dec -24.466667
-	Distance 17436
-	Radius 12.7
+	RA 7.68550902
+	Dec -23.38211115
+	Radius 57.128
+	Distance 10977.765
 }
 
-OpenCluster "Haffner 15"
+OpenCluster "MWSC 1309:OCL 606:Ruprecht 151:Theia 4005"
 {
-	RA 7.758889
-	Dec -31.150000
-	Distance 6777
-	Radius 3.0
+	RA 7.68664721
+	Dec -16.2793144
+	Radius 67.698
+	Distance 3507.646
 }
 
-OpenCluster "Ruprecht 34"
+OpenCluster "HXHWL 3:Teutsch 211:Theia 2319:Theia 3524:Theia 5438"
 {
-	RA 7.765278
-	Dec -19.616667
-	Distance 3261
-	Radius 2.8
+	RA 7.68676988
+	Dec -21.86375761
+	Radius 59.666
+	Distance 5347.434
 }
 
-OpenCluster "Berkeley 39"
+OpenCluster "CWNU 1483"
 {
-	RA 7.778333
-	Dec -3.400000
-	Distance 15590
-	Radius 15.9
+	RA 7.68695393
+	Dec -24.14639544
+	Radius 65.091
+	Distance 10970.813
 }
 
-OpenCluster "Herschel 1"
+OpenCluster "UBC 458"
 {
-	RA 7.783889
-	Dec 0.018333
-	Distance 1206
-	Radius 7.6
+	RA 7.68876808
+	Dec -18.69621613
+	Radius 73.835
+	Distance 10896.347
 }
 
-OpenCluster "NGC 2453"
+OpenCluster "FSR 1211:MWSC 1312"
 {
-	RA 7.793056
-	Dec -26.805000
-	Distance 7012
-	Radius 4.1
+	RA 7.68918623
+	Dec -9.61713644
+	Radius 67.791
+	Distance 10315.496
 }
 
-OpenCluster "Ruprecht 36"
+OpenCluster "UBC 455"
 {
-	RA 7.806389
-	Dec -25.700000
-	Distance 5482
-	Radius 4.0
+	RA 7.69217329
+	Dec -17.57666746
+	Radius 109.097
+	Distance 10494.688
 }
 
-OpenCluster "Haffner 16"
+OpenCluster "HSC 1893"
 {
-	RA 7.838889
-	Dec -24.533333
-	Distance 10323
-	Radius 7.5
+	RA 7.69722446
+	Dec -21.20494729
+	Radius 49.67
+	Distance 7890.599
 }
 
-OpenCluster "Czernik 32"
+OpenCluster "M 46:NGC 2437:Melotte 75:Collinder 159:FSR 1241:MWSC 1313:OCL 601:Theia 3371"
 {
-	RA 7.841667
-	Dec -28.154167
-	Distance 13372
-	Radius 5.8
+	RA 7.6973193
+	Dec -14.8335351
+	Radius 120.406
+	Distance 5070.224
 }
 
-OpenCluster "Haffner 17"
+OpenCluster "UPK 540"
 {
-	RA 7.860278
-	Dec -30.183333
-	Distance 9393
-	Radius 2.7
+	RA 7.70109476
+	Dec -58.66151951
+	Radius 86.241
+	Distance 1188.32
 }
 
-OpenCluster "NGC 2477"
+OpenCluster "UBC 231"
 {
-	RA 7.869444
-	Dec -37.470000
-	Distance 4240
-	Radius 9.3
+	RA 7.70291427
+	Dec -26.31256313
+	Radius 79.525
+	Distance 9056.481
 }
 
-OpenCluster "NGC 2467"
+OpenCluster "CWNU 2333"
 {
-	RA 7.873889
-	Dec -25.563333
-	Distance 4419
-	Radius 9.0
+	RA 7.70405005
+	Dec -25.88314663
+	Radius 73.655
+	Distance 12104.462
 }
 
-OpenCluster "ESO 123-26"
+OpenCluster "HSC 1988"
 {
-	RA 7.875000
-	Dec -59.670000
-	Distance 1793
-	Radius 4.2
+	RA 7.70461999
+	Dec -32.06444243
+	Radius 23.22
+	Distance 4211.536
 }
 
-OpenCluster "Haffner 18"
+OpenCluster "HSC 1934"
 {
-	RA 7.877500
-	Dec -25.616667
-	Distance 19661
-	Radius 14.3
+	RA 7.70605966
+	Dec -26.09165951
+	Radius 74.23
+	Distance 10950.414
+}
+
+OpenCluster "Theia 2637:Theia 3524"
+{
+	RA 7.71158396
+	Dec -22.10466012
+	Radius 86.714
+	Distance 4609.99
+}
+
+OpenCluster "CWWL 2084:Theia 4168:Theia 4494:Theia 5438:UBC 1384"
+{
+	RA 7.71223581
+	Dec -21.06240289
+	Radius 166.19
+	Distance 10141.458
+}
+
+OpenCluster "HSC 1886"
+{
+	RA 7.7122674
+	Dec -20.73307929
+	Radius 107.714
+	Distance 11794.659
+}
+
+OpenCluster "Theia 5779"
+{
+	RA 7.71349678
+	Dec -39.1750081
+	Radius 77.271
+	Distance 3436.544
+}
+
+OpenCluster "UBC 1391"
+{
+	RA 7.71545392
+	Dec -25.19810544
+	Radius 154.164
+	Distance 12464.287
+}
+
+OpenCluster "HSC 1880"
+{
+	RA 7.71650344
+	Dec -20.21983634
+	Radius 38.944
+	Distance 10196.118
+}
+
+OpenCluster "HSC 1867"
+{
+	RA 7.71669867
+	Dec -18.48123368
+	Radius 32.025
+	Distance 3552.047
+}
+
+OpenCluster "HSC 1957"
+{
+	RA 7.71987549
+	Dec -28.17322682
+	Radius 138.559
+	Distance 8588.925
+}
+
+OpenCluster "PHOC 3"
+{
+	RA 7.72177742
+	Dec -30.48788904
+	Radius 41.582
+	Distance 7046.093
+}
+
+OpenCluster "UBC 1368"
+{
+	RA 7.72242998
+	Dec -11.84245218
+	Radius 54.42
+	Distance 8062.432
+}
+
+OpenCluster "UBC 1386"
+{
+	RA 7.72353957
+	Dec -23.40384639
+	Radius 211.422
+	Distance 12954.85
+}
+
+OpenCluster "HSC 1594"
+{
+	RA 7.72702142
+	Dec 19.37946598
+	Radius 120.718
+	Distance 19900.746
+}
+
+OpenCluster "HSC 1824"
+{
+	RA 7.72729942
+	Dec -13.33025838
+	Radius 90.106
+	Distance 12823.228
+}
+
+OpenCluster "Theia 107:UPK 526"
+{
+	RA 7.72975977
+	Dec -52.83553664
+	Radius 173.879
+	Distance 1815.768
+}
+
+OpenCluster "Platais 7:NGC 2451:NGC 2451A:NGC 2451B:Collinder 161:BH 9:ESO 311-8:Escorial 24:HIP 37742 Group:MWSC 1308:MWSC 1322:OCL 716"
+{
+	RA 7.73137811
+	Dec -38.24075459
+	Radius 57.243
+	Distance 619.968
+}
+
+OpenCluster "ESO 493-8:MWSC 1323:NGC 2448:Theia 2468"
+{
+	RA 7.7352717
+	Dec -24.94540276
+	Radius 62.31
+	Distance 3478.859
+}
+
+OpenCluster "Theia 2468"
+{
+	RA 7.73559205
+	Dec -24.10786857
+	Radius 177.953
+	Distance 3644.464
+}
+
+OpenCluster "ESO 368-11:ESO 368 11:FSR 1353:MWSC 1320:MWSC 1321"
+{
+	RA 7.73887366
+	Dec -34.6298671
+	Radius 41.032
+	Distance 6718.683
+}
+
+OpenCluster "Theia 2018"
+{
+	RA 7.73914205
+	Dec -26.87141624
+	Radius 55.658
+	Distance 9122.602
+}
+
+OpenCluster "NGC 2448:ESO 493-8:MWSC 1323:UBC 1389"
+{
+	RA 7.73946292
+	Dec -24.72825982
+	Radius 96.33
+	Distance 12150.2
+}
+
+OpenCluster "Theia 2018:UBC 1393"
+{
+	RA 7.74119745
+	Dec -26.6401094
+	Radius 93.308
+	Distance 12779.871
+}
+
+OpenCluster "Critter Cluster:M 93:NGC 2447:Melotte 76:Collinder 160:FSR 1301:MWSC 1324:OCL 649:Theia 277"
+{
+	RA 7.7423051
+	Dec -23.84885439
+	Radius 67.062
+	Distance 3166.69
+}
+
+OpenCluster "HSC 1903"
+{
+	RA 7.74233428
+	Dec -21.86649247
+	Radius 69.667
+	Distance 9596.787
+}
+
+OpenCluster "CWNU 1031"
+{
+	RA 7.74270226
+	Dec -43.50391511
+	Radius 50.793
+	Distance 880.339
+}
+
+OpenCluster "Theia 7057"
+{
+	RA 7.74487431
+	Dec -25.36512596
+	Radius 79.224
+	Distance 9179.542
+}
+
+OpenCluster "UBC 1387"
+{
+	RA 7.74492138
+	Dec -23.26038105
+	Radius 59.634
+	Distance 12383.383
+}
+
+OpenCluster "Platais 7:NGC 2451:NGC 2451A:NGC 2451B:Collinder 161:BH 9:ESO 311-8:Escorial 24:HIP 37742 Group:MWSC 1308:MWSC 1322:OCL 716"
+{
+	RA 7.74507482
+	Dec -37.94207387
+	Radius 117.965
+	Distance 1198.739
+}
+
+OpenCluster "BH 7:ESO 429-16:FSR 1319:Haffner 14:MWSC 1326:OCL 674:OC 0422:Theia 2576"
+{
+	RA 7.74515956
+	Dec -28.37975471
+	Radius 132.809
+	Distance 11693.958
+}
+
+OpenCluster "Critter Cluster Far:M 93 Far:NGC 2447 Far:Melotte 76 Far:Collinder 160 Far:FSR 1301 Far:MWSC 1324 Far:OCL 6491 Far:Theia 277 Far"
+{
+	RA 7.75002998
+	Dec -23.68056432
+	Radius 57.587
+	Distance 5124.774
+}
+
+OpenCluster "HSC 1993"
+{
+	RA 7.75007576
+	Dec -32.59718521
+	Radius 63.118
+	Distance 9573.75
+}
+
+OpenCluster "CWNU 2724"
+{
+	RA 7.75080809
+	Dec -24.95929829
+	Radius 89.344
+	Distance 9984.973
+}
+
+OpenCluster "HXHWL 24:Theia 3229"
+{
+	RA 7.75147387
+	Dec -20.04038704
+	Radius 40.762
+	Distance 5127.659
+}
+
+OpenCluster "HSC 2023"
+{
+	RA 7.75247311
+	Dec -36.96672453
+	Radius 35.836
+	Distance 6448.452
+}
+
+OpenCluster "HSC 1917"
+{
+	RA 7.75648658
+	Dec -24.00380757
+	Radius 77.946
+	Distance 15047.364
+}
+
+OpenCluster "Theia 6920:UBC 466"
+{
+	RA 7.75748837
+	Dec -27.24478104
+	Radius 69.882
+	Distance 13957.872
+}
+
+OpenCluster "BH 8:ESO 368-12:FSR 1340:Haffner 15:MWSC 1328:OCL 696:OC 0434:OC 0435"
+{
+	RA 7.75859878
+	Dec -32.83994474
+	Radius 62.724
+	Distance 10893.551
+}
+
+OpenCluster "UBC 647"
+{
+	RA 7.7608887
+	Dec -48.2754173
+	Radius 43.885
+	Distance 4383.013
+}
+
+OpenCluster "HSC 1876"
+{
+	RA 7.76232083
+	Dec -19.1883955
+	Radius 63.184
+	Distance 11721.993
+}
+
+OpenCluster "ESO 560-11:MWSC 1332:OCL 640:Ruprecht 33"
+{
+	RA 7.76299111
+	Dec -21.91730865
+	Radius 78.071
+	Distance 7096.99
+}
+
+OpenCluster "UBC 1394"
+{
+	RA 7.76521881
+	Dec -26.61348802
+	Radius 43.457
+	Distance 10196.398
+}
+
+OpenCluster "Berkeley 38:ESO 560-10:MWSC 1330:OCL 628:Ruprecht 34"
+{
+	RA 7.76546862
+	Dec -20.38500879
+	Radius 71.335
+	Distance 8391.296
+}
+
+OpenCluster "HSC 1946"
+{
+	RA 7.76751558
+	Dec -26.71396339
+	Radius 45.385
+	Distance 8690.993
+}
+
+OpenCluster "BH 10:ESO 429-18:MWSC 1333:OCL 689:Ruprecht 35"
+{
+	RA 7.77023033
+	Dec -31.27850436
+	Radius 44.687
+	Distance 11196.37
+}
+
+OpenCluster "HSC 1935"
+{
+	RA 7.77025892
+	Dec -25.60173606
+	Radius 31.71
+	Distance 14337.826
+}
+
+OpenCluster "Theia 2472:UBC 463"
+{
+	RA 7.77047807
+	Dec -26.20628989
+	Radius 28.76
+	Distance 6337.838
+}
+
+OpenCluster "CWNU 135"
+{
+	RA 7.77095375
+	Dec -52.84209208
+	Radius 82.96
+	Distance 2402.58
+}
+
+OpenCluster "Cmg 1066:FSR 1352:MWSC 1334"
+{
+	RA 7.77347614
+	Dec -34.291103
+	Radius 91.052
+	Distance 10795.087
+}
+
+OpenCluster "HSC 1933"
+{
+	RA 7.77407772
+	Dec -25.5344035
+	Radius 59.304
+	Distance 6796.029
+}
+
+OpenCluster "BH 10:ESO 429-18:MWSC 1333:OCL 689:OC 0432:Ruprecht 35"
+{
+	RA 7.77519088
+	Dec -31.31036215
+	Radius 22.629
+	Distance 4666.801
+}
+
+OpenCluster "Berkeley 39:FSR 1174:MWSC 1336:OCL 561"
+{
+	RA 7.78048887
+	Dec -4.67270544
+	Radius 142.385
+	Distance 12424.396
+}
+
+OpenCluster "ADS 6366:ASCC 41:FSR 1141:Herschel 1:MWSC 1335:MWSC 1337:Theia 225"
+{
+	RA 7.7805227
+	Dec 0.077203
+	Radius 72.701
+	Distance 957.14
+}
+
+OpenCluster "HSC 1904"
+{
+	RA 7.78293612
+	Dec -21.62453827
+	Radius 47.554
+	Distance 11606.361
+}
+
+OpenCluster "UBC 1385"
+{
+	RA 7.78305745
+	Dec -20.97260919
+	Radius 142.998
+	Distance 12123.321
+}
+
+OpenCluster "ESO 368-14:ESO 368 14:FSR 1343:MWSC 1338:MWSC 1339:OC 0437"
+{
+	RA 7.78339665
+	Dec -32.96315518
+	Radius 32.942
+	Distance 10830.927
+}
+
+OpenCluster "HSC 1999"
+{
+	RA 7.78365999
+	Dec -33.19792389
+	Radius 69.428
+	Distance 10821.836
+}
+
+OpenCluster "HSC 1846"
+{
+	RA 7.78412149
+	Dec -16.17517843
+	Radius 64.345
+	Distance 18885.95
+}
+
+OpenCluster "UBC 1397"
+{
+	RA 7.78457994
+	Dec -28.66616632
+	Radius 60.265
+	Distance 9307.219
+}
+
+OpenCluster "Theia 3995"
+{
+	RA 7.788613
+	Dec -25.24165198
+	Radius 58.95
+	Distance 15071.325
+}
+
+OpenCluster "HSC 1810"
+{
+	RA 7.79325947
+	Dec -11.04040505
+	Radius 65.73
+	Distance 7729.183
+}
+
+OpenCluster "NGC 2453:Collinder 162:ESO 493-12:MWSC 13409:OCL 670:OC 0420"
+{
+	RA 7.79343834
+	Dec -27.19590963
+	Radius 87.174
+	Distance 13146.801
+}
+
+OpenCluster "CWWL 1438:CWWL 2073"
+{
+	RA 7.79614176
+	Dec -24.70479828
+	Radius 122.303
+	Distance 13276.745
+}
+
+OpenCluster "HSC 1943"
+{
+	RA 7.79722939
+	Dec -25.88347254
+	Radius 34.005
+	Distance 12139.622
+}
+
+OpenCluster "HSC 1992"
+{
+	RA 7.79729357
+	Dec -31.88861838
+	Radius 52.498
+	Distance 12432.022
+}
+
+OpenCluster "FSR 1347:MWSC 1343:SAI 79:UBC 238"
+{
+	RA 7.80183262
+	Dec -33.71467265
+	Radius 84.394
+	Distance 11038.783
+}
+
+OpenCluster "UBC 1405"
+{
+	RA 7.80220086
+	Dec -29.46873867
+	Radius 136.185
+	Distance 14416.044
+}
+
+OpenCluster "OC 0440"
+{
+	RA 7.80333334
+	Dec -36.14814408
+	Radius 287.429
+	Distance 32050.307
+}
+
+OpenCluster "Theia 3265"
+{
+	RA 7.80363205
+	Dec -25.86700452
+	Radius 127.336
+	Distance 14123.639
+}
+
+OpenCluster "HSC 1960"
+{
+	RA 7.80551007
+	Dec -27.72994483
+	Radius 40.873
+	Distance 3357.511
+}
+
+OpenCluster "ESO 493-14:MWSC 1344:OCL 660:Ruprecht 36"
+{
+	RA 7.80600132
+	Dec -26.28996455
+	Radius 39.715
+	Distance 8127.897
+}
+
+OpenCluster "CWNU 1548:DSH J0748.4-2754:MWSC 1345:SAI 80:Teutsch 25"
+{
+	RA 7.80750015
+	Dec -27.92997319
+	Radius 34.561
+	Distance 10809.238
+}
+
+OpenCluster "CWNU 1434:Theia 3265"
+{
+	RA 7.80904877
+	Dec -25.77235089
+	Radius 38.229
+	Distance 13352.502
+}
+
+OpenCluster "CWNU 246"
+{
+	RA 7.80958293
+	Dec -23.73405289
+	Radius 118.501
+	Distance 5496.889
+}
+
+OpenCluster "HXHWL 9:Theia 3111:Theia 3142:Theia 3628:Theia 4559:Theia 6412"
+{
+	RA 7.80962382
+	Dec -25.45186668
+	Radius 76
+	Distance 7176.224
+}
+
+OpenCluster "AH03 J0748+26.9:AH03 J0748-26.9:AH03 J0748 26.9:FSR 1315:MWSC 1347:MWSC 1348"
+{
+	RA 7.81039246
+	Dec -26.97267949
+	Radius 42.776
+	Distance 12977.974
+}
+
+OpenCluster "HSC 1884"
+{
+	RA 7.8122281
+	Dec -19.62895352
+	Radius 140.895
+	Distance 11046.39
+}
+
+OpenCluster "CWNU 140:UBC 1388"
+{
+	RA 7.81306977
+	Dec -23.56105165
+	Radius 37.69
+	Distance 7444.708
+}
+
+OpenCluster "NGC 2455:Melotte 77:Collinder 163:CWNU 1495:ESO 560-15:MWSC 1350:OCL 636"
+{
+	RA 7.8148272
+	Dec -21.20306292
+	Radius 65.227
+	Distance 10777.823
+}
+
+OpenCluster "HSC 1945"
+{
+	RA 7.81581652
+	Dec -26.28199074
+	Radius 45.764
+	Distance 12859.328
+}
+
+OpenCluster "CWNU 1093"
+{
+	RA 7.81730171
+	Dec 20.17878912
+	Radius 58.425
+	Distance 1775.896
+}
+
+OpenCluster "NGC 2455:Melotte 77:Collinder 163:ESO 560-15:MWSC 1350:OCL 636:Theia 3157"
+{
+	RA 7.81977547
+	Dec -21.29067296
+	Radius 185.513
+	Distance 9300.539
+}
+
+OpenCluster "UBC 235"
+{
+	RA 7.82342764
+	Dec -29.3457803
+	Radius 142.639
+	Distance 5371.207
+}
+
+OpenCluster "CWWL 3526:OC 0470"
+{
+	RA 7.825001
+	Dec -46.36827056
+	Radius 59.861
+	Distance 1269.334
+}
+
+OpenCluster "HSC 2001"
+{
+	RA 7.82583346
+	Dec -33.09864501
+	Radius 36.39
+	Distance 11786.418
+}
+
+OpenCluster "Theia 2406"
+{
+	RA 7.82770212
+	Dec -26.84385565
+	Radius 98.358
+	Distance 13138.092
+}
+
+OpenCluster "Berkeley 40:MWSC 1353:OCL 615:Ruprecht 37"
+{
+	RA 7.83000977
+	Dec -17.24841279
+	Radius 126.404
+	Distance 14998.076
+}
+
+OpenCluster "CWNU 260"
+{
+	RA 7.83295097
+	Dec -49.71826688
+	Radius 56.048
+	Distance 2451.79
+}
+
+OpenCluster "CWNU 538"
+{
+	RA 7.83389251
+	Dec -30.94231293
+	Radius 62.874
+	Distance 4851.387
+}
+
+OpenCluster "ESO 493-20:FSR 1309:Haffner 16:MWSC 1355:OCL 655"
+{
+	RA 7.83897388
+	Dec -25.45600962
+	Radius 49.248
+	Distance 9762.231
+}
+
+OpenCluster "CWNU 129"
+{
+	RA 7.83932615
+	Dec -34.35912489
+	Radius 53.888
+	Distance 4476.877
+}
+
+OpenCluster "CWNU 2397"
+{
+	RA 7.84112111
+	Dec -27.60187574
+	Radius 37.781
+	Distance 11895.902
+}
+
+OpenCluster "BH 11:Czernik 32:ESO 494-20:FSR 1325:King 24:MWSC 1357:OCL 683:OC 0426:OC 0427"
+{
+	RA 7.8411598
+	Dec -29.85344463
+	Radius 54.444
+	Distance 12207.804
+}
+
+OpenCluster "HSC 2021"
+{
+	RA 7.84184464
+	Dec -36.01997834
+	Radius 56.5
+	Distance 4013.624
+}
+
+OpenCluster "BH 11:Czernik 32:ESO 494-20:FSR 1325:King 24:MWSC 1357:OCL 683:OC 0428:UBC 236"
+{
+	RA 7.8424562
+	Dec -29.94705786
+	Radius 55.66
+	Distance 9391.302
+}
+
+OpenCluster "FSR 1361:MWSC 1358:Theia 3799"
+{
+	RA 7.84381212
+	Dec -36.39727572
+	Radius 70.866
+	Distance 7951.328
+}
+
+OpenCluster "CWNU 128"
+{
+	RA 7.84634711
+	Dec -35.11955948
+	Radius 71.412
+	Distance 4467.058
+}
+
+OpenCluster "CWNU 2407"
+{
+	RA 7.84638882
+	Dec -32.97313961
+	Radius 46.459
+	Distance 4987.065
+}
+
+OpenCluster "HSC 1931"
+{
+	RA 7.84824382
+	Dec -24.62224001
+	Radius 101.991
+	Distance 7369.189
+}
+
+OpenCluster "HSC 1938"
+{
+	RA 7.85458628
+	Dec -25.17764746
+	Radius 48.219
+	Distance 7783.48
+}
+
+OpenCluster "LISC 1152:UBC 1407"
+{
+	RA 7.85715008
+	Dec -29.51314554
+	Radius 73.689
+	Distance 8902.128
+}
+
+OpenCluster "BH 12:ESO 429-22:FSR 1337:Haffner 17:MWSC 1360:OCL 694"
+{
+	RA 7.8598496
+	Dec -31.81476142
+	Radius 58.037
+	Distance 10440.305
+}
+
+OpenCluster "OC 0431"
+{
+	RA 7.86203587
+	Dec -30.63886649
+	Radius 104.049
+	Distance 22159.42
+}
+
+OpenCluster "CWNU 1635"
+{
+	RA 7.86205365
+	Dec -32.36228118
+	Radius 53.219
+	Distance 9334.644
+}
+
+OpenCluster "HSC 1954"
+{
+	RA 7.86467008
+	Dec -26.79794763
+	Radius 124.909
+	Distance 16184.37
+}
+
+OpenCluster "NGC 2467:UBC 1615"
+{
+	RA 7.86645094
+	Dec -26.41051063
+	Radius 63.276
+	Distance 12957.286
+}
+
+OpenCluster "HSC 1967"
+{
+	RA 7.86718691
+	Dec -27.66596986
+	Radius 66.554
+	Distance 13605.452
+}
+
+OpenCluster "HSC 1970"
+{
+	RA 7.86850617
+	Dec -27.85569064
+	Radius 34.159
+	Distance 4034.62
+}
+
+OpenCluster "ASCC 43:MWSC 1362:MWSC 1374:SAI 81"
+{
+	RA 7.86904276
+	Dec -28.1256193
+	Radius 60.884
+	Distance 12278.952
+}
+
+OpenCluster "NGC 2477:Melotte 78:Collinder 165:BH 13:ESO 311-17:FSR 1369:MWSC 1363:OCL 720:Theia 5145"
+{
+	RA 7.86966825
+	Dec -38.53444436
+	Radius 95.582
+	Distance 4513.741
+}
+
+OpenCluster "Theia 2822:UBC 1392"
+{
+	RA 7.8697385
+	Dec -25.49087281
+	Radius 70.288
+	Distance 16431.398
+}
+
+OpenCluster "OC 0450"
+{
+	RA 7.87585302
+	Dec -42.43187045
+	Radius 130.753
+	Distance 1055.55
+}
+
+OpenCluster "ESO 123-26:ESO 123 26:MWSC 1364:Theia 779:UBC 250"
+{
+	RA 7.87623727
+	Dec -60.37587847
+	Radius 66.59
+	Distance 3018.279
+}
+
+OpenCluster "Haffner 18:NGC 2467-east"
+{
+	RA 7.87767197
+	Dec -26.38288436
+	Radius 17.916
+	Distance 13960.023
 }
 
 OpenCluster "Haffner 19"
 {
-	RA 7.879722
-	Dec -25.716667
-	Distance 16614
-	Radius 4.8
+	RA 7.87903297
+	Dec -26.28014523
+	Radius 22.475
+	Distance 13127.396
 }
 
-OpenCluster "Alessi-Teutsch 3"
+OpenCluster "CWNU 2451"
 {
-	RA 7.883611
-	Dec -52.955000
-	Distance 2609
-	Radius 16.4
+	RA 7.88372713
+	Dec -25.20592847
+	Radius 37.256
+	Distance 9305.191
 }
 
-OpenCluster "ASCC 43"
+OpenCluster "ASCC 42:AT 3:Alessi-Teutsch 3:Alessi 30:Alessi Teutsch 3:MWSC 1373"
 {
-	RA 7.885000
-	Dec -27.830000
-	Distance 3261
-	Radius 19.9
+	RA 7.88570095
+	Dec -53.00078285
+	Radius 89.697
+	Distance 2240.694
 }
 
-OpenCluster "NGC 2479"
+OpenCluster "CWNU 1586"
 {
-	RA 7.918333
-	Dec -16.290000
-	Distance 5433
-	Radius 7.9
+	RA 7.8867688
+	Dec -26.59720182
+	Radius 47.368
+	Distance 7998.149
 }
 
-OpenCluster "Waterloo 3"
+OpenCluster "HXHWL 70:Theia 3768"
 {
-	RA 7.918333
-	Dec -24.635000
-	Distance 16960
-	Radius 4.9
+	RA 7.88800875
+	Dec -39.70212948
+	Radius 45.924
+	Distance 3793.267
 }
 
-OpenCluster "NGC 2482"
+OpenCluster "UBC 1400"
 {
-	RA 7.920000
-	Dec -23.741667
-	Distance 4380
-	Radius 6.4
+	RA 7.88841396
+	Dec -28.24799413
+	Radius 49.874
+	Distance 13138.744
 }
 
-OpenCluster "NGC 2483"
+OpenCluster "HSC 2015"
 {
-	RA 7.927500
-	Dec -26.105000
-	Distance 5411
-	Radius 5.5
+	RA 7.88993577
+	Dec -35.024282
+	Radius 127.937
+	Distance 2351.654
 }
 
-OpenCluster "Trumpler 9"
+OpenCluster "FSR 1298:MWSC 1377"
 {
-	RA 7.927778
-	Dec -24.116667
-	Distance 7465
-	Radius 5.4
+	RA 7.89144449
+	Dec -22.43099354
+	Radius 52.199
+	Distance 10497.251
 }
 
-OpenCluster "NGC 2489"
+OpenCluster "CWNU 2205"
 {
-	RA 7.937500
-	Dec -29.936667
-	Distance 12906
-	Radius 11.3
+	RA 7.89202336
+	Dec -18.34596123
+	Radius 24.02
+	Distance 9092.591
 }
 
-OpenCluster "Haffner 20"
+OpenCluster "FSR 1298:MWSC 1377:OC 0415:UBC 228"
 {
-	RA 7.937500
-	Dec -29.633333
-	Distance 10166
-	Radius 4.4
+	RA 7.8921187
+	Dec -22.40357545
+	Radius 49.864
+	Distance 8861.149
 }
 
-OpenCluster "NGC 2516"
+OpenCluster "UPK 468"
 {
-	RA 7.967778
-	Dec -59.246667
-	Distance 1334
-	Radius 5.8
+	RA 7.89313865
+	Dec -13.46614618
+	Radius 60.612
+	Distance 2872.76
 }
 
-OpenCluster "Ruprecht 44"
+OpenCluster "ESO 493-31:FSR 1318:MWSC 1378:OCL 673:Ruprecht 41"
 {
-	RA 7.980833
-	Dec -27.416667
-	Distance 15427
-	Radius 22.4
+	RA 7.8949489
+	Dec -27.00724617
+	Radius 48.303
+	Distance 12218.932
 }
 
-OpenCluster "Ruprecht 43"
+OpenCluster "UBC 1396"
 {
-	RA 7.988333
-	Dec -27.033333
-	Distance 3261
-	Radius 2.8
+	RA 7.90012842
+	Dec -26.76044459
+	Radius 45.779
+	Distance 12676.262
 }
 
-OpenCluster "NGC 2506"
+OpenCluster "CWNU 2312"
 {
-	RA 8.000278
-	Dec -9.230000
-	Distance 11285
-	Radius 19.7
+	RA 7.90143847
+	Dec -27.37348651
+	Radius 81.8
+	Distance 9317.686
 }
 
-OpenCluster "NGC 2509"
+OpenCluster "UBC 1429"
 {
-	RA 8.013333
-	Dec -18.948333
-	Distance 2974
-	Radius 2.6
+	RA 7.90437424
+	Dec -37.00512303
+	Radius 75.318
+	Distance 10200.144
 }
 
-OpenCluster "Haffner 21"
+OpenCluster "NGC 2479:Collinder 167:ESO 561-1:FSR 1271:MWSC 1380:OCL 623:Theia 3144:Trumpler 8"
 {
-	RA 8.019167
-	Dec -26.783333
-	Distance 9625
-	Radius 4.2
+	RA 7.90536912
+	Dec -17.74427326
+	Radius 30.174
+	Distance 4488.158
 }
 
-OpenCluster "Alessi 34"
+OpenCluster "UBC 237"
 {
-	RA 8.030000
-	Dec -49.441667
-	Distance 3587
-	Radius 25.0
+	RA 7.90564934
+	Dec -29.72227439
+	Radius 36.894
+	Distance 5522.852
 }
 
-OpenCluster "Ruprecht 47"
+OpenCluster "FoF 947:UBC 234"
 {
-	RA 8.038611
-	Dec -30.933333
-	Distance 9804
-	Radius 5.7
+	RA 7.90731424
+	Dec -27.51157482
+	Radius 84.591
+	Distance 8871.19
 }
 
-OpenCluster "Collinder 173"
+OpenCluster "LISC 1445:Theia 4356"
 {
-	RA 8.046944
-	Dec -45.616667
-	Distance 1373
-	Radius 73.9
+	RA 7.90746335
+	Dec -28.3296463
+	Radius 50.723
+	Distance 8979.122
 }
 
-OpenCluster "Ruprecht 49"
+OpenCluster "BH 14:ESO 311-19:MWSC 1379:OCL 719:Ruprecht 152"
 {
-	RA 8.054167
-	Dec -25.233333
-	Distance 5946
-	Radius 1.7
+	RA 7.90793687
+	Dec -38.23887163
+	Radius 251.652
+	Distance 25684.215
 }
 
-OpenCluster "NGC 2527"
+OpenCluster "HSC 1994"
 {
-	RA 8.082778
-	Dec -27.853333
-	Distance 1960
-	Radius 2.9
+	RA 7.90810907
+	Dec -31.49943152
+	Radius 32.803
+	Distance 7334.365
 }
 
-OpenCluster "ESO 430-18"
+OpenCluster "HSC 2064"
 {
-	RA 8.114444
-	Dec -29.163333
-	Distance 2707
-	Radius 4.7
+	RA 7.91051055
+	Dec -42.69204237
+	Radius 43.676
+	Distance 5371.367
 }
 
-OpenCluster "NGC 2533"
+OpenCluster "CWNU 2523"
 {
-	RA 8.117778
-	Dec -28.116667
-	Distance 5544
-	Radius 4.0
+	RA 7.91051092
+	Dec -29.1883683
+	Radius 158.38
+	Distance 11352.721
 }
 
-OpenCluster "Pozzo 1"
+OpenCluster "UBC 1411"
 {
-	RA 8.158889
-	Dec -46.663333
-	Distance 1095
-	Radius 2.9
+	RA 7.91623503
+	Dec -29.80175094
+	Radius 102.938
+	Distance 13540.447
+}
+
+OpenCluster "CWNU 1384"
+{
+	RA 7.91671099
+	Dec -23.36518782
+	Radius 98.608
+	Distance 11707.695
+}
+
+OpenCluster "NGC 2479:Collinder 167:ESO 561-1:FSR 1271:MWSC 1380:OCL 623:Theia 5185:Trumpler 8:UBC 226"
+{
+	RA 7.91813367
+	Dec -17.73449401
+	Radius 52.969
+	Distance 5033.988
+}
+
+#VALOR!
+OpenCluster "NGC 2482:Collinder 166:ESO 494-3:MWSC 1382:OCL 653:Theia 2811"
+{
+	RA 7.9206402
+	Dec -24.27989053
+	Radius 61.469
+	Distance 4198.097
+}
+
+OpenCluster "NGC 2482:Collinder 166:ESO 494-3:MWSC 1382:OCL 653:UBC 636"
+{
+	RA 7.92150472
+	Dec -24.30109357
+	Radius 29.95
+	Distance 8902.86
+}
+
+OpenCluster "HSC 1985"
+{
+	RA 7.92162752
+	Dec -30.29485057
+	Radius 28.15
+	Distance 4164.491
+}
+
+OpenCluster "HSC 1952"
+{
+	RA 7.92289091
+	Dec -26.25964758
+	Radius 34.365
+	Distance 13046.333
+}
+
+OpenCluster "NGC 2483:ESO 430-2:MWSC 1383:OCL 677.1:UBC 1401"
+{
+	RA 7.92525436
+	Dec -27.94510849
+	Radius 88.336
+	Distance 11610.093
+}
+
+OpenCluster "Collinder 168:ESO 494-5:FSR 1313:Harvard 2:MWSC 1384:OCL 663:Theia 4717:Trumpler 9"
+{
+	RA 7.92769036
+	Dec -25.88324394
+	Radius 127.586
+	Distance 8044.011
+}
+
+OpenCluster "HSC 1833"
+{
+	RA 7.92799198
+	Dec -12.55195603
+	Radius 58.835
+	Distance 2957.225
+}
+
+OpenCluster "HSC 1981"
+{
+	RA 7.93026633
+	Dec -29.47443197
+	Radius 59.879
+	Distance 11143.035
+}
+
+OpenCluster "HSC 1940"
+{
+	RA 7.93108449
+	Dec -24.63508198
+	Radius 43.384
+	Distance 5519.425
+}
+
+OpenCluster "HSC 2072"
+{
+	RA 7.93516794
+	Dec -43.19854896
+	Radius 94.457
+	Distance 3746.614
+}
+
+OpenCluster "UBC 1409"
+{
+	RA 7.93543366
+	Dec -29.17449504
+	Radius 85.389
+	Distance 8091.59
+}
+
+OpenCluster "CWNU 1679"
+{
+	RA 7.93561447
+	Dec -32.15451226
+	Radius 50.749
+	Distance 10205.06
+}
+
+OpenCluster "BH 16:ESO 430-4:Haffner 20:MWSC 1385:OCL 692"
+{
+	RA 7.93768568
+	Dec -30.36880526
+	Radius 97.613
+	Distance 12828.062
+}
+
+OpenCluster "NGC 2489:Melotte 79:Collinder 169:BH 15:ESO 430-3:FSR 1330:MWSC 1386:OCL 690"
+{
+	RA 7.93780444
+	Dec -30.06262363
+	Radius 40.858
+	Distance 6099.836
+}
+
+OpenCluster "HSC 2003"
+{
+	RA 7.94174381
+	Dec -32.53933999
+	Radius 40.866
+	Distance 11236.466
+}
+
+OpenCluster "CWNU 268"
+{
+	RA 7.94439132
+	Dec -31.06106327
+	Radius 87.854
+	Distance 9335.917
+}
+
+OpenCluster "CWNU 269:Theia 3992:UBC 1413"
+{
+	RA 7.94646105
+	Dec -29.60739634
+	Radius 40.976
+	Distance 8792.169
+}
+
+OpenCluster "Theia 3748:UBC 461"
+{
+	RA 7.94654094
+	Dec -23.82139865
+	Radius 235.847
+	Distance 9477.617
+}
+
+OpenCluster "LISC 0896:UBC 229"
+{
+	RA 7.95021576
+	Dec -22.8129141
+	Radius 71.194
+	Distance 7588.299
+}
+
+OpenCluster "HSC 2097"
+{
+	RA 7.95109417
+	Dec -46.95187249
+	Radius 94.263
+	Distance 4901.856
+}
+
+OpenCluster "FoF 1428:UBC 1403"
+{
+	RA 7.95140121
+	Dec -27.91529067
+	Radius 87.582
+	Distance 9302.718
+}
+
+OpenCluster "Casado 5:Theia 3932"
+{
+	RA 7.95169648
+	Dec -35.19071148
+	Radius 58.804
+	Distance 3898.938
+}
+
+OpenCluster "CWNU 1762"
+{
+	RA 7.95241577
+	Dec -24.48162995
+	Radius 54.073
+	Distance 16365.656
+}
+
+OpenCluster "CWNU 2423"
+{
+	RA 7.95323067
+	Dec -33.52947055
+	Radius 94.777
+	Distance 5552.225
+}
+
+OpenCluster "CWNU 1069"
+{
+	RA 7.95430964
+	Dec -43.51074701
+	Radius 90.295
+	Distance 1300.346
+}
+
+OpenCluster "HSC 1670"
+{
+	RA 7.95608676
+	Dec 9.71069246
+	Radius 50.273
+	Distance 4061.32
+}
+
+OpenCluster "HSC 1968"
+{
+	RA 7.95706306
+	Dec -26.94915039
+	Radius 96.895
+	Distance 4368.969
+}
+
+OpenCluster "HSC 1932"
+{
+	RA 7.95776698
+	Dec -23.75036589
+	Radius 50.564
+	Distance 5605.35
+}
+
+OpenCluster "Berkeley 41:ESO 494-8:MWSC 1388:OCL 669:OC 0421:Ruprecht 42"
+{
+	RA 7.960274
+	Dec -25.92532908
+	Radius 149.835
+	Distance 16292.241
+}
+
+OpenCluster "UBC 478"
+{
+	RA 7.96030035
+	Dec -44.64953137
+	Radius 68.139
+	Distance 8275.506
+}
+
+OpenCluster "Southern Beehive Cluster:Sprinter:NGC 2516:Melotte 82:Collinder 172:Caldwell 96:ESO 124-6:FSR 1487:MWSC 1393:OCL 776:Theia 613"
+{
+	RA 7.96100416
+	Dec -60.8920033
+	Radius 26.882
+	Distance 1062.701
+}
+
+OpenCluster "FSR 1342:MWSC 1391:OC 0436"
+{
+	RA 7.96578595
+	Dec -31.51353902
+	Radius 132.789
+	Distance 11584.746
+}
+
+OpenCluster "NGC 2516:Melotte 82:Collinder 172:ESO 124-6:FSR 1487:MWSC 1393:OCL 776:Theia 613"
+{
+	RA 7.96809991
+	Dec -60.79290454
+	Radius 161.842
+	Distance 1327.745
+}
+
+OpenCluster "HSC 1738"
+{
+	RA 7.96893198
+	Dec 0.08534996
+	Radius 74.026
+	Distance 2299.156
+}
+
+OpenCluster "OC 0479"
+{
+	RA 7.97010424
+	Dec -49.19828207
+	Radius 49.584
+	Distance 1301.685
+}
+
+OpenCluster "UBC 1420"
+{
+	RA 7.97230702
+	Dec -32.15155551
+	Radius 92.541
+	Distance 11224.404
+}
+
+OpenCluster "HSC 1963"
+{
+	RA 7.97867417
+	Dec -26.58634159
+	Radius 57.105
+	Distance 13576.564
+}
+
+OpenCluster "UBC 1424"
+{
+	RA 7.97879651
+	Dec -33.59348361
+	Radius 87.648
+	Distance 11807.372
+}
+
+OpenCluster "ESO 430-5:MWSC 1398:OCL 681:Ruprecht 44"
+{
+	RA 7.97943892
+	Dec -28.54717454
+	Radius 183.667
+	Distance 15209.98
+}
+
+OpenCluster "HSC 2011"
+{
+	RA 7.98046889
+	Dec -33.04279903
+	Radius 58.364
+	Distance 9306.613
+}
+
+OpenCluster "ESO 494-09:ESO 494 09:UBC 1402"
+{
+	RA 7.98171415
+	Dec -27.67258635
+	Radius 40.996
+	Distance 8857.371
+}
+
+OpenCluster "FoF 589:OC 0409:UBC 227"
+{
+	RA 7.98751506
+	Dec -19.1278656
+	Radius 112.361
+	Distance 9463.043
+}
+
+OpenCluster "HSC 1990"
+{
+	RA 7.98808472
+	Dec -30.06406343
+	Radius 81.939
+	Distance 7701.577
+}
+
+OpenCluster "CWNU 150:OC 0448:Theia 2402:Theia 3920:Theia 6170"
+{
+	RA 7.98917212
+	Dec -40.24757256
+	Radius 183.603
+	Distance 5611.603
+}
+
+OpenCluster "MWSC 1404:OCL 617:OC 0402:Ruprecht 45"
+{
+	RA 7.99333702
+	Dec -16.29146991
+	Radius 162.83
+	Distance 13150.033
+}
+
+OpenCluster "CWNU 306:UBC 1619"
+{
+	RA 7.99717802
+	Dec -45.59959142
+	Radius 27.915
+	Distance 4988.349
+}
+
+OpenCluster "NGC 2506:Melotte 80:Collinder 170:FSR 1230:MWSC 1406:OCL 593:Theia 6245"
+{
+	RA 8.00012374
+	Dec -10.76986105
+	Radius 121.543
+	Distance 10242.52
+}
+
+OpenCluster "CWNU 298:UBC 1431"
+{
+	RA 8.00348624
+	Dec -36.72624049
+	Radius 36.337
+	Distance 7433.287
+}
+
+OpenCluster "ASCC 44:Alessi 34:MWSC 1414"
+{
+	RA 8.0041558
+	Dec -50.65517502
+	Radius 179.12
+	Distance 1583.507
+}
+
+OpenCluster "CWWL 2091:UBC 232"
+{
+	RA 8.00450264
+	Dec -24.26721829
+	Radius 77.245
+	Distance 9456.075
+}
+
+OpenCluster "UBC 1412"
+{
+	RA 8.00524062
+	Dec -29.03796102
+	Radius 81.262
+	Distance 8879.398
+}
+
+OpenCluster "LISC-III 3323:LISC-III 3668"
+{
+	RA 8.00745789
+	Dec -44.1892035
+	Radius 176.877
+	Distance 1870.902
+}
+
+OpenCluster "HSC 2043"
+{
+	RA 8.00797005
+	Dec -38.31016161
+	Radius 103.472
+	Distance 14470.898
+}
+
+OpenCluster "CWNU 1769"
+{
+	RA 8.0091198
+	Dec -32.24643542
+	Radius 14.788
+	Distance 6439.222
+}
+
+OpenCluster "NGC 2509:Melotte 81:Collinder 171:ESO 561-7:FSR 1282:MWSC 1410:OCL 630:Theia 5956"
+{
+	RA 8.01337543
+	Dec -19.05770344
+	Radius 161.009
+	Distance 7919.538
+}
+
+OpenCluster "OCSN 83:Theia 58"
+{
+	RA 8.01442232
+	Dec -30.74983592
+	Radius 107.425
+	Distance 1579.414
+}
+
+OpenCluster "ESO 494-11:Haffner 21:MWSC 1411:OCL 677"
+{
+	RA 8.01934588
+	Dec -27.21082476
+	Radius 59.791
+	Distance 9922.277
+}
+
+OpenCluster "FSR 1378:MWSC 1412:SAI 85"
+{
+	RA 8.02074275
+	Dec -40.68100491
+	Radius 251.797
+	Distance 5079.669
+}
+
+OpenCluster "CWNU 193"
+{
+	RA 8.02538074
+	Dec -31.96934695
+	Radius 37.983
+	Distance 6660.737
+}
+
+OpenCluster "CWNU 1179"
+{
+	RA 8.02612139
+	Dec -57.90021704
+	Radius 79.382
+	Distance 759.718
+}
+
+OpenCluster "HSC 2057"
+{
+	RA 8.02646199
+	Dec -41.03345081
+	Radius 38.283
+	Distance 3058.225
+}
+
+OpenCluster "HSC 1918"
+{
+	RA 8.02660544
+	Dec -21.7757547
+	Radius 93.714
+	Distance 3468.441
+}
+
+OpenCluster "FSR 1360:MWSC 1413"
+{
+	RA 8.02667321
+	Dec -34.48085022
+	Radius 36.199
+	Distance 7481.366
+}
+
+OpenCluster "HSC 1976"
+{
+	RA 8.02792579
+	Dec -27.55231213
+	Radius 60.388
+	Distance 13894.386
+}
+
+OpenCluster "CWNU 2110:Theia 4705:Theia 665"
+{
+	RA 8.02793483
+	Dec -32.7039116
+	Radius 111.089
+	Distance 4945.52
+}
+
+OpenCluster "ESO 311-21:ESO 311 21:MWSC 1415"
+{
+	RA 8.0285297
+	Dec -41.59311835
+	Radius 73.047
+	Distance 14727.368
+}
+
+OpenCluster "HSC 1950"
+{
+	RA 8.02868049
+	Dec -25.22851801
+	Radius 34.867
+	Distance 9864.047
+}
+
+OpenCluster "UBC 643"
+{
+	RA 8.03364756
+	Dec -34.39832056
+	Radius 72.893
+	Distance 11745.898
+}
+
+OpenCluster "CWNU 233:UBC 1437"
+{
+	RA 8.03392295
+	Dec -42.79449471
+	Radius 46.055
+	Distance 6294.06
+}
+
+OpenCluster "CWNU 2302"
+{
+	RA 8.03414969
+	Dec -24.94600953
+	Radius 35.621
+	Distance 9109.016
+}
+
+OpenCluster "CWNU 1321"
+{
+	RA 8.03753376
+	Dec -31.35579125
+	Radius 54.852
+	Distance 16790.782
+}
+
+OpenCluster "ESO 430-8:FSR 1344:MWSC 1419:OCL 699:Ruprecht 47"
+{
+	RA 8.03801246
+	Dec -31.07313058
+	Radius 57.867
+	Distance 10865.529
+}
+
+OpenCluster "Casado 10:UBC 1421"
+{
+	RA 8.03865766
+	Dec -32.13376974
+	Radius 18.805
+	Distance 10357.06
+}
+
+OpenCluster "ESO 430-09:ESO 430-430:ESO 430-9:ESO 430 09:MWSC 1420:UBC 1414"
+{
+	RA 8.0399176
+	Dec -29.77650655
+	Radius 40.785
+	Distance 10388.698
+}
+
+OpenCluster "OC 0447:Theia 2360"
+{
+	RA 8.04021746
+	Dec -39.61427023
+	Radius 44.159
+	Distance 3320.33
+}
+
+OpenCluster "CWNU 212"
+{
+	RA 8.04123053
+	Dec -28.86507481
+	Radius 49.26
+	Distance 4615.363
+}
+
+OpenCluster "UBC 640"
+{
+	RA 8.04157745
+	Dec -27.83003896
+	Radius 44.102
+	Distance 15053.328
+}
+
+OpenCluster "Theia 4690:UBC 1404"
+{
+	RA 8.04290155
+	Dec -27.34253334
+	Radius 82.938
+	Distance 8976.756
+}
+
+OpenCluster "ESO 430-11:FSR 1349:MWSC 1421:OCL 702:OC 0438:Ruprecht 48:Theia 3638:Theia 5108"
+{
+	RA 8.04493528
+	Dec -32.04277914
+	Radius 124.46
+	Distance 11207.501
+}
+
+OpenCluster "CWNU 1924"
+{
+	RA 8.04576374
+	Dec -22.30370903
+	Radius 34.316
+	Distance 5164.005
+}
+
+OpenCluster "Theia 665"
+{
+	RA 8.04633288
+	Dec -32.27275445
+	Radius 72.164
+	Distance 2477.105
+}
+
+OpenCluster "HSC 2054"
+{
+	RA 8.04668673
+	Dec -40.53423262
+	Radius 90.047
+	Distance 11625.27
+}
+
+OpenCluster "PHOC 29"
+{
+	RA 8.04712588
+	Dec -28.55486189
+	Radius 30.688
+	Distance 8624.077
+}
+
+OpenCluster "Casado 9:UBC 1422"
+{
+	RA 8.04961121
+	Dec -32.23717645
+	Radius 13.335
+	Distance 10890.942
+}
+
+OpenCluster "OC 0441:UBC 472"
+{
+	RA 8.05059562
+	Dec -35.06343475
+	Radius 40.715
+	Distance 5868.951
+}
+
+OpenCluster "HSC 2007"
+{
+	RA 8.05132338
+	Dec -31.96404917
+	Radius 117.418
+	Distance 19191.671
+}
+
+OpenCluster "ESO 494-15:MWSC 1423:OCL 676:Ruprecht 49:UBC 1398"
+{
+	RA 8.05412723
+	Dec -26.76592907
+	Radius 94.627
+	Distance 7832.001
+}
+
+OpenCluster "CWNU 2657"
+{
+	RA 8.05446566
+	Dec -33.19227977
+	Radius 37.653
+	Distance 12725
+}
+
+OpenCluster "BH 17:ESO 430-12:MWSC 1424:OCL 698:Ruprecht 50:Theia 4907"
+{
+	RA 8.05838547
+	Dec -30.86765337
+	Radius 53.01
+	Distance 6991.933
+}
+
+OpenCluster "HSC 2084"
+{
+	RA 8.06024718
+	Dec -43.79690609
+	Radius 307.578
+	Distance 35202.094
+}
+
+OpenCluster "HSC 2336"
+{
+	RA 8.06223579
+	Dec -71.70507143
+	Radius 72.819
+	Distance 885.871
+}
+
+OpenCluster "HXHWL 71:Theia 2402:Theia 6170"
+{
+	RA 8.06466344
+	Dec -39.75618695
+	Radius 42.776
+	Distance 4614.106
+}
+
+OpenCluster "CWNU 204"
+{
+	RA 8.07141693
+	Dec -29.21475772
+	Radius 42.793
+	Distance 5354.28
+}
+
+OpenCluster "HSC 2019"
+{
+	RA 8.07189327
+	Dec -33.96218821
+	Radius 55.393
+	Distance 9795.642
+}
+
+OpenCluster "HSC 1624"
+{
+	RA 8.07224525
+	Dec 16.16342016
+	Radius 139.515
+	Distance 1504.004
+}
+
+OpenCluster "HSC 2004"
+{
+	RA 8.07709658
+	Dec -31.52365025
+	Radius 76.956
+	Distance 3636.663
+}
+
+OpenCluster "CWNU 363:OC 0446"
+{
+	RA 8.07957277
+	Dec -39.18827085
+	Radius 28.911
+	Distance 2771.977
+}
+
+OpenCluster "UBC 1417"
+{
+	RA 8.08451962
+	Dec -30.69660032
+	Radius 73.255
+	Distance 12018.938
+}
+
+OpenCluster "NGC 2527:Collinder 174:ESO 430-15:MWSC 1428:OCL 685:Theia 1047"
+{
+	RA 8.08491867
+	Dec -28.13087654
+	Radius 68.007
+	Distance 2034.153
+}
+
+OpenCluster "HSC 2017"
+{
+	RA 8.085137
+	Dec -33.72448496
+	Radius 105.05
+	Distance 14698.56
+}
+
+OpenCluster "Theia 395:UPK 467"
+{
+	RA 8.08597978
+	Dec -11.32474433
+	Radius 98.352
+	Distance 1883.795
+}
+
+OpenCluster "UBC 240"
+{
+	RA 8.0869918
+	Dec -32.99919111
+	Radius 59.652
+	Distance 7632.126
+}
+
+OpenCluster "UBC 1419"
+{
+	RA 8.08903078
+	Dec -31.15997481
+	Radius 53.304
+	Distance 16317.084
+}
+
+OpenCluster "HSC 2025"
+{
+	RA 8.08952417
+	Dec -35.40067223
+	Radius 42.953
+	Distance 11145.731
+}
+
+OpenCluster "UBC 1425"
+{
+	RA 8.09058166
+	Dec -34.32378852
+	Radius 138.517
+	Distance 9627.225
+}
+
+OpenCluster "CWNU 2357"
+{
+	RA 8.09113492
+	Dec -36.01629117
+	Radius 48.509
+	Distance 5101.52
+}
+
+OpenCluster "Theia 2103"
+{
+	RA 8.09232607
+	Dec -40.94336349
+	Radius 51.622
+	Distance 2421.651
+}
+
+OpenCluster "Casado 6"
+{
+	RA 8.09426706
+	Dec -31.59620234
+	Radius 36.101
+	Distance 14062.9
+}
+
+OpenCluster "UPK 492"
+{
+	RA 8.09564445
+	Dec -33.55837707
+	Radius 69.778
+	Distance 2291.038
+}
+
+OpenCluster "HSC 2006"
+{
+	RA 8.09696227
+	Dec -31.59434944
+	Radius 38.771
+	Distance 11456.994
+}
+
+OpenCluster "HSC 1975"
+{
+	RA 8.09869582
+	Dec -26.94748413
+	Radius 57.33
+	Distance 11279.743
+}
+
+OpenCluster "CWNU 2587"
+{
+	RA 8.10337701
+	Dec -30.36455063
+	Radius 35.133
+	Distance 8482.29
+}
+
+OpenCluster "CWNU 2923"
+{
+	RA 8.10361618
+	Dec -30.65941864
+	Radius 88.229
+	Distance 13947.254
+}
+
+OpenCluster "UBC 471"
+{
+	RA 8.1037936
+	Dec -33.05500236
+	Radius 95.911
+	Distance 13149.514
+}
+
+OpenCluster "UBC 632"
+{
+	RA 8.10578386
+	Dec -9.64024997
+	Radius 53.479
+	Distance 10708.642
+}
+
+OpenCluster "UBC 1416"
+{
+	RA 8.11135096
+	Dec -29.28843164
+	Radius 92.689
+	Distance 15311.037
+}
+
+OpenCluster "HSC 1889"
+{
+	RA 8.11435341
+	Dec -17.39842143
+	Radius 57.628
+	Distance 3427.515
+}
+
+OpenCluster "ESO 430-18:ESO 430 18:MWSC 1431:UBC 470"
+{
+	RA 8.1150841
+	Dec -30.87553666
+	Radius 133.74
+	Distance 13195.271
+}
+
+OpenCluster "UBC 1435"
+{
+	RA 8.11577902
+	Dec -40.62198525
+	Radius 102.509
+	Distance 12153.737
+}
+
+OpenCluster "PHOC 21"
+{
+	RA 8.11611509
+	Dec -21.08775467
+	Radius 53.614
+	Distance 6241.694
+}
+
+OpenCluster "NGC 2533:Collinder 175:BH 18:ESO 430-19:FSR 1338:MWSC 1432:OCL 695:OC 0433:XDOCC 5"
+{
+	RA 8.11736869
+	Dec -29.88731025
+	Radius 53.153
+	Distance 5190.263
+}
+
+OpenCluster "BH 19:ESO 430-21:MWSC 1433:vdBergh-Hagen 19"
+{
+	RA 8.11789863
+	Dec -32.35786541
+	Radius 99.734
+	Distance 13141.741
+}
+
+OpenCluster "HSC 1995"
+{
+	RA 8.11791183
+	Dec -29.86040384
+	Radius 68.28
+	Distance 8535.857
+}
+
+OpenCluster "CWNU 1631"
+{
+	RA 8.12706206
+	Dec -30.8788329
+	Radius 32.848
+	Distance 11366.255
+}
+
+OpenCluster "MWSC 1435:SAI 86"
+{
+	RA 8.13673336
+	Dec -36.60889653
+	Radius 77.235
+	Distance 11674.34
+}
+
+OpenCluster "Gaia 6:UBC 1395"
+{
+	RA 8.14054751
+	Dec -23.69873785
+	Radius 59.051
+	Distance 12049.897
+}
+
+OpenCluster "CWNU 435"
+{
+	RA 8.14170108
+	Dec -37.62793594
+	Radius 64.353
+	Distance 2793.49
+}
+
+OpenCluster "UBC 1418"
+{
+	RA 8.14267894
+	Dec -30.38548736
+	Radius 52.257
+	Distance 12403.142
+}
+
+OpenCluster "HSC 2002"
+{
+	RA 8.14309282
+	Dec -30.81489461
+	Radius 49.094
+	Distance 12757.346
+}
+
+OpenCluster "HSC 2034"
+{
+	RA 8.14390895
+	Dec -36.2250454
+	Radius 87.233
+	Distance 18912.255
+}
+
+OpenCluster "Gulliver 4"
+{
+	RA 8.14469985
+	Dec -37.50469721
+	Radius 64.88
+	Distance 9161.222
+}
+
+OpenCluster "HSC 1984"
+{
+	RA 8.1450683
+	Dec -28.11260828
+	Radius 49.939
+	Distance 11210.411
+}
+
+OpenCluster "HSC 2113"
+{
+	RA 8.14772311
+	Dec -47.31945692
+	Radius 29.544
+	Distance 3854.827
+}
+
+OpenCluster "UBC 1406"
+{
+	RA 8.15450823
+	Dec -27.0208915
+	Radius 131.383
+	Distance 12691.434
+}
+
+OpenCluster "CWNU 2065"
+{
+	RA 8.15454173
+	Dec -32.80056875
+	Radius 72.236
+	Distance 5298.694
+}
+
+OpenCluster "HXHWL 42"
+{
+	RA 8.15479112
+	Dec -35.65939733
+	Radius 52.717
+	Distance 3496.083
+}
+
+OpenCluster "CWNU 198:Theia 2948:UBC 1583"
+{
+	RA 8.15628126
+	Dec -38.83512548
+	Radius 79.446
+	Distance 4378.46
+}
+
+OpenCluster "Pozzo 1:Theia 22:Theia 99"
+{
+	RA 8.15830897
+	Dec -47.35367097
+	Radius 39.364
+	Distance 1131.386
+}
+
+OpenCluster "HXHWL 65"
+{
+	RA 8.16157866
+	Dec -27.13638081
+	Radius 43.225
+	Distance 3143.255
+}
+
+OpenCluster "HSC 2077"
+{
+	RA 8.16367702
+	Dec -42.17329703
+	Radius 183.991
+	Distance 31478.589
+}
+
+OpenCluster "CWNU 2661"
+{
+	RA 8.16686426
+	Dec -29.85440785
+	Radius 70.14
+	Distance 13457.777
+}
+
+OpenCluster "Gulliver 3"
+{
+	RA 8.16884265
+	Dec -37.24835149
+	Radius 40.871
+	Distance 13419.764
 }
 
 OpenCluster "NGC 2547"
 {
-	RA 8.169167
-	Dec -48.785000
-	Distance 1177
-	Radius 4.3
+	RA 8.16889835
+	Dec -49.1946722
+	Radius 173.971
+	Distance 1247.165
 }
 
-OpenCluster "NGC 2539"
+OpenCluster "CWNU 1766:DSH J0810.1-3922:Teutsch 63"
 {
-	RA 8.176944
-	Dec -11.181667
-	Distance 4445
-	Radius 5.8
+	RA 8.16891041
+	Dec -39.38031332
+	Radius 41.177
+	Distance 11604.586
 }
 
-OpenCluster "Ruprecht 53"
+OpenCluster "CWNU 2409"
 {
-	RA 8.181667
-	Dec -27.000000
-	Distance 3261
-	Radius 2.4
+	RA 8.16981326
+	Dec -25.74565865
+	Radius 106.494
+	Distance 9052.542
 }
 
-OpenCluster "NGC 2546"
+OpenCluster "CWNU 1972"
 {
-	RA 8.204167
-	Dec -36.405000
-	Distance 2997
-	Radius 30.5
+	RA 8.17130476
+	Dec -24.5996499
+	Radius 57.504
+	Distance 6264.003
 }
 
-OpenCluster "Ruprecht 55"
+OpenCluster "HSC 2040"
 {
-	RA 8.207500
-	Dec -31.416667
-	Distance 15003
-	Radius 10.9
+	RA 8.17223294
+	Dec -36.86917509
+	Radius 61.205
+	Distance 18159.398
 }
 
-OpenCluster "Ruprecht 56"
+OpenCluster "HSC 2041"
 {
-	RA 8.209167
-	Dec -39.533333
-	Distance 2716
-	Radius 15.4
+	RA 8.17379119
+	Dec -36.93420208
+	Radius 132.279
+	Distance 15870.572
 }
 
-OpenCluster "NGC 2548"
+OpenCluster "HSC 2174"
 {
-	RA 8.228611
-	Dec -4.250000
-	Distance 2511
-	Radius 11.0
+	RA 8.17384496
+	Dec -53.87589934
+	Radius 37.546
+	Distance 2499.924
 }
 
-OpenCluster "BH 23"
+OpenCluster "NGC 2539:Melotte 83:Collinder 176:MWSC 1439:OCL 611:Theia 3938"
 {
-	RA 8.240000
-	Dec -35.616667
-	Distance 1425
-	Radius 8.1
+	RA 8.17760786
+	Dec -12.82726114
+	Radius 53.432
+	Distance 4080.318
 }
 
-OpenCluster "Haffner 26"
+OpenCluster "FSR 1363:MWSC 1438"
 {
-	RA 8.260833
-	Dec -29.166667
-	Distance 3261
-	Radius 2.4
+	RA 8.1780674
+	Dec -34.6156709
+	Radius 95.816
+	Distance 11788.561
 }
 
-OpenCluster "ASCC 45"
+OpenCluster "HSC 2018"
 {
-	RA 8.263889
-	Dec -34.350000
-	Distance 9785
-	Radius 34.2
+	RA 8.17914392
+	Dec -33.06227677
+	Radius 91.943
+	Distance 3080.048
 }
 
-OpenCluster "ASCC 46"
+OpenCluster "CWNU 1746:ESO 494-32:MWSC 1442:OCL 682:Ruprecht 53:Theia 484"
 {
-	RA 8.276111
-	Dec -47.490000
-	Distance 2935
-	Radius 20.5
+	RA 8.18053127
+	Dec -26.7889953
+	Radius 89.779
+	Distance 7772.011
 }
 
-OpenCluster "Pismis 2"
+OpenCluster "CWNU 1026:ESO 494-32:MWSC 1442:OCL 682:Ruprecht 53:Theia 484"
 {
-	RA 8.298333
-	Dec -40.333333
-	Distance 10796
-	Radius 6.3
+	RA 8.18274515
+	Dec -27.00274644
+	Radius 47.487
+	Distance 3237.647
 }
 
-OpenCluster "Pismis 1"
+OpenCluster "HSC 2010"
 {
-	RA 8.305000
-	Dec -36.900000
-	Distance 19266
-	Radius 8.4
+	RA 8.18354672
+	Dec -31.23003343
+	Radius 31.356
+	Distance 4953.064
 }
 
-OpenCluster "NGC 2567"
+OpenCluster "FSR 1380:MWSC 1443:SAI 87"
 {
-	RA 8.308889
-	Dec -29.360000
-	Distance 5469
-	Radius 5.6
+	RA 8.18467387
+	Dec -39.99481421
+	Radius 67.474
+	Distance 10615.912
 }
 
-OpenCluster "NGC 2571"
+OpenCluster "HSC 2110"
 {
-	RA 8.315556
-	Dec -28.250000
-	Distance 4377
-	Radius 5.1
+	RA 8.18613102
+	Dec -46.54064605
+	Radius 49.81
+	Distance 19861.21
 }
 
-OpenCluster "Ruprecht 59"
+OpenCluster "BH 20:ESO 430-23:FoF 386:MWSC 1444:OCL 710:Ruprecht 54"
 {
-	RA 8.322500
-	Dec -33.516667
-	Distance 2850
-	Radius 1.2
+	RA 8.18959788
+	Dec -31.94887972
+	Radius 43.352
+	Distance 12881.086
 }
 
-OpenCluster "NGC 2579"
+OpenCluster "Theia 1079:Theia 2103:Theia 3975"
 {
-	RA 8.347778
-	Dec -35.783333
-	Distance 3369
-	Radius 3.4
+	RA 8.19142918
+	Dec -42.34247211
+	Radius 84.271
+	Distance 4255.791
 }
 
-OpenCluster "NGC 2580"
+OpenCluster "HSC 2160"
 {
-	RA 8.357778
-	Dec -29.700000
-	Distance 13046
-	Radius 6.6
+	RA 8.19178232
+	Dec -52.24887672
+	Radius 37.923
+	Distance 4541.953
 }
 
-OpenCluster "NGC 2588"
+OpenCluster "NGC 2546:Collinder 178:BH 22:ESO 369-7:Gulliver 2:MWSC 1447:OCL 726"
 {
-	RA 8.386111
-	Dec -31.025000
-	Distance 16145
-	Radius 4.7
+	RA 8.19297346
+	Dec -37.39325616
+	Radius 71.25
+	Distance 4311.601
 }
 
-OpenCluster "Collinder 185"
+OpenCluster "UBC 1427"
 {
-	RA 8.389167
-	Dec -35.666667
-	Distance 4846
-	Radius 7.0
+	RA 8.19639171
+	Dec -33.77648898
+	Radius 120.095
+	Distance 11800.163
 }
 
-OpenCluster "Ruprecht 61"
+OpenCluster "ESO 312-1:MWSC 1452:OCL 730:Ruprecht 56"
 {
-	RA 8.421389
-	Dec -33.850000
-	Distance 12720
-	Radius 3.7
+	RA 8.19717811
+	Dec -40.49615168
+	Radius 68.919
+	Distance 17515.148
 }
 
-OpenCluster "Saurer 2"
+OpenCluster "HSC 2076"
 {
-	RA 8.424444
-	Dec -38.366111
-	Distance 21527
-	Radius 9.4
+	RA 8.19875714
+	Dec -41.58673903
+	Radius 37.622
+	Distance 4149.059
 }
 
-OpenCluster "BH 34"
+OpenCluster "FSR 1335:MWSC 1448"
 {
-	RA 8.520833
-	Dec -43.500000
-	Distance 2185
-	Radius 7.9
+	RA 8.20098268
+	Dec -28.98107908
+	Radius 86.136
+	Distance 16216.824
 }
 
-OpenCluster "Pismis 3"
+OpenCluster "NGC 2546:Collinder 178:BH 22:ESO 369-7:MWSC 1447:OCL 726:Theia 2948:Theia 298:Theia 472:Theia 4930"
 {
-	RA 8.522778
-	Dec -37.350000
-	Distance 4546
-	Radius 3.3
+	RA 8.20100935
+	Dec -37.64262584
+	Radius 88.999
+	Distance 2964.901
 }
 
-OpenCluster "Alessi-Teutsch 7"
+OpenCluster "HSC 2088"
 {
-	RA 8.528889
-	Dec -38.868333
-	Distance 2935
-	Radius 25.6
+	RA 8.20137698
+	Dec -44.12070764
+	Radius 107.312
+	Distance 13031.36
 }
 
-OpenCluster "ASCC 48"
+OpenCluster "UBC 1423"
 {
-	RA 8.575000
-	Dec -36.390000
-	Distance 1304
-	Radius 7.3
+	RA 8.20165627
+	Dec -31.14895636
+	Radius 66.438
+	Distance 13751.188
 }
 
-OpenCluster "Pismis 4"
+OpenCluster "HSC 2075"
 {
-	RA 8.576667
-	Dec -43.583333
-	Distance 1934
-	Radius 7.0
+	RA 8.20218301
+	Dec -41.50276045
+	Radius 40.571
+	Distance 7651.282
 }
 
-OpenCluster "NGC 2627"
+OpenCluster "BH 21:ESO 430-24:FSR 1333:Haffner 22:MWSC 1450:OCL 691:Theia 6095"
 {
-	RA 8.620833
-	Dec -28.045000
-	Distance 6523
-	Radius 7.6
+	RA 8.20748629
+	Dec -27.91183393
+	Radius 77.351
+	Distance 8285.053
 }
 
-OpenCluster "Ruprecht 64"
+OpenCluster "Gulliver 10"
 {
-	RA 8.622222
-	Dec -39.850000
-	Distance 2175
-	Radius 22.1
+	RA 8.20894266
+	Dec -38.71167269
+	Radius 28.988
+	Distance 1896.101
 }
 
-OpenCluster "Pismis 5"
+OpenCluster "Gulliver 36:Theia 4283"
 {
-	RA 8.627222
-	Dec -38.416667
-	Distance 2834
-	Radius 0.8
+	RA 8.21040215
+	Dec -35.09680977
+	Radius 66.037
+	Distance 4236.575
 }
 
-OpenCluster "NGC 2635"
+OpenCluster "OC 0474:UBC 1440"
 {
-	RA 8.640556
-	Dec -33.230000
-	Distance 13046
-	Radius 15.2
+	RA 8.21179161
+	Dec -45.28981552
+	Radius 112.494
+	Distance 11268.897
 }
 
-OpenCluster "NGC 2645"
+OpenCluster "UBC 467"
 {
-	RA 8.650833
-	Dec -45.766667
-	Distance 5440
-	Radius 2.4
+	RA 8.21204236
+	Dec -25.65755167
+	Radius 93.893
+	Distance 14126.262
 }
 
-OpenCluster "Ruprecht 65"
+OpenCluster "UBC 1582"
 {
-	RA 8.654444
-	Dec -43.950000
-	Distance 2165
-	Radius 1.6
+	RA 8.21667499
+	Dec -37.5938474
+	Radius 79.613
+	Distance 10166.583
 }
 
-OpenCluster "Praesepe:Beehive Cluster:NGC 2632"
+OpenCluster "CWNU 290:Theia 2621"
 {
-	RA 8.673333
-	Dec 19.666667
-	Distance 609
-	Radius 6.2
+	RA 8.21824532
+	Dec -22.00584032
+	Radius 53.825
+	Distance 3503.698
 }
 
-OpenCluster "IC 2391"
+OpenCluster "CWNU 1897"
 {
-	RA 8.675556
-	Dec -52.966667
-	Distance 570
-	Radius 5.0
+	RA 8.22030961
+	Dec -27.60612185
+	Radius 76.783
+	Distance 8741.614
 }
 
-OpenCluster "Pismis 7"
+OpenCluster "HSC 1980"
 {
-	RA 8.685556
-	Dec -37.300000
-	Distance 15982
-	Radius 7.0
+	RA 8.22074792
+	Dec -26.91217118
+	Radius 33.605
+	Distance 4954.409
+}
+
+OpenCluster "HSC 1874"
+{
+	RA 8.22102911
+	Dec -15.06835881
+	Radius 91.206
+	Distance 3867.9
+}
+
+OpenCluster "CWNU 1889"
+{
+	RA 8.22654094
+	Dec -38.50044607
+	Radius 32.099
+	Distance 5588.949
+}
+
+OpenCluster "CWNU 1562:Theia 3339:Theia 5252"
+{
+	RA 8.22752122
+	Dec -33.19724396
+	Radius 87.841
+	Distance 6246.039
+}
+
+OpenCluster "BH 23:Theia 80"
+{
+	RA 8.22985026
+	Dec -36.3562227
+	Radius 112.556
+	Distance 1394.166
+}
+
+OpenCluster "M 48:NGC 2548:Melotte 85:Collinder 179:FSR 1217:MWSC 1454:OCL 584:Theia 870"
+{
+	RA 8.23032136
+	Dec -5.7696807
+	Radius 128.219
+	Distance 2436.661
+}
+
+OpenCluster "HSC 2039"
+{
+	RA 8.23101623
+	Dec -36.13888316
+	Radius 36.421
+	Distance 4372.854
+}
+
+OpenCluster "Casado 8:UBC 1581"
+{
+	RA 8.23132681
+	Dec -30.97236588
+	Radius 60.694
+	Distance 10736.885
+}
+
+OpenCluster "CWNU 366:OC 0464"
+{
+	RA 8.23480273
+	Dec -43.09637171
+	Radius 36.984
+	Distance 5551.515
+}
+
+OpenCluster "ESO 430-27:FSR 1358:MWSC 1456:OCL 712:Ruprecht 58"
+{
+	RA 8.24751981
+	Dec -31.94253085
+	Radius 82.656
+	Distance 9651.867
+}
+
+OpenCluster "UBC 637:UBC 638"
+{
+	RA 8.25017346
+	Dec -22.19260637
+	Radius 106.958
+	Distance 15986.174
+}
+
+OpenCluster "Theia 256"
+{
+	RA 8.25058806
+	Dec 7.06131386
+	Radius 89.091
+	Distance 1756.096
+}
+
+OpenCluster "Theia 7334:UBC 239"
+{
+	RA 8.25068375
+	Dec -30.16528945
+	Radius 49.721
+	Distance 6256.304
+}
+
+OpenCluster "HXHWL 36"
+{
+	RA 8.25200421
+	Dec -47.27480199
+	Radius 31.146
+	Distance 3256.103
+}
+
+OpenCluster "HSC 2030"
+{
+	RA 8.25418447
+	Dec -34.75491573
+	Radius 29.62
+	Distance 4405.002
+}
+
+OpenCluster "ASCC 45:MWSC 1460:Theia 80"
+{
+	RA 8.25721669
+	Dec -35.64676808
+	Radius 23.73
+	Distance 1723.774
+}
+
+OpenCluster "Theia 4338:Theia 5865:UBC 475"
+{
+	RA 8.25839621
+	Dec -33.90020796
+	Radius 33.126
+	Distance 6226.436
+}
+
+OpenCluster "HSC 1987"
+{
+	RA 8.2587399
+	Dec -27.631373
+	Radius 69.796
+	Distance 4187.737
+}
+
+OpenCluster "ESO 430-29:Haffner 26:OCL 707:Theia 3672"
+{
+	RA 8.25986734
+	Dec -30.84973915
+	Radius 68.861
+	Distance 8982.035
+}
+
+OpenCluster "HSC 2093"
+{
+	RA 8.26040351
+	Dec -44.38232695
+	Radius 23.132
+	Distance 2273.682
+}
+
+OpenCluster "CWNU 1378:Theia 4338"
+{
+	RA 8.26427386
+	Dec -33.9829619
+	Radius 119.96
+	Distance 12737.048
+}
+
+OpenCluster "HSC 1962"
+{
+	RA 8.26451467
+	Dec -24.10502547
+	Radius 98.066
+	Distance 14714.149
+}
+
+OpenCluster "Theia 773"
+{
+	RA 8.26507683
+	Dec -40.89333402
+	Radius 58.526
+	Distance 2610.533
+}
+
+OpenCluster "HSC 2058"
+{
+	RA 8.27301705
+	Dec -39.30474314
+	Radius 23.568
+	Distance 2307.822
+}
+
+OpenCluster "ASCC 45:MWSC 1460:Theia 2131"
+{
+	RA 8.27632768
+	Dec -35.65482525
+	Radius 103.302
+	Distance 11529.723
+}
+
+OpenCluster "HSC 2085"
+{
+	RA 8.28666102
+	Dec -42.23969523
+	Radius 49.876
+	Distance 2642.362
+}
+
+OpenCluster "Theia 1079:Theia 1884:UBC 479"
+{
+	RA 8.28856013
+	Dec -42.53980149
+	Radius 36.48
+	Distance 4635.286
+}
+
+OpenCluster "Theia 472:UPK 502"
+{
+	RA 8.29060675
+	Dec -37.77862039
+	Radius 49.263
+	Distance 2211.755
+}
+
+OpenCluster "CWNU 72"
+{
+	RA 8.29165145
+	Dec -40.39143231
+	Radius 54.761
+	Distance 4617.366
+}
+
+OpenCluster "UBC 1433"
+{
+	RA 8.2920627
+	Dec -36.34424246
+	Radius 46.173
+	Distance 11061.627
+}
+
+OpenCluster "Theia 3817:Theia 4930"
+{
+	RA 8.2922057
+	Dec -36.67589059
+	Radius 31.735
+	Distance 2993.543
+}
+
+OpenCluster "CWNU 12:Theia 5697:UBC 1584"
+{
+	RA 8.29264567
+	Dec -43.59540782
+	Radius 50.679
+	Distance 4412.875
+}
+
+OpenCluster "UBC 1617"
+{
+	RA 8.29453705
+	Dec -30.29247677
+	Radius 106.708
+	Distance 16284.603
+}
+
+OpenCluster "CWNU 323:Theia 7593"
+{
+	RA 8.29560439
+	Dec -55.63234784
+	Radius 102.815
+	Distance 3232.827
+}
+
+OpenCluster "CWNU 338:OC 0451:Theia 472"
+{
+	RA 8.29618158
+	Dec -39.32858691
+	Radius 117.595
+	Distance 1971.236
+}
+
+OpenCluster "CWNU 331"
+{
+	RA 8.29805653
+	Dec -39.52053131
+	Radius 25.358
+	Distance 3774.155
+}
+
+OpenCluster "BH 25:ESO 312-2:FSR 1392:MWSC 1465:OCL 733:OC 0455:OC 0456:Pismis 2"
+{
+	RA 8.29834764
+	Dec -41.67157824
+	Radius 79.222
+	Distance 11479.245
+}
+
+OpenCluster "CWNU 2368"
+{
+	RA 8.29917827
+	Dec -33.46146948
+	Radius 34.701
+	Distance 14353.754
+}
+
+OpenCluster "HSC 2082"
+{
+	RA 8.3031273
+	Dec -41.82338896
+	Radius 46.761
+	Distance 2581.335
+}
+
+OpenCluster "NGC 2568:BH 24:ESO 370-5:FSR 1374:MWSC 1466:OCL 727:Pismis 1"
+{
+	RA 8.30477104
+	Dec -37.10181969
+	Radius 88.175
+	Distance 15100.241
+}
+
+OpenCluster "CWNU 437:Theia 1884:Theia 5697"
+{
+	RA 8.30586888
+	Dec -43.34038265
+	Radius 40.505
+	Distance 3554.497
+}
+
+OpenCluster "NGC 2567:Melotte 86:Collinder 180:BH 26:ESO 431-3:FSR 1354:MWSC 1467:OCL 708:Theia 3423:Theia 4190"
+{
+	RA 8.3099802
+	Dec -30.64301931
+	Radius 61.951
+	Distance 5362.16
+}
+
+OpenCluster "NGC 2567:Melotte 86:Collinder 180:BH 26:ESO 431-3:FSR 1354:MWSC 1467:OCL 708:Theia 3423"
+{
+	RA 8.31178193
+	Dec -30.56177481
+	Radius 20.859
+	Distance 4215.813
+}
+
+OpenCluster "HSC 2100"
+{
+	RA 8.31285895
+	Dec -44.73348643
+	Radius 66.047
+	Distance 30672.915
+}
+
+OpenCluster "FSR 1419:MWSC 1468"
+{
+	RA 8.3143005
+	Dec -47.78331218
+	Radius 110.183
+	Distance 28295.996
+}
+
+OpenCluster "NGC 2571:Collinder 181:BH 27:ESO 431-5:MWSC 1469:OCL 701"
+{
+	RA 8.31437958
+	Dec -29.75561793
+	Radius 107.769
+	Distance 4172.579
+}
+
+OpenCluster "CWNU 2546"
+{
+	RA 8.31478642
+	Dec -36.14324382
+	Radius 72.419
+	Distance 11199.965
+}
+
+OpenCluster "BPI 8:Ivanov 8:MWSC 1470"
+{
+	RA 8.31917231
+	Dec -35.65351045
+	Radius 58.577
+	Distance 14700.304
+}
+
+OpenCluster "ESO 370-7:MWSC 1472:OCL 717:Ruprecht 59:UBC 1432"
+{
+	RA 8.32171621
+	Dec -34.48211017
+	Radius 96.672
+	Distance 16740.593
+}
+
+OpenCluster "HSC 1983"
+{
+	RA 8.32360703
+	Dec -26.33351522
+	Radius 41.934
+	Distance 9466.786
+}
+
+OpenCluster "Theia 472"
+{
+	RA 8.32363935
+	Dec -38.40523395
+	Radius 69.204
+	Distance 2086.144
+}
+
+OpenCluster "HSC 2104"
+{
+	RA 8.32381926
+	Dec -44.86572386
+	Radius 84.285
+	Distance 32443.176
+}
+
+OpenCluster "CWNU 2500"
+{
+	RA 8.32440992
+	Dec -37.53290353
+	Radius 49.815
+	Distance 11146.986
+}
+
+OpenCluster "UBC 1434"
+{
+	RA 8.32494896
+	Dec -37.76229205
+	Radius 79.634
+	Distance 9973.301
+}
+
+OpenCluster "OC 0449:UFMG 58"
+{
+	RA 8.32644398
+	Dec -38.27103651
+	Radius 79.792
+	Distance 16882.716
+}
+
+OpenCluster "UBC 474"
+{
+	RA 8.32937651
+	Dec -33.21809498
+	Radius 129.434
+	Distance 17252.068
+}
+
+OpenCluster "HSC 2123"
+{
+	RA 8.33135879
+	Dec -47.33180464
+	Radius 21.881
+	Distance 4725.856
+}
+
+OpenCluster "CWNU 1458:Theia 2316"
+{
+	RA 8.33176579
+	Dec -44.47937457
+	Radius 100.244
+	Distance 5413.155
+}
+
+OpenCluster "HSC 2045"
+{
+	RA 8.33658835
+	Dec -37.24757552
+	Radius 41.99
+	Distance 7711.487
+}
+
+OpenCluster "OC 0453"
+{
+	RA 8.33807194
+	Dec -40.47952999
+	Radius 31.98
+	Distance 7021.306
+}
+
+OpenCluster "CWNU 399:Theia 2941:Theia 5697"
+{
+	RA 8.33838382
+	Dec -43.20975031
+	Radius 44.884
+	Distance 3855.867
+}
+
+OpenCluster "CWNU 2914"
+{
+	RA 8.33904244
+	Dec -44.8648945
+	Radius 62.511
+	Distance 12390.329
+}
+
+OpenCluster "Theia 1079:Theia 1884:Theia 2015:Theia 5697"
+{
+	RA 8.35284566
+	Dec -42.41355297
+	Radius 154.742
+	Distance 5257.756
+}
+
+OpenCluster "HSC 1997"
+{
+	RA 8.35408865
+	Dec -28.16819714
+	Radius 82.274
+	Distance 2848.27
+}
+
+OpenCluster "NGC 2580:Collinder 183:BH 28:ESO 431-6:MWSC 1476:OCL 709"
+{
+	RA 8.35795461
+	Dec -30.30481722
+	Radius 162.907
+	Distance 13371.726
+}
+
+OpenCluster "HSC 2073"
+{
+	RA 8.35946113
+	Dec -40.17729877
+	Radius 31.154
+	Distance 6904.384
+}
+
+OpenCluster "HSC 2078"
+{
+	RA 8.36046441
+	Dec -40.90159087
+	Radius 76.259
+	Distance 14684.539
+}
+
+OpenCluster "Theia 3286"
+{
+	RA 8.36510311
+	Dec -37.17949093
+	Radius 32.649
+	Distance 4289.993
+}
+
+OpenCluster "Majaess 99:OC 0463"
+{
+	RA 8.36594422
+	Dec -42.08376555
+	Radius 37.434
+	Distance 4715.3
+}
+
+OpenCluster "CWNU 430:OC 0471"
+{
+	RA 8.36881033
+	Dec -42.99193636
+	Radius 32.967
+	Distance 4676.893
+}
+
+OpenCluster "HXHWL 15:Theia 2015"
+{
+	RA 8.37122044
+	Dec -41.38956618
+	Radius 60.805
+	Distance 4207.033
+}
+
+OpenCluster "HSC 2187"
+{
+	RA 8.37133457
+	Dec -53.82838226
+	Radius 48.767
+	Distance 8603.174
+}
+
+OpenCluster "Theia 1128:UPK 537"
+{
+	RA 8.37638533
+	Dec -51.56926157
+	Radius 110.599
+	Distance 1947.708
+}
+
+OpenCluster "Theia 986"
+{
+	RA 8.37648147
+	Dec -42.44555959
+	Radius 81.157
+	Distance 2442.562
+}
+
+OpenCluster "HSC 2060"
+{
+	RA 8.37686932
+	Dec -38.70135674
+	Radius 34.342
+	Distance 1563.764
+}
+
+OpenCluster "OC 0477"
+{
+	RA 8.37754421
+	Dec -45.59840062
+	Radius 42.132
+	Distance 10003.823
+}
+
+OpenCluster "CWNU 1389"
+{
+	RA 8.37887283
+	Dec -42.99798737
+	Radius 60.445
+	Distance 6881.947
+}
+
+OpenCluster "CWNU 301"
+{
+	RA 8.37989255
+	Dec -31.61583773
+	Radius 41.057
+	Distance 4100.997
+}
+
+OpenCluster "Casado 4:Theia 3286:UBC 1618"
+{
+	RA 8.3849457
+	Dec -37.58262361
+	Radius 47.539
+	Distance 3866.467
+}
+
+OpenCluster "NGC 2588:Collinder 186:BH 29:ESO 370-10:MWSC 1480:OCL 715"
+{
+	RA 8.38655525
+	Dec -32.97284562
+	Radius 55.273
+	Distance 14718.824
+}
+
+OpenCluster "Collinder 185:Theia 2572:Theia 3286:Theia 3554:Theia 3817:Theia 3963:Theia 5741"
+{
+	RA 8.388457
+	Dec -36.35727134
+	Radius 120.591
+	Distance 4767.763
+}
+
+OpenCluster "HSC 2156"
+{
+	RA 8.38947416
+	Dec -50.70432618
+	Radius 103.375
+	Distance 573.345
+}
+
+OpenCluster "CWNU 433:Theia 2572:Theia 3286"
+{
+	RA 8.38968109
+	Dec -37.09403108
+	Radius 60.193
+	Distance 4782.893
+}
+
+OpenCluster "CWNU 339"
+{
+	RA 8.39079078
+	Dec -42.98492285
+	Radius 59.092
+	Distance 4819.205
+}
+
+OpenCluster "NGC 2587:Collinder 184:BH 30:ESO 431-7:MWSC 1482:OCL 706"
+{
+	RA 8.3909398
+	Dec -29.50406705
+	Radius 86.882
+	Distance 9299.999
+}
+
+OpenCluster "AT 4:Alessi-Teutsch 4:Alessi 26:TRSG 3:Theia 929:UBC 12"
+{
+	RA 8.40219528
+	Dec -8.37472945
+	Radius 91.511
+	Distance 1432.744
+}
+
+OpenCluster "CWNU 228:OC 0442"
+{
+	RA 8.40328421
+	Dec -32.57880264
+	Radius 124.388
+	Distance 5287.039
+}
+
+OpenCluster "BH 31:ESO 259-7:FSR 1420:MWSC 1485:OCL 751:Ruprecht 60"
+{
+	RA 8.40732915
+	Dec -47.21135925
+	Radius 191.071
+	Distance 13420.977
+}
+
+OpenCluster "ESO 312-03:ESO 312-3:ESO 312-312:ESO 312-4:ESO 312 03:FSR 1394:MWSC 1484:MWSC 1487:MWSC 1491:OC 0458"
+{
+	RA 8.40843685
+	Dec -41.28999222
+	Radius 80.16
+	Distance 10590.721
+}
+
+OpenCluster "HSC 2005"
+{
+	RA 8.40878575
+	Dec -28.77844306
+	Radius 84.88
+	Distance 6379.724
+}
+
+OpenCluster "CWNU 1083"
+{
+	RA 8.40903345
+	Dec -41.01827387
+	Radius 63.284
+	Distance 1101.992
+}
+
+OpenCluster "HSC 2031"
+{
+	RA 8.40940244
+	Dec -33.5436116
+	Radius 164.206
+	Distance 17399.857
+}
+
+OpenCluster "HSC 2020"
+{
+	RA 8.41052262
+	Dec -31.26071211
+	Radius 74.465
+	Distance 5442.819
+}
+
+OpenCluster "Theia 7673"
+{
+	RA 8.41120152
+	Dec -29.5167701
+	Radius 76.556
+	Distance 5993.447
+}
+
+OpenCluster "CWNU 1163"
+{
+	RA 8.41196792
+	Dec -42.80853061
+	Radius 31.808
+	Distance 1622.417
+}
+
+OpenCluster "HXHWL 68"
+{
+	RA 8.41227476
+	Dec -45.43819567
+	Radius 49.074
+	Distance 3866.523
+}
+
+OpenCluster "CWNU 408:Theia 2316:UBC 1442"
+{
+	RA 8.41448986
+	Dec -44.303866
+	Radius 81.23
+	Distance 7003.61
+}
+
+OpenCluster "UBC 1439"
+{
+	RA 8.41488286
+	Dec -43.64380254
+	Radius 73.891
+	Distance 11370.861
+}
+
+OpenCluster "HSC 1555"
+{
+	RA 8.41626079
+	Dec 27.22484004
+	Radius 211.104
+	Distance 563.985
+}
+
+OpenCluster "HSC 2063"
+{
+	RA 8.42025123
+	Dec -38.55387476
+	Radius 59.515
+	Distance 15015.388
+}
+
+OpenCluster "BH 32:ESO 360-12:FSR 1368:MWSC 1488:OCL 718:Ruprecht 61"
+{
+	RA 8.42150339
+	Dec -34.14507341
+	Radius 32.571
+	Distance 10943.48
+}
+
+OpenCluster "HSC 2198"
+{
+	RA 8.42259998
+	Dec -54.39091594
+	Radius 104.452
+	Distance 2351.678
+}
+
+OpenCluster "HSC 2036"
+{
+	RA 8.42373107
+	Dec -34.13492431
+	Radius 12.29
+	Distance 8148.382
+}
+
+OpenCluster "FSR 1386:MWSC 1489:Saurer 2"
+{
+	RA 8.42417401
+	Dec -39.63488953
+	Radius 76.403
+	Distance 19067.259
+}
+
+OpenCluster "Theia 1179"
+{
+	RA 8.42888622
+	Dec -42.98301881
+	Radius 67.008
+	Distance 3128.811
+}
+
+OpenCluster "UFMG 59"
+{
+	RA 8.43244918
+	Dec -38.33742035
+	Radius 40.196
+	Distance 4251.434
+}
+
+OpenCluster "UPK 535"
+{
+	RA 8.43787467
+	Dec -50.08335551
+	Radius 52.662
+	Distance 1030.113
+}
+
+OpenCluster "CWNU 223:Theia 5320"
+{
+	RA 8.43972672
+	Dec -33.74322898
+	Radius 90.014
+	Distance 4194.367
+}
+
+OpenCluster "UBC 476"
+{
+	RA 8.44009546
+	Dec -33.83348389
+	Radius 84.163
+	Distance 12941.858
+}
+
+OpenCluster "HSC 2102"
+{
+	RA 8.44182132
+	Dec -43.91928958
+	Radius 133.16
+	Distance 17050.662
+}
+
+OpenCluster "HSC 2105"
+{
+	RA 8.44340629
+	Dec -44.08789555
+	Radius 53.682
+	Distance 4065.62
+}
+
+OpenCluster "HSC 2068"
+{
+	RA 8.44444202
+	Dec -39.03190175
+	Radius 51.555
+	Distance 555.321
+}
+
+OpenCluster "ESO 312-04:ESO 312-3:ESO 312-312:ESO 312-4:ESO 312 04:FSR 1394:MWSC 1484:MWSC 1487:MWSC 1491:OC 0461:Theia 1994"
+{
+	RA 8.44808701
+	Dec -41.25103179
+	Radius 95.345
+	Distance 15474.347
+}
+
+OpenCluster "LISC 3315:UBC 247"
+{
+	RA 8.44890146
+	Dec -50.75014159
+	Radius 51.868
+	Distance 3578.069
+}
+
+OpenCluster "HSC 2091"
+{
+	RA 8.44945242
+	Dec -42.65819684
+	Radius 27.315
+	Distance 4719.604
+}
+
+OpenCluster "HSC 2066"
+{
+	RA 8.44979996
+	Dec -38.90146038
+	Radius 96.406
+	Distance 14613.507
+}
+
+OpenCluster "CWNU 2165"
+{
+	RA 8.45397661
+	Dec -48.70472261
+	Radius 83.009
+	Distance 5481.759
+}
+
+OpenCluster "HSC 2052"
+{
+	RA 8.4641201
+	Dec -36.99027624
+	Radius 25
+	Distance 11868.807
+}
+
+OpenCluster "PHOC 1"
+{
+	RA 8.46521905
+	Dec -42.76239916
+	Radius 27.901
+	Distance 4463.037
+}
+
+OpenCluster "CWNU 2122"
+{
+	RA 8.46651282
+	Dec -37.45532032
+	Radius 131.663
+	Distance 12566.047
+}
+
+OpenCluster "Theia 31"
+{
+	RA 8.46677346
+	Dec -34.91061465
+	Radius 47.276
+	Distance 1148.42
+}
+
+OpenCluster "HSC 2081"
+{
+	RA 8.46686244
+	Dec -40.37896118
+	Radius 41.597
+	Distance 7553.951
+}
+
+OpenCluster "MWSC 1493:SAI 90:Theia 1890:Theia 1994:Theia 2073:Theia 2855:Theia 4583:Theia 5247"
+{
+	RA 8.46841256
+	Dec -41.75374515
+	Radius 128.326
+	Distance 7201.024
+}
+
+OpenCluster "CWNU 1280"
+{
+	RA 8.46856737
+	Dec -34.04225815
+	Radius 102.929
+	Distance 14534.551
+}
+
+OpenCluster "HSC 1969"
+{
+	RA 8.46963559
+	Dec -22.5521644
+	Radius 71.488
+	Distance 1382.8
+}
+
+OpenCluster "UBC 241"
+{
+	RA 8.4708568
+	Dec -31.01205211
+	Radius 67.772
+	Distance 13280.011
+}
+
+OpenCluster "HSC 2026"
+{
+	RA 8.47672638
+	Dec -32.25715959
+	Radius 62.905
+	Distance 825.498
+}
+
+OpenCluster "HSC 2114"
+{
+	RA 8.47843153
+	Dec -45.31433138
+	Radius 64.904
+	Distance 5423.892
+}
+
+OpenCluster "Gulliver 9:Theia 82"
+{
+	RA 8.48025826
+	Dec -47.92490661
+	Radius 92.767
+	Distance 1603.93
+}
+
+OpenCluster "CWNU 1096"
+{
+	RA 8.48371452
+	Dec -38.82488501
+	Radius 29.917
+	Distance 1177.937
+}
+
+OpenCluster "Gulliver 44"
+{
+	RA 8.48525603
+	Dec -38.11390178
+	Radius 46.874
+	Distance 3872.634
+}
+
+OpenCluster "OC 0465:Theia 2073:Theia 2855"
+{
+	RA 8.48760886
+	Dec -41.21942156
+	Radius 95.98
+	Distance 16616.236
+}
+
+OpenCluster "HSC 2143"
+{
+	RA 8.48779708
+	Dec -48.96446285
+	Radius 55.881
+	Distance 9264.246
+}
+
+OpenCluster "FoF 2220:Theia 4108:UBC 242"
+{
+	RA 8.49406367
+	Dec -41.2717579
+	Radius 64.42
+	Distance 4216.52
+}
+
+OpenCluster "HSC 2027"
+{
+	RA 8.49696496
+	Dec -32.26340392
+	Radius 106.469
+	Distance 16275.792
+}
+
+OpenCluster "HSC 2089"
+{
+	RA 8.49708571
+	Dec -42.0844581
+	Radius 54.06
+	Distance 15566.593
+}
+
+OpenCluster "CWNU 1030:Theia 1890:Theia 4583:Theia 5247"
+{
+	RA 8.49818173
+	Dec -41.91432886
+	Radius 56.331
+	Distance 3909.748
+}
+
+OpenCluster "HSC 2022"
+{
+	RA 8.49978039
+	Dec -30.8457758
+	Radius 23.606
+	Distance 3088.381
+}
+
+OpenCluster "HSC 2080"
+{
+	RA 8.51089721
+	Dec -39.92156775
+	Radius 29.748
+	Distance 4197.314
+}
+
+OpenCluster "HSC 2142"
+{
+	RA 8.51271494
+	Dec -48.7171586
+	Radius 40.388
+	Distance 4686.339
+}
+
+OpenCluster "CWNU 2748"
+{
+	RA 8.51559913
+	Dec -40.43204884
+	Radius 82.088
+	Distance 6756.68
+}
+
+OpenCluster "BH 33:ESO 313-2:FSR 1385:MWSC 1498:OCL 731:OC 0452:Pismis 3"
+{
+	RA 8.52217189
+	Dec -38.66462769
+	Radius 136.505
+	Distance 6887.664
+}
+
+OpenCluster "HSC 2095"
+{
+	RA 8.52946242
+	Dec -42.66826489
+	Radius 52.089
+	Distance 14599.395
+}
+
+OpenCluster "ESO 370-17:ESO 370 17:MWSC 1501"
+{
+	RA 8.53033015
+	Dec -36.21057376
+	Radius 103.509
+	Distance 21000.036
+}
+
+OpenCluster "CWNU 1944"
+{
+	RA 8.53096761
+	Dec -52.09991864
+	Radius 94.987
+	Distance 11101.083
+}
+
+OpenCluster "HSC 2050"
+{
+	RA 8.53659148
+	Dec -36.11239622
+	Radius 47.198
+	Distance 3439.976
+}
+
+OpenCluster "HSC 2103"
+{
+	RA 8.53915667
+	Dec -43.16951975
+	Radius 58.487
+	Distance 5832.441
+}
+
+OpenCluster "CWNU 1656:Theia 2073:Theia 4583:Theia 5247"
+{
+	RA 8.54225617
+	Dec -41.39918453
+	Radius 74.945
+	Distance 7178.612
+}
+
+OpenCluster "BH 35:ESO 210-1:FSR 1444:MWSC 1504:OCL 758:OC 0488:Ruprecht 63"
+{
+	RA 8.54425558
+	Dec -48.30120272
+	Radius 84.014
+	Distance 12306.761
+}
+
+OpenCluster "CWNU 59:Theia 4981"
+{
+	RA 8.55465783
+	Dec -47.52892838
+	Radius 59.8
+	Distance 4258.154
+}
+
+OpenCluster "HSC 2096"
+{
+	RA 8.55787855
+	Dec -42.54191897
+	Radius 66.163
+	Distance 19145.348
+}
+
+OpenCluster "HSC 2139"
+{
+	RA 8.55874191
+	Dec -47.51818277
+	Radius 78.753
+	Distance 613.686
+}
+
+OpenCluster "Theia 4103:Theia 5431:Theia 5465:Theia 5548:Theia 7354:Theia 8137"
+{
+	RA 8.56203559
+	Dec -34.57226539
+	Radius 214.684
+	Distance 5330.55
+}
+
+OpenCluster "Theia 1472:UBC 255"
+{
+	RA 8.57016877
+	Dec -61.46644914
+	Radius 68.35
+	Distance 3001.232
+}
+
+OpenCluster "Theia 274"
+{
+	RA 8.57184985
+	Dec -39.5224181
+	Radius 112.928
+	Distance 2431.772
+}
+
+OpenCluster "CWNU 384"
+{
+	RA 8.57196648
+	Dec -27.69962444
+	Radius 50.414
+	Distance 2358.761
+}
+
+OpenCluster "FSR 1411:OC 0476"
+{
+	RA 8.57275461
+	Dec -43.83652802
+	Radius 34.803
+	Distance 9094.542
+}
+
+OpenCluster "FSR 1411"
+{
+	RA 8.57824982
+	Dec -43.95389232
+	Radius 18.857
+	Distance 6090.598
+}
+
+OpenCluster "HSC 2059"
+{
+	RA 8.58419166
+	Dec -36.88681622
+	Radius 46.973
+	Distance 8811.274
+}
+
+OpenCluster "Pismis 4:Theia 2451:Theia 343"
+{
+	RA 8.58459701
+	Dec -44.40366811
+	Radius 153.975
+	Distance 2220.155
+}
+
+OpenCluster "CWNU 102"
+{
+	RA 8.58496986
+	Dec -36.57483129
+	Radius 17.512
+	Distance 2974.501
+}
+
+OpenCluster "CWNU 1665"
+{
+	RA 8.59086428
+	Dec -41.69827219
+	Radius 46.604
+	Distance 6783.708
+}
+
+OpenCluster "DBSB 19:OC 0469"
+{
+	RA 8.59324048
+	Dec -40.6099213
+	Radius 16.288
+	Distance 2971.407
+}
+
+OpenCluster "BH 37:ESO 259-13:FSR 1410:MWSC 1509:OC 0475:vdBergh-Hagen 37"
+{
+	RA 8.59662318
+	Dec -43.60432864
+	Radius 32.812
+	Distance 11699.316
+}
+
+OpenCluster "CWNU 2347"
+{
+	RA 8.60128414
+	Dec -48.14322641
+	Radius 59.644
+	Distance 14883.676
+}
+
+OpenCluster "UBC 1585"
+{
+	RA 8.60296417
+	Dec -44.66958875
+	Radius 56.271
+	Distance 6108.967
+}
+
+OpenCluster "CWNU 1101:Theia 1918"
+{
+	RA 8.61300185
+	Dec -48.11716688
+	Radius 132.421
+	Distance 1321.79
+}
+
+OpenCluster "MWSC 1511:OC 0495:SAI 91"
+{
+	RA 8.61652479
+	Dec -50.06169035
+	Radius 83.485
+	Distance 11211.921
+}
+
+OpenCluster "UBC 245"
+{
+	RA 8.61796862
+	Dec -45.33738024
+	Radius 43.446
+	Distance 6790.57
+}
+
+OpenCluster "NGC 2627:Melotte 87:Collinder 188:BH 38:ESO 431-20:FSR 1362:MWSC 1514:OCL 714:Theia 6581"
+{
+	RA 8.62071875
+	Dec -29.9489719
+	Radius 47.567
+	Distance 5568.313
+}
+
+OpenCluster "UBC 1446"
+{
+	RA 8.62141502
+	Dec -48.10676107
+	Radius 47.627
+	Distance 6277.538
+}
+
+OpenCluster "HSC 2199"
+{
+	RA 8.62492424
+	Dec -53.18427926
+	Radius 83.598
+	Distance 6616.943
+}
+
+OpenCluster "ESO 313-6:MWSC 1515:OCL 740:OC 0467:Ruprecht 64"
+{
+	RA 8.62721078
+	Dec -40.29213581
+	Radius 28.068
+	Distance 2905.574
+}
+
+OpenCluster "ESO 313-6:MWSC 1515:OCL 740:Pismis 5:Ruprecht 64"
+{
+	RA 8.62757189
+	Dec -39.58434921
+	Radius 26.219
+	Distance 2978.574
+}
+
+OpenCluster "FSR 1406:UBC 1441"
+{
+	RA 8.63872118
+	Dec -42.36090466
+	Radius 67.555
+	Distance 8189.561
+}
+
+OpenCluster "HSC 2049"
+{
+	RA 8.64089339
+	Dec -34.78076763
+	Radius 30.484
+	Distance 10600.28
+}
+
+OpenCluster "NGC 2635:Melotte 89:Collinder 190:BH 39:ESO 371-1:FSR 1375:MWSC 1519:OCL 728"
+{
+	RA 8.64141001
+	Dec -34.77139479
+	Radius 122.847
+	Distance 16139.933
+}
+
+OpenCluster "ESO 259-15:MWSC 1522:OCL 750:Ruprecht 65:UBC 244"
+{
+	RA 8.65557007
+	Dec -44.05779537
+	Radius 55.12
+	Distance 6979.447
+}
+
+OpenCluster "CWNU 1364:FSR 1443"
+{
+	RA 8.65685691
+	Dec -47.35319435
+	Radius 46.771
+	Distance 10044.584
+}
+
+OpenCluster "FSR 1441"
+{
+	RA 8.65897947
+	Dec -47.09562881
+	Radius 39.796
+	Distance 13746.695
+}
+
+OpenCluster "CWNU 1847"
+{
+	RA 8.65942866
+	Dec -32.30745056
+	Radius 57.371
+	Distance 11059.034
+}
+
+OpenCluster "FoF 58:Pismis 6:Theia 1833:Theia 2277"
+{
+	RA 8.65945314
+	Dec -46.29047155
+	Radius 30.888
+	Distance 5610.93
+}
+
+OpenCluster "HSC 2115"
+{
+	RA 8.66083554
+	Dec -43.87148083
+	Radius 116.072
+	Distance 17574.114
+}
+
+OpenCluster "CWNU 1044"
+{
+	RA 8.66202714
+	Dec -51.85904489
+	Radius 122.415
+	Distance 1179.418
+}
+
+OpenCluster "CWNU 2907"
+{
+	RA 8.66317423
+	Dec -45.52050999
+	Radius 41.884
+	Distance 6617.993
+}
+
+OpenCluster "CWNU 242:UBC 1450"
+{
+	RA 8.66619357
+	Dec -48.22543394
+	Radius 51.581
+	Distance 6605.962
+}
+
+OpenCluster "HSC 2042"
+{
+	RA 8.6703878
+	Dec -32.67215769
+	Radius 62.565
+	Distance 6091.038
+}
+
+OpenCluster "Beehive Cluster:Praesepe:M 44:NGC 2632:Melotte 88:Collinder 189:MWSC 1527:OCL 507"
+{
+	RA 8.67254026
+	Dec 19.66587324
+	Radius 104.292
+	Distance 598.468
+}
+
+OpenCluster "HSC 2083"
+{
+	RA 8.67405625
+	Dec -38.76771352
+	Radius 110.939
+	Distance 19470.924
+}
+
+OpenCluster "CWNU 1926"
+{
+	RA 8.67421885
+	Dec -33.09210721
+	Radius 67.322
+	Distance 11382.038
+}
+
+OpenCluster "BH 41:ESO 313-8:FSR 1388:MWSC 1530:OCL 732:Ruprecht 66"
+{
+	RA 8.67558991
+	Dec -38.07197476
+	Radius 128.504
+	Distance 11764.071
+}
+
+OpenCluster "HSC 2055"
+{
+	RA 8.67978662
+	Dec -35.63954555
+	Radius 64.496
+	Distance 18716.198
+}
+
+OpenCluster "HSC 2038"
+{
+	RA 8.68117975
+	Dec -32.00085299
+	Radius 13.039
+	Distance 3855.443
+}
+
+OpenCluster "Theia 3251"
+{
+	RA 8.68118328
+	Dec -48.76792405
+	Radius 25.648
+	Distance 3524.091
+}
+
+OpenCluster "HSC 2118"
+{
+	RA 8.68244768
+	Dec -44.02995421
+	Radius 51.672
+	Distance 6370.655
+}
+
+OpenCluster "CWNU 1134"
+{
+	RA 8.68345625
+	Dec -52.44621364
+	Radius 82.488
+	Distance 1011.17
+}
+
+OpenCluster "Omicron Velorum Cluster:IC 2391:Caldwell 85:Theia 114"
+{
+	RA 8.68401008
+	Dec -53.04169916
+	Radius 102.617
+	Distance 489.856
+}
+
+OpenCluster "BH 43:ESO 313-9:FSR 1393:MWSC 1532:OCL 734:Pismis 7"
+{
+	RA 8.68536391
+	Dec -38.70295491
+	Radius 105.936
+	Distance 16133.651
+}
+
+OpenCluster "HSC 2071"
+{
+	RA 8.68646837
+	Dec -37.21151404
+	Radius 33.694
+	Distance 2719.408
 }
 
 OpenCluster "Pismis 8"
 {
-	RA 8.693333
-	Dec -45.733333
-	Distance 4279
-	Radius 1.9
+	RA 8.69356681
+	Dec -46.26259544
+	Radius 9.439
+	Distance 5756.947
 }
 
-OpenCluster "Ruprecht 67"
+OpenCluster "HSC 2099"
 {
-	RA 8.694167
-	Dec -42.633333
-	Distance 4905
-	Radius 4.3
+	RA 8.69630616
+	Dec -41.63216776
+	Radius 25.747
+	Distance 4788.355
 }
 
-OpenCluster "Mamajek 1"
+OpenCluster "ESO 260-1:MWSC 1534:OCL 748:Ruprecht 67"
 {
-	RA 8.701667
-	Dec -78.972778
-	Distance 316
-	Radius 1.8
+	RA 8.69819041
+	Dec -43.36802671
+	Radius 40.396
+	Distance 4905.671
 }
 
-OpenCluster "IC 2395"
+OpenCluster "CWNU 2337"
 {
-	RA 8.708333
-	Dec -47.886667
-	Distance 2609
-	Radius 7.1
+	RA 8.6986201
+	Dec -49.89830795
+	Radius 81.544
+	Distance 6131.931
 }
 
-OpenCluster "NGC 2659"
+OpenCluster "MWSC 1535:Mamajek 1:Theia 63:eta Chamaeleontis"
 {
-	RA 8.710278
-	Dec -43.016667
-	Distance 5587
-	Radius 4.1
+	RA 8.70428067
+	Dec -78.97287956
+	Radius 15.586
+	Distance 320.399
 }
 
-OpenCluster "NGC 2660"
+OpenCluster "DBSB 21"
 {
-	RA 8.710556
-	Dec -46.800000
-	Distance 9217
-	Radius 4.7
+	RA 8.7058443
+	Dec -40.73471877
+	Radius 47.875
+	Distance 4928.743
 }
 
-OpenCluster "NGC 2658"
+OpenCluster "IC 2395:Theia 25:Theia 6786"
 {
-	RA 8.724167
-	Dec -31.341667
-	Distance 6591
-	Radius 5.8
+	RA 8.70802946
+	Dec -48.13421815
+	Radius 85.551
+	Distance 2269.063
 }
 
-OpenCluster "Bochum 7"
+OpenCluster "NGC 2659:Melotte 91:Collinder 194:BH 46:ESO 260-3:MWSC 1538:OCL 752:Pismis 9"
 {
-	RA 8.746667
-	Dec -44.033333
-	Distance 18767
-	Radius 54.6
+	RA 8.70894605
+	Dec -45.00000498
+	Radius 48.271
+	Distance 6456.054
+}
+
+OpenCluster "FSR 1382:MWSC 1541"
+{
+	RA 8.70986028
+	Dec -35.81651242
+	Radius 102.304
+	Distance 4286.999
+}
+
+OpenCluster "NGC 2660:Melotte 92:Collinder 193:BH 45:ESO 260-4:FSR 1445:MWSC 1539:OCL 759:Theia 6176"
+{
+	RA 8.71109376
+	Dec -47.2002809
+	Radius 72.707
+	Distance 8867.647
+}
+
+OpenCluster "HSC 2226"
+{
+	RA 8.71443776
+	Dec -58.42053896
+	Radius 88.7
+	Distance 817.322
+}
+
+OpenCluster "NGC 2660:Melotte 92:Collinder 193:BH 45:ESO 260-4:FSR 1445:MWSC 1539:OCL 759:Theia 4284"
+{
+	RA 8.71481129
+	Dec -47.23734754
+	Radius 50.253
+	Distance 4273.169
+}
+
+OpenCluster "NGC 2659:Melotte 91:Collinder 194:BH 46:ESO 260-3:MWSC 1538:OCL 752:Pismis 9:Theia 3156:UBC 246"
+{
+	RA 8.71533467
+	Dec -44.92580381
+	Radius 69.844
+	Distance 6082.487
+}
+
+OpenCluster "HSC 2165"
+{
+	RA 8.71536169
+	Dec -49.56192641
+	Radius 49.946
+	Distance 12118.76
+}
+
+OpenCluster "HSC 2159"
+{
+	RA 8.71869581
+	Dec -48.60319083
+	Radius 50.117
+	Distance 13526.476
+}
+
+OpenCluster "UBC 1436"
+{
+	RA 8.72268259
+	Dec -36.95561151
+	Radius 101.537
+	Distance 10839.011
+}
+
+OpenCluster "OC 0483"
+{
+	RA 8.72372414
+	Dec -46.14579358
+	Radius 55.408
+	Distance 16852.966
+}
+
+OpenCluster "NGC 2658:Melotte 90:Collinder 195:BH 48:ESO 432-4:FSR 1373:MWSC 1542:OCL 723:OC 0445"
+{
+	RA 8.72431482
+	Dec -32.66586358
+	Radius 225.161
+	Distance 12469.607
+}
+
+OpenCluster "CWNU 2422"
+{
+	RA 8.72485482
+	Dec -47.60262784
+	Radius 37.746
+	Distance 16671.878
+}
+
+OpenCluster "Theia 110"
+{
+	RA 8.72547587
+	Dec -47.22909137
+	Radius 126.315
+	Distance 2160.839
+}
+
+OpenCluster "FoF 2219:Theia 2474:Theia 4386:UBC 481"
+{
+	RA 8.72572494
+	Dec -45.85235402
+	Radius 52.517
+	Distance 4711.97
+}
+
+OpenCluster "HSC 2106"
+{
+	RA 8.72627574
+	Dec -41.85349074
+	Radius 75.081
+	Distance 2620.659
+}
+
+OpenCluster "IC 2395:UBC 1452:XDOCC 6"
+{
+	RA 8.72817634
+	Dec -48.15534765
+	Radius 25.736
+	Distance 4148.062
+}
+
+OpenCluster "Theia 2474:Theia 2626:Theia 4364:Theia 4386:UBC 482"
+{
+	RA 8.72938655
+	Dec -45.87619022
+	Radius 90.55
+	Distance 6614.129
+}
+
+OpenCluster "CWNU 417:Theia 651"
+{
+	RA 8.73046556
+	Dec -30.73740681
+	Radius 46.859
+	Distance 2341.541
+}
+
+OpenCluster "HSC 2380"
+{
+	RA 8.73090371
+	Dec -74.37534071
+	Radius 70.554
+	Distance 975.046
+}
+
+OpenCluster "UPK 545"
+{
+	RA 8.73163812
+	Dec -58.78431833
+	Radius 222.931
+	Distance 1089.425
+}
+
+OpenCluster "CWNU 322:LISC-III 2824:Theia 2767:Theia 4584:Theia 4828:Theia 6361:UBC 1455"
+{
+	RA 8.7334497
+	Dec -54.12947053
+	Radius 134.963
+	Distance 4387.666
+}
+
+OpenCluster "HSC 2094"
+{
+	RA 8.73422235
+	Dec -40.618725
+	Radius 69.94
+	Distance 4639.896
+}
+
+OpenCluster "FSR 1399:MWSC 1546"
+{
+	RA 8.73602054
+	Dec -39.35492493
+	Radius 151.32
+	Distance 8834.954
+}
+
+OpenCluster "BH 49:ESO 371-12:FSR 1384:MWSC 1547:OCL 729:Ruprecht 68"
+{
+	RA 8.74251883
+	Dec -35.89798443
+	Radius 77.074
+	Distance 8877.884
+}
+
+OpenCluster "CWNU 88"
+{
+	RA 8.74485489
+	Dec -59.95995214
+	Radius 129.016
+	Distance 1736.718
+}
+
+OpenCluster "HSC 2147"
+{
+	RA 8.74511885
+	Dec -47.33616484
+	Radius 49.892
+	Distance 2280.855
+}
+
+OpenCluster "HSC 2151"
+{
+	RA 8.7452118
+	Dec -47.68872087
+	Radius 41.98
+	Distance 21201.737
+}
+
+OpenCluster "MWSC 1549:SAI 94:Theia 2626"
+{
+	RA 8.74533602
+	Dec -46.28644046
+	Radius 75.503
+	Distance 12538.485
+}
+
+OpenCluster "HSC 2140"
+{
+	RA 8.74534121
+	Dec -46.1511712
+	Radius 21.608
+	Distance 13235.919
 }
 
 OpenCluster "Collinder 197"
 {
-	RA 8.747500
-	Dec -40.766667
-	Distance 2733
-	Radius 9.9
+	RA 8.74768184
+	Dec -41.2600674
+	Radius 12.092
+	Distance 3014.102
 }
 
-OpenCluster "NGC 2670"
+OpenCluster "NGC 2670:Melotte 93:Collinder 200:BH 50:ESO 210-5:MWSC 1554:OCL 764:Theia 2717"
 {
-	RA 8.758333
-	Dec -47.200000
-	Distance 3874
-	Radius 3.9
+	RA 8.75790256
+	Dec -48.79050959
+	Radius 52.148
+	Distance 4672.831
 }
 
-OpenCluster "NGC 2671"
+OpenCluster "HSC 2129"
 {
-	RA 8.770000
-	Dec -40.121667
-	Distance 5414
-	Radius 4.7
+	RA 8.76117414
+	Dec -44.55392086
+	Radius 31.81
+	Distance 5980.916
 }
 
-OpenCluster "NGC 2669"
+OpenCluster "HSC 2130"
 {
-	RA 8.772778
-	Dec -51.051667
-	Distance 3411
-	Radius 9.9
+	RA 8.76155689
+	Dec -44.71091533
+	Radius 35.801
+	Distance 6997.682
 }
 
-OpenCluster "BH 52"
+OpenCluster "OC 0493"
 {
-	RA 8.775000
-	Dec -51.100000
-	Distance 2175
-	Radius 1.9
+	RA 8.76419887
+	Dec -48.13602066
+	Radius 106.615
+	Distance 15818.833
+}
+
+OpenCluster "HSC 2145"
+{
+	RA 8.76769032
+	Dec -46.9922773
+	Radius 101.376
+	Distance 5158.804
+}
+
+OpenCluster "NGC 2671:Collinder 201:BH 51:ESO 313-14:FSR 1409:MWSC 1558:OCL 745:Theia 2912"
+{
+	RA 8.77038118
+	Dec -41.88008735
+	Radius 97.155
+	Distance 4404.904
+}
+
+OpenCluster "HSC 2090"
+{
+	RA 8.77181492
+	Dec -39.80651439
+	Radius 31.777
+	Distance 11778.769
+}
+
+OpenCluster "Theia 2078"
+{
+	RA 8.77281238
+	Dec -46.56840628
+	Radius 25.253
+	Distance 5387.564
+}
+
+OpenCluster "HSC 2181"
+{
+	RA 8.77287019
+	Dec -50.81464249
+	Radius 62.037
+	Distance 15616.523
+}
+
+OpenCluster "NGC 2669:Collinder 199:Collinder 202:BH 52:ESO 165-5:Harvard 3:MWSC 1561:MWSC 1562:OCL 768:Theia 2767"
+{
+	RA 8.77380981
+	Dec -52.93667768
+	Radius 58.424
+	Distance 3641.24
+}
+
+OpenCluster "ASCC 49:MWSC 1569:Teutsch 38"
+{
+	RA 8.78298874
+	Dec -37.85376069
+	Radius 71.774
+	Distance 2097.848
+}
+
+OpenCluster "HSC 2135"
+{
+	RA 8.78986801
+	Dec -45.42856877
+	Radius 49.193
+	Distance 10077.167
+}
+
+OpenCluster "FSR 1418:MWSC 1568"
+{
+	RA 8.79022314
+	Dec -43.91970204
+	Radius 73.832
+	Distance 7210.905
+}
+
+OpenCluster "HSC 2132"
+{
+	RA 8.79130716
+	Dec -44.95464366
+	Radius 23.804
+	Distance 5996.085
+}
+
+OpenCluster "CWNU 515"
+{
+	RA 8.79347957
+	Dec -63.58268838
+	Radius 77.865
+	Distance 662.734
+}
+
+OpenCluster "HSC 2086"
+{
+	RA 8.79436449
+	Dec -38.95028347
+	Radius 57.051
+	Distance 1855.203
 }
 
 OpenCluster "Trumpler 10"
 {
-	RA 8.798333
-	Dec -41.550000
-	Distance 1382
-	Radius 5.8
+	RA 8.79578205
+	Dec -42.53380129
+	Radius 491.299
+	Distance 1396.396
 }
 
-OpenCluster "Teutsch 38"
+OpenCluster "UBC 1620"
 {
-	RA 8.799444
-	Dec -37.941667
-	Distance 2935
-	Radius 23.1
+	RA 8.79682928
+	Dec -44.61358429
+	Radius 14.973
+	Distance 6143.158
 }
 
-OpenCluster "Ruprecht 71"
+OpenCluster "HSC 2155"
 {
-	RA 8.823056
-	Dec -45.150000
-	Distance 3261
-	Radius 2.8
+	RA 8.8009782
+	Dec -47.69212133
+	Radius 102.736
+	Distance 6257.206
 }
 
-OpenCluster "Alessi 43"
+OpenCluster "UBC 1621"
 {
-	RA 8.838056
-	Dec -40.280000
-	Distance 2772
-	Radius 19.4
+	RA 8.80597568
+	Dec -49.1923028
+	Radius 28.175
+	Distance 5268.114
 }
 
-OpenCluster "NGC 2682"
+OpenCluster "HSC 2158"
 {
-	RA 8.855000
-	Dec 11.800000
-	Distance 2961
-	Radius 10.8
+	RA 8.80910743
+	Dec -47.75541759
+	Radius 66.434
+	Distance 20839.935
 }
 
-OpenCluster "Ruprecht 72"
+OpenCluster "HSC 2297"
 {
-	RA 8.868056
-	Dec -36.400000
-	Distance 9846
-	Radius 4.3
+	RA 8.81973174
+	Dec -65.5607011
+	Radius 185.996
+	Distance 1430.402
 }
 
-OpenCluster "Ruprecht 158"
+OpenCluster "ESO 260-9:MWSC 1574:OCL 761:Ruprecht 71:Theia 1999"
 {
-	RA 8.874167
-	Dec -36.433333
-	Distance 13594
-	Radius 4.0
+	RA 8.82154964
+	Dec -46.8732979
+	Radius 69.782
+	Distance 6138.87
 }
 
-OpenCluster "BH 56"
+OpenCluster "HSC 2150"
 {
-	RA 8.952222
-	Dec -42.750000
-	Distance 2175
-	Radius 6.3
+	RA 8.82266531
+	Dec -47.00520042
+	Radius 32.97
+	Distance 17492.183
+}
+
+OpenCluster "BH 54:vdBergh-Hagen 54"
+{
+	RA 8.82744833
+	Dec -44.35319866
+	Radius 35.138
+	Distance 6952.29
+}
+
+OpenCluster "HSC 2092"
+{
+	RA 8.82816818
+	Dec -39.55566036
+	Radius 35.463
+	Distance 2755.225
+}
+
+OpenCluster "OC 0480"
+{
+	RA 8.83045028
+	Dec -43.15164603
+	Radius 88.205
+	Distance 7302.645
+}
+
+OpenCluster "OC 0506"
+{
+	RA 8.83149487
+	Dec -51.64342686
+	Radius 71.914
+	Distance 7536.782
+}
+
+OpenCluster "CWNU 1914"
+{
+	RA 8.83557399
+	Dec -54.5760136
+	Radius 40.856
+	Distance 6539.724
+}
+
+OpenCluster "Gulliver 5"
+{
+	RA 8.83805702
+	Dec -45.51903705
+	Radius 116.243
+	Distance 6983.518
+}
+
+OpenCluster "ASCC 50:Alessi 43:Theia 2087:Theia 28"
+{
+	RA 8.83842779
+	Dec -41.69151493
+	Radius 64.715
+	Distance 2993.562
+}
+
+OpenCluster "HSC 2157"
+{
+	RA 8.83895211
+	Dec -47.45668802
+	Radius 15.663
+	Distance 15000.486
+}
+
+OpenCluster "FSR 1424:UBC 1444"
+{
+	RA 8.84155149
+	Dec -43.88674778
+	Radius 30.087
+	Distance 7153.863
+}
+
+OpenCluster "DSH J0850.5-4629:Teutsch 65"
+{
+	RA 8.84202779
+	Dec -46.50227345
+	Radius 62.59
+	Distance 17687.677
+}
+
+OpenCluster "FSR 1424:UBC 1444"
+{
+	RA 8.84608114
+	Dec -43.84473369
+	Radius 20.243
+	Distance 7179.744
+}
+
+OpenCluster "CWNU 1315"
+{
+	RA 8.8477293
+	Dec -47.666799
+	Radius 24.27
+	Distance 13200.738
+}
+
+OpenCluster "UBC 1448"
+{
+	RA 8.85351405
+	Dec -46.39293585
+	Radius 38.005
+	Distance 7043.261
+}
+
+OpenCluster "King Cobra Cluster:Golden Eye Cluster:M 67:NGC 2682:Melotte 94:Collinder 204:MWSC 1585:OCL 549"
+{
+	RA 8.85665613
+	Dec 11.81745461
+	Radius 80.277
+	Distance 2730.802
+}
+
+OpenCluster "HSC 2141"
+{
+	RA 8.85836964
+	Dec -45.85030694
+	Radius 52.354
+	Distance 13054.516
+}
+
+OpenCluster "ESO 211-03:ESO 211-211:ESO 211-3:ESO 211 03:FSR 1463:MWSC 1587:MWSC 1588:OC 0503"
+{
+	RA 8.86003055
+	Dec -50.25430197
+	Radius 115.892
+	Distance 15730.673
+}
+
+OpenCluster "FSR 1430"
+{
+	RA 8.86507655
+	Dec -44.27653458
+	Radius 84.764
+	Distance 14470.948
+}
+
+OpenCluster "HSC 2128"
+{
+	RA 8.86693021
+	Dec -43.52664975
+	Radius 176.801
+	Distance 15994.128
+}
+
+OpenCluster "HSC 2126"
+{
+	RA 8.87140507
+	Dec -43.4265334
+	Radius 189.991
+	Distance 1698.422
+}
+
+OpenCluster "CWNU 1150"
+{
+	RA 8.87152942
+	Dec -47.40862304
+	Radius 64.736
+	Distance 1572.032
+}
+
+OpenCluster "OC 0494"
+{
+	RA 8.87282861
+	Dec -47.96300749
+	Radius 34.133
+	Distance 17156.026
+}
+
+OpenCluster "HSC 2175"
+{
+	RA 8.87411671
+	Dec -49.22826607
+	Radius 69.02
+	Distance 6263.639
+}
+
+OpenCluster "Theia 1742:Theia 2717"
+{
+	RA 8.87431643
+	Dec -47.93305286
+	Radius 123.199
+	Distance 5196.791
+}
+
+OpenCluster "HSC 1908"
+{
+	RA 8.87535924
+	Dec -12.09987608
+	Radius 50.187
+	Distance 1548.686
+}
+
+OpenCluster "UBC 1449"
+{
+	RA 8.87578646
+	Dec -46.28998232
+	Radius 49.19
+	Distance 6783.449
+}
+
+OpenCluster "CWNU 89"
+{
+	RA 8.87608514
+	Dec -54.44623563
+	Radius 24.505
+	Distance 3987.831
+}
+
+OpenCluster "CWNU 2268"
+{
+	RA 8.87674152
+	Dec -47.80970366
+	Radius 53.703
+	Distance 14259.087
+}
+
+OpenCluster "CWNU 2528"
+{
+	RA 8.87941705
+	Dec -46.28943102
+	Radius 47.094
+	Distance 6004.924
+}
+
+OpenCluster "ESO 371-25:ESO 371 25:MWSC 1595"
+{
+	RA 8.88316454
+	Dec -35.47902771
+	Radius 174.695
+	Distance 17521.295
+}
+
+OpenCluster "FSR 1452:Theia 1742"
+{
+	RA 8.88854396
+	Dec -47.8551214
+	Radius 75.867
+	Distance 7694.046
+}
+
+OpenCluster "CWNU 163:UBC 1447"
+{
+	RA 8.88944882
+	Dec -46.03853046
+	Radius 62.746
+	Distance 6321.68
+}
+
+OpenCluster "CWNU 29"
+{
+	RA 8.89066871
+	Dec -72.48503362
+	Radius 44.121
+	Distance 1862.198
+}
+
+OpenCluster "CWNU 1983"
+{
+	RA 8.89324755
+	Dec -44.78057451
+	Radius 49.69
+	Distance 9158.067
+}
+
+OpenCluster "HSC 2137"
+{
+	RA 8.90764332
+	Dec -44.43816777
+	Radius 60.643
+	Distance 4530.499
+}
+
+OpenCluster "Theia 2087:Theia 28"
+{
+	RA 8.90842939
+	Dec -42.12603336
+	Radius 69.613
+	Distance 3281.351
+}
+
+OpenCluster "HSC 2153"
+{
+	RA 8.90939511
+	Dec -46.50705227
+	Radius 58.572
+	Distance 6923.705
+}
+
+OpenCluster "CWNU 2002:Theia 2087"
+{
+	RA 8.91073565
+	Dec -42.13526382
+	Radius 104.321
+	Distance 9194.324
+}
+
+OpenCluster "HSC 2237"
+{
+	RA 8.91178033
+	Dec -58.2432045
+	Radius 31.112
+	Distance 804.706
+}
+
+OpenCluster "HSC 2177"
+{
+	RA 8.91554703
+	Dec -49.15075634
+	Radius 42.338
+	Distance 10028.421
+}
+
+OpenCluster "UBC 483"
+{
+	RA 8.91682523
+	Dec -47.41620542
+	Radius 44.453
+	Distance 6011.231
+}
+
+OpenCluster "UBC 243"
+{
+	RA 8.92386362
+	Dec -40.74551615
+	Radius 64.908
+	Distance 6296.135
+}
+
+OpenCluster "HSC 2213"
+{
+	RA 8.92766124
+	Dec -53.57169658
+	Radius 51.253
+	Distance 20073.272
+}
+
+OpenCluster "LISC 0901:Theia 6978:UBC 1438"
+{
+	RA 8.92826115
+	Dec -38.56684408
+	Radius 93.878
+	Distance 12119.141
+}
+
+OpenCluster "HSC 2112"
+{
+	RA 8.92980277
+	Dec -40.99588181
+	Radius 48.183
+	Distance 17534.805
+}
+
+OpenCluster "CWNU 509"
+{
+	RA 8.93121621
+	Dec -25.54085325
+	Radius 57.507
+	Distance 3051.442
+}
+
+OpenCluster "BH 55:ESO 314-1:FSR 1404:MWSC 1600:vdBergh-Hagen 55"
+{
+	RA 8.93603351
+	Dec -39.52239231
+	Radius 123.418
+	Distance 13217.404
+}
+
+OpenCluster "Theia 1024:Theia 655"
+{
+	RA 8.94012051
+	Dec -38.07984469
+	Radius 55.752
+	Distance 1640.34
+}
+
+OpenCluster "HSC 2144"
+{
+	RA 8.94220258
+	Dec -45.41792532
+	Radius 43.192
+	Distance 2706.707
+}
+
+OpenCluster "HSC 2149"
+{
+	RA 8.94584194
+	Dec -45.8915787
+	Radius 84.51
+	Distance 6817.26
+}
+
+OpenCluster "Theia 880:UPK 542"
+{
+	RA 8.94934264
+	Dec -54.46896461
+	Radius 44.64
+	Distance 2653.096
+}
+
+OpenCluster "FSR 1435:MWSC 1604:SAI 98"
+{
+	RA 8.95071569
+	Dec -43.75703633
+	Radius 42.797
+	Distance 6487.362
+}
+
+OpenCluster "OC 0492"
+{
+	RA 8.95212849
+	Dec -46.04764803
+	Radius 47.074
+	Distance 6761.605
+}
+
+OpenCluster "Theia 3967"
+{
+	RA 8.95223335
+	Dec -30.73879258
+	Radius 75.08
+	Distance 3375.961
+}
+
+OpenCluster "CWNU 2015"
+{
+	RA 8.95483295
+	Dec -48.31296486
+	Radius 23.581
+	Distance 7006.416
+}
+
+OpenCluster "HSC 2131"
+{
+	RA 8.95597454
+	Dec -43.14491427
+	Radius 38.366
+	Distance 2250.002
+}
+
+OpenCluster "BH 56:ESO 260-12:MWSC 1605:Magakian 425:vdBergh-Hagen 56"
+{
+	RA 8.9579577
+	Dec -43.22044909
+	Radius 40.349
+	Distance 2870.003
+}
+
+OpenCluster "FSR 1421"
+{
+	RA 8.96337572
+	Dec -42.6562819
+	Radius 66.942
+	Distance 2938.358
+}
+
+OpenCluster "Muzzio 1"
+{
+	RA 8.96686385
+	Dec -47.69669168
+	Radius 84.869
+	Distance 5778.136
+}
+
+OpenCluster "HSC 2170"
+{
+	RA 8.96695503
+	Dec -48.17293537
+	Radius 61.332
+	Distance 9558.031
+}
+
+OpenCluster "CWNU 2216:Theia 5677"
+{
+	RA 8.97915048
+	Dec -54.87422718
+	Radius 73.774
+	Distance 8357.017
+}
+
+OpenCluster "CWNU 1348:FSR 1478:MWSC 1612"
+{
+	RA 8.99543803
+	Dec -52.70975319
+	Radius 155.334
+	Distance 6661.54
+}
+
+OpenCluster "CWNU 185:UBC 1451"
+{
+	RA 8.99558615
+	Dec -45.81025967
+	Radius 38.196
+	Distance 6400.15
+}
+
+OpenCluster "CWNU 1020"
+{
+	RA 9.00040269
+	Dec -54.5099512
+	Radius 134.961
+	Distance 1427.237
+}
+
+OpenCluster "HSC 1965"
+{
+	RA 9.00573646
+	Dec -16.81401752
+	Radius 31.435
+	Distance 4875.764
+}
+
+OpenCluster "HSC 2173"
+{
+	RA 9.00728088
+	Dec -47.98856294
+	Radius 57.37
+	Distance 14641.393
+}
+
+OpenCluster "Theia 1062"
+{
+	RA 9.00736835
+	Dec -49.27746444
+	Radius 66.661
+	Distance 4958.992
 }
 
 OpenCluster "Collinder 205"
 {
-	RA 9.008889
-	Dec -47.016667
-	Distance 6043
-	Radius 4.4
+	RA 9.00829825
+	Dec -48.98726627
+	Radius 68.044
+	Distance 5765.221
 }
 
-OpenCluster "ESO 165-09"
+OpenCluster "HSC 2246"
 {
-	RA 9.087500
-	Dec -54.045000
-	Distance 1467
-	Radius 3.2
+	RA 9.02151387
+	Dec -58.64604057
+	Radius 24.787
+	Distance 3731.107
+}
+
+OpenCluster "CWNU 1541"
+{
+	RA 9.02287354
+	Dec -40.47095846
+	Radius 69.951
+	Distance 13823.145
+}
+
+OpenCluster "HSC 2136"
+{
+	RA 9.02617118
+	Dec -43.30258005
+	Radius 21.407
+	Distance 2603.085
+}
+
+OpenCluster "HSC 2168"
+{
+	RA 9.03569728
+	Dec -47.04393293
+	Radius 41.49
+	Distance 5777.631
+}
+
+OpenCluster "HSC 2182"
+{
+	RA 9.03755876
+	Dec -48.69443025
+	Radius 32.738
+	Distance 7285.143
+}
+
+OpenCluster "HSC 2163"
+{
+	RA 9.04188786
+	Dec -46.39580408
+	Radius 76.799
+	Distance 7066.048
+}
+
+OpenCluster "CWNU 188:OC 0496:Theia 1858"
+{
+	RA 9.0489589
+	Dec -46.72645649
+	Radius 60.006
+	Distance 3647.939
+}
+
+OpenCluster "Theia 891:UBC 477:UPK 508"
+{
+	RA 9.05026317
+	Dec -34.94544101
+	Radius 72.38
+	Distance 2635.839
+}
+
+OpenCluster "CWNU 207"
+{
+	RA 9.05053821
+	Dec -46.86333434
+	Radius 31.646
+	Distance 2661.517
+}
+
+OpenCluster "CWNU 182:Theia 1081:Theia 3374"
+{
+	RA 9.05657458
+	Dec -43.86964209
+	Radius 98.095
+	Distance 2979.494
+}
+
+OpenCluster "HSC 2183"
+{
+	RA 9.05840357
+	Dec -48.52490702
+	Radius 38.833
+	Distance 6600.098
+}
+
+OpenCluster "OC 0511:PHOC 27"
+{
+	RA 9.06232925
+	Dec -53.84931507
+	Radius 66.058
+	Distance 9943.708
+}
+
+OpenCluster "HSC 2236"
+{
+	RA 9.09274582
+	Dec -56.93939656
+	Radius 115.566
+	Distance 3601.07
+}
+
+OpenCluster "HSC 2148"
+{
+	RA 9.09548859
+	Dec -44.42761808
+	Radius 60.957
+	Distance 2969.966
+}
+
+OpenCluster "FSR 1402:MWSC 1626:SAI 102"
+{
+	RA 9.09620926
+	Dec -37.87514172
+	Radius 97.953
+	Distance 13391.739
+}
+
+OpenCluster "UBC 1443"
+{
+	RA 9.11417412
+	Dec -40.86209768
+	Radius 93.325
+	Distance 10653.722
+}
+
+OpenCluster "HSC 2167"
+{
+	RA 9.1169038
+	Dec -46.17333108
+	Radius 27.025
+	Distance 5426.709
+}
+
+OpenCluster "CWNU 164:Theia 1081"
+{
+	RA 9.11960298
+	Dec -44.31040224
+	Radius 43.903
+	Distance 3393.321
+}
+
+OpenCluster "UBC 249"
+{
+	RA 9.12389948
+	Dec -52.90672144
+	Radius 109.195
+	Distance 5927.777
 }
 
 OpenCluster "Platais 8"
 {
-	RA 9.158333
-	Dec -58.871667
-	Distance 430
-	Radius 59.4
+	RA 9.12632238
+	Dec -59.30881905
+	Radius 68.187
+	Distance 435.726
 }
 
-OpenCluster "ESO 166-04"
+OpenCluster "FSR 1460:MWSC 1628:SAI 103"
 {
-	RA 9.175000
-	Dec -52.113333
-	Distance 2886
-	Radius 1.7
+	RA 9.12718221
+	Dec -47.82396577
+	Radius 46.64
+	Distance 9540.463
+}
+
+OpenCluster "UBC 1463"
+{
+	RA 9.13294912
+	Dec -56.41228821
+	Radius 41.47
+	Distance 12998.63
+}
+
+OpenCluster "HSC 2230"
+{
+	RA 9.13583525
+	Dec -55.77933148
+	Radius 91.882
+	Distance 3784.679
+}
+
+OpenCluster "Theia 2652:Theia 4431:UPK 528"
+{
+	RA 9.13626223
+	Dec -43.3619956
+	Radius 44.642
+	Distance 3076.831
+}
+
+OpenCluster "HSC 2176"
+{
+	RA 9.13991153
+	Dec -46.91996236
+	Radius 32.421
+	Distance 6036.852
+}
+
+OpenCluster "UBC 1457"
+{
+	RA 9.1430683
+	Dec -52.21335377
+	Radius 74.813
+	Distance 14833.379
+}
+
+OpenCluster "OC 0501"
+{
+	RA 9.15011785
+	Dec -46.43412231
+	Radius 68.033
+	Distance 4973.999
+}
+
+OpenCluster "OC 0490:Theia 8106"
+{
+	RA 9.15725018
+	Dec -43.30879221
+	Radius 89.539
+	Distance 7487.362
+}
+
+OpenCluster "HSC 2204"
+{
+	RA 9.15744709
+	Dec -50.39047749
+	Radius 40.602
+	Distance 7397.448
+}
+
+OpenCluster "HSC 2116"
+{
+	RA 9.16011046
+	Dec -39.20252718
+	Radius 141.758
+	Distance 17656.221
+}
+
+OpenCluster "HSC 2185"
+{
+	RA 9.16383719
+	Dec -47.81678773
+	Radius 46.816
+	Distance 5017.018
+}
+
+OpenCluster "SAI 104"
+{
+	RA 9.16457644
+	Dec -48.86344715
+	Radius 42.345
+	Distance 8531.973
+}
+
+OpenCluster "HSC 2193"
+{
+	RA 9.1664795
+	Dec -48.68632207
+	Radius 12.499
+	Distance 2264.365
+}
+
+OpenCluster "HSC 2221"
+{
+	RA 9.16846815
+	Dec -53.66257571
+	Radius 64.253
+	Distance 16485.512
+}
+
+OpenCluster "HSC 2195"
+{
+	RA 9.16957189
+	Dec -48.7188008
+	Radius 75.52
+	Distance 3454.272
+}
+
+OpenCluster "OC 0508"
+{
+	RA 9.16974688
+	Dec -49.79273118
+	Radius 81.337
+	Distance 7414
+}
+
+OpenCluster "HSC 2178"
+{
+	RA 9.17375394
+	Dec -46.98158743
+	Radius 57.416
+	Distance 8761.761
+}
+
+OpenCluster "ESO 166-04:ESO 166-166:ESO 166-4:ESO 166 04:MWSC 1633:Theia 3535"
+{
+	RA 9.17470586
+	Dec -53.88620386
+	Radius 26.364
+	Distance 3563.321
+}
+
+OpenCluster "Theia 1170"
+{
+	RA 9.17592214
+	Dec -54.55510443
+	Radius 153.151
+	Distance 2153.962
+}
+
+OpenCluster "HSC 2206"
+{
+	RA 9.17919271
+	Dec -50.72216041
+	Radius 70.398
+	Distance 6743.182
+}
+
+OpenCluster "HSC 2192"
+{
+	RA 9.18530365
+	Dec -48.37610969
+	Radius 49.579
+	Distance 4255.074
+}
+
+OpenCluster "CWNU 2315:ESO 261-03:ESO 261-261:ESO 261-3:ESO 261-7:ESO 261 03:MWSC 1634:MWSC 1664"
+{
+	RA 9.18875769
+	Dec -47.02572041
+	Radius 59.477
+	Distance 4592.362
+}
+
+OpenCluster "CWNU 208:OC 0497"
+{
+	RA 9.19014853
+	Dec -45.56842332
+	Radius 18.291
+	Distance 2439.447
+}
+
+OpenCluster "HSC 2211"
+{
+	RA 9.19247524
+	Dec -51.09666829
+	Radius 16.247
+	Distance 4680.161
+}
+
+OpenCluster "PHOC 28:UBC 248"
+{
+	RA 9.19852438
+	Dec -52.22996693
+	Radius 41.08
+	Distance 8933.378
+}
+
+OpenCluster "FoF 2149:Theia 2565:Theia 2915:Theia 3374:Theia 3404:UBC 484"
+{
+	RA 9.20153038
+	Dec -44.81439303
+	Radius 38.298
+	Distance 6589.118
+}
+
+OpenCluster "FoF 2149:Theia 2565:Theia 2915:Theia 3374:Theia 3590:UBC 485"
+{
+	RA 9.21207569
+	Dec -44.92634791
+	Radius 39.756
+	Distance 5384.083
+}
+
+OpenCluster "UBC 1453"
+{
+	RA 9.21250816
+	Dec -45.43416515
+	Radius 61.287
+	Distance 7222.241
+}
+
+OpenCluster "HSC 2202"
+{
+	RA 9.21404812
+	Dec -49.52518813
+	Radius 33.344
+	Distance 2571.636
+}
+
+OpenCluster "LISC-III 3783:OCSN 86"
+{
+	RA 9.21721454
+	Dec -29.7467166
+	Radius 105.093
+	Distance 845.942
+}
+
+OpenCluster "Platais 9:Theia 105:Theia 455"
+{
+	RA 9.22039108
+	Dec -44.18631488
+	Radius 46.955
+	Distance 1467.438
 }
 
 OpenCluster "Platais 9"
 {
-	RA 9.229722
-	Dec -42.260000
-	Distance 567
-	Radius 32.7
+	RA 9.22137909
+	Dec -43.55757013
+	Radius 85.467
+	Distance 604.232
 }
 
-OpenCluster "NGC 2818"
+OpenCluster "UBC 1458"
 {
-	RA 9.266944
-	Dec -35.375000
-	Distance 6050
-	Radius 7.9
+	RA 9.22480492
+	Dec -51.90521116
+	Radius 35.517
+	Distance 7613.161
+}
+
+OpenCluster "Theia 4456"
+{
+	RA 9.24025453
+	Dec -42.7981574
+	Radius 44.482
+	Distance 3213.715
+}
+
+OpenCluster "CWNU 1867"
+{
+	RA 9.24673429
+	Dec -44.24782987
+	Radius 126.691
+	Distance 5730.052
+}
+
+OpenCluster "CWNU 1854:Theia 3317"
+{
+	RA 9.24770301
+	Dec -45.30629871
+	Radius 21.672
+	Distance 6785.567
 }
 
 OpenCluster "Pismis 11"
 {
-	RA 9.264722
-	Dec -49.983333
-	Distance 9132
-	Radius 2.7
+	RA 9.26486541
+	Dec -50.00717922
+	Radius 75.624
+	Distance 8078.79
 }
 
-OpenCluster "ASCC 51"
+OpenCluster "HSC 2053"
 {
-	RA 9.300000
-	Dec -68.310000
-	Distance 1630
-	Radius 18.8
+	RA 9.26522173
+	Dec -29.04850185
+	Radius 53.147
+	Distance 6858.043
 }
 
-OpenCluster "NGC 2849"
+OpenCluster "CWNU 535:Theia 3337:UBC 1586"
 {
-	RA 9.323056
-	Dec -39.476667
-	Distance 20874
-	Radius 10.6
+	RA 9.26678461
+	Dec -44.88181013
+	Radius 25.941
+	Distance 5572.423
 }
 
-OpenCluster "Teutsch 48"
+OpenCluster "NGC 2818:NGC 2818A:Melotte 96:Collinder 206:BH 59:ESO 372-14:FSR 1408:MWSC 1644:OCL 743"
 {
-	RA 9.342222
-	Dec -51.148333
-	Distance 22831
-	Radius 7.3
+	RA 9.26943654
+	Dec -36.62091714
+	Radius 179.735
+	Distance 9628.035
 }
 
-OpenCluster "BH 63"
+OpenCluster "UBC 252"
 {
-	RA 9.344167
-	Dec -48.776944
-	Distance 7501
-	Radius 2.7
+	RA 9.27731413
+	Dec -54.12784754
+	Radius 91.443
+	Distance 14904.612
 }
 
-OpenCluster "Ruprecht 75"
+OpenCluster "HSC 2214"
 {
-	RA 9.365278
-	Dec -55.683333
-	Distance 14025
-	Radius 4.1
+	RA 9.27810063
+	Dec -50.88540783
+	Radius 48.359
+	Distance 9807.611
 }
 
-OpenCluster "NGC 2866"
+OpenCluster "DBSB 36"
 {
-	RA 9.368611
-	Dec -50.900000
-	Distance 8480
-	Radius 2.5
+	RA 9.2791764
+	Dec -47.95042071
+	Radius 75.503
+	Distance 5097.542
 }
 
-OpenCluster "Ruprecht 76"
+OpenCluster "CWNU 1492"
 {
-	RA 9.403611
-	Dec -50.333333
-	Distance 4116
-	Radius 3.0
+	RA 9.29029521
+	Dec -44.70265439
+	Radius 119.424
+	Distance 13226.022
 }
 
-OpenCluster "BH 66"
+OpenCluster "OC 0509:SAI 106"
 {
-	RA 9.421667
-	Dec -53.283333
-	Distance 22831
-	Radius 13.3
+	RA 9.29897304
+	Dec -51.00114806
+	Radius 93.593
+	Distance 17593.069
 }
 
-OpenCluster "Ruprecht 77"
+OpenCluster "Theia 4384:UBC 253"
 {
-	RA 9.451111
-	Dec -54.883333
-	Distance 13467
-	Radius 9.8
+	RA 9.30227386
+	Dec -56.01035294
+	Radius 52.877
+	Distance 5107.193
 }
 
-OpenCluster "IC 2488"
+OpenCluster "Theia 105"
 {
-	RA 9.460556
-	Dec -57.000000
-	Distance 3698
-	Radius 9.7
+	RA 9.30272016
+	Dec -45.84655466
+	Radius 136.196
+	Distance 1666.502
 }
 
-OpenCluster "ASCC 52"
+OpenCluster "UBC 1461"
 {
-	RA 9.466111
-	Dec -53.740000
-	Distance 4892
-	Radius 23.1
+	RA 9.30393427
+	Dec -53.27600356
+	Radius 76.398
+	Distance 15971.94
+}
+
+OpenCluster "Platais 8:Theia 104:Theia 953"
+{
+	RA 9.31068904
+	Dec -58.60498512
+	Radius 208.841
+	Distance 1788.022
+}
+
+OpenCluster "UBC 487"
+{
+	RA 9.31208308
+	Dec -51.58770975
+	Radius 27.812
+	Distance 5841.689
+}
+
+OpenCluster "UBC 486"
+{
+	RA 9.31478555
+	Dec -50.54156644
+	Radius 35.318
+	Distance 4549.49
+}
+
+OpenCluster "CWNU 2"
+{
+	RA 9.31720299
+	Dec -65.6491218
+	Radius 72.262
+	Distance 2312.307
+}
+
+OpenCluster "UBC 488"
+{
+	RA 9.31803184
+	Dec -53.5766607
+	Radius 52.736
+	Distance 20033.688
+}
+
+OpenCluster "Theia 149"
+{
+	RA 9.32019998
+	Dec -50.41609588
+	Radius 143.107
+	Distance 1922.811
+}
+
+OpenCluster "NGC 2849:Collinder 207:BH 61:ESO 314-13:FSR 1439:MWSC 1648:OCL 756"
+{
+	RA 9.32329523
+	Dec -40.51929389
+	Radius 178.057
+	Distance 16844.904
+}
+
+OpenCluster "HSC 2189"
+{
+	RA 9.32391936
+	Dec -46.50178856
+	Radius 102.662
+	Distance 10222.827
+}
+
+OpenCluster "BH 62:ESO 261-5:FSR 1458:MWSC 1650:OCL 765:OC 0502:Pismis 12"
+{
+	RA 9.33373309
+	Dec -45.12788009
+	Radius 58.972
+	Distance 6828.603
+}
+
+OpenCluster "CWNU 292:UBC 1456"
+{
+	RA 9.33464154
+	Dec -50.2081555
+	Radius 48.276
+	Distance 5948.603
+}
+
+OpenCluster "HSC 2120"
+{
+	RA 9.33552007
+	Dec -37.61171276
+	Radius 173.12
+	Distance 1440.728
+}
+
+OpenCluster "HSC 2179"
+{
+	RA 9.33752897
+	Dec -45.39113379
+	Radius 28.026
+	Distance 2571.983
+}
+
+OpenCluster "HSC 2184"
+{
+	RA 9.3441615
+	Dec -45.99835108
+	Radius 71.012
+	Distance 16703.025
+}
+
+OpenCluster "OC 0510"
+{
+	RA 9.35302719
+	Dec -50.82522755
+	Radius 73.094
+	Distance 7683.986
+}
+
+OpenCluster "ASCC 51:MWSC 1647:Theia 185:Theia 245:Theia 966:UBC 260"
+{
+	RA 9.35978178
+	Dec -69.8552943
+	Radius 158.806
+	Distance 1777.013
+}
+
+OpenCluster "Theia 3220:UBC 251"
+{
+	RA 9.36352876
+	Dec -51.24949248
+	Radius 64.477
+	Distance 5763.616
+}
+
+OpenCluster "BH 65:ESO 166-8:FSR 1499:MWSC 1657:OCL 786:OC 0519:Ruprecht 75:Theia 3858"
+{
+	RA 9.36550004
+	Dec -56.31266164
+	Radius 73.844
+	Distance 12900.746
+}
+
+OpenCluster "HSC 2210"
+{
+	RA 9.36709905
+	Dec -49.45612429
+	Radius 40.294
+	Distance 8027.073
+}
+
+OpenCluster "NGC 2866:BH 64:ESO 212-3:FSR 1482:MWSC 1658:OCL 774:Pismis 13"
+{
+	RA 9.36832838
+	Dec -51.09968442
+	Radius 33.975
+	Distance 8702.617
+}
+
+OpenCluster "UBC 490"
+{
+	RA 9.37075561
+	Dec -53.89782277
+	Radius 43.933
+	Distance 8263.813
+}
+
+OpenCluster "ESO 212-5:MWSC 1663:OCL 775:OC 0512:Ruprecht 76:Theia 2136:Theia 2331"
+{
+	RA 9.4051212
+	Dec -51.65070514
+	Radius 44.754
+	Distance 6018.313
+}
+
+OpenCluster "Teutsch J0924.3+5313:Teutsch J0924.3-5313"
+{
+	RA 9.40604654
+	Dec -53.21431212
+	Radius 58.487
+	Distance 16083.761
+}
+
+OpenCluster "DBSB 39:Theia 2788:UBC 489"
+{
+	RA 9.40837019
+	Dec -53.12596021
+	Radius 57.485
+	Distance 8224.972
+}
+
+OpenCluster "UBC 493"
+{
+	RA 9.41256538
+	Dec -57.33567587
+	Radius 33.511
+	Distance 5284.453
+}
+
+OpenCluster "Gulliver 57:Theia 3103"
+{
+	RA 9.41341403
+	Dec -48.06380178
+	Radius 35.12
+	Distance 4254.477
+}
+
+OpenCluster "CWNU 1394"
+{
+	RA 9.42090911
+	Dec -52.33055782
+	Radius 37.858
+	Distance 7636.183
+}
+
+OpenCluster "BH 66:ESO 166-11:MWSC 1667:UKS 2:vdBergh-Hagen 66"
+{
+	RA 9.42111125
+	Dec -54.71944957
+	Radius 170.133
+	Distance 20620.816
+}
+
+OpenCluster "UBC 1462"
+{
+	RA 9.42250769
+	Dec -52.68310879
+	Radius 30.404
+	Distance 7780.5
+}
+
+OpenCluster "Miller 1"
+{
+	RA 9.42863227
+	Dec -53.24169765
+	Radius 46.271
+	Distance 19180.917
+}
+
+OpenCluster "HSC 2228"
+{
+	RA 9.42883464
+	Dec -53.24101269
+	Radius 60.889
+	Distance 24412.279
+}
+
+OpenCluster "BH 67:ESO 212-7:FSR 1486:MWSC 1669:vdBergh-Hagen 67"
+{
+	RA 9.44562026
+	Dec -51.27311496
+	Radius 170.299
+	Distance 22626.997
+}
+
+OpenCluster "HSC 2227"
+{
+	RA 9.44706464
+	Dec -52.93301594
+	Radius 39.31
+	Distance 10873.428
+}
+
+OpenCluster "BH 68:ESO 166-12:Gulliver 7:MWSC 1670:OCL 784:Ruprecht 77"
+{
+	RA 9.45043935
+	Dec -55.12458952
+	Radius 304.43
+	Distance 22132.749
+}
+
+OpenCluster "HSC 2244"
+{
+	RA 9.45093733
+	Dec -54.97703399
+	Radius 87.164
+	Distance 1920.333
+}
+
+OpenCluster "HSC 2261"
+{
+	RA 9.45340463
+	Dec -57.72000186
+	Radius 203.612
+	Distance 31965.606
+}
+
+OpenCluster "ASCC 52:MWSC 1672:Theia 4502"
+{
+	RA 9.45485523
+	Dec -54.50968599
+	Radius 73.627
+	Distance 7663.746
+}
+
+OpenCluster "BH 68:ESO 166-12:MWSC 1670:OCL 784:Ruprecht 77"
+{
+	RA 9.45612625
+	Dec -55.09806021
+	Radius 42.428
+	Distance 10443.922
+}
+
+OpenCluster "HSC 2271"
+{
+	RA 9.45652379
+	Dec -58.95285478
+	Radius 53.784
+	Distance 1725.008
+}
+
+OpenCluster "UBC 1460"
+{
+	RA 9.45826761
+	Dec -51.47568983
+	Radius 36.295
+	Distance 10134.079
+}
+
+OpenCluster "IC 2488:Melotte 97:Collinder 208:BH 69:ESO 166-14:MWSC 1671:OCL 789:Theia 2692"
+{
+	RA 9.4591158
+	Dec -56.98788512
+	Radius 57.091
+	Distance 4259.694
+}
+
+OpenCluster "HSC 2215"
+{
+	RA 9.46120348
+	Dec -49.8298204
+	Radius 166.695
+	Distance 1699.504
+}
+
+OpenCluster "HSC 2217"
+{
+	RA 9.46383058
+	Dec -50.24894902
+	Radius 36.779
+	Distance 8616.001
+}
+
+OpenCluster "HSC 2203"
+{
+	RA 9.46615853
+	Dec -47.33034875
+	Radius 74.962
+	Distance 12530.733
+}
+
+OpenCluster "HSC 2224"
+{
+	RA 9.47398329
+	Dec -52.11785238
+	Radius 34.593
+	Distance 13841.131
+}
+
+OpenCluster "DSH J0928.5-4636:FSR 1472:MWSC 1674:SAI 107:Teutsch 103"
+{
+	RA 9.47626863
+	Dec -46.60518283
+	Radius 51.669
+	Distance 8418.604
+}
+
+OpenCluster "CWNU 383"
+{
+	RA 9.48194552
+	Dec -35.73762184
+	Radius 83.26
+	Distance 5332.931
+}
+
+OpenCluster "HSC 2399"
+{
+	RA 9.48212865
+	Dec -73.77866827
+	Radius 23.913
+	Distance 251.761
 }
 
 OpenCluster "Ruprecht 78"
 {
-	RA 9.486111
-	Dec -52.300000
-	Distance 5352
-	Radius 2.3
+	RA 9.4853168
+	Dec -53.69856243
+	Radius 155.615
+	Distance 21520.52
 }
 
-OpenCluster "NGC 2910"
+OpenCluster "HSC 2220"
 {
-	RA 9.508333
-	Dec -51.081667
-	Distance 8503
-	Radius 4.9
+	RA 9.49442655
+	Dec -50.5556385
+	Radius 38.851
+	Distance 11762.72
 }
 
-OpenCluster "Basel 20"
+OpenCluster "HSC 2180"
 {
-	RA 9.518889
-	Dec -55.583333
-	Distance 6601
-	Radius 9.6
+	RA 9.49493271
+	Dec -43.90253478
+	Radius 128.838
+	Distance 2027.02
+}
+
+OpenCluster "FSR 1407"
+{
+	RA 9.49637833
+	Dec -33.84766594
+	Radius 101.079
+	Distance 10230.097
+}
+
+OpenCluster "FSR 1484:MWSC 1677"
+{
+	RA 9.49643833
+	Dec -50.69963557
+	Radius 39.868
+	Distance 7153.001
+}
+
+OpenCluster "UBC 1464"
+{
+	RA 9.49862921
+	Dec -53.45335576
+	Radius 95.521
+	Distance 9679.346
+}
+
+OpenCluster "HSC 2241"
+{
+	RA 9.50052944
+	Dec -54.32380433
+	Radius 40.861
+	Distance 10622.821
+}
+
+OpenCluster "UBC 648"
+{
+	RA 9.50364665
+	Dec -34.14185158
+	Radius 78.022
+	Distance 13833.503
+}
+
+OpenCluster "CWNU 1300"
+{
+	RA 9.50652807
+	Dec -50.07419357
+	Radius 24.637
+	Distance 5844.587
+}
+
+OpenCluster "HSC 2218"
+{
+	RA 9.50688255
+	Dec -50.04398173
+	Radius 51.371
+	Distance 7427.088
+}
+
+OpenCluster "HSC 2270"
+{
+	RA 9.50800806
+	Dec -58.51606901
+	Radius 50.827
+	Distance 1218.309
+}
+
+OpenCluster "NGC 2910:Collinder 209:BH 71:ESO 166-17:FSR 1493:MWSC 1679:OCL 781:Theia 2765"
+{
+	RA 9.50934572
+	Dec -52.90944238
+	Radius 42.517
+	Distance 4038.789
+}
+
+OpenCluster "OC 0513"
+{
+	RA 9.51428471
+	Dec -51.42006715
+	Radius 23.767
+	Distance 5777.447
+}
+
+OpenCluster "Theia 3823:UBC 1459"
+{
+	RA 9.51737408
+	Dec -50.31374013
+	Radius 28.435
+	Distance 4698.624
+}
+
+OpenCluster "HSC 2458"
+{
+	RA 9.52099499
+	Dec -80.95191326
+	Radius 28.947
+	Distance 559.288
+}
+
+OpenCluster "BH 72:ESO 166-20:FSR 1494:MWSC 1681:OC 0516:UBC 491:vdBergh-Hagen 72"
+{
+	RA 9.52279845
+	Dec -53.04170424
+	Radius 36.3
+	Distance 14697.51
+}
+
+OpenCluster "BH 73:ESO 212-9:FSR 1483:MWSC 1682:vdBergh-Hagen 73"
+{
+	RA 9.53212511
+	Dec -50.22324762
+	Radius 64.18
+	Distance 16605.401
+}
+
+OpenCluster "Theia 5867:UBC 1469"
+{
+	RA 9.5373631
+	Dec -57.17270703
+	Radius 77.496
+	Distance 8532.116
+}
+
+OpenCluster "MWSC 1684:Theia 443:Turner 5"
+{
+	RA 9.54257544
+	Dec -36.42924371
+	Radius 82.272
+	Distance 1342.406
+}
+
+OpenCluster "CWNU 1290"
+{
+	RA 9.54368936
+	Dec -55.8236289
+	Radius 80.932
+	Distance 8269.212
+}
+
+OpenCluster "NGC 2925:UBC 1466"
+{
+	RA 9.5451707
+	Dec -53.27372895
+	Radius 85.303
+	Distance 25810.514
+}
+
+OpenCluster "CWNU 1768"
+{
+	RA 9.54955067
+	Dec -52.6125353
+	Radius 45.349
+	Distance 5844.27
+}
+
+OpenCluster "Theia 2092:UBC 1467"
+{
+	RA 9.55137646
+	Dec -54.36681555
+	Radius 134.258
+	Distance 7139.225
 }
 
 OpenCluster "NGC 2925"
 {
-	RA 9.553056
-	Dec -52.601667
-	Distance 2524
-	Radius 3.7
+	RA 9.55557082
+	Dec -53.40578606
+	Radius 62.752
+	Distance 2407.125
 }
 
-OpenCluster "Turner 5"
+OpenCluster "DSH J0933.4-5223:MWSC 1688:Teutsch 66"
 {
-	RA 9.564167
-	Dec -35.385000
-	Distance 7501
-	Radius 196.4
+	RA 9.55838708
+	Dec -52.38092845
+	Radius 54.524
+	Distance 13258.221
 }
 
-OpenCluster "Pismis 15"
+OpenCluster "Theia 2092:UBC 254"
 {
-	RA 9.579167
-	Dec -47.966667
-	Distance 9458
-	Radius 5.0
+	RA 9.57900253
+	Dec -54.38557192
+	Radius 42.05
+	Distance 5565.926
 }
 
-OpenCluster "ASCC 53"
+OpenCluster "BH 74:ESO 212-10:FSR 1480:MWSC 1690:OCL 773:Pismis 15:Theia 5512:Theia 6050"
 {
-	RA 9.631944
-	Dec -58.450000
-	Distance 8154
-	Radius 44.1
+	RA 9.57917051
+	Dec -48.04032936
+	Radius 66.923
+	Distance 7352.684
 }
 
-OpenCluster "NGC 2972"
+OpenCluster "HSC 2239"
 {
-	RA 9.670000
-	Dec -49.676667
-	Distance 6725
-	Radius 2.9
+	RA 9.58633503
+	Dec -53.1514055
+	Radius 47.829
+	Distance 2108.604
 }
 
-OpenCluster "Ruprecht 79"
+OpenCluster "BH 75:Theia 2092:Theia 2114:vdBergh-Hagen 75"
 {
-	RA 9.683056
-	Dec -52.150000
-	Distance 6454
-	Radius 4.7
+	RA 9.58671274
+	Dec -54.62675864
+	Radius 87.635
+	Distance 7385.543
 }
 
-OpenCluster "Ruprecht 80"
+OpenCluster "UBC 494"
 {
-	RA 9.700833
-	Dec -43.983333
-	Distance 4657
-	Radius 8.1
+	RA 9.59198346
+	Dec -57.31336166
+	Radius 55.552
+	Distance 11703.117
 }
 
-OpenCluster "ASCC 54"
+OpenCluster "PHOC 22"
 {
-	RA 9.746111
-	Dec -53.560000
-	Distance 3914
-	Radius 15.0
+	RA 9.60084931
+	Dec -56.58332729
+	Radius 46.863
+	Distance 8181.382
 }
 
-OpenCluster "Ruprecht 82"
+OpenCluster "HSC 2260"
 {
-	RA 9.762778
-	Dec -54.000000
-	Distance 8007
-	Radius 5.8
+	RA 9.61975954
+	Dec -56.00225772
+	Radius 124.426
+	Distance 1372.338
 }
 
-OpenCluster "NGC 3033"
+OpenCluster "FSR 1500:MWSC 1695"
 {
-	RA 9.810278
-	Dec -55.578333
-	Distance 3007
-	Radius 1.7
+	RA 9.62753376
+	Dec -53.96517781
+	Radius 96.692
+	Distance 18764.222
 }
 
-OpenCluster "Ruprecht 84"
+OpenCluster "PHOC 30"
 {
-	RA 9.818889
-	Dec -64.750000
-	Distance 8154
-	Radius 4.7
+	RA 9.64766768
+	Dec -51.22409474
+	Radius 60.009
+	Distance 5681.956
 }
 
-OpenCluster "Ruprecht 83"
+OpenCluster "OC 0523"
 {
-	RA 9.820833
-	Dec -53.400000
-	Distance 8020
-	Radius 3.5
+	RA 9.64881003
+	Dec -54.51379855
+	Radius 67.879
+	Distance 13526.161
 }
 
-OpenCluster "NGC 3036"
+OpenCluster "HSC 2234"
 {
-	RA 9.821111
-	Dec -61.328333
-	Distance 3914
-	Radius 2.3
+	RA 9.64922083
+	Dec -52.00003506
+	Radius 32.854
+	Distance 3186.105
 }
 
-OpenCluster "Pismis 16"
+OpenCluster "MWSC 1698:OC 0517:SAI 108"
 {
-	RA 9.854444
-	Dec -52.833333
-	Distance 5949
-	Radius 1.7
+	RA 9.64943263
+	Dec -52.93633731
+	Radius 32.078
+	Distance 11018.039
 }
 
-OpenCluster "ASCC 55"
+OpenCluster "Theia 2145:Theia 2310:Theia 2765:Theia 3127:Theia 3439:Theia 4547:Theia 4603"
 {
-	RA 9.905000
-	Dec -56.920000
-	Distance 3587
-	Radius 14.4
+	RA 9.65017314
+	Dec -54.07070512
+	Radius 163.092
+	Distance 4942.903
 }
 
-OpenCluster "Collinder 213"
+OpenCluster "HSC 2273"
 {
-	RA 9.911944
-	Dec -49.083333
-	Distance 4566
-	Radius 11.3
+	RA 9.65902069
+	Dec -57.28064095
+	Radius 25.168
+	Distance 7673.39
 }
 
-OpenCluster "NGC 3105"
+OpenCluster "CWNU 2472"
 {
-	RA 10.010833
-	Dec -53.211667
-	Distance 27822
-	Radius 8.1
+	RA 9.65977705
+	Dec -55.26486778
+	Radius 43.199
+	Distance 10159.197
 }
 
-OpenCluster "Ruprecht 85"
+OpenCluster "CWNU 1833"
 {
-	RA 10.023889
-	Dec -54.883333
-	Distance 2716
-	Radius 1.2
+	RA 9.66194453
+	Dec -51.58691336
+	Radius 49.751
+	Distance 6442.035
 }
 
-OpenCluster "NGC 3114"
+OpenCluster "HSC 2248"
 {
-	RA 10.043333
-	Dec -59.880000
-	Distance 2971
-	Radius 15.1
+	RA 9.66274826
+	Dec -53.70640874
+	Radius 50.465
+	Distance 11643.701
 }
 
-OpenCluster "Loden 28"
+OpenCluster "UBC 495"
 {
-	RA 10.053333
-	Dec -57.850000
-	Distance 12883
-	Radius 37.5
+	RA 9.66345612
+	Dec -57.27421242
+	Radius 52.371
+	Distance 12729.652
 }
 
-OpenCluster "Trumpler 11"
+OpenCluster "OC 0521"
 {
-	RA 10.081667
-	Dec -60.400000
-	Distance 10111
-	Radius 7.4
+	RA 9.66432325
+	Dec -54.04152866
+	Radius 71.82
+	Distance 8798.018
 }
 
-OpenCluster "Loden 1"
+OpenCluster "HSC 2282"
 {
-	RA 10.084167
-	Dec -54.200000
-	Distance 1174
-	Radius 3.6
+	RA 9.66866366
+	Dec -58.85733082
+	Radius 246.675
+	Distance 1404.783
 }
 
-OpenCluster "Trumpler 12"
+OpenCluster "NGC 2972:Collinder 211:BH 76:ESO 212-11:MWSC 1699:OCL 778:Theia 4052"
 {
-	RA 10.108056
-	Dec -59.700000
-	Distance 4073
-	Radius 2.4
+	RA 9.67078769
+	Dec -50.32449364
+	Radius 45.283
+	Distance 6166.141
 }
 
-OpenCluster "Hogg 6"
+OpenCluster "UBC 650"
 {
-	RA 10.110278
-	Dec -59.500000
-	Distance 6523
-	Radius 2.8
+	RA 9.67478196
+	Dec -49.68433253
+	Radius 40.121
+	Distance 10127.085
 }
 
-OpenCluster "ASCC 56"
+OpenCluster "NGC 2972:Collinder 211:BH 76:CWNU 1671:ESO 212-11:MWSC 1699:OCL 778"
 {
-	RA 10.136944
-	Dec -63.630000
-	Distance 2609
-	Radius 15.9
+	RA 9.67516765
+	Dec -50.25954837
+	Radius 67.146
+	Distance 6363.932
 }
 
-OpenCluster "Ruprecht 161"
+OpenCluster "HSC 2231"
 {
-	RA 10.146111
-	Dec -60.750000
-	Distance 4657
-	Radius 21.7
+	RA 9.67970954
+	Dec -51.24560344
+	Radius 37.904
+	Distance 506.842
 }
 
-OpenCluster "ASCC 57"
+OpenCluster "BH 77:ESO 167-11:FSR 1502:MWSC 1701:OCL 787:Ruprecht 79"
 {
-	RA 10.180000
-	Dec -65.320000
-	Distance 4892
-	Radius 32.4
+	RA 9.68407995
+	Dec -53.83437023
+	Radius 105.022
+	Distance 11817.088
 }
 
-OpenCluster "BH 90"
+OpenCluster "HSC 2272"
 {
-	RA 10.202778
-	Dec -57.933333
-	Distance 8389
-	Radius 4.9
+	RA 9.69245109
+	Dec -56.94694938
+	Radius 39.717
+	Distance 14341.083
 }
 
-OpenCluster "ESO 092-18"
+OpenCluster "HSC 2319"
 {
-	RA 10.249444
-	Dec -63.388333
-	Distance 34596
-	Radius 25.2
+	RA 9.69665459
+	Dec -62.7052606
+	Radius 41.034
+	Distance 6601.514
 }
 
-OpenCluster "ASCC 58"
+OpenCluster "HSC 2257"
 {
-	RA 10.251944
-	Dec -53.030000
-	Distance 1957
-	Radius 13.7
+	RA 9.69834257
+	Dec -54.35545026
+	Radius 56.83
+	Distance 3749.281
 }
 
-OpenCluster "BH 91"
+OpenCluster "CWNU 1673"
 {
-	RA 10.288333
-	Dec -57.300000
-	Distance 2964
-	Radius 2.2
+	RA 9.69960049
+	Dec -56.31624325
+	Radius 88.144
+	Distance 10518.304
 }
 
-OpenCluster "BH 92"
+OpenCluster "CWNU 1459"
 {
-	RA 10.318611
-	Dec -55.583333
-	Distance 4073
-	Radius 1.2
+	RA 9.70566695
+	Dec -38.45806131
+	Radius 174.578
+	Distance 12030.748
 }
 
-OpenCluster "ASCC 59"
+OpenCluster "CWNU 2354"
 {
-	RA 10.336944
-	Dec -56.350000
-	Distance 1793
-	Radius 11.0
+	RA 9.70590182
+	Dec -52.16032604
+	Radius 90.378
+	Distance 15060.85
 }
 
-OpenCluster "NGC 3228"
+OpenCluster "HSC 2298"
 {
-	RA 10.356111
-	Dec -50.271667
-	Distance 1774
-	Radius 1.3
+	RA 9.71523987
+	Dec -60.39247443
+	Radius 78.469
+	Distance 2019.729
 }
 
-OpenCluster "Loden 46"
+OpenCluster "CWNU 2493:FSR 1496"
 {
-	RA 10.383333
-	Dec -53.200000
-	Distance 1761
-	Radius 9.7
+	RA 9.71568195
+	Dec -52.11859734
+	Radius 48.678
+	Distance 11934.344
 }
 
-OpenCluster "Trumpler 13"
+OpenCluster "Theia 2145"
 {
-	RA 10.396667
-	Dec -59.866667
-	Distance 7828
-	Radius 5.7
+	RA 9.72020715
+	Dec -54.29992742
+	Radius 91.964
+	Distance 12229.976
+}
+
+OpenCluster "Theia 5426"
+{
+	RA 9.72621581
+	Dec -53.97383624
+	Radius 158.86
+	Distance 17983.978
+}
+
+OpenCluster "HSC 2223"
+{
+	RA 9.72681987
+	Dec -49.03412049
+	Radius 32.206
+	Distance 4648.771
+}
+
+OpenCluster "MWSC 1705:SAI 109"
+{
+	RA 9.72813225
+	Dec -50.79475487
+	Radius 99
+	Distance 20148.768
+}
+
+OpenCluster "BH 78:FSR 1512:MWSC 1706:vdBergh-Hagen 78"
+{
+	RA 9.73006601
+	Dec -56.57429224
+	Radius 69.545
+	Distance 20376.453
+}
+
+OpenCluster "HSC 2232"
+{
+	RA 9.73853969
+	Dec -50.66077544
+	Radius 71.535
+	Distance 3246.42
+}
+
+OpenCluster "DSH J0944.3-5407:FSR 1504:Gulliver 27:Teutsch 68:Theia 3127"
+{
+	RA 9.73916757
+	Dec -54.11244295
+	Radius 33.716
+	Distance 8827.413
+}
+
+OpenCluster "BH 79:CWNU 2646:MWSC 1708:vdBergh-Hagen 79"
+{
+	RA 9.74420559
+	Dec -53.27497294
+	Radius 92.802
+	Distance 9904.217
+}
+
+OpenCluster "CWNU 2757:Theia 4025:Theia 5094"
+{
+	RA 9.75094061
+	Dec -56.60239545
+	Radius 62.397
+	Distance 5111.368
+}
+
+OpenCluster "HSC 2335"
+{
+	RA 9.75359975
+	Dec -64.29222746
+	Radius 61.927
+	Distance 675.265
+}
+
+OpenCluster "ESO 167-5:MWSC 1711:OCL 788:Ruprecht 82:Theia 3127:Theia 5426"
+{
+	RA 9.76207737
+	Dec -54.0024347
+	Radius 62.535
+	Distance 6888.086
+}
+
+OpenCluster "FoF 2236:Theia 1242:UBC 256:UPK 549"
+{
+	RA 9.76552081
+	Dec -52.48209161
+	Radius 60.943
+	Distance 3238.623
+}
+
+OpenCluster "CWNU 1272"
+{
+	RA 9.76712093
+	Dec -51.88501062
+	Radius 35.872
+	Distance 8083.924
+}
+
+OpenCluster "UBC 1468"
+{
+	RA 9.77231458
+	Dec -53.58532914
+	Radius 73.307
+	Distance 13407.629
+}
+
+OpenCluster "HSC 2274"
+{
+	RA 9.78199553
+	Dec -56.1410404
+	Radius 52.956
+	Distance 16937.269
+}
+
+OpenCluster "Theia 1315"
+{
+	RA 9.79173967
+	Dec -65.11506968
+	Radius 135.352
+	Distance 1409.961
+}
+
+OpenCluster "HSC 2233"
+{
+	RA 9.7918094
+	Dec -50.43141127
+	Radius 25.943
+	Distance 3126.162
+}
+
+OpenCluster "CWNU 184:Theia 2890:Theia 6111:UBC 1465"
+{
+	RA 9.79366125
+	Dec -50.55166904
+	Radius 74.115
+	Distance 4857.59
+}
+
+OpenCluster "HSC 2275"
+{
+	RA 9.7961029
+	Dec -56.45797984
+	Radius 56.789
+	Distance 14773.665
+}
+
+OpenCluster "HSC 2266"
+{
+	RA 9.79751872
+	Dec -55.51850533
+	Radius 93.761
+	Distance 2133.58
+}
+
+OpenCluster "OC 0531"
+{
+	RA 9.80415478
+	Dec -58.18475698
+	Radius 85.928
+	Distance 5967.696
+}
+
+OpenCluster "HSC 2288"
+{
+	RA 9.80474968
+	Dec -58.19292011
+	Radius 81.942
+	Distance 4463.88
+}
+
+OpenCluster "NGC 3033:Collinder 212:ESO 167-6:MWSC 1715:OCL 796"
+{
+	RA 9.80982972
+	Dec -56.41172819
+	Radius 43.729
+	Distance 5635.633
+}
+
+OpenCluster "HSC 2294"
+{
+	RA 9.81135782
+	Dec -58.6680575
+	Radius 83.813
+	Distance 13470.377
+}
+
+OpenCluster "CWNU 2526:Theia 4371"
+{
+	RA 9.81228854
+	Dec -51.261497
+	Radius 51.859
+	Distance 10101.706
+}
+
+OpenCluster "HSC 2249"
+{
+	RA 9.81634932
+	Dec -52.13794754
+	Radius 23.83
+	Distance 7361.912
+}
+
+OpenCluster "ESO 91-19:FSR 1544:MWSC 1717:OCL 814:Ruprecht 84"
+{
+	RA 9.81841261
+	Dec -65.26095582
+	Radius 65.479
+	Distance 5988.651
+}
+
+OpenCluster "HSC 2304"
+{
+	RA 9.82099257
+	Dec -60.18446359
+	Radius 54.211
+	Distance 3491.305
+}
+
+OpenCluster "BH 80:ESO 167-7:FSR 1508:MWSC 1718:OCL 791:OC 0526:OC 0527:OC 0528:Ruprecht 83"
+{
+	RA 9.82163897
+	Dec -54.60621968
+	Radius 65.904
+	Distance 11444.15
+}
+
+OpenCluster "HSC 2290"
+{
+	RA 9.83657634
+	Dec -58.07867525
+	Radius 27.288
+	Distance 3892.338
+}
+
+OpenCluster "UBC 1622"
+{
+	RA 9.83994372
+	Dec -48.21819076
+	Radius 46.613
+	Distance 7950.438
+}
+
+OpenCluster "HSC 2107"
+{
+	RA 9.84952648
+	Dec -28.98392228
+	Radius 32.214
+	Distance 6126.366
+}
+
+OpenCluster "HSC 2333"
+{
+	RA 9.85102867
+	Dec -63.4171802
+	Radius 84.246
+	Distance 24061.359
+}
+
+OpenCluster "BH 81:ESO 167-8:MWSC 1721:OCL 790:OC 0524:Pismis 16"
+{
+	RA 9.85452463
+	Dec -53.1756621
+	Radius 79.095
+	Distance 7915.464
+}
+
+OpenCluster "HSC 2284"
+{
+	RA 9.85912611
+	Dec -57.31213209
+	Radius 113.01
+	Distance 23642.529
+}
+
+OpenCluster "HSC 2327"
+{
+	RA 9.88223668
+	Dec -62.20127401
+	Radius 102.86
+	Distance 726.864
+}
+
+OpenCluster "HD 85891:MF 1:Moffat-Fitzgerald 1:Theia 2106:Theia 3929:UBC 1471"
+{
+	RA 9.88460973
+	Dec -55.02761742
+	Radius 46.109
+	Distance 7634.904
+}
+
+OpenCluster "OC 0530"
+{
+	RA 9.88533588
+	Dec -57.40196282
+	Radius 33.823
+	Distance 8693.903
+}
+
+OpenCluster "HSC 2013"
+{
+	RA 9.88746611
+	Dec -13.57023679
+	Radius 68.035
+	Distance 763.928
+}
+
+OpenCluster "UBC 651"
+{
+	RA 9.89491404
+	Dec -55.7409034
+	Radius 48.902
+	Distance 10703.274
+}
+
+OpenCluster "Collinder 213:ESO 213-4:MWSC 1725:OCL 785:UBC 492"
+{
+	RA 9.90880683
+	Dec -50.89791991
+	Radius 106.023
+	Distance 7200.854
+}
+
+OpenCluster "HSC 2280"
+{
+	RA 9.9186505
+	Dec -56.26136062
+	Radius 120.06
+	Distance 1824.006
+}
+
+OpenCluster "HSC 1559"
+{
+	RA 9.9194054
+	Dec 30.81307633
+	Radius 62.762
+	Distance 506.095
+}
+
+OpenCluster "FSR 1521:MWSC 1727:SAI 111"
+{
+	RA 9.92202133
+	Dec -56.61746391
+	Radius 71.674
+	Distance 11655.056
+}
+
+OpenCluster "HSC 2311"
+{
+	RA 9.92446638
+	Dec -59.9543455
+	Radius 112.347
+	Distance 35252.843
+}
+
+OpenCluster "UBC 1470"
+{
+	RA 9.92688706
+	Dec -54.13366118
+	Radius 123.433
+	Distance 9392.028
+}
+
+OpenCluster "HSC 1138"
+{
+	RA 9.93185912
+	Dec 69.11983391
+	Radius 322.968
+	Distance 11218.24
+}
+
+OpenCluster "OC 0534:Theia 6242:Theia 6850"
+{
+	RA 9.93371881
+	Dec -60.18405576
+	Radius 58.719
+	Distance 8942.993
+}
+
+OpenCluster "CWNU 2321"
+{
+	RA 9.94638736
+	Dec -55.82767504
+	Radius 42.029
+	Distance 11465.663
+}
+
+OpenCluster "CWNU 264"
+{
+	RA 9.9466932
+	Dec -60.52954639
+	Radius 28.775
+	Distance 4126.019
+}
+
+OpenCluster "CWNU 1375"
+{
+	RA 9.94866
+	Dec -57.53227823
+	Radius 41.47
+	Distance 4764.671
+}
+
+OpenCluster "HSC 2281"
+{
+	RA 9.95159693
+	Dec -56.04558745
+	Radius 130.42
+	Distance 7707.934
+}
+
+OpenCluster "HSC 2235"
+{
+	RA 9.96103898
+	Dec -48.39258159
+	Radius 100.28
+	Distance 1718.319
+}
+
+OpenCluster "ESO 167-13:FSR 1515:Hogg 4:MWSC 1734:OCL 793"
+{
+	RA 9.96182088
+	Dec -54.63244661
+	Radius 81.009
+	Distance 11903.815
+}
+
+OpenCluster "Theia 2121"
+{
+	RA 9.96271747
+	Dec -58.0599346
+	Radius 108.419
+	Distance 12398.05
+}
+
+OpenCluster "CWNU 1843"
+{
+	RA 9.96392412
+	Dec -55.56461751
+	Radius 36.167
+	Distance 6776.041
+}
+
+OpenCluster "HSC 2166"
+{
+	RA 9.97624918
+	Dec -35.81772981
+	Radius 65.894
+	Distance 1048.181
+}
+
+OpenCluster "CWNU 2452"
+{
+	RA 9.99252411
+	Dec -58.71267017
+	Radius 116.156
+	Distance 15045.384
+}
+
+OpenCluster "CWNU 2678"
+{
+	RA 9.99581653
+	Dec -58.12425202
+	Radius 52.493
+	Distance 8839.758
+}
+
+OpenCluster "CWNU 1863"
+{
+	RA 9.99712629
+	Dec -53.28407341
+	Radius 35.223
+	Distance 9089.252
+}
+
+OpenCluster "NGC 3105:Collinder 214:BH 82:ESO 167-14:FSR 1519:MWSC 1742:OCL 798"
+{
+	RA 10.01150868
+	Dec -54.78939624
+	Radius 162.075
+	Distance 22778.301
+}
+
+OpenCluster "BH 84:vdBergh-Hagen 84"
+{
+	RA 10.02203552
+	Dec -58.22375019
+	Radius 45.191
+	Distance 12403.884
+}
+
+OpenCluster "BH 83:ESO 167-15:FSR 1520:MWSC 1746:OCL 799:Ruprecht 85"
+{
+	RA 10.02416468
+	Dec -55.10945131
+	Radius 96.49
+	Distance 15522.405
+}
+
+OpenCluster "BH 84:Gulliver 35:vdBergh-Hagen 84"
+{
+	RA 10.02529298
+	Dec -58.20612049
+	Radius 43.516
+	Distance 6996.006
+}
+
+OpenCluster "HSC 2302"
+{
+	RA 10.02657082
+	Dec -57.79406859
+	Radius 25.46
+	Distance 7408.787
+}
+
+OpenCluster "BH 85:ESO 213-5:FSR 1501:MWSC 1748:MWSC 1750:OC 0520:vdBergh-Hagen 85"
+{
+	RA 10.03108831
+	Dec -49.56158275
+	Radius 77.798
+	Distance 19801.747
+}
+
+OpenCluster "CWNU 1590"
+{
+	RA 10.03202111
+	Dec -51.87790523
+	Radius 63.855
+	Distance 4983.603
+}
+
+OpenCluster "HSC 2367"
+{
+	RA 10.03272849
+	Dec -66.62477413
+	Radius 55.03
+	Distance 9779.721
+}
+
+OpenCluster "HSC 2268"
+{
+	RA 10.03535609
+	Dec -53.01434294
+	Radius 71.705
+	Distance 6047.615
+}
+
+OpenCluster "NGC 3114:Melotte 98:Collinder 215:BH 86:ESO 127-2:MWSC 1749:OCL 802:Theia 293:Theia 295"
+{
+	RA 10.03770473
+	Dec -60.00720924
+	Radius 105.11
+	Distance 3217.691
+}
+
+OpenCluster "ESO 092-05:ESO 092-92:ESO 092 05:ESO 92-18:ESO 92-5:MWSC 1752:MWSC 1781"
+{
+	RA 10.0526546
+	Dec -64.75443606
+	Radius 272.37
+	Distance 36364.645
+}
+
+OpenCluster "HSC 2351"
+{
+	RA 10.05811329
+	Dec -64.72277498
+	Radius 136.76
+	Distance 609.553
+}
+
+OpenCluster "DBSB 43"
+{
+	RA 10.0630733
+	Dec -59.2257722
+	Radius 114.872
+	Distance 14675.96
+}
+
+OpenCluster "HSC 2286"
+{
+	RA 10.06865186
+	Dec -55.09561223
+	Radius 30.451
+	Distance 5990.179
+}
+
+OpenCluster "UBC 1473"
+{
+	RA 10.07569213
+	Dec -55.59327234
+	Radius 166.907
+	Distance 8269.64
+}
+
+OpenCluster "CWNU 2702"
+{
+	RA 10.07569393
+	Dec -60.0493886
+	Radius 48.421
+	Distance 9366.076
+}
+
+OpenCluster "BH 87:OC 0532:Theia 2288:Theia 2644:vdBergh-Hagen 87"
+{
+	RA 10.07636765
+	Dec -55.39112823
+	Radius 120.411
+	Distance 7104.727
+}
+
+OpenCluster "Collinder 216:ESO 127-5:MWSC 1757:OCL 808:OC 0539:Trumpler 11"
+{
+	RA 10.08336821
+	Dec -61.61768676
+	Radius 82.007
+	Distance 11083.54
+}
+
+OpenCluster "HSC 2315"
+{
+	RA 10.08391278
+	Dec -58.57577907
+	Radius 78.394
+	Distance 7875.893
+}
+
+OpenCluster "HSC 2320"
+{
+	RA 10.08855363
+	Dec -59.18454607
+	Radius 43.447
+	Distance 15138.117
+}
+
+OpenCluster "Theia 453"
+{
+	RA 10.10321924
+	Dec -55.65136868
+	Radius 73.571
+	Distance 2178.824
+}
+
+OpenCluster "HSC 2355"
+{
+	RA 10.1053208
+	Dec -64.84008927
+	Radius 40.611
+	Distance 4631.707
+}
+
+OpenCluster "BH 88:MWSC 1764:OC 0529:vdBergh-Hagen 88"
+{
+	RA 10.10769926
+	Dec -51.55472154
+	Radius 32.528
+	Distance 5689.245
+}
+
+OpenCluster "BH 89:Collinder 217:ESO 127-7:FSR 1537:MWSC 1763:OCL 803:OC 0538:Trumpler 12"
+{
+	RA 10.1082497
+	Dec -60.29464852
+	Radius 79.963
+	Distance 10699.629
+}
+
+OpenCluster "FSR 1527:MWSC 1765"
+{
+	RA 10.11021042
+	Dec -57.42709009
+	Radius 72.373
+	Distance 7846.41
+}
+
+OpenCluster "CWNU 1553"
+{
+	RA 10.11099046
+	Dec -55.4388919
+	Radius 54.93
+	Distance 10752.699
+}
+
+OpenCluster "PHOC 12:Theia 2448"
+{
+	RA 10.12841953
+	Dec -59.72866523
+	Radius 102.329
+	Distance 5859.528
+}
+
+OpenCluster "Theia 5091:UBC 511"
+{
+	RA 10.13085093
+	Dec -70.74594149
+	Radius 44.343
+	Distance 4203.147
+}
+
+OpenCluster "HSC 2321"
+{
+	RA 10.14678909
+	Dec -58.89428343
+	Radius 20.785
+	Distance 4939.54
+}
+
+OpenCluster "FSR 1530"
+{
+	RA 10.14946427
+	Dec -57.28183629
+	Radius 44.265
+	Distance 15238.781
+}
+
+OpenCluster "ESO 127-9:MWSC 1773:OCL 810:Ruprecht 161:Theia 295"
+{
+	RA 10.15446308
+	Dec -61.24555585
+	Radius 75.761
+	Distance 2873.335
+}
+
+OpenCluster "Theia 1075"
+{
+	RA 10.1677261
+	Dec -55.31159374
+	Radius 81.048
+	Distance 2957.403
+}
+
+OpenCluster "ESO 127-9:MWSC 1773:OCL 810:Ruprecht 161:Theia 295"
+{
+	RA 10.16937513
+	Dec -61.47662781
+	Radius 35.236
+	Distance 4630.478
+}
+
+OpenCluster "HSC 2296"
+{
+	RA 10.17020576
+	Dec -54.95724752
+	Radius 78.166
+	Distance 8976.607
+}
+
+OpenCluster "HSC 2161"
+{
+	RA 10.17319336
+	Dec -32.00372892
+	Radius 161.123
+	Distance 6392.683
+}
+
+OpenCluster "UBC 1475"
+{
+	RA 10.18743809
+	Dec -59.08586745
+	Radius 76.391
+	Distance 11477.685
+}
+
+OpenCluster "CWNU 2072"
+{
+	RA 10.20121522
+	Dec -58.18328904
+	Radius 23.069
+	Distance 5158.518
+}
+
+OpenCluster "BH 90:vdBergh-Hagen 90"
+{
+	RA 10.20347588
+	Dec -58.07528763
+	Radius 75.84
+	Distance 8084.583
+}
+
+OpenCluster "HSC 2305"
+{
+	RA 10.20547496
+	Dec -56.48274826
+	Radius 86.527
+	Distance 7851.608
+}
+
+OpenCluster "FoF 2059:OC 0540:Theia 295:Theia 5358:Theia 5606:UBC 257"
+{
+	RA 10.21210938
+	Dec -60.95338126
+	Radius 53.798
+	Distance 6251.705
+}
+
+OpenCluster "HSC 2322"
+{
+	RA 10.21303635
+	Dec -58.16755484
+	Radius 73.16
+	Distance 12550.901
+}
+
+OpenCluster "HSC 2289"
+{
+	RA 10.21474806
+	Dec -53.78572045
+	Radius 44.708
+	Distance 5560.678
+}
+
+OpenCluster "Theia 2436"
+{
+	RA 10.22636654
+	Dec -54.63203221
+	Radius 58.862
+	Distance 5617.093
+}
+
+OpenCluster "HSC 2194"
+{
+	RA 10.23032537
+	Dec -35.27494296
+	Radius 45.19
+	Distance 5798.892
+}
+
+OpenCluster "CWNU 61"
+{
+	RA 10.23469663
+	Dec -71.04131609
+	Radius 85.189
+	Distance 1752.693
+}
+
+OpenCluster "CWNU 2304"
+{
+	RA 10.23557406
+	Dec -58.32122831
+	Radius 123.585
+	Distance 10908.421
+}
+
+OpenCluster "ASCC 58:MWSC 1782:Theia 453"
+{
+	RA 10.24703946
+	Dec -55.02031159
+	Radius 99.1
+	Distance 1537.625
+}
+
+OpenCluster "HSC 2365"
+{
+	RA 10.24898088
+	Dec -64.61671013
+	Radius 29.797
+	Distance 16296.24
+}
+
+OpenCluster "ESO 092-18:ESO 092-92:ESO 092 18:ESO 92-18:ESO 92-5:MWSC 1752:MWSC 1781"
+{
+	RA 10.24899391
+	Dec -64.61269069
+	Radius 90.372
+	Distance 37041.341
+}
+
+OpenCluster "HSC 2306"
+{
+	RA 10.24984521
+	Dec -56.16857104
+	Radius 62.262
+	Distance 8230.086
+}
+
+OpenCluster "LISC 0192:OC 0537"
+{
+	RA 10.25119585
+	Dec -58.23448793
+	Radius 157.878
+	Distance 12728.564
+}
+
+OpenCluster "ASCC 58:CWNU 265:MWSC 1782"
+{
+	RA 10.25130852
+	Dec -54.60047242
+	Radius 38.918
+	Distance 4084.613
+}
+
+OpenCluster "HSC 2464"
+{
+	RA 10.25440177
+	Dec -79.44799683
+	Radius 38.167
+	Distance 775.323
+}
+
+OpenCluster "CWNU 1579"
+{
+	RA 10.25673925
+	Dec -57.07678828
+	Radius 147.592
+	Distance 7559.377
+}
+
+OpenCluster "UBC 1474"
+{
+	RA 10.25733623
+	Dec -57.37887983
+	Radius 73.255
+	Distance 5275.201
+}
+
+OpenCluster "HSC 2263"
+{
+	RA 10.25778406
+	Dec -49.40015269
+	Radius 85.755
+	Distance 895.004
+}
+
+OpenCluster "HSC 2309"
+{
+	RA 10.25920676
+	Dec -56.26038827
+	Radius 69.164
+	Distance 5526.053
+}
+
+OpenCluster "HSC 2330"
+{
+	RA 10.26482942
+	Dec -59.03466412
+	Radius 50.23
+	Distance 10020.241
+}
+
+OpenCluster "CWNU 2138"
+{
+	RA 10.29170601
+	Dec -55.5935279
+	Radius 49.804
+	Distance 6461.768
+}
+
+OpenCluster "HSC 2324"
+{
+	RA 10.30142633
+	Dec -57.29509865
+	Radius 29.796
+	Distance 7669.384
+}
+
+OpenCluster "HSC 2325"
+{
+	RA 10.30584723
+	Dec -57.32709779
+	Radius 124.772
+	Distance 16394.426
+}
+
+OpenCluster "CWNU 2300"
+{
+	RA 10.30774675
+	Dec -59.8225832
+	Radius 53.103
+	Distance 12871.879
+}
+
+OpenCluster "BH 92:ESO 168-1:FSR 1533:MWSC 1791:OC 0535:vdBergh-Hagen 92"
+{
+	RA 10.31825509
+	Dec -56.42269665
+	Radius 56.747
+	Distance 7813.666
+}
+
+OpenCluster "HSC 2287"
+{
+	RA 10.31899055
+	Dec -52.02970569
+	Radius 177.912
+	Distance 24827.394
+}
+
+OpenCluster "HSC 2251"
+{
+	RA 10.32538454
+	Dec -45.52332856
+	Radius 192.606
+	Distance 1325.744
+}
+
+OpenCluster "HSC 2329"
+{
+	RA 10.33091008
+	Dec -57.91154158
+	Radius 71.18
+	Distance 9863.95
+}
+
+OpenCluster "HSC 2334"
+{
+	RA 10.34001774
+	Dec -58.63562239
+	Radius 43.96
+	Distance 11523.685
+}
+
+OpenCluster "OC 0541:Theia 3949:UBC 498"
+{
+	RA 10.34108733
+	Dec -59.6799485
+	Radius 68.01
+	Distance 9558.411
+}
+
+OpenCluster "UBC 1476"
+{
+	RA 10.34426502
+	Dec -57.92514288
+	Radius 32.697
+	Distance 9135.193
+}
+
+OpenCluster "Theia 411"
+{
+	RA 10.34890745
+	Dec -60.68370883
+	Radius 146.514
+	Distance 2243.943
+}
+
+OpenCluster "NGC 3228:Collinder 218:BH 93:ESO 214-1:MWSC 1794:OCL 800:Theia 102"
+{
+	RA 10.35185533
+	Dec -51.84506453
+	Radius 67.346
+	Distance 1556.169
+}
+
+OpenCluster "CWNU 287"
+{
+	RA 10.35330224
+	Dec -55.97186833
+	Radius 40.97
+	Distance 1406.348
+}
+
+OpenCluster "UBC 1477"
+{
+	RA 10.35353382
+	Dec -58.98113606
+	Radius 28.181
+	Distance 9808.321
+}
+
+OpenCluster "DSH J1021.4-5427:FSR 1528:MWSC 1795:Teutsch 44"
+{
+	RA 10.35652702
+	Dec -54.44901028
+	Radius 96.303
+	Distance 20072.529
+}
+
+OpenCluster "ASCC 59:MWSC 1793"
+{
+	RA 10.35973594
+	Dec -57.67908029
+	Radius 33.438
+	Distance 6240.366
+}
+
+OpenCluster "HSC 2332"
+{
+	RA 10.37269178
+	Dec -58.11910764
+	Radius 68.618
+	Distance 14857.421
+}
+
+OpenCluster "SAI 113"
+{
+	RA 10.37827355
+	Dec -59.508965
+	Radius 75.337
+	Distance 13458.062
+}
+
+OpenCluster "Loden 46:MWSC 1798:Theia 4106"
+{
+	RA 10.39183489
+	Dec -54.67692501
+	Radius 59.218
+	Distance 3554.295
+}
+
+OpenCluster "BH 94:Collinder 219:ESO 127-17:MWSC 1800:OCL 815:Trumpler 13"
+{
+	RA 10.39711163
+	Dec -60.13826334
+	Radius 146.477
+	Distance 13762.672
+}
+
+OpenCluster "HSC 2312"
+{
+	RA 10.39748119
+	Dec -54.63656098
+	Radius 24.708
+	Distance 5422.057
 }
 
 OpenCluster "Westerlund 2"
 {
-	RA 10.400556
-	Dec -56.233333
-	Distance 20874
-	Radius 6.1
+	RA 10.40023179
+	Dec -57.75556637
+	Radius 85.004
+	Distance 14783.768
 }
 
-OpenCluster "Collinder 220"
+OpenCluster "CWNU 1816"
 {
-	RA 10.431111
-	Dec -56.073333
-	Distance 5045
-	Radius 7.0
+	RA 10.41278732
+	Dec -57.27765581
+	Radius 98.911
+	Distance 7335.286
 }
 
-OpenCluster "NGC 3255"
+OpenCluster "UBC 503"
 {
-	RA 10.441944
-	Dec -59.323333
-	Distance 4713
-	Radius 1.4
+	RA 10.41760789
+	Dec -62.32377393
+	Radius 71.043
+	Distance 6468.375
+}
+
+OpenCluster "FoF 5:Theia 7784:UBC 274"
+{
+	RA 10.42156338
+	Dec -72.54640421
+	Radius 104.634
+	Distance 5884.466
+}
+
+OpenCluster "Theia 3227:UBC 1478"
+{
+	RA 10.42261463
+	Dec -59.08031226
+	Radius 29.51
+	Distance 11070.254
+}
+
+OpenCluster "NGC 3247:Collinder 220:ESO 127-19:MWSC 1803:OCL 809"
+{
+	RA 10.4281681
+	Dec -57.9234578
+	Radius 77.955
+	Distance 7547.328
+}
+
+OpenCluster "HSC 2339"
+{
+	RA 10.43041047
+	Dec -58.58677637
+	Radius 25.945
+	Distance 11114.7
+}
+
+OpenCluster "HSC 2398"
+{
+	RA 10.43236584
+	Dec -67.8393619
+	Radius 78.403
+	Distance 1223.503
+}
+
+OpenCluster "HSC 2331"
+{
+	RA 10.4362259
+	Dec -57.17504882
+	Radius 30.002
+	Distance 8239.876
+}
+
+OpenCluster "NGC 3255:Collinder 221:BH 96:ESO 127-20:FSR 1546:MWSC 1804:OCL 817"
+{
+	RA 10.44247158
+	Dec -60.67178024
+	Radius 77.828
+	Distance 17307.511
+}
+
+OpenCluster "HSC 2343"
+{
+	RA 10.45436498
+	Dec -59.27063331
+	Radius 40.72
+	Distance 12083.634
+}
+
+OpenCluster "Theia 1982"
+{
+	RA 10.45517066
+	Dec -59.94223841
+	Radius 54.246
+	Distance 8367.534
 }
 
 OpenCluster "IC 2581"
 {
-	RA 10.458056
-	Dec -56.383333
-	Distance 7978
-	Radius 5.8
+	RA 10.45828277
+	Dec -57.62985064
+	Radius 51.144
+	Distance 7991.753
 }
 
-OpenCluster "Ruprecht 89"
+OpenCluster "HSC 2376"
 {
-	RA 10.473889
-	Dec -57.816667
-	Distance 2964
-	Radius 1.7
+	RA 10.46121778
+	Dec -63.96214074
+	Radius 82.746
+	Distance 1703.55
 }
 
-OpenCluster "Loden 143"
+OpenCluster "HSC 2338"
 {
-	RA 10.481667
-	Dec -57.216667
-	Distance 1304
-	Radius 7.8
+	RA 10.467329
+	Dec -57.17357981
+	Radius 54.8
+	Distance 11841
 }
 
-OpenCluster "Loden 89"
+OpenCluster "HSC 2225"
 {
-	RA 10.486667
-	Dec -55.216667
-	Distance 1239
-	Radius 6.3
+	RA 10.46927441
+	Dec -38.78483459
+	Radius 43.354
+	Distance 954.52
 }
 
-OpenCluster "Loden 59"
+OpenCluster "DSH J1028.2-5841:FSR 1542:Juchert 16:OC 0543"
 {
-	RA 10.505000
-	Dec -53.866667
-	Distance 3623
-	Radius 1.1
+	RA 10.47018934
+	Dec -58.70203532
+	Radius 39.443
+	Distance 11789.521
 }
 
-OpenCluster "Ruprecht 90"
+OpenCluster "HSC 1774"
 {
-	RA 10.516667
-	Dec -57.550000
-	Distance 3261
-	Radius 2.4
+	RA 10.48009378
+	Dec 15.18318281
+	Radius 89.698
+	Distance 895.481
 }
 
-OpenCluster "Collinder 223"
+OpenCluster "HSC 2372"
 {
-	RA 10.537778
-	Dec -59.980000
-	Distance 9197
-	Radius 24.1
+	RA 10.49113814
+	Dec -62.8825215
+	Radius 44.901
+	Distance 8576.803
+}
+
+OpenCluster "Theia 1982:Theia 2014:Theia 2580:UBC 259"
+{
+	RA 10.50935423
+	Dec -60.07843584
+	Radius 103.965
+	Distance 7676.602
+}
+
+OpenCluster "HSC 2353"
+{
+	RA 10.51744261
+	Dec -60.25904673
+	Radius 26.146
+	Distance 8247.989
+}
+
+OpenCluster "HSC 2348"
+{
+	RA 10.52496975
+	Dec -59.52437733
+	Radius 203.729
+	Distance 39535.901
+}
+
+OpenCluster "HSC 2253"
+{
+	RA 10.52943008
+	Dec -42.37906016
+	Radius 77.522
+	Distance 587.747
+}
+
+OpenCluster "Teutsch 226:UBC 497"
+{
+	RA 10.53387102
+	Dec -57.00795295
+	Radius 54.103
+	Distance 5835.248
+}
+
+OpenCluster "HSC 2364"
+{
+	RA 10.5370027
+	Dec -61.33707052
+	Radius 56.27
+	Distance 7397.312
+}
+
+OpenCluster "HSC 2133"
+{
+	RA 10.54420896
+	Dec -21.37888631
+	Radius 68.733
+	Distance 1235.752
+}
+
+OpenCluster "ASCC 60:CWNU 2275:MWSC 1823"
+{
+	RA 10.54472681
+	Dec -58.63124986
+	Radius 123.525
+	Distance 14311.81
+}
+
+OpenCluster "Theia 704"
+{
+	RA 10.54654303
+	Dec -69.73044559
+	Radius 99.381
+	Distance 1678.963
+}
+
+OpenCluster "HSC 2342"
+{
+	RA 10.5480757
+	Dec -58.04850494
+	Radius 36.508
+	Distance 7906.905
+}
+
+OpenCluster "OC 0549"
+{
+	RA 10.55088728
+	Dec -62.00552213
+	Radius 73.148
+	Distance 5356.851
+}
+
+OpenCluster "CWNU 2638"
+{
+	RA 10.55190589
+	Dec -56.00786376
+	Radius 82.925
+	Distance 8031.938
 }
 
 OpenCluster "Loden 112"
 {
-	RA 10.540000
-	Dec -55.300000
-	Distance 8154
-	Radius 8.3
+	RA 10.55338972
+	Dec -56.68874377
+	Radius 23.042
+	Distance 7697.689
 }
 
-OpenCluster "ASCC 60"
+OpenCluster "HSC 2341"
 {
-	RA 10.551944
-	Dec -57.520000
-	Distance 2609
-	Radius 5.5
+	RA 10.55525677
+	Dec -57.62858038
+	Radius 69.427
+	Distance 2420.852
 }
 
-OpenCluster "Loden 153"
+OpenCluster "Theia 549:UPK 560"
 {
-	RA 10.578333
-	Dec -57.866667
-	Distance 8708
-	Radius 2.5
+	RA 10.55732732
+	Dec -44.50325828
+	Radius 162.156
+	Distance 1925.787
 }
 
-OpenCluster "Bochum 9"
+OpenCluster "CWNU 2046"
 {
-	RA 10.596111
-	Dec -59.883333
-	Distance 15003
-	Radius 32.7
+	RA 10.55825417
+	Dec -54.50997678
+	Radius 54.402
+	Distance 7518.29
+}
+
+OpenCluster "UPK 552"
+{
+	RA 10.5640219
+	Dec -46.98559404
+	Radius 49.658
+	Distance 1022.744
+}
+
+OpenCluster "CWNU 1821"
+{
+	RA 10.56870692
+	Dec -59.52747854
+	Radius 19.216
+	Distance 6589.152
+}
+
+OpenCluster "HSC 2344"
+{
+	RA 10.57047687
+	Dec -58.30407219
+	Radius 49.565
+	Distance 12519.383
+}
+
+OpenCluster "HSC 2307"
+{
+	RA 10.57408834
+	Dec -51.705797
+	Radius 73.107
+	Distance 1040.497
+}
+
+OpenCluster "UBC 499"
+{
+	RA 10.57769338
+	Dec -59.76652893
+	Radius 36.736
+	Distance 7235.987
+}
+
+OpenCluster "UBC 514"
+{
+	RA 10.5792971
+	Dec -73.08650428
+	Radius 52.339
+	Distance 5747.516
+}
+
+OpenCluster "CWNU 2738"
+{
+	RA 10.58305689
+	Dec -58.91687827
+	Radius 45.491
+	Distance 13496.946
+}
+
+OpenCluster "HSC 2354"
+{
+	RA 10.58394307
+	Dec -59.63121414
+	Radius 43.583
+	Distance 13878.634
+}
+
+OpenCluster "HSC 2363"
+{
+	RA 10.58792944
+	Dec -60.69351877
+	Radius 72.633
+	Distance 19255.259
+}
+
+OpenCluster "HSC 2388"
+{
+	RA 10.5894957
+	Dec -64.64117874
+	Radius 34.214
+	Distance 3931.048
+}
+
+OpenCluster "Bochum 9:UBC 1480"
+{
+	RA 10.59090508
+	Dec -60.06619931
+	Radius 96.646
+	Distance 14296.148
 }
 
 OpenCluster "NGC 3293"
 {
-	RA 10.597500
-	Dec -57.770000
-	Distance 7589
-	Radius 6.6
+	RA 10.59776378
+	Dec -58.23873702
+	Radius 27.673
+	Distance 7600.416
 }
 
-OpenCluster "Loden 165"
+OpenCluster "CWNU 84:UBC 1494"
 {
-	RA 10.598889
-	Dec -57.263333
-	Distance 6197
-	Radius 9.9
+	RA 10.59816292
+	Dec -65.15454636
+	Radius 30.02
+	Distance 6912.858
 }
 
-OpenCluster "Carraro 1"
+OpenCluster "Bochum 9:UBC 1481"
 {
-	RA 10.616667
-	Dec -57.266667
-	Distance 6197
-	Radius 3.6
+	RA 10.59898325
+	Dec -60.05456727
+	Radius 39.878
+	Distance 7464.738
+}
+
+OpenCluster "HSC 2384"
+{
+	RA 10.60324545
+	Dec -64.21205425
+	Radius 176.034
+	Distance 1796.264
+}
+
+OpenCluster "UBC 258"
+{
+	RA 10.60369899
+	Dec -57.62642123
+	Radius 27.484
+	Distance 7694.646
+}
+
+OpenCluster "Theia 3409:UBC 1483"
+{
+	RA 10.60374688
+	Dec -60.64822378
+	Radius 78.152
+	Distance 7540.984
+}
+
+OpenCluster "CWNU 2601"
+{
+	RA 10.6137716
+	Dec -61.57309144
+	Radius 39.751
+	Distance 16168
+}
+
+OpenCluster "UBC 506"
+{
+	RA 10.61638802
+	Dec -62.02821204
+	Radius 43.255
+	Distance 10018.35
+}
+
+OpenCluster "UBC 654"
+{
+	RA 10.61775115
+	Dec -59.88992053
+	Radius 22.649
+	Distance 11245.364
 }
 
 OpenCluster "NGC 3324"
 {
-	RA 10.622222
-	Dec -57.358333
-	Distance 7557
-	Radius 13.2
+	RA 10.62169546
+	Dec -58.62443741
+	Radius 19.225
+	Distance 7889.54
 }
 
-OpenCluster "BH 99"
+OpenCluster "OC 0545:OC 0546:Teutsch J1037.3+6034:Teutsch J1037.3-6034"
 {
-	RA 10.631667
-	Dec -58.816667
-	Distance 1653
-	Radius 4.8
+	RA 10.62206432
+	Dec -60.57193074
+	Radius 140.673
+	Distance 16965.378
 }
 
-OpenCluster "NGC 3330"
+OpenCluster "BH 99:vdBergh-Hagen 99"
 {
-	RA 10.646111
-	Dec -53.876667
-	Distance 2915
-	Radius 1.7
+	RA 10.63691784
+	Dec -59.10926371
+	Radius 55.971
+	Distance 1435.787
 }
 
-OpenCluster "ESO 062-11"
+OpenCluster "HSC 2356"
 {
-	RA 10.648611
-	Dec -68.966667
-	Distance 2968
-	Radius 2.6
+	RA 10.63915798
+	Dec -58.97832553
+	Radius 38.682
+	Distance 1682.053
 }
 
-OpenCluster "Saurer 3"
+OpenCluster "UBC 502"
 {
-	RA 10.690278
-	Dec -54.694444
-	Distance 31148
-	Radius 18.1
+	RA 10.63947489
+	Dec -59.53472804
+	Radius 28.635
+	Distance 5686.538
 }
 
-OpenCluster "Bochum 10"
+OpenCluster "NGC 3330:Collinder 226:BH 100:ESO 168-11:Harvard 4:MWSC 1835:OCL 806"
 {
-	RA 10.703333
-	Dec -58.866667
-	Distance 6611
-	Radius 19.2
+	RA 10.6444985
+	Dec -54.14153136
+	Radius 35.37
+	Distance 5300.846
 }
 
-OpenCluster "Melotte 101"
+OpenCluster "UBC 504"
 {
-	RA 10.703333
-	Dec -64.900000
-	Distance 6507
-	Radius 14.2
+	RA 10.64933825
+	Dec -61.1181894
+	Radius 56.359
+	Distance 14414.679
 }
 
-OpenCluster "IC 2602"
+OpenCluster "UBC 496"
 {
-	RA 10.716111
-	Dec -63.600000
-	Distance 525
-	Radius 7.6
+	RA 10.65300053
+	Dec -54.25520581
+	Radius 120.665
+	Distance 5207.207
 }
 
-OpenCluster "Alessi 5"
+OpenCluster "HSC 2361"
 {
-	RA 10.718889
-	Dec -60.833333
-	Distance 1298
-	Radius 6.2
+	RA 10.66089163
+	Dec -59.48153865
+	Radius 60.173
+	Distance 6081.652
+}
+
+OpenCluster "UBC 261"
+{
+	RA 10.66249392
+	Dec -60.47527232
+	Radius 70.053
+	Distance 12257.576
+}
+
+OpenCluster "DC 5:DSH J1039.9-5911:FSR 1549:Kronberger 38:MWSC 1838"
+{
+	RA 10.66639388
+	Dec -59.19477006
+	Radius 56.11
+	Distance 14421.505
+}
+
+OpenCluster "CWNU 2413"
+{
+	RA 10.68981862
+	Dec -56.63886764
+	Radius 46.121
+	Distance 6895.732
+}
+
+OpenCluster "MWSC 1839:Saurer 3"
+{
+	RA 10.6898348
+	Dec -55.28827151
+	Radius 110.287
+	Distance 18317.911
+}
+
+OpenCluster "HSC 2358"
+{
+	RA 10.69395293
+	Dec -58.46861518
+	Radius 35.4
+	Distance 7857.81
+}
+
+OpenCluster "CWNU 2554"
+{
+	RA 10.69746764
+	Dec -58.37419802
+	Radius 56.468
+	Distance 9236.393
+}
+
+OpenCluster "HSC 2370"
+{
+	RA 10.70242664
+	Dec -59.91103522
+	Radius 27.828
+	Distance 6382.447
+}
+
+OpenCluster "Melotte 101:Collinder 227:BH 101:ESO 93-1:FSR 1564:MWSC 1840:OCL 841:OC 0555:Theia 3281:Theia 4350"
+{
+	RA 10.70443131
+	Dec -65.11092246
+	Radius 44.578
+	Distance 6619.885
+}
+
+OpenCluster "UBC 262"
+{
+	RA 10.70444775
+	Dec -60.48513443
+	Radius 43.363
+	Distance 10969.223
+}
+
+OpenCluster "Bochum 10:UBC 653"
+{
+	RA 10.70452028
+	Dec -59.15903245
+	Radius 122.732
+	Distance 7660.451
+}
+
+OpenCluster "CWNU 1663:Theia 2185"
+{
+	RA 10.70542519
+	Dec -57.15386192
+	Radius 52.307
+	Distance 8005.946
+}
+
+OpenCluster "HSC 2359"
+{
+	RA 10.70691848
+	Dec -58.7234813
+	Radius 176.694
+	Distance 16048.091
+}
+
+OpenCluster "HSC 2337"
+{
+	RA 10.70920024
+	Dec -53.5165777
+	Radius 69.215
+	Distance 6080.97
+}
+
+OpenCluster "HSC 2362"
+{
+	RA 10.71660613
+	Dec -58.76814133
+	Radius 41.036
+	Distance 8575.277
+}
+
+OpenCluster "Alessi 5:MWSC 1844"
+{
+	RA 10.72681038
+	Dec -61.11150292
+	Radius 50.692
+	Distance 1277.959
+}
+
+OpenCluster "Theia 735:UPK 567"
+{
+	RA 10.73006517
+	Dec -67.51979748
+	Radius 151.773
+	Distance 2060.06
+}
+
+OpenCluster "Collinder 228:UBC 505"
+{
+	RA 10.73018578
+	Dec -60.11478367
+	Radius 50.787
+	Distance 10381.039
+}
+
+OpenCluster "Southern Pleiades:Theta Carinae Cluster:IC 2602:Melotte 102:Collinder 229:Caldwell 102:BH 103:ESO 93-2:MWSC 1840:OCL 838"
+{
+	RA 10.73153885
+	Dec -64.39323626
+	Radius 116.06
+	Distance 491.033
 }
 
 OpenCluster "Trumpler 14"
 {
-	RA 10.732222
-	Dec -58.450000
-	Distance 8154
-	Radius 5.9
+	RA 10.73236009
+	Dec -59.55184119
+	Radius 24.343
+	Distance 7794.623
 }
 
-OpenCluster "Collinder 228"
+OpenCluster "Collinder 228:OC 0550"
 {
-	RA 10.733333
-	Dec -59.913333
-	Distance 7178
-	Radius 14.6
+	RA 10.73405652
+	Dec -60.09090285
+	Radius 27.795
+	Distance 7508.105
 }
 
-OpenCluster "Collinder 232"
+OpenCluster "FoF 403:UBC 501"
 {
-	RA 10.744167
-	Dec -58.440000
-	Distance 7501
-	Radius 4.4
+	RA 10.73446378
+	Dec -58.09910226
+	Radius 52.288
+	Distance 7998.987
+}
+
+OpenCluster "HSC 1537"
+{
+	RA 10.73660342
+	Dec 32.5358605
+	Radius 57.088
+	Distance 302.073
+}
+
+OpenCluster "HSC 2308"
+{
+	RA 10.73779481
+	Dec -48.96797045
+	Radius 40.345
+	Distance 10307.626
+}
+
+OpenCluster "HSC 2369"
+{
+	RA 10.74450264
+	Dec -59.03242933
+	Radius 19.666
+	Distance 6861.996
 }
 
 OpenCluster "Trumpler 15"
 {
-	RA 10.745278
-	Dec -58.633333
-	Distance 6043
-	Radius 12.3
+	RA 10.74494671
+	Dec -59.36886411
+	Radius 25.247
+	Distance 7687.569
 }
 
 OpenCluster "Trumpler 16"
 {
-	RA 10.752778
-	Dec -58.283333
-	Distance 12720
-	Radius 18.5
+	RA 10.75096911
+	Dec -59.69697133
+	Radius 50.664
+	Distance 7491.757
 }
 
-OpenCluster "ASCC 61"
+OpenCluster "HSC 2375"
 {
-	RA 10.768889
-	Dec -55.140000
-	Distance 5544
-	Radius 31.0
+	RA 10.76768985
+	Dec -60.13443525
+	Radius 32.358
+	Distance 6532.659
 }
 
-OpenCluster "Bochum 11"
+OpenCluster "HSC 2352"
 {
-	RA 10.787500
-	Dec -59.916667
-	Distance 7867
-	Radius 24.0
+	RA 10.7688916
+	Dec -56.52633612
+	Radius 36.382
+	Distance 12177.288
 }
 
-OpenCluster "Ruprecht 91"
+OpenCluster "ASCC 61:Gulliver 1:MWSC 1853"
 {
-	RA 10.793889
-	Dec -56.532778
-	Distance 2508
-	Radius 6.2
+	RA 10.77269956
+	Dec -57.04482418
+	Radius 41.19
+	Distance 8870.549
+}
+
+OpenCluster "UBC 1482"
+{
+	RA 10.77357452
+	Dec -57.6801159
+	Radius 70.706
+	Distance 14624.233
+}
+
+OpenCluster "Gulliver 52"
+{
+	RA 10.77380679
+	Dec -59.48522792
+	Radius 89.626
+	Distance 7334.211
+}
+
+OpenCluster "HSC 2350"
+{
+	RA 10.79707269
+	Dec -55.87792452
+	Radius 221.654
+	Distance 24339.137
+}
+
+OpenCluster "ESO 169-1:MWSC 1855:OCL 824:Ruprecht 91:Theia 2396"
+{
+	RA 10.79779006
+	Dec -57.48805629
+	Radius 128.363
+	Distance 3364.253
+}
+
+OpenCluster "HSC 2368"
+{
+	RA 10.81028197
+	Dec -58.03442881
+	Radius 18.276
+	Distance 7935.617
+}
+
+OpenCluster "UBC 652"
+{
+	RA 10.8107127
+	Dec -54.70858133
+	Radius 57.568
+	Distance 7571.276
+}
+
+OpenCluster "UBC 1484"
+{
+	RA 10.81524206
+	Dec -59.04592335
+	Radius 52.71
+	Distance 12117.017
+}
+
+OpenCluster "CWNU 2512"
+{
+	RA 10.81796375
+	Dec -59.06816755
+	Radius 43.027
+	Distance 7655.83
+}
+
+OpenCluster "Theia 2151"
+{
+	RA 10.82610931
+	Dec -59.73058011
+	Radius 55.601
+	Distance 5619.133
+}
+
+OpenCluster "CWNU 1678:Loden 189"
+{
+	RA 10.82689062
+	Dec -56.46258778
+	Radius 44.333
+	Distance 6517.133
+}
+
+OpenCluster "CWNU 1053:Loden 189"
+{
+	RA 10.82795802
+	Dec -56.60755579
+	Radius 93.749
+	Distance 1716.434
+}
+
+OpenCluster "UBC 507"
+{
+	RA 10.84072456
+	Dec -61.44759927
+	Radius 113.712
+	Distance 17613.746
 }
 
 OpenCluster "Loden 189"
 {
-	RA 10.833333
-	Dec -55.600000
-	Distance 2348
-	Radius 7.5
+	RA 10.84866351
+	Dec -56.32963298
+	Radius 44.547
+	Distance 4048.847
 }
 
-OpenCluster "ASCC 62"
+OpenCluster "HSC 2374"
 {
-	RA 10.848056
-	Dec -59.900000
-	Distance 9785
-	Radius 47.8
+	RA 10.84923809
+	Dec -58.88078913
+	Radius 24.747
+	Distance 7761.523
 }
 
-OpenCluster "ESO 128-16"
+OpenCluster "ASCC 62:MWSC 1859:Theia 2151:UBC 263"
 {
-	RA 10.894722
-	Dec -57.760000
-	Distance 2935
-	Radius 4.3
+	RA 10.850789
+	Dec -60.08322363
+	Radius 94.186
+	Distance 7472.911
 }
 
-OpenCluster "Ruprecht 92"
+OpenCluster "UBC 500"
 {
-	RA 10.896389
-	Dec -60.250000
-	Distance 7704
-	Radius 7.8
+	RA 10.85148562
+	Dec -55.83503512
+	Radius 60.221
+	Distance 7749.656
 }
 
-OpenCluster "Kronberger 39"
+OpenCluster "HSC 2377"
 {
-	RA 10.903889
-	Dec -60.262222
-	Distance 36204
-	Radius 4.2
+	RA 10.86578927
+	Dec -58.69907096
+	Radius 89.144
+	Distance 9118.724
 }
 
-OpenCluster "ASCC 63"
+OpenCluster "HSC 2381"
 {
-	RA 10.931111
-	Dec -59.590000
-	Distance 11415
-	Radius 29.9
+	RA 10.86794836
+	Dec -60.47206714
+	Radius 28.581
+	Distance 10106.097
 }
 
-OpenCluster "Graham 1"
+OpenCluster "Gulliver 40"
 {
-	RA 10.942222
-	Dec -62.982222
-	Distance 11742
-	Radius 3.4
+	RA 10.87018747
+	Dec -58.3850348
+	Radius 34.561
+	Distance 5079.112
 }
 
-OpenCluster "Trumpler 17"
+OpenCluster "CWNU 1734"
 {
-	RA 10.940000
-	Dec -58.800000
-	Distance 7139
-	Radius 5.2
+	RA 10.87113641
+	Dec -59.63009265
+	Radius 67.39
+	Distance 13632.736
 }
 
-OpenCluster "Collinder 236"
+OpenCluster "OC 0557"
 {
-	RA 10.947500
-	Dec -60.883333
-	Distance 2508
-	Radius 3.6
+	RA 10.87147143
+	Dec -64.47339152
+	Radius 32.297
+	Distance 5048.16
 }
 
-OpenCluster "Bochum 12"
+OpenCluster "UBC 264"
 {
-	RA 10.956667
-	Dec -60.283333
-	Distance 7234
-	Radius 10.5
+	RA 10.87745989
+	Dec -60.59963061
+	Radius 41.857
+	Distance 8672.421
 }
 
-OpenCluster "NGC 3496"
+OpenCluster "UBC 510"
 {
-	RA 10.993333
-	Dec -59.663333
-	Distance 3229
-	Radius 3.8
+	RA 10.88130791
+	Dec -62.74657728
+	Radius 66.961
+	Distance 13357.989
 }
 
-OpenCluster "Sher 1"
+OpenCluster "HSC 2392"
 {
-	RA 11.017778
-	Dec -59.766667
-	Distance 19162
-	Radius 2.8
+	RA 10.88217417
+	Dec -61.29101786
+	Radius 38.336
+	Distance 15547.457
 }
 
-OpenCluster "Pismis 17"
+OpenCluster "BH 106:MWSC 1863:vdBergh-Hagen 106"
 {
-	RA 11.018333
-	Dec -58.183333
-	Distance 11428
-	Radius 10.0
+	RA 10.88993139
+	Dec -54.24813215
+	Radius 21.327
+	Distance 8097.118
 }
 
-OpenCluster "ASCC 64"
+OpenCluster "UBC 1488"
 {
-	RA 11.051111
-	Dec -59.080000
-	Distance 4892
-	Radius 15.4
+	RA 10.89521104
+	Dec -60.6706303
+	Radius 79.271
+	Distance 10898.962
 }
 
-OpenCluster "Ruprecht 93"
+OpenCluster "HSC 2382"
 {
-	RA 11.073333
-	Dec -60.631667
-	Distance 4687
-	Radius 4.8
+	RA 10.89952496
+	Dec -60.10800476
+	Radius 59.024
+	Distance 12725.226
 }
 
-OpenCluster "NGC 3532"
+OpenCluster "CWNU 2232"
 {
-	RA 11.094167
-	Dec -57.246667
-	Distance 1585
-	Radius 11.5
+	RA 10.90024526
+	Dec -59.18813386
+	Radius 91.384
+	Distance 13905.048
 }
 
-OpenCluster "Feinstein 1"
+OpenCluster "CWNU 2522"
 {
-	RA 11.098889
-	Dec -58.183333
-	Distance 3780
-	Radius 13.7
+	RA 10.9022056
+	Dec -57.39965015
+	Radius 29.814
+	Distance 8049.529
 }
 
-OpenCluster "Loden 306"
+OpenCluster "HSC 2409"
 {
-	RA 11.102222
-	Dec -60.900000
-	Distance 6523
-	Radius 24.7
+	RA 10.90276322
+	Dec -65.6712105
+	Radius 105.675
+	Distance 19683.969
 }
 
-OpenCluster "Shorlin 1"
+OpenCluster "HSC 2396"
 {
-	RA 11.105278
-	Dec -60.761667
-	Distance 41097
-	Radius 4.8
+	RA 10.90518521
+	Dec -62.13221438
+	Radius 31.702
+	Distance 15755.185
 }
 
-OpenCluster "BH 111"
+OpenCluster "Theia 1844:UBC 1489"
 {
-	RA 11.152222
-	Dec -62.166667
-	Distance 2175
-	Radius 0.6
+	RA 10.90928938
+	Dec -60.54867671
+	Radius 54.38
+	Distance 8224.836
+}
+
+OpenCluster "UBC 1490"
+{
+	RA 10.91070035
+	Dec -60.64857302
+	Radius 120.209
+	Distance 13303.871
+}
+
+OpenCluster "Gulliver 39"
+{
+	RA 10.91353342
+	Dec -58.04832615
+	Radius 48.611
+	Distance 8272.153
+}
+
+OpenCluster "UBC 1487"
+{
+	RA 10.91729308
+	Dec -60.09131108
+	Radius 45.142
+	Distance 7184.939
+}
+
+OpenCluster "ASCC 63:MWSC 1869:UBC 508"
+{
+	RA 10.93978829
+	Dec -60.47665098
+	Radius 76.771
+	Distance 16685.996
+}
+
+OpenCluster "Theia 4055:Trumpler 17"
+{
+	RA 10.94054937
+	Dec -59.2292717
+	Radius 52.87
+	Distance 7869.013
+}
+
+OpenCluster "Collinder 236:UBC 509"
+{
+	RA 10.94224777
+	Dec -61.09297849
+	Radius 55.226
+	Distance 9371.439
+}
+
+OpenCluster "HSC 2386"
+{
+	RA 10.95061448
+	Dec -59.69206627
+	Radius 69.982
+	Distance 14078.306
+}
+
+OpenCluster "HSC 2378"
+{
+	RA 10.95542576
+	Dec -57.83224128
+	Radius 60.357
+	Distance 8440.732
+}
+
+OpenCluster "Theia 2296:Theia 3050"
+{
+	RA 10.95761669
+	Dec -60.4490957
+	Radius 61.486
+	Distance 3493.384
+}
+
+OpenCluster "HSC 2389"
+{
+	RA 10.95860449
+	Dec -59.72710059
+	Radius 38.308
+	Distance 16770.774
+}
+
+OpenCluster "Majaess 133"
+{
+	RA 10.97802524
+	Dec -61.18015737
+	Radius 163.63
+	Distance 22294.772
+}
+
+OpenCluster "CWNU 1730"
+{
+	RA 10.97983842
+	Dec -60.11882607
+	Radius 31.671
+	Distance 7767.51
+}
+
+OpenCluster "HSC 2397"
+{
+	RA 10.98713172
+	Dec -61.01874758
+	Radius 19.126
+	Distance 4138.514
+}
+
+OpenCluster "DSH J1059.3-5932:FSR 1559:MWSC 1877:Teutsch 106:Turner 6"
+{
+	RA 10.98891034
+	Dec -59.54417417
+	Radius 71.133
+	Distance 21625.056
+}
+
+OpenCluster "DSH J1059.3-5932:FSR 1559:MWSC 1877:Teutsch 106"
+{
+	RA 10.98980804
+	Dec -59.54887654
+	Radius 41.163
+	Distance 16236.702
+}
+
+OpenCluster "NGC 3496:Collinder 237:BH 108:ESO 128-26:FSR 1562:MWSC 1878:OCL 836:Theia 3050"
+{
+	RA 10.9917964
+	Dec -60.3324425
+	Radius 51.186
+	Distance 7467.196
+}
+
+OpenCluster "UBC 1486"
+{
+	RA 10.99260846
+	Dec -58.19612351
+	Radius 84.514
+	Distance 12190.99
+}
+
+OpenCluster "HSC 2393"
+{
+	RA 11.00570692
+	Dec -59.99369763
+	Radius 54.646
+	Distance 24479.599
+}
+
+OpenCluster "UBC 1485"
+{
+	RA 11.01478801
+	Dec -56.75722114
+	Radius 37.273
+	Distance 7980.963
+}
+
+OpenCluster "HSC 2442"
+{
+	RA 11.01593157
+	Dec -70.57977917
+	Radius 105.206
+	Distance 914.919
+}
+
+OpenCluster "ESO 128-27:MWSC 1881:Miller 2:OCL 837:Sher 1"
+{
+	RA 11.01702171
+	Dec -60.23033074
+	Radius 132.638
+	Distance 22355.879
+}
+
+OpenCluster "UBC 268"
+{
+	RA 11.02247591
+	Dec -63.68107251
+	Radius 59.082
+	Distance 11893.813
+}
+
+OpenCluster "MWSC 1882:OCL 833:Pismis 17"
+{
+	RA 11.02359924
+	Dec -59.87044513
+	Radius 54.945
+	Distance 8150.291
+}
+
+OpenCluster "HSC 2395"
+{
+	RA 11.03578091
+	Dec -59.99758664
+	Radius 118.713
+	Distance 14266.28
+}
+
+OpenCluster "CWNU 2487"
+{
+	RA 11.04761014
+	Dec -59.78278154
+	Radius 111.007
+	Distance 7930.887
+}
+
+OpenCluster "Theia 417:UPK 562"
+{
+	RA 11.06364493
+	Dec -57.02446614
+	Radius 45.077
+	Distance 2621.878
+}
+
+OpenCluster "HSC 2402"
+{
+	RA 11.06912317
+	Dec -61.65391329
+	Radius 41.075
+	Distance 3900.474
+}
+
+OpenCluster "NGC 3519:ESO 128-30:MWSC 1885:OCL 844:Ruprecht 93:Theia 2841"
+{
+	RA 11.0700053
+	Dec -61.376688
+	Radius 56.578
+	Distance 6755.495
+}
+
+OpenCluster "HXHWL 64:Theia 2745"
+{
+	RA 11.07775769
+	Dec -67.52225429
+	Radius 53.177
+	Distance 3397.062
+}
+
+OpenCluster "ESO 63-5:MWSC 1886:OCL 857:Ruprecht 163"
+{
+	RA 11.07813351
+	Dec -67.99815384
+	Radius 96.26
+	Distance 3006.06
+}
+
+OpenCluster "Feinstein 1:UBC 266:UBC 658"
+{
+	RA 11.08623952
+	Dec -59.72938619
+	Radius 67.196
+	Distance 7773.224
+}
+
+OpenCluster "Pincushion Cluster:Football Cluster:Black Arrow Cluster:Wishing Well Cluster:NGC 3532:Melotte 103:Collinder 238:Caldwell 91:BH 109:ESO 128-31:MWSC 1890:OCL 839:Theia 720"
+{
+	RA 11.09290259
+	Dec -58.69378637
+	Radius 94.537
+	Distance 1539.083
+}
+
+OpenCluster "UBC 512"
+{
+	RA 11.0947352
+	Dec -60.45382589
+	Radius 110.587
+	Distance 13174.902
+}
+
+OpenCluster "HSC 2417"
+{
+	RA 11.10266978
+	Dec -64.22780797
+	Radius 46.055
+	Distance 4534.763
+}
+
+OpenCluster "BH 110:MWSC 1894:vdBergh-Hagen 110"
+{
+	RA 11.11808956
+	Dec -61.50967266
+	Radius 102.032
+	Distance 23114.614
+}
+
+OpenCluster "UBC 269"
+{
+	RA 11.11824416
+	Dec -62.86229101
+	Radius 67.219
+	Distance 5624.3
+}
+
+OpenCluster "Chamaleon I:OC 0579:Theia 2"
+{
+	RA 11.14113328
+	Dec -77.49945855
+	Radius 37.964
+	Distance 615.346
+}
+
+OpenCluster "CWNU 1405"
+{
+	RA 11.14224054
+	Dec -59.44178384
+	Radius 60.33
+	Distance 13939.202
+}
+
+OpenCluster "DSH J1108.5-6044:DSH J1108.6-6042:FSR 1570:MWSC 1898:Teutsch 143a:Teutsch 143b:Wray 1:Wray 15-751"
+{
+	RA 11.14307412
+	Dec -60.74473383
+	Radius 117.426
+	Distance 12560.009
+}
+
+OpenCluster "HSC 2401"
+{
+	RA 11.14348861
+	Dec -60.38751313
+	Radius 83.76
+	Distance 19174.674
+}
+
+OpenCluster "DSH J1108.6-6042:FSR 1570:MWSC 1898:Teutsch 143a:Wray 1:Wray 15-751"
+{
+	RA 11.1451838
+	Dec -60.71173304
+	Radius 100.106
+	Distance 27027.496
+}
+
+OpenCluster "HSC 2405"
+{
+	RA 11.14915739
+	Dec -61.22897012
+	Radius 25.879
+	Distance 15181.25
+}
+
+OpenCluster "DSH J1108.6-6042:FSR 1570:MWSC 1898:Teutsch 143a:UBC 659:Wray 1:Wray 15-751"
+{
+	RA 11.15398637
+	Dec -60.67063956
+	Radius 23.495
+	Distance 7818.092
+}
+
+OpenCluster "BH 111:ESO 93-5:MWSC 1901:OC 0561:vdBergh-Hagen 111"
+{
+	RA 11.15444018
+	Dec -63.83025709
+	Radius 61.067
+	Distance 8033.009
+}
+
+OpenCluster "Loden 309:Theia 5888"
+{
+	RA 11.15794001
+	Dec -60.48398066
+	Radius 105.169
+	Distance 5848.178
 }
 
 OpenCluster "NGC 3572"
 {
-	RA 11.173056
-	Dec -59.751667
-	Distance 6507
-	Radius 4.7
+	RA 11.17501059
+	Dec -60.2800644
+	Radius 24.382
+	Distance 7911.622
 }
 
 OpenCluster "Basel 17"
 {
-	RA 11.176111
-	Dec -58.966667
-	Distance 5336
-	Radius 7.8
+	RA 11.17581877
+	Dec -59.03539336
+	Radius 48.47
+	Distance 6819.733
 }
 
-OpenCluster "Hogg 10"
+OpenCluster "CWNU 2265"
 {
-	RA 11.178333
-	Dec -59.600000
-	Distance 5792
-	Radius 2.5
+	RA 11.17979585
+	Dec -57.88712408
+	Radius 61.993
+	Distance 10022.566
 }
 
-OpenCluster "Loden 309"
+OpenCluster "HSC 2416"
 {
-	RA 11.178611
-	Dec -59.616667
-	Distance 3261
-	Radius 0.7
+	RA 11.18006314
+	Dec -62.73659651
+	Radius 131.057
+	Distance 11899.674
 }
 
-OpenCluster "ASCC 65"
+OpenCluster "UBC 275"
 {
-	RA 11.185000
-	Dec -60.880000
-	Distance 11415
-	Radius 43.8
+	RA 11.18087986
+	Dec -65.71076461
+	Radius 63.028
+	Distance 12060.127
+}
+
+OpenCluster "FoF 2238:Theia 4070:UBC 265"
+{
+	RA 11.18093527
+	Dec -56.80807737
+	Radius 57.155
+	Distance 3786.957
+}
+
+OpenCluster "Gulliver 34:OC 0556"
+{
+	RA 11.18240129
+	Dec -59.16805817
+	Radius 58.192
+	Distance 13775.506
 }
 
 OpenCluster "Trumpler 18"
 {
-	RA 11.191111
-	Dec -59.333333
-	Distance 4429
-	Radius 3.2
+	RA 11.18837969
+	Dec -60.63029515
+	Radius 47.581
+	Distance 4736.004
 }
 
-OpenCluster "Hogg 11"
+OpenCluster "ASCC 65:MWSC 1909"
 {
-	RA 11.193611
-	Dec -59.600000
-	Distance 7403
-	Radius 2.2
+	RA 11.18893245
+	Dec -61.16702171
+	Radius 70.985
+	Distance 7786.085
 }
 
-OpenCluster "Collinder 240"
+OpenCluster "OC 0558"
 {
-	RA 11.194444
-	Dec -59.690278
-	Distance 5143
-	Radius 23.9
+	RA 11.19104013
+	Dec -59.53765866
+	Radius 40.622
+	Distance 14380.231
 }
 
-OpenCluster "ESO 570-12"
+OpenCluster "UBC 272"
 {
-	RA 11.201944
-	Dec -20.650000
-	Distance 2087
-	Radius 2.4
+	RA 11.20511593
+	Dec -62.26742401
+	Radius 93.319
+	Distance 7191.446
 }
 
-OpenCluster "NGC 3590"
+OpenCluster "CWNU 73"
 {
-	RA 11.216389
-	Dec -59.211667
-	Distance 5385
-	Radius 2.3
+	RA 11.20585488
+	Dec -57.94159015
+	Radius 32.087
+	Distance 4356.215
 }
 
-OpenCluster "Hogg 12"
+OpenCluster "HSC 2406"
 {
-	RA 11.216944
-	Dec -59.216667
-	Distance 4657
-	Radius 2.7
+	RA 11.20660283
+	Dec -60.49320639
+	Radius 20.374
+	Distance 7799.442
 }
 
-OpenCluster "Stock 13"
+OpenCluster "Stock 13:UBC 267"
 {
-	RA 11.218056
-	Dec -57.116667
-	Distance 5143
-	Radius 3.7
+	RA 11.20833155
+	Dec -58.77928326
+	Radius 65.401
+	Distance 8946.038
 }
 
-OpenCluster "ASCC 66"
+OpenCluster "HSC 2404"
 {
-	RA 11.226944
-	Dec -54.580000
-	Distance 3261
-	Radius 17.1
+	RA 11.20899774
+	Dec -59.69693781
+	Radius 68.105
+	Distance 10861.075
+}
+
+OpenCluster "CWNU 2478"
+{
+	RA 11.20907244
+	Dec -57.82520451
+	Radius 68.585
+	Distance 7070.661
+}
+
+OpenCluster "HSC 2430"
+{
+	RA 11.21179215
+	Dec -65.1982527
+	Radius 19.138
+	Distance 7070.327
+}
+
+OpenCluster "NGC 3590:DBSB 61:ESO 129-11:Hogg 12:MWSC 1918:MWSC 1919:OCL 851"
+{
+	RA 11.21720792
+	Dec -60.79024279
+	Radius 75.741
+	Distance 7861.372
+}
+
+OpenCluster "ASCC 66:MWSC 1922"
+{
+	RA 11.22291737
+	Dec -55.42612746
+	Radius 95.084
+	Distance 3101.443
+}
+
+OpenCluster "UBC 661"
+{
+	RA 11.22389497
+	Dec -61.21405208
+	Radius 41.393
+	Distance 7081.146
+}
+
+OpenCluster "UBC 660"
+{
+	RA 11.23547949
+	Dec -59.71075048
+	Radius 45.906
+	Distance 6303.397
+}
+
+OpenCluster "Collinder 243:ESO 169-7:FSR 1565:MWSC 1924:OCL 843:Theia 6137:Trumpler 19"
+{
+	RA 11.24166304
+	Dec -57.56358666
+	Radius 177.944
+	Distance 7596.697
+}
+
+OpenCluster "HSC 2403"
+{
+	RA 11.24308426
+	Dec -58.8357895
+	Radius 86.572
+	Distance 2196.824
+}
+
+OpenCluster "PHOC 31"
+{
+	RA 11.24903142
+	Dec -59.42954176
+	Radius 24.693
+	Distance 3374.147
+}
+
+OpenCluster "CWNU 2383"
+{
+	RA 11.25029951
+	Dec -58.15320829
+	Radius 30.899
+	Distance 9984.371
 }
 
 OpenCluster "NGC 3603"
 {
-	RA 11.251944
-	Dec -60.740000
-	Distance 22505
-	Radius 13.1
+	RA 11.25265564
+	Dec -61.26088008
+	Radius 162.683
+	Distance 22097.854
 }
 
-OpenCluster "IC 2714"
+OpenCluster "HSC 2411"
 {
-	RA 11.290833
-	Dec -61.266667
-	Distance 4037
-	Radius 8.2
+	RA 11.2683211
+	Dec -60.14083002
+	Radius 18.728
+	Distance 4452.611
 }
 
-OpenCluster "ESO 093-08"
+OpenCluster "HSC 2432"
 {
-	RA 11.328056
-	Dec -64.780000
-	Distance 45663
-	Radius 6.6
+	RA 11.27153956
+	Dec -64.83969043
+	Radius 26.937
+	Distance 5076.981
 }
 
-OpenCluster "Melotte 105"
+OpenCluster "HSC 2303"
 {
-	RA 11.328333
-	Dec -62.516667
-	Distance 7201
-	Radius 5.2
+	RA 11.27589008
+	Dec -35.5980225
+	Radius 231.167
+	Distance 504.361
 }
 
-OpenCluster "NGC 3680"
+OpenCluster "CWNU 1759"
 {
-	RA 11.427222
-	Dec -42.756667
-	Distance 3059
-	Radius 2.2
+	RA 11.28675173
+	Dec -59.63866115
+	Radius 37.195
+	Distance 5884.014
+}
+
+OpenCluster "HSC 2423"
+{
+	RA 11.28845319
+	Dec -62.08862217
+	Radius 39.047
+	Distance 15648.465
+}
+
+OpenCluster "IC 2714:Melotte 104:Collinder 245:BH 116:ESO 129-18:FSR 1582:MWSC 1929:MWSC 1930:OCL 855:Theia 3798"
+{
+	RA 11.29128391
+	Dec -62.73408478
+	Radius 50.888
+	Distance 4221.379
+}
+
+OpenCluster "HSC 2408"
+{
+	RA 11.30054719
+	Dec -59.08580463
+	Radius 134.489
+	Distance 863.272
+}
+
+OpenCluster "HSC 2419"
+{
+	RA 11.30617137
+	Dec -60.84706516
+	Radius 111.769
+	Distance 3928.805
+}
+
+OpenCluster "HSC 2424"
+{
+	RA 11.31358401
+	Dec -61.62153935
+	Radius 121.249
+	Distance 11663.294
+}
+
+OpenCluster "CWNU 2735"
+{
+	RA 11.31668665
+	Dec -61.37716211
+	Radius 63.436
+	Distance 13392.902
+}
+
+OpenCluster "CWNU 2529"
+{
+	RA 11.31762488
+	Dec -61.45819672
+	Radius 156.893
+	Distance 21489.128
+}
+
+OpenCluster "UBC 270"
+{
+	RA 11.32188392
+	Dec -59.56933353
+	Radius 54.8
+	Distance 7311.605
+}
+
+OpenCluster "CWNU 2517"
+{
+	RA 11.32326375
+	Dec -66.80728441
+	Radius 60.746
+	Distance 6219.283
+}
+
+OpenCluster "Melotte 105:Collinder 246:BH 117:ESO 93-7:FSR 1587:MWSC 1933:OCL 856:OC 0564"
+{
+	RA 11.32782606
+	Dec -63.48363112
+	Radius 58.444
+	Distance 7232.101
+}
+
+OpenCluster "CWNU 2280"
+{
+	RA 11.33838069
+	Dec -61.14825021
+	Radius 38.152
+	Distance 12323.517
+}
+
+OpenCluster "HSC 2418"
+{
+	RA 11.34537171
+	Dec -60.04116752
+	Radius 52.73
+	Distance 3330.08
+}
+
+OpenCluster "CWNU 1008"
+{
+	RA 11.34620849
+	Dec -60.57219471
+	Radius 101.263
+	Distance 1484.008
+}
+
+OpenCluster "FoF 1540:UBC 271"
+{
+	RA 11.34745725
+	Dec -59.30055693
+	Radius 89.046
+	Distance 8528.431
+}
+
+OpenCluster "LISC 2337:UBC 273"
+{
+	RA 11.35449988
+	Dec -60.56475266
+	Radius 52.313
+	Distance 7072.381
+}
+
+OpenCluster "UPK 569"
+{
+	RA 11.35866404
+	Dec -72.1139612
+	Radius 103.84
+	Distance 801.062
+}
+
+OpenCluster "CWNU 1356"
+{
+	RA 11.35926039
+	Dec -60.88712664
+	Radius 40.203
+	Distance 8083.144
+}
+
+OpenCluster "HSC 2412"
+{
+	RA 11.36828631
+	Dec -58.38648519
+	Radius 34.275
+	Distance 3116.797
+}
+
+OpenCluster "HSC 2428"
+{
+	RA 11.37448601
+	Dec -61.58089572
+	Radius 45.271
+	Distance 12626.139
+}
+
+OpenCluster "OC 0562"
+{
+	RA 11.37561916
+	Dec -61.51599311
+	Radius 66.03
+	Distance 10284.184
+}
+
+OpenCluster "FSR 1586:MWSC 1938:SAI 115"
+{
+	RA 11.37834359
+	Dec -62.31559086
+	Radius 64.083
+	Distance 12133.256
+}
+
+OpenCluster "BH 118:ESO 129-20:MWSC 1939:vdBergh-Hagen 118"
+{
+	RA 11.38379746
+	Dec -58.54575293
+	Radius 110.854
+	Distance 23829.063
+}
+
+OpenCluster "HSC 2429"
+{
+	RA 11.38424153
+	Dec -61.49921029
+	Radius 70.673
+	Distance 6435.38
+}
+
+OpenCluster "DBSB 64"
+{
+	RA 11.39817118
+	Dec -58.92044605
+	Radius 35.458
+	Distance 2958.547
+}
+
+OpenCluster "HSC 2425"
+{
+	RA 11.40300391
+	Dec -60.40386503
+	Radius 39.042
+	Distance 6170.643
+}
+
+OpenCluster "UBC 1500"
+{
+	RA 11.4104249
+	Dec -61.52496634
+	Radius 37.192
+	Distance 9418.139
+}
+
+OpenCluster "CWNU 1095"
+{
+	RA 11.42349961
+	Dec 63.83982667
+	Radius 295.384
+	Distance 798.625
+}
+
+OpenCluster "UBC 513"
+{
+	RA 11.42392141
+	Dec -61.44806536
+	Radius 39.559
+	Distance 7851.946
+}
+
+OpenCluster "HSC 2427"
+{
+	RA 11.424977
+	Dec -60.17928675
+	Radius 102.238
+	Distance 7211.247
+}
+
+OpenCluster "HSC 2449"
+{
+	RA 11.42580563
+	Dec -67.04127922
+	Radius 154.813
+	Distance 2088.039
+}
+
+OpenCluster "NGC 3680:Melotte 106:Collinder 247:ESO 265-32:FSR 1548:MWSC 1942:OCL 823:Theia 6552"
+{
+	RA 11.42699042
+	Dec -43.2282272
+	Radius 54.528
+	Distance 3335.152
+}
+
+OpenCluster "PHOC 32"
+{
+	RA 11.42937929
+	Dec -63.69372834
+	Radius 96.526
+	Distance 5591.737
+}
+
+OpenCluster "HSC 2278"
+{
+	RA 11.47686849
+	Dec -24.58945524
+	Radius 109.355
+	Distance 402.504
+}
+
+OpenCluster "HSC 2435"
+{
+	RA 11.47764766
+	Dec -62.37814188
+	Radius 90.981
+	Distance 10154.523
+}
+
+OpenCluster "UBC 1587"
+{
+	RA 11.48768298
+	Dec -64.04341815
+	Radius 49.435
+	Distance 7306.602
+}
+
+OpenCluster "HSC 2394"
+{
+	RA 11.48772778
+	Dec -49.97096909
+	Radius 56.825
+	Distance 356.644
+}
+
+OpenCluster "UBC 1501"
+{
+	RA 11.49107451
+	Dec -61.26206331
+	Radius 60.2
+	Distance 9309.355
+}
+
+OpenCluster "UBC 1502"
+{
+	RA 11.50292387
+	Dec -61.08611779
+	Radius 81.951
+	Distance 16560.074
+}
+
+OpenCluster "BH 119:ESO 129-23:FSR 1588:MWSC 1951:OCL 858:Ruprecht 164"
+{
+	RA 11.50704122
+	Dec -60.74580732
+	Radius 61.034
+	Distance 13417.238
 }
 
 OpenCluster "Ruprecht 94"
 {
-	RA 11.510278
-	Dec -62.566667
-	Distance 3623
-	Radius 10.5
+	RA 11.50921217
+	Dec -63.45550643
+	Radius 35.058
+	Distance 7742.963
 }
 
-OpenCluster "Ruprecht 164"
+OpenCluster "ESO 129-24:Loden 372:MWSC 1952:OCL 853.1"
 {
-	RA 11.514167
-	Dec -59.266667
-	Distance 3261
-	Radius 2.4
+	RA 11.51807498
+	Dec -58.50768543
+	Radius 26.305
+	Distance 5387.204
 }
 
-OpenCluster "Loden 372"
+OpenCluster "HSC 2446"
 {
-	RA 11.515278
-	Dec -57.516667
-	Distance 3914
-	Radius 3.4
+	RA 11.52184604
+	Dec -63.78455162
+	Radius 65.21
+	Distance 11441.426
 }
 
-OpenCluster "Loden 402"
+OpenCluster "BH 119:ESO 129-23:FSR 1588:Loden 402:MWSC 1951:MWSC 1954:OCL 858:Ruprecht 164:UBC 276"
 {
-	RA 11.547778
-	Dec -59.283333
-	Distance 7991
-	Radius 11.6
+	RA 11.52378971
+	Dec -60.76466013
+	Radius 35.476
+	Distance 13931.15
 }
 
-OpenCluster "NGC 3766"
+OpenCluster "UBC 1503"
 {
-	RA 11.603889
-	Dec -60.391667
-	Distance 7234
-	Radius 9.8
+	RA 11.52909447
+	Dec -60.8220744
+	Radius 20.864
+	Distance 8984.974
 }
 
-OpenCluster "IC 2944"
+OpenCluster "HSC 2486"
 {
-	RA 11.638889
-	Dec -62.627222
-	Distance 5851
-	Radius 55.3
+	RA 11.53174432
+	Dec -76.08383889
+	Radius 25.517
+	Distance 6753.076
 }
 
-OpenCluster "ASCC 67"
+OpenCluster "HXHWL 16:LISC 3316:Theia 2982"
 {
-	RA 11.691944
-	Dec -60.980000
-	Distance 4892
-	Radius 17.1
+	RA 11.54278982
+	Dec -68.11773042
+	Radius 51.833
+	Distance 4533.906
 }
 
-OpenCluster "Bica 5"
+OpenCluster "HSC 2447"
 {
-	RA 11.692778
-	Dec -61.581944
-	Distance 5675
-	Radius 2.5
+	RA 11.54761481
+	Dec -63.42899002
+	Radius 42.124
+	Distance 1489.941
 }
 
-OpenCluster "Stock 14"
+OpenCluster "Theia 882"
 {
-	RA 11.730000
-	Dec -61.483333
-	Distance 6999
-	Radius 6.1
+	RA 11.54856239
+	Dec -69.2469144
+	Radius 61.615
+	Distance 2589.152
 }
 
-OpenCluster "NGC 3960"
+OpenCluster "OC 0565:Theia 621:Theia 743"
 {
-	RA 11.842500
-	Dec -54.326667
-	Distance 6034
-	Radius 4.4
+	RA 11.5653504
+	Dec -60.65670477
+	Radius 68.063
+	Distance 2104.956
 }
 
-OpenCluster "Ruprecht 96"
+OpenCluster "Theia 3153:Theia 4842:Theia 5361:UBC 279"
 {
-	RA 11.843611
-	Dec -61.866667
-	Distance 2805
-	Radius 2.0
+	RA 11.56560985
+	Dec -66.11084034
+	Radius 101.978
+	Distance 4885.641
 }
 
-OpenCluster "Loden 481"
+OpenCluster "CWNU 1062"
 {
-	RA 11.863056
-	Dec -60.716667
-	Distance 4957
-	Radius 18.7
+	RA 11.58009447
+	Dec 16.84499191
+	Radius 75.363
+	Distance 999.267
 }
 
-OpenCluster "Loden 480"
+OpenCluster "CWNU 2264"
 {
-	RA 11.933333
-	Dec -57.566667
-	Distance 4660
-	Radius 1.7
+	RA 11.58105865
+	Dec -62.36158244
+	Radius 45.668
+	Distance 7135.291
 }
 
-OpenCluster "Ruprecht 97"
+OpenCluster "HSC 2462"
 {
-	RA 11.957778
-	Dec -61.283333
-	Distance 4426
-	Radius 3.2
+	RA 11.58119844
+	Dec -67.62587929
+	Radius 214.678
+	Distance 978.203
 }
 
-OpenCluster "Ruprecht 98"
+OpenCluster "UBC 1499"
 {
-	RA 11.977778
-	Dec -63.416667
-	Distance 1611
-	Radius 3.3
+	RA 11.59110948
+	Dec -55.63598209
+	Radius 116.381
+	Distance 12470.993
 }
 
-OpenCluster "Feigelson 1"
+OpenCluster "HSC 2433"
 {
-	RA 11.997500
-	Dec -77.792500
-	Distance 371
-	Radius 1.0
+	RA 11.59315902
+	Dec -58.34898518
+	Radius 108.57
+	Distance 3139.392
 }
 
-OpenCluster "NGC 4052"
+OpenCluster "LISC 3241:Theia 4161:UBC 277"
 {
-	RA 12.017222
-	Dec -62.775000
-	Distance 3943
-	Radius 5.2
+	RA 11.59930541
+	Dec -59.49042146
+	Radius 49.808
+	Distance 5835.665
 }
 
-OpenCluster "Alessi-Teutsch 8"
+OpenCluster "Pearl Cluster:NGC 3766:Melotte 107:Collinder 248:Caldwell 97:Theia 1849:Theia 1935:Theia 2813"
 {
-	RA 12.048611
-	Dec -59.075000
-	Distance 2120
-	Radius 7.4
+	RA 11.60476238
+	Dec -61.60585281
+	Radius 40.349
+	Distance 6324.252
 }
 
-OpenCluster "Ruprecht 99"
+OpenCluster "HSC 2431"
 {
-	RA 12.051111
-	Dec -62.150000
-	Distance 2152
-	Radius 1.6
+	RA 11.61238785
+	Dec -57.61291302
+	Radius 47.629
+	Distance 6109.545
 }
 
-OpenCluster "ASCC 69"
+OpenCluster "FSR 1591:MWSC 1959"
 {
-	RA 12.110000
-	Dec -68.230000
-	Distance 3261
-	Radius 22.8
+	RA 11.61719528
+	Dec -62.73720614
+	Radius 67.738
+	Distance 12466.493
 }
 
-OpenCluster "NGC 4103"
+OpenCluster "CWNU 2261"
 {
-	RA 12.111111
-	Dec -60.750000
-	Distance 5323
-	Radius 4.6
+	RA 11.63856138
+	Dec -61.20125341
+	Radius 129.591
+	Distance 14232.385
 }
 
-OpenCluster "ESO 130-06"
+OpenCluster "Lambda Centauri Cluster:IC 2944:BH 121:vdBergh-Hagen 121"
 {
-	RA 12.129444
-	Dec -58.700000
-	Distance 7175
-	Radius 10.4
+	RA 11.63994923
+	Dec -63.38076092
+	Radius 13.223
+	Distance 7706.229
 }
 
-OpenCluster "Loden 565"
+OpenCluster "CWNU 2712"
 {
-	RA 12.138611
-	Dec -59.350000
-	Distance 3623
-	Radius 8.4
+	RA 11.64621601
+	Dec -60.69135026
+	Radius 32.592
+	Distance 5831.872
 }
 
-OpenCluster "Saurer 4"
+OpenCluster "IC 2948"
 {
-	RA 12.234167
-	Dec -62.406667
-	Distance 20189
-	Radius 5.3
+	RA 11.66070682
+	Dec -63.47155513
+	Radius 15.266
+	Distance 7394.277
 }
 
-OpenCluster "ASCC 70"
+OpenCluster "HSC 2438"
 {
-	RA 12.250000
-	Dec -63.570000
-	Distance 8806
-	Radius 46.1
+	RA 11.68364301
+	Dec -58.20581754
+	Radius 28.268
+	Distance 6836.529
 }
 
-OpenCluster "Loden 615"
+OpenCluster "Theia 585"
 {
-	RA 12.344167
-	Dec -63.216667
-	Distance 5437
-	Radius 2.0
+	RA 11.68782807
+	Dec -60.76802441
+	Radius 65.495
+	Distance 2818.577
 }
 
-OpenCluster "ASCC 71"
+OpenCluster "ASCC 67:MWSC 1963:OC 0569"
 {
-	RA 12.345000
-	Dec -66.480000
-	Distance 4240
-	Radius 30.3
+	RA 11.69168675
+	Dec -61.05654916
+	Radius 53.343
+	Distance 6146.84
 }
 
-OpenCluster "NGC 4337"
+OpenCluster "UBC 1504"
 {
-	RA 12.401111
-	Dec -57.876667
-	Distance 1594
-	Radius 0.9
+	RA 11.6932589
+	Dec -59.56412445
+	Radius 42.393
+	Distance 7136.442
 }
 
-OpenCluster "NGC 4349"
+OpenCluster "FoF 2094:Theia 3341:UBC 278"
 {
-	RA 12.402222
-	Dec -60.128333
-	Distance 7097
-	Radius 5.2
+	RA 11.69767872
+	Dec -61.95177248
+	Radius 47.338
+	Distance 5381.336
 }
 
-OpenCluster "Melotte 111"
+OpenCluster "Bica 5:Lynga 15:Theia 2727"
 {
-	RA 12.418333
-	Dec 26.100000
-	Distance 313
-	Radius 5.5
+	RA 11.69916428
+	Dec -62.49356482
+	Radius 40.488
+	Distance 5367.327
 }
 
-OpenCluster "Harvard 5"
+OpenCluster "HSC 2443"
 {
-	RA 12.454444
-	Dec -59.221111
-	Distance 3861
-	Radius 2.8
+	RA 11.71841041
+	Dec -58.01664233
+	Radius 23.881
+	Distance 2656.362
+}
+
+OpenCluster "Loden 466:Stock 14:Theia 2727"
+{
+	RA 11.72835954
+	Dec -62.53260105
+	Radius 61.423
+	Distance 7633.053
+}
+
+OpenCluster "Stock 14:Theia 2727"
+{
+	RA 11.72992253
+	Dec -62.37582126
+	Radius 76.228
+	Distance 11921.26
+}
+
+OpenCluster "HSC 2450"
+{
+	RA 11.73143617
+	Dec -60.51336563
+	Radius 16.195
+	Distance 9419.692
+}
+
+OpenCluster "UBC 1505"
+{
+	RA 11.73427561
+	Dec -60.54596989
+	Radius 98.493
+	Distance 15674.612
+}
+
+OpenCluster "CWNU 2695"
+{
+	RA 11.73957163
+	Dec -63.55013836
+	Radius 86.357
+	Distance 9534.558
+}
+
+OpenCluster "CWNU 2419"
+{
+	RA 11.74586386
+	Dec -63.22541997
+	Radius 130.301
+	Distance 7426.219
+}
+
+OpenCluster "Loden 467"
+{
+	RA 11.75792086
+	Dec -62.44401181
+	Radius 31.326
+	Distance 13838.697
+}
+
+OpenCluster "OC 0573:UBC 1509"
+{
+	RA 11.77116628
+	Dec -64.09535717
+	Radius 45.347
+	Distance 10518.166
+}
+
+OpenCluster "CWNU 1608:Theia 4367"
+{
+	RA 11.77538371
+	Dec -62.04544094
+	Radius 57.79
+	Distance 12576.151
+}
+
+OpenCluster "FSR 1595"
+{
+	RA 11.78456278
+	Dec -62.63627062
+	Radius 74.96
+	Distance 13387.566
+}
+
+OpenCluster "HSC 2434"
+{
+	RA 11.78461259
+	Dec -53.08911641
+	Radius 61.547
+	Distance 13855.669
+}
+
+OpenCluster "HSC 2326"
+{
+	RA 11.7857117
+	Dec -21.60915029
+	Radius 67.954
+	Distance 9618.377
+}
+
+OpenCluster "CWNU 2089"
+{
+	RA 11.79242766
+	Dec -62.78956695
+	Radius 71.07
+	Distance 13189.094
+}
+
+OpenCluster "HSC 2469"
+{
+	RA 11.79393912
+	Dec -64.9663729
+	Radius 120.887
+	Distance 3925.171
+}
+
+OpenCluster "OC 0571"
+{
+	RA 11.807442
+	Dec -61.3394642
+	Radius 69.356
+	Distance 6300.121
+}
+
+OpenCluster "CWNU 1238:DBSB 70"
+{
+	RA 11.80865962
+	Dec -62.3174424
+	Radius 20.016
+	Distance 3345.836
+}
+
+OpenCluster "FSR 1596:MWSC 1978:OC 0572:SAI 116:Teutsch 230"
+{
+	RA 11.82105914
+	Dec -62.22569612
+	Radius 65.543
+	Distance 12109.317
+}
+
+OpenCluster "UBC 1507"
+{
+	RA 11.82415088
+	Dec -61.47842403
+	Radius 59.065
+	Distance 6728.391
+}
+
+OpenCluster "UBC 1506"
+{
+	RA 11.83564686
+	Dec -60.7140101
+	Radius 36.76
+	Distance 13030.203
+}
+
+OpenCluster "NGC 3960:Melotte 108:Collinder 250:BH 123:ESO 170-14:FSR 1590:MWSC 1982:OCL 861:Theia 5390:UBC 1624"
+{
+	RA 11.84334675
+	Dec -55.67652888
+	Radius 71.774
+	Distance 7200.82
+}
+
+OpenCluster "ESO 130-2:MWSC 1983:OCL 866:OC 0574:Ruprecht 96"
+{
+	RA 11.84568213
+	Dec -62.14094442
+	Radius 48.647
+	Distance 10072.767
+}
+
+OpenCluster "HSC 2474"
+{
+	RA 11.84610809
+	Dec -65.71468176
+	Radius 69.24
+	Distance 27213.436
+}
+
+OpenCluster "LISC 1273"
+{
+	RA 11.85241256
+	Dec -63.3140632
+	Radius 95.237
+	Distance 11330.011
+}
+
+OpenCluster "Theia 2840:UBC 280"
+{
+	RA 11.85377359
+	Dec -62.65829124
+	Radius 39.512
+	Distance 7104.068
+}
+
+OpenCluster "HSC 2452"
+{
+	RA 11.85527292
+	Dec -57.84074237
+	Radius 168.818
+	Distance 1367.578
+}
+
+OpenCluster "OC 0575:UBC 281"
+{
+	RA 11.87379912
+	Dec -64.60014422
+	Radius 110.014
+	Distance 7217.843
+}
+
+OpenCluster "HSC 2461"
+{
+	RA 11.89946489
+	Dec -59.57027387
+	Radius 36.293
+	Distance 3622.317
+}
+
+OpenCluster "HSC 2454"
+{
+	RA 11.89988801
+	Dec -57.61978147
+	Radius 65.543
+	Distance 10498.255
+}
+
+OpenCluster "UBC 1625"
+{
+	RA 11.90342266
+	Dec -61.96180798
+	Radius 22.629
+	Distance 6293.194
+}
+
+OpenCluster "UBC 1510"
+{
+	RA 11.92030982
+	Dec -61.64987543
+	Radius 47.49
+	Distance 9607.727
+}
+
+OpenCluster "HSC 2460"
+{
+	RA 11.92094354
+	Dec -58.7391645
+	Radius 36.582
+	Distance 5694.911
+}
+
+OpenCluster "HSC 2459"
+{
+	RA 11.92141478
+	Dec -58.13315786
+	Radius 50.623
+	Distance 14128.094
+}
+
+OpenCluster "HSC 2470"
+{
+	RA 11.92376649
+	Dec -61.74522745
+	Radius 21.034
+	Distance 7445.343
+}
+
+OpenCluster "UBC 662"
+{
+	RA 11.92650989
+	Dec -61.53289904
+	Radius 44.662
+	Distance 13475.567
+}
+
+OpenCluster "HXHWL 55"
+{
+	RA 11.9429034
+	Dec -71.02029588
+	Radius 107.587
+	Distance 4118.392
+}
+
+OpenCluster "HSC 1077"
+{
+	RA 11.9480656
+	Dec 64.35810408
+	Radius 62.944
+	Distance 317.863
+}
+
+OpenCluster "Loden 480:MWSC 1986:OCL 865.3:Theia 473"
+{
+	RA 11.95446959
+	Dec -58.30020863
+	Radius 68.294
+	Distance 2314.67
+}
+
+OpenCluster "UBC 515"
+{
+	RA 11.95566525
+	Dec -62.97290311
+	Radius 71.566
+	Distance 9879.146
+}
+
+OpenCluster "BH 124:ESO 130-3:MWSC 1997:OCL 867:Ruprecht 97:Theia 2984"
+{
+	RA 11.95775335
+	Dec -62.71003227
+	Radius 33.611
+	Distance 11064.444
+}
+
+OpenCluster "DSH J1158.3-6152:GLIMPSE 27:Mercer 27:OC 0577:Teutsch 78"
+{
+	RA 11.97220705
+	Dec -61.87543282
+	Radius 30.612
+	Distance 14530.726
+}
+
+OpenCluster "UBC 283"
+{
+	RA 11.97626062
+	Dec -68.6935312
+	Radius 65.151
+	Distance 4253.917
+}
+
+OpenCluster "BH 125:ESO 94-9:MWSC 1988:OCL 868:Ruprecht 98:Theia 1028"
+{
+	RA 11.98076153
+	Dec -64.61283405
+	Radius 180.73
+	Distance 1544.992
+}
+
+OpenCluster "CWNU 1470"
+{
+	RA 11.98407292
+	Dec -55.61725692
+	Radius 33.789
+	Distance 6081.757
+}
+
+OpenCluster "HSC 2471"
+{
+	RA 11.98843429
+	Dec -59.68390122
+	Radius 28.041
+	Distance 6736.923
+}
+
+OpenCluster "CWNU 1173"
+{
+	RA 11.99478966
+	Dec -70.28608802
+	Radius 147.673
+	Distance 1421.182
+}
+
+OpenCluster "CWNU 2671:Theia 2119"
+{
+	RA 11.99660381
+	Dec -61.30408303
+	Radius 33.165
+	Distance 6180.936
+}
+
+OpenCluster "HSC 2477"
+{
+	RA 12.0094347
+	Dec -62.86300331
+	Radius 54.299
+	Distance 13085.908
+}
+
+OpenCluster "HSC 2515"
+{
+	RA 12.01007368
+	Dec -78.56442691
+	Radius 12.264
+	Distance 330.046
+}
+
+OpenCluster "OC 0576:UBC 282"
+{
+	RA 12.01016584
+	Dec -60.50272388
+	Radius 77.79
+	Distance 9508.534
+}
+
+OpenCluster "CWNU 1544"
+{
+	RA 12.01371521
+	Dec -64.05716965
+	Radius 73.747
+	Distance 12339.785
+}
+
+OpenCluster "HSC 2481"
+{
+	RA 12.02693655
+	Dec -64.42074523
+	Radius 20.253
+	Distance 8966.688
+}
+
+OpenCluster "HSC 2478"
+{
+	RA 12.02704911
+	Dec -62.70943069
+	Radius 60.663
+	Distance 11508.975
+}
+
+OpenCluster "UBC 1511"
+{
+	RA 12.02771063
+	Dec -62.77509631
+	Radius 56.895
+	Distance 13330.303
+}
+
+OpenCluster "DSH J1201.6-6406:FSR 1600:Juchert 13:MWSC 1992:OC 0580"
+{
+	RA 12.02891968
+	Dec -64.10055104
+	Radius 138.69
+	Distance 9369.239
+}
+
+OpenCluster "NGC 4052:Collinder 251:BH 126:ESO 94-10:MWSC 1991:OCL 870"
+{
+	RA 12.031535
+	Dec -63.22852745
+	Radius 41.754
+	Distance 8346.136
+}
+
+OpenCluster "HSC 2490"
+{
+	RA 12.04557665
+	Dec -68.58767362
+	Radius 150.92
+	Distance 3012.282
+}
+
+OpenCluster "ASCC 68:AT 8:Alessi-Teutsch 8:Alessi Teutsch 8:MWSC 1993:Theia 498"
+{
+	RA 12.04686555
+	Dec -60.95324402
+	Radius 54.116
+	Distance 3185.707
+}
+
+OpenCluster "HSC 2489"
+{
+	RA 12.05638689
+	Dec -67.38507311
+	Radius 33.224
+	Distance 5352.902
+}
+
+OpenCluster "CWNU 2700"
+{
+	RA 12.05773554
+	Dec -63.59485969
+	Radius 31.169
+	Distance 6982.036
+}
+
+OpenCluster "LISC 1274:UBC 1512"
+{
+	RA 12.06413601
+	Dec -63.6121122
+	Radius 114.381
+	Distance 10240.305
+}
+
+OpenCluster "Gulliver 12"
+{
+	RA 12.07800273
+	Dec -61.31241975
+	Radius 42.071
+	Distance 5288.779
+}
+
+OpenCluster "ESO 130-4:Gulliver 50:MWSC 1995:OCL 873:Ruprecht 100"
+{
+	RA 12.09074953
+	Dec -62.68647347
+	Radius 58.649
+	Distance 5590.277
+}
+
+OpenCluster "ESO 130-4:MWSC 1995:OCL 873:Ruprecht 100"
+{
+	RA 12.10143123
+	Dec -62.62334668
+	Radius 82.896
+	Distance 10471.375
+}
+
+OpenCluster "HSC 2499"
+{
+	RA 12.10150579
+	Dec -70.09213315
+	Radius 25.352
+	Distance 2912.156
+}
+
+OpenCluster "HSC 1137"
+{
+	RA 12.10601118
+	Dec 48.72240653
+	Radius 146.623
+	Distance 646.509
+}
+
+OpenCluster "ASCC 69:MWSC 1996"
+{
+	RA 12.10624427
+	Dec -69.85703281
+	Radius 88.034
+	Distance 2370.165
+}
+
+OpenCluster "NGC 4103:Melotte 109:Collinder 252:BH 127:ESO 130-5:MWSC 1997:OCL 871:Theia 2558"
+{
+	RA 12.1103704
+	Dec -61.24663987
+	Radius 89.712
+	Distance 6189.544
+}
+
+OpenCluster "CWNU 1440"
+{
+	RA 12.11273045
+	Dec -62.98858005
+	Radius 24.156
+	Distance 6543.176
+}
+
+OpenCluster "ESO 130-06:ESO 130-130:ESO 130-6:ESO 130 06:MWSC 1998:Steine 4"
+{
+	RA 12.13166935
+	Dec -59.30950607
+	Radius 44.866
+	Distance 2592.063
+}
+
+OpenCluster "UBC 1513"
+{
+	RA 12.13421587
+	Dec -61.88361655
+	Radius 33.874
+	Distance 9389.861
+}
+
+OpenCluster "CWNU 1580"
+{
+	RA 12.13786761
+	Dec -59.97767219
+	Radius 89.215
+	Distance 7689.955
+}
+
+OpenCluster "CWNU 1399"
+{
+	RA 12.145819
+	Dec -62.59405333
+	Radius 66.231
+	Distance 14891.064
+}
+
+OpenCluster "HSC 2468"
+{
+	RA 12.14862822
+	Dec -51.5402197
+	Radius 79.206
+	Distance 355.433
+}
+
+OpenCluster "Teutsch J1209.3+6120:Teutsch J1209.3-6120:UBC 1514"
+{
+	RA 12.1558729
+	Dec -61.3272249
+	Radius 51.053
+	Distance 8861.171
+}
+
+OpenCluster "Ruprecht 101"
+{
+	RA 12.16035988
+	Dec -62.99040708
+	Radius 106.961
+	Distance 10054.145
+}
+
+OpenCluster "Theia 2739:Theia 3053:Theia 3059:Theia 4856:UBC 517"
+{
+	RA 12.16429545
+	Dec -63.9660026
+	Radius 156.173
+	Distance 7335.181
+}
+
+OpenCluster "OC 0581:UBC 516"
+{
+	RA 12.16912993
+	Dec -62.32711388
+	Radius 40.66
+	Distance 9674.207
+}
+
+OpenCluster "CWNU 2350"
+{
+	RA 12.17272547
+	Dec -62.04149573
+	Radius 50.079
+	Distance 14169.76
+}
+
+OpenCluster "ESO 130-08:ESO 130 08:Stock 15:Theia 3044"
+{
+	RA 12.17521457
+	Dec -59.47329178
+	Radius 51.544
+	Distance 4271.208
+}
+
+OpenCluster "UBC 1590"
+{
+	RA 12.1921824
+	Dec -64.80357029
+	Radius 69.785
+	Distance 13967.249
+}
+
+OpenCluster "CWNU 2410"
+{
+	RA 12.20551168
+	Dec -61.96948679
+	Radius 60.219
+	Distance 12855.727
+}
+
+OpenCluster "Theia 3784"
+{
+	RA 12.20984384
+	Dec -61.33026017
+	Radius 35.623
+	Distance 7633.625
+}
+
+OpenCluster "Theia 1985:Theia 4169:Theia 7490"
+{
+	RA 12.22345521
+	Dec -63.75705449
+	Radius 117.58
+	Distance 5822.234
+}
+
+OpenCluster "CWNU 2745"
+{
+	RA 12.22606788
+	Dec -63.02844442
+	Radius 82.977
+	Distance 12476.124
+}
+
+OpenCluster "NGC 4184:BH 128:ESO 130-10:MWSC 2007:OCL 877:Ruprecht 102"
+{
+	RA 12.2266227
+	Dec -62.71625498
+	Radius 67.344
+	Distance 9612.019
+}
+
+OpenCluster "HSC 2482"
+{
+	RA 12.23695589
+	Dec -55.63487018
+	Radius 32.167
+	Distance 8911.322
+}
+
+OpenCluster "CWNU 2299"
+{
+	RA 12.23738409
+	Dec -59.49612547
+	Radius 32.193
+	Distance 9818.214
+}
+
+OpenCluster "HSC 2495"
+{
+	RA 12.24390906
+	Dec -63.81661148
+	Radius 44.289
+	Distance 16467.368
+}
+
+OpenCluster "HSC 2498"
+{
+	RA 12.24505525
+	Dec -64.9469913
+	Radius 80.532
+	Distance 7506.391
+}
+
+OpenCluster "CWNU 2634"
+{
+	RA 12.24516638
+	Dec -61.02647001
+	Radius 133.598
+	Distance 11562.584
+}
+
+OpenCluster "UBC 1588"
+{
+	RA 12.24565443
+	Dec -60.32387839
+	Radius 67.59
+	Distance 11588.635
+}
+
+OpenCluster "HSC 2507"
+{
+	RA 12.2499729
+	Dec -68.68456581
+	Radius 42.72
+	Distance 3115.921
+}
+
+OpenCluster "Theia 2191:Theia 5228"
+{
+	RA 12.2510535
+	Dec -64.90297386
+	Radius 76.773
+	Distance 4313.935
+}
+
+OpenCluster "HSC 2503"
+{
+	RA 12.25747423
+	Dec -67.12343191
+	Radius 58.594
+	Distance 3706.671
+}
+
+OpenCluster "CWNU 503"
+{
+	RA 12.26470484
+	Dec -64.95308928
+	Radius 59.345
+	Distance 10152.675
+}
+
+OpenCluster "HSC 2494"
+{
+	RA 12.27129028
+	Dec -61.61524323
+	Radius 63.052
+	Distance 10976.642
+}
+
+OpenCluster "Theia 4811:UBC 284"
+{
+	RA 12.28601382
+	Dec -62.95343292
+	Radius 41.621
+	Distance 5753.625
+}
+
+OpenCluster "HSC 2518"
+{
+	RA 12.28736178
+	Dec -75.32422408
+	Radius 63.785
+	Distance 979.301
+}
+
+OpenCluster "UBC 518"
+{
+	RA 12.30006303
+	Dec -62.93524895
+	Radius 68.771
+	Distance 10135.953
+}
+
+OpenCluster "Theia 2191:UBC 285"
+{
+	RA 12.31165922
+	Dec -65.4419462
+	Radius 33.408
+	Distance 5453.548
+}
+
+OpenCluster "HSC 2502"
+{
+	RA 12.31225458
+	Dec -62.6201483
+	Radius 38.236
+	Distance 15354.537
+}
+
+OpenCluster "HSC 2505"
+{
+	RA 12.33473332
+	Dec -64.09667216
+	Radius 34.833
+	Distance 345.25
+}
+
+OpenCluster "CWNU 2405:Theia 2191"
+{
+	RA 12.33870818
+	Dec -65.63668267
+	Radius 56.396
+	Distance 7354.13
+}
+
+OpenCluster "CWNU 2269"
+{
+	RA 12.34236695
+	Dec -61.68418843
+	Radius 45.756
+	Distance 9816.954
+}
+
+OpenCluster "ASCC 71:MWSC 2016"
+{
+	RA 12.34460629
+	Dec -67.52149108
+	Radius 56.323
+	Distance 3986.839
+}
+
+OpenCluster "CWNU 252"
+{
+	RA 12.35985049
+	Dec -61.07169588
+	Radius 62.08
+	Distance 4017.614
+}
+
+OpenCluster "UBC 519"
+{
+	RA 12.36309466
+	Dec -60.38852997
+	Radius 83.951
+	Distance 9218.115
+}
+
+OpenCluster "UFMG 61"
+{
+	RA 12.36410498
+	Dec -63.62797271
+	Radius 46.842
+	Distance 6569.427
+}
+
+OpenCluster "HSC 2504"
+{
+	RA 12.36638529
+	Dec -61.60310366
+	Radius 52.524
+	Distance 9127.948
+}
+
+OpenCluster "HSC 2506"
+{
+	RA 12.36671531
+	Dec -62.29981032
+	Radius 117.781
+	Distance 12839.601
+}
+
+OpenCluster "HSC 2484"
+{
+	RA 12.37245894
+	Dec -47.71503114
+	Radius 28.152
+	Distance 3393.047
+}
+
+OpenCluster "ESO 130-13:ESO 130 13:FSR 1612:MWSC 2021:MWSC 2022"
+{
+	RA 12.38523964
+	Dec -59.65661452
+	Radius 71.518
+	Distance 7691.61
+}
+
+OpenCluster "HSC 2512"
+{
+	RA 12.39729451
+	Dec -62.7614658
+	Radius 46.912
+	Distance 14509.851
+}
+
+OpenCluster "Coma Star Cluster:Melotte 111:Collinder 256:MWSC 2020:OCL 558"
+{
+	RA 12.40114659
+	Dec 26.42267478
+	Radius 200.228
+	Distance 278.054
+}
+
+OpenCluster "NGC 4337:Collinder 254:BH 129:ESO 131-2:FSR 1611:MWSC 2023:OCL 878"
+{
+	RA 12.40147024
+	Dec -58.12181095
+	Radius 67.128
+	Distance 7873.135
+}
+
+OpenCluster "NGC 4349:Melotte 110:Collinder 255:BH 130:ESO 131-3:FSR 1614:Loden 624:MWSC 2024:OCL 882:Theia 2499:Theia 3079:Theia 3101"
+{
+	RA 12.40364189
+	Dec -61.86413846
+	Radius 47.631
+	Distance 5834.676
+}
+
+OpenCluster "UBC 520"
+{
+	RA 12.40487837
+	Dec -66.67359113
+	Radius 33.851
+	Distance 5951.782
+}
+
+OpenCluster "ESO 064-05:ESO 064-64:ESO 064 05:ESO 64-5:MWSC 2026"
+{
+	RA 12.4098959
+	Dec -68.43617226
+	Radius 50.084
+	Distance 4002.588
+}
+
+OpenCluster "CWNU 1685:Loden 624"
+{
+	RA 12.41466076
+	Dec -61.5070793
+	Radius 70.197
+	Distance 6630.69
+}
+
+OpenCluster "NGC 4349:Melotte 110:Collinder 255:BH 130:DSH J1224.9-6158:ESO 131-3:FSR 1614:Gulliver 46:MWSC 2024:OCL 882:Teutsch 108:Theia 3079"
+{
+	RA 12.41560624
+	Dec -61.97228179
+	Radius 75.923
+	Distance 12844.578
+}
+
+OpenCluster "HSC 2514"
+{
+	RA 12.41876614
+	Dec -65.20913739
+	Radius 161.037
+	Distance 7310.233
+}
+
+OpenCluster "OCSN 89:Theia 246"
+{
+	RA 12.43000795
+	Dec -65.88346546
+	Radius 113.668
+	Distance 1344.703
+}
+
+OpenCluster "BH 131:FSR 1615:MWSC 2030:vdBergh-Hagen 131"
+{
+	RA 12.43744527
+	Dec -63.41572946
+	Radius 186.409
+	Distance 19224.627
+}
+
+OpenCluster "UBC 1515"
+{
+	RA 12.44695286
+	Dec -62.37978458
+	Radius 40.068
+	Distance 11404.737
+}
+
+OpenCluster "BH 132:MWSC 2032:vdBergh-Hagen 132"
+{
+	RA 12.44875203
+	Dec -64.05576826
+	Radius 56.816
+	Distance 8052.047
+}
+
+OpenCluster "BH 133:Collinder 257:Collinder 258:ESO 131-5:HD 108353:Harvard 5:MWSC 2027:MWSC 2033:OCL 880"
+{
+	RA 12.45263238
+	Dec -60.76860522
+	Radius 27.92
+	Distance 3925.512
+}
+
+OpenCluster "HSC 2511"
+{
+	RA 12.45515874
+	Dec -58.33959936
+	Radius 48.686
+	Distance 2876.568
+}
+
+OpenCluster "CWNU 2690"
+{
+	RA 12.45650897
+	Dec -62.66184284
+	Radius 50.623
+	Distance 9908.727
+}
+
+OpenCluster "Theia 2351:Theia 980"
+{
+	RA 12.46234882
+	Dec -64.33139936
+	Radius 85.391
+	Distance 3315.687
+}
+
+OpenCluster "CWNU 2750:Loden 624:Theia 3079:Theia 4121"
+{
+	RA 12.46473539
+	Dec -61.98580099
+	Radius 50.031
+	Distance 6704.502
 }
 
 OpenCluster "NGC 4439"
 {
-	RA 12.474167
-	Dec -59.895000
-	Distance 5822
-	Radius 3.4
+	RA 12.47408333
+	Dec -60.09732025
+	Radius 79.94
+	Distance 6039.689
 }
 
-OpenCluster "Hogg 23"
+OpenCluster "UBC 286"
 {
-	RA 12.475556
-	Dec -59.104722
-	Distance 4077
-	Radius 4.2
+	RA 12.48816778
+	Dec -62.45312042
+	Radius 38.491
+	Distance 6764.857
 }
 
-OpenCluster "Hogg 14"
+OpenCluster "NGC 4463:Collinder 260:BH 135:ESO 95-10:MWSC 2042:OCL 885:Theia 1930:Theia 2125:Theia 2351:Theia 4223"
 {
-	RA 12.476667
-	Dec -58.183333
-	Distance 3160
-	Radius 1.4
+	RA 12.49760493
+	Dec -64.79678646
+	Radius 65.04
+	Distance 5716.041
 }
 
-OpenCluster "NGC 4463"
+OpenCluster "HSC 2523"
 {
-	RA 12.498889
-	Dec -63.210000
-	Distance 3424
-	Radius 1.7
+	RA 12.50234836
+	Dec -72.94015418
+	Radius 18.981
+	Distance 331.303
 }
 
-OpenCluster "ASCC 72"
+OpenCluster "UBC 521"
 {
-	RA 12.550000
-	Dec -59.050000
-	Distance 3587
-	Radius 15.7
+	RA 12.50569499
+	Dec -64.1680828
+	Radius 97.197
+	Distance 9406.778
 }
 
-OpenCluster "Ruprecht 105"
+OpenCluster "CWNU 1573"
 {
-	RA 12.570556
-	Dec -60.433333
-	Distance 3098
-	Radius 5.4
+	RA 12.53968601
+	Dec -62.83744544
+	Radius 60.169
+	Distance 9930.869
 }
 
-OpenCluster "ASCC 73"
+OpenCluster "CWNU 1256"
 {
-	RA 12.610000
-	Dec -66.710000
-	Distance 2120
-	Radius 14.8
+	RA 12.54445024
+	Dec -72.30159937
+	Radius 60.407
+	Distance 1532.584
 }
 
-OpenCluster "Collinder 261"
+OpenCluster "Theia 980"
 {
-	RA 12.632500
-	Dec -67.633333
-	Distance 7143
-	Radius 9.4
+	RA 12.54817765
+	Dec -65.19355823
+	Radius 131.579
+	Distance 2437.102
 }
 
-OpenCluster "NGC 4609"
+OpenCluster "CWNU 175"
 {
-	RA 12.705000
-	Dec -61.005000
-	Distance 3989
-	Radius 2.3
+	RA 12.56043479
+	Dec -63.51549475
+	Radius 66.632
+	Distance 4465.942
 }
 
-OpenCluster "Hogg 15"
+OpenCluster "HSC 2520"
 {
-	RA 12.726944
-	Dec -62.900000
-	Distance 7377
-	Radius 2.1
+	RA 12.57175612
+	Dec -62.25779356
+	Radius 142.412
+	Distance 11700.709
 }
 
-OpenCluster "Loden 682"
+OpenCluster "ESO 131-12:MWSC 2047:OCL 886:Ruprecht 105:Slotegraaf 41:Theia 3539:Theia 4683"
 {
-	RA 12.788056
-	Dec -59.350000
-	Distance 2935
-	Radius 11.1
+	RA 12.57576682
+	Dec -61.59491953
+	Radius 42.688
+	Distance 6392.13
 }
 
-OpenCluster "Loden 694"
+OpenCluster "CWNU 147"
 {
-	RA 12.883611
-	Dec -59.233333
-	Distance 5544
-	Radius 18.5
+	RA 12.58334083
+	Dec -58.08856056
+	Radius 33.548
+	Distance 2582.737
 }
 
-OpenCluster "NGC 4755"
+OpenCluster "ASCC 73:MWSC 2053:Theia 1076:Theia 1162:Theia 246:Theia 338"
 {
-	RA 12.894167
-	Dec -59.638333
-	Distance 6445
-	Radius 9.4
+	RA 12.61948021
+	Dec -67.21018149
+	Radius 126.96
+	Distance 2048.299
 }
 
-OpenCluster "NGC 4815"
+OpenCluster "HSC 2521"
 {
-	RA 12.966389
-	Dec -63.040000
-	Distance 10042
-	Radius 7.3
+	RA 12.62138348
+	Dec -59.34964098
+	Radius 93.613
+	Distance 22320.356
 }
 
-OpenCluster "NGC 4852"
+OpenCluster "CWNU 2632"
 {
-	RA 13.002500
-	Dec -58.386667
-	Distance 3587
-	Radius 5.2
+	RA 12.62656142
+	Dec -62.79137233
+	Radius 51.681
+	Distance 10107.086
+}
+
+OpenCluster "CWNU 1507"
+{
+	RA 12.63048007
+	Dec -60.27298889
+	Radius 38.339
+	Distance 6883.48
+}
+
+OpenCluster "BH 136:Collinder 261:ESO 65-2:FSR 1627:Harvard 6:MWSC 2055:OCL 889"
+{
+	RA 12.6351065
+	Dec -68.38076034
+	Radius 118.493
+	Distance 8730.906
+}
+
+OpenCluster "OC 0582:Theia 2544:UBC 287"
+{
+	RA 12.65238815
+	Dec -61.25822836
+	Radius 85.175
+	Distance 6626.221
+}
+
+OpenCluster "FSR 1621:MWSC 2058"
+{
+	RA 12.65445608
+	Dec -57.40489906
+	Radius 92.512
+	Distance 4647.344
+}
+
+OpenCluster "Collinder 262:ESO 131-13:FSR 1624:Harvard 7:MWSC 2060:OCL 888:Trumpler 20"
+{
+	RA 12.65919071
+	Dec -60.63287457
+	Radius 166.125
+	Distance 10695.926
+}
+
+OpenCluster "CWNU 1866"
+{
+	RA 12.69023269
+	Dec -62.43774496
+	Radius 28.583
+	Distance 7058.39
+}
+
+OpenCluster "HSC 2526"
+{
+	RA 12.69103778
+	Dec -62.1838794
+	Radius 36.963
+	Distance 10304.07
+}
+
+OpenCluster "HSC 2527"
+{
+	RA 12.69354037
+	Dec -62.04379696
+	Radius 93.76
+	Distance 11745.565
+}
+
+OpenCluster "HSC 2525"
+{
+	RA 12.6955516
+	Dec -60.73038694
+	Radius 76.144
+	Distance 27582.417
+}
+
+OpenCluster "Theia 358"
+{
+	RA 12.70043019
+	Dec -69.45775853
+	Radius 112.359
+	Distance 3039.442
+}
+
+OpenCluster "Theia 954"
+{
+	RA 12.70274005
+	Dec -61.65487377
+	Radius 73.484
+	Distance 1719.777
+}
+
+OpenCluster "NGC 4609:Theia 2070"
+{
+	RA 12.70448898
+	Dec -62.99255981
+	Radius 69.955
+	Distance 4558.436
+}
+
+OpenCluster "CWNU 2292"
+{
+	RA 12.71338959
+	Dec -61.9135762
+	Radius 110.074
+	Distance 10020.779
+}
+
+OpenCluster "CWNU 2664"
+{
+	RA 12.71924203
+	Dec -61.16615383
+	Radius 45.918
+	Distance 6467.122
+}
+
+OpenCluster "UBC 1516"
+{
+	RA 12.72014329
+	Dec -61.84395322
+	Radius 41.879
+	Distance 10732.484
+}
+
+OpenCluster "UBC 522"
+{
+	RA 12.7219756
+	Dec -61.65650775
+	Radius 85.554
+	Distance 7156.009
+}
+
+OpenCluster "HSC 2528"
+{
+	RA 12.7240162
+	Dec -60.74765529
+	Radius 17.379
+	Distance 4542.328
+}
+
+OpenCluster "BH 139:ESO 95-15:Hogg 15:MWSC 2063:OCL 891:OC 0585"
+{
+	RA 12.72749289
+	Dec -63.10232183
+	Radius 84.907
+	Distance 10324.054
+}
+
+OpenCluster "FoF 1994:Theia 4596:UBC 288"
+{
+	RA 12.73451202
+	Dec -58.09172184
+	Radius 138.802
+	Distance 5821.835
+}
+
+OpenCluster "UBC 289"
+{
+	RA 12.74334039
+	Dec -61.17610348
+	Radius 50.69
+	Distance 6188.471
+}
+
+OpenCluster "HSC 2529"
+{
+	RA 12.74652406
+	Dec -61.37457227
+	Radius 66.677
+	Distance 644.974
+}
+
+OpenCluster "HSC 2519"
+{
+	RA 12.75229595
+	Dec -20.28417009
+	Radius 57.24
+	Distance 814.576
+}
+
+OpenCluster "HSC 2532"
+{
+	RA 12.75989253
+	Dec -70.43992871
+	Radius 33.586
+	Distance 6994.49
+}
+
+OpenCluster "Gulliver 58"
+{
+	RA 12.7690277
+	Dec -61.96352879
+	Radius 91.723
+	Distance 7274.381
+}
+
+OpenCluster "HSC 2531"
+{
+	RA 12.77604749
+	Dec -61.18972617
+	Radius 22.471
+	Distance 6748.455
+}
+
+OpenCluster "UBC 523"
+{
+	RA 12.77622429
+	Dec -66.20863679
+	Radius 53.855
+	Distance 9685.943
+}
+
+OpenCluster "HSC 2534"
+{
+	RA 12.780175
+	Dec -70.83231792
+	Radius 18.006
+	Distance 3738.275
+}
+
+OpenCluster "Theia 2208:Theia 3288:Theia 3924:UBC 290"
+{
+	RA 12.78278972
+	Dec -59.37596507
+	Radius 88.817
+	Distance 5064.054
+}
+
+OpenCluster "CWNU 1800"
+{
+	RA 12.78862559
+	Dec -63.70324019
+	Radius 82.686
+	Distance 6696.149
+}
+
+OpenCluster "HSC 2533"
+{
+	RA 12.78967342
+	Dec -65.52792121
+	Radius 40.059
+	Distance 3488.663
+}
+
+OpenCluster "CWNU 2088:Loden 682:MWSC 2065"
+{
+	RA 12.81176452
+	Dec -60.74271118
+	Radius 25.525
+	Distance 5666.06
+}
+
+OpenCluster "CWNU 277:Loden 682:MWSC 2065"
+{
+	RA 12.81397346
+	Dec -60.57552676
+	Radius 55.299
+	Distance 6375.65
+}
+
+OpenCluster "LISC 0672:UBC 524"
+{
+	RA 12.84119726
+	Dec -60.98380652
+	Radius 87.031
+	Distance 10169.42
+}
+
+OpenCluster "CWNU 2675"
+{
+	RA 12.84310677
+	Dec -64.38230866
+	Radius 74.224
+	Distance 6903.847
+}
+
+OpenCluster "CWNU 490:Loden 694:MWSC 2070:Theia 1748:Theia 2900:Theia 4255"
+{
+	RA 12.86029532
+	Dec -60.68074975
+	Radius 75.272
+	Distance 5982.082
+}
+
+OpenCluster "HSC 2536"
+{
+	RA 12.86344723
+	Dec -59.44557966
+	Radius 50.518
+	Distance 6155.431
+}
+
+OpenCluster "Theia 1082:UPK 578"
+{
+	RA 12.86670673
+	Dec -57.37408211
+	Radius 46.723
+	Distance 2988.904
+}
+
+OpenCluster "HXHWL 20"
+{
+	RA 12.88589566
+	Dec -63.75046268
+	Radius 37.964
+	Distance 4801.202
+}
+
+OpenCluster "Theia 404:UPK 579"
+{
+	RA 12.88676801
+	Dec -50.83242077
+	Radius 88.83
+	Distance 2311.031
+}
+
+OpenCluster "Jewel Box:kappa Crucis Cluster:NGC 4755:Melotte 114:Collinder 264:BH 141:ESO 131-16:FSR 1633:MWSC 2072:OCL 892:Theia 1748:Theia 2900"
+{
+	RA 12.89425154
+	Dec -60.37098487
+	Radius 60.566
+	Distance 6452.733
+}
+
+OpenCluster "CWNU 480"
+{
+	RA 12.89901648
+	Dec -61.99960147
+	Radius 54.804
+	Distance 7191.801
+}
+
+OpenCluster "HSC 2538"
+{
+	RA 12.89964386
+	Dec -69.25435303
+	Radius 23.22
+	Distance 5129.781
+}
+
+OpenCluster "Theia 1082"
+{
+	RA 12.91011382
+	Dec -58.95988914
+	Radius 106.537
+	Distance 2703.517
+}
+
+OpenCluster "CWNU 486:OC 0587"
+{
+	RA 12.913804
+	Dec -61.76693021
+	Radius 35.037
+	Distance 6015.212
+}
+
+OpenCluster "HSC 2540"
+{
+	RA 12.91684598
+	Dec -59.02991492
+	Radius 49.221
+	Distance 6306.06
+}
+
+OpenCluster "ASCC 72:CWNU 231:MWSC 2044:UBC 1517"
+{
+	RA 12.91758419
+	Dec -61.05354969
+	Radius 85.295
+	Distance 9389.259
+}
+
+OpenCluster "Theia 246"
+{
+	RA 12.91890535
+	Dec -66.42911126
+	Radius 102.616
+	Distance 1245.273
+}
+
+OpenCluster "HSC 2539"
+{
+	RA 12.92368466
+	Dec -63.03971771
+	Radius 80.251
+	Distance 11916.592
+}
+
+OpenCluster "CWNU 2692"
+{
+	RA 12.93866971
+	Dec -60.44606613
+	Radius 36.066
+	Distance 6653.77
+}
+
+OpenCluster "UBC 1518"
+{
+	RA 12.94417897
+	Dec -63.82383427
+	Radius 34.44
+	Distance 8519.322
+}
+
+OpenCluster "CWNU 450:Theia 323"
+{
+	RA 12.94685644
+	Dec -55.76296976
+	Radius 251.38
+	Distance 1590.46
+}
+
+OpenCluster "CWNU 1500"
+{
+	RA 12.95501703
+	Dec -61.3938956
+	Radius 34.717
+	Distance 5560.772
+}
+
+OpenCluster "HSC 2546"
+{
+	RA 12.9586191
+	Dec -63.49415704
+	Radius 73.914
+	Distance 6715.51
+}
+
+OpenCluster "UBC 1519"
+{
+	RA 12.96068692
+	Dec -65.25703112
+	Radius 112.216
+	Distance 12406.354
+}
+
+OpenCluster "CWNU 2384:DSH J1257.8-6315:Teutsch 109"
+{
+	RA 12.96363292
+	Dec -63.26594103
+	Radius 25.902
+	Distance 10809.975
+}
+
+OpenCluster "NGC 4815:Collinder 265:BH 142:ESO 96-1:FSR 1637:MWSC 2075:OCL 893:Theia 4324"
+{
+	RA 12.96713838
+	Dec -64.95909495
+	Radius 80.789
+	Distance 10248.735
+}
+
+OpenCluster "HSC 2554"
+{
+	RA 12.9773838
+	Dec -42.29187818
+	Radius 52.519
+	Distance 8586.93
+}
+
+OpenCluster "UBC 1520"
+{
+	RA 12.98301972
+	Dec -61.08186257
+	Radius 59.105
+	Distance 8458.67
+}
+
+OpenCluster "CWNU 2498"
+{
+	RA 12.98494458
+	Dec -60.68050972
+	Radius 79.927
+	Distance 8989.742
+}
+
+OpenCluster "HSC 2549"
+{
+	RA 12.99158378
+	Dec -64.01188477
+	Radius 64.225
+	Distance 7066.029
+}
+
+OpenCluster "NGC 4852:Melotte 116:Collinder 266:BH 143:ESO 131-17:MWSC 2078:OCL 894:Theia 2553"
+{
+	RA 13.00240095
+	Dec -59.60523408
+	Radius 50.088
+	Distance 4038.899
+}
+
+OpenCluster "HSC 2552"
+{
+	RA 13.0058277
+	Dec -60.61919583
+	Radius 53.137
+	Distance 6531.202
+}
+
+OpenCluster "HSC 2551"
+{
+	RA 13.00628206
+	Dec -60.98088117
+	Radius 35.348
+	Distance 5867.613
+}
+
+OpenCluster "HSC 2550"
+{
+	RA 13.00717371
+	Dec -62.39743891
+	Radius 39.242
+	Distance 5970.288
+}
+
+OpenCluster "UFMG 53"
+{
+	RA 13.03313179
+	Dec -64.03963768
+	Radius 32.711
+	Distance 9035.027
+}
+
+OpenCluster "CWNU 2245"
+{
+	RA 13.03800581
+	Dec -59.82492313
+	Radius 26.204
+	Distance 6024.479
+}
+
+OpenCluster "CWNU 2400"
+{
+	RA 13.0397566
+	Dec -64.35914565
+	Radius 62.482
+	Distance 11938.339
+}
+
+OpenCluster "Gulliver 59:Theia 2930:Theia 4019"
+{
+	RA 13.04786257
+	Dec -64.60738986
+	Radius 94.919
+	Distance 6743.426
+}
+
+OpenCluster "HSC 2553"
+{
+	RA 13.05622002
+	Dec -61.76848622
+	Radius 104.098
+	Distance 2441.025
+}
+
+OpenCluster "CWNU 1122:OC 0588"
+{
+	RA 13.06651989
+	Dec -60.09600847
+	Radius 201.353
+	Distance 2129.841
+}
+
+OpenCluster "UBC 525"
+{
+	RA 13.07623969
+	Dec -63.95390062
+	Radius 72.964
+	Distance 7022.046
+}
+
+OpenCluster "CWNU 467:OC 0589"
+{
+	RA 13.08165663
+	Dec -61.70704666
+	Radius 111.638
+	Distance 5886.418
+}
+
+OpenCluster "UBC 1521"
+{
+	RA 13.0899327
+	Dec -60.98849643
+	Radius 44.346
+	Distance 9498.915
+}
+
+OpenCluster "CWNU 27:OC 0591:Theia 1934"
+{
+	RA 13.09237778
+	Dec -56.85528354
+	Radius 71.91
+	Distance 3716.96
+}
+
+OpenCluster "HSC 2557"
+{
+	RA 13.09287362
+	Dec -62.38934138
+	Radius 66.783
+	Distance 11420.183
+}
+
+OpenCluster "HSC 2555"
+{
+	RA 13.09492845
+	Dec -63.65873759
+	Radius 35.912
+	Distance 16162.496
+}
+
+OpenCluster "HSC 2558"
+{
+	RA 13.09926569
+	Dec -61.88049116
+	Radius 108.479
+	Distance 7070.933
+}
+
+OpenCluster "Theia 29"
+{
+	RA 13.10271305
+	Dec -77.58526246
+	Radius 26.584
+	Distance 636.655
+}
+
+OpenCluster "HSC 2556"
+{
+	RA 13.11041564
+	Dec -65.06783255
+	Radius 64.648
+	Distance 7312.339
+}
+
+OpenCluster "OC 0593:UFMG 55"
+{
+	RA 13.13576125
+	Dec -61.25022828
+	Radius 67.301
+	Distance 9816.066
+}
+
+OpenCluster "OC 0594"
+{
+	RA 13.16875234
+	Dec -63.19699619
+	Radius 56.701
+	Distance 14364.56
+}
+
+OpenCluster "HSC 2561"
+{
+	RA 13.17416756
+	Dec -63.39707431
+	Radius 41.2
+	Distance 12295.97
+}
+
+OpenCluster "HSC 2559"
+{
+	RA 13.18005721
+	Dec -66.9874464
+	Radius 76.738
+	Distance 4295.643
+}
+
+OpenCluster "CWNU 1453:Theia 2478"
+{
+	RA 13.18723798
+	Dec -64.30200702
+	Radius 86.992
+	Distance 6937.179
+}
+
+OpenCluster "CWNU 382"
+{
+	RA 13.19013835
+	Dec -56.44486395
+	Radius 72.409
+	Distance 3025.271
+}
+
+OpenCluster "HSC 2562"
+{
+	RA 13.1909982
+	Dec -63.44880194
+	Radius 27.061
+	Distance 7065.845
+}
+
+OpenCluster "HSC 2565"
+{
+	RA 13.20282882
+	Dec -62.38440334
+	Radius 29.519
+	Distance 8417.345
+}
+
+OpenCluster "HSC 2564"
+{
+	RA 13.20491232
+	Dec -62.89978739
+	Radius 50.513
+	Distance 7570.117
+}
+
+OpenCluster "UBC 1626"
+{
+	RA 13.20745494
+	Dec -66.84533101
+	Radius 38.04
+	Distance 7960.521
+}
+
+OpenCluster "Danks 2"
+{
+	RA 13.21483885
+	Dec -62.68008513
+	Radius 92.251
+	Distance 16811.156
+}
+
+OpenCluster "CWNU 278:LISC 3164:UBC 1522"
+{
+	RA 13.21582301
+	Dec -64.27589231
+	Radius 60.048
+	Distance 6578.06
+}
+
+OpenCluster "HSC 2567"
+{
+	RA 13.21901066
+	Dec -62.19624412
+	Radius 28.026
+	Distance 8408.371
 }
 
 OpenCluster "NGC 5045"
 {
-	RA 13.236111
-	Dec -62.610000
-	Distance 4892
-	Radius 32.2
+	RA 13.24822623
+	Dec -63.57198571
+	Radius 32.127
+	Distance 6218.873
 }
 
-OpenCluster "BH 144"
+OpenCluster "AL 1:Andrews-Lindsay 1:BH 144:ESO 96-4:MWSC 2098:vdBergh-Hagen 144"
 {
-	RA 13.251667
-	Dec -64.083333
-	Distance 39140
-	Radius 8.5
+	RA 13.25554799
+	Dec -65.91788942
+	Radius 170.896
+	Distance 42030.244
 }
 
-OpenCluster "NGC 5043"
+OpenCluster "CWNU 485:OC 0596"
 {
-	RA 13.269167
-	Dec -59.926667
-	Distance 3163
-	Radius 6.4
+	RA 13.25678384
+	Dec -61.59412369
+	Radius 20.381
+	Distance 5349.242
+}
+
+OpenCluster "Theia 771"
+{
+	RA 13.2592631
+	Dec -59.229644
+	Radius 104.103
+	Distance 2721.363
+}
+
+OpenCluster "UBC 291"
+{
+	RA 13.26955571
+	Dec -63.44181055
+	Radius 53.72
+	Distance 8683.943
+}
+
+OpenCluster "CWNU 1643"
+{
+	RA 13.27002882
+	Dec -63.42585771
+	Radius 28.19
+	Distance 14132.826
+}
+
+OpenCluster "Theia 782"
+{
+	RA 13.27215157
+	Dec -69.48379993
+	Radius 87.434
+	Distance 2984.062
+}
+
+OpenCluster "HSC 2569"
+{
+	RA 13.27282486
+	Dec -63.3685937
+	Radius 41.194
+	Distance 6369.5
+}
+
+OpenCluster "HSC 2571"
+{
+	RA 13.27809291
+	Dec -61.81289395
+	Radius 62.083
+	Distance 1584.402
+}
+
+OpenCluster "CWNU 2616"
+{
+	RA 13.28650571
+	Dec -63.89098697
+	Radius 31.636
+	Distance 13528.07
 }
 
 OpenCluster "Collinder 268"
 {
-	RA 13.303611
-	Dec -66.916667
-	Distance 6402
-	Radius 4.7
+	RA 13.30291803
+	Dec -67.08401503
+	Radius 51.605
+	Distance 7829.477
 }
 
-OpenCluster "Stock 16"
+OpenCluster "HSC 2570"
 {
-	RA 13.324722
-	Dec -61.366667
-	Distance 5903
-	Radius 2.6
+	RA 13.30298086
+	Dec -63.80772173
+	Radius 35.826
+	Distance 12537.09
 }
 
-OpenCluster "Ruprecht 107"
+OpenCluster "HSC 2575"
 {
-	RA 13.329444
-	Dec -63.050000
-	Distance 4703
-	Radius 2.1
+	RA 13.30974949
+	Dec -62.46612095
+	Radius 144.32
+	Distance 13239.681
 }
 
-OpenCluster "Collinder 269"
+OpenCluster "HSC 2576"
 {
-	RA 13.391944
-	Dec -65.816667
-	Distance 4240
-	Radius 9.3
+	RA 13.31188287
+	Dec -62.52539711
+	Radius 78.761
+	Distance 6295.493
 }
 
-OpenCluster "Teutsch 79"
+OpenCluster "BH 146:ESO 96-8:MWSC 2108:OCL 896:Ruprecht 107"
 {
-	RA 13.394167
-	Dec -62.330556
-	Distance 21853
-	Radius 6.4
+	RA 13.32937462
+	Dec -64.9453569
+	Radius 50.514
+	Distance 11607.089
 }
 
-OpenCluster "Loden 821"
+OpenCluster "HSC 2579"
 {
-	RA 13.405833
-	Dec -58.266667
-	Distance 9132
-	Radius 25.2
+	RA 13.3431299
+	Dec -62.8457541
+	Radius 40.442
+	Distance 11059.327
 }
 
-OpenCluster "Loden 807"
+OpenCluster "UBC 292"
 {
-	RA 13.411111
-	Dec -61.516667
-	Distance 3017
-	Radius 8.8
+	RA 13.34452473
+	Dec -61.32175708
+	Radius 43.092
+	Distance 6865.377
 }
 
-OpenCluster "NGC 5138"
+OpenCluster "CWNU 1342"
 {
-	RA 13.454444
-	Dec -58.966667
-	Distance 6477
-	Radius 6.6
+	RA 13.35205951
+	Dec -63.19705824
+	Radius 21.665
+	Distance 10218.841
 }
 
-OpenCluster "Basel 18"
+OpenCluster "HSC 2578"
 {
-	RA 13.462222
-	Dec -61.687222
-	Distance 7260
-	Radius 6.3
+	RA 13.35272861
+	Dec -63.4510103
+	Radius 51.47
+	Distance 2721.534
 }
 
-OpenCluster "Hogg 16"
+OpenCluster "FSR 1645"
 {
-	RA 13.488333
-	Dec -60.800000
-	Distance 5169
-	Radius 4.5
+	RA 13.35505458
+	Dec -61.9885468
+	Radius 37.792
+	Distance 10592.99
 }
 
-OpenCluster "Collinder 271"
+OpenCluster "HSC 2580"
 {
-	RA 13.498333
-	Dec -63.800000
-	Distance 3812
-	Radius 2.8
+	RA 13.35519745
+	Dec -63.43336403
+	Radius 37.735
+	Distance 14755.894
 }
 
-OpenCluster "Collinder 272"
+OpenCluster "HSC 2582"
 {
-	RA 13.507222
-	Dec -60.683333
-	Distance 6670
-	Radius 9.7
+	RA 13.38378341
+	Dec -61.15605241
+	Radius 21.892
+	Distance 6649.561
 }
 
-OpenCluster "NGC 5168"
+OpenCluster "DSH J1323.6-6340:MWSC 2114:Teutsch 79"
 {
-	RA 13.518333
-	Dec -59.060000
-	Distance 5795
-	Radius 3.4
+	RA 13.3948361
+	Dec -63.67252823
+	Radius 50.075
+	Distance 19190.732
 }
 
-OpenCluster "ESO 383-10"
+OpenCluster "HSC 906"
 {
-	RA 13.525000
-	Dec -34.934444
-	Distance 3261
-	Radius 2.8
+	RA 13.39673817
+	Dec 55.70816654
+	Radius 50.44
+	Distance 81.815
 }
 
-OpenCluster "Ruprecht 108"
+OpenCluster "Collinder 269:ESO 96-10:MWSC 2113:OCL 897:Theia 4348"
 {
-	RA 13.536389
-	Dec -57.533333
-	Distance 2938
-	Radius 4.3
+	RA 13.39760723
+	Dec -66.19097902
+	Radius 49.043
+	Distance 5279.67
 }
 
-OpenCluster "Trumpler 21"
+OpenCluster "HSC 2581"
 {
-	RA 13.537222
-	Dec -61.200000
-	Distance 4119
-	Radius 3.0
+	RA 13.40045596
+	Dec -63.2033965
+	Radius 26.674
+	Distance 13550.461
 }
 
-OpenCluster "Loden 915"
+OpenCluster "UPK 587"
 {
-	RA 13.568333
-	Dec -58.750000
-	Distance 1630
-	Radius 7.6
+	RA 13.41002246
+	Dec -49.92700804
+	Radius 66.625
+	Distance 2878.21
 }
 
-OpenCluster "C1331-622"
+OpenCluster "CWNU 2888"
 {
-	RA 13.570000
-	Dec -61.582778
-	Distance 2671
-	Radius 2.7
+	RA 13.42209969
+	Dec -62.27896451
+	Radius 64.043
+	Distance 6847.948
 }
 
-OpenCluster "ASCC 74"
+OpenCluster "HSC 2601"
 {
-	RA 13.596944
-	Dec -57.190000
-	Distance 1793
-	Radius 6.3
+	RA 13.42338268
+	Dec -52.0564325
+	Radius 74.886
+	Distance 15306.511
 }
 
-OpenCluster "ESO 132-14"
+OpenCluster "CWNU 1351:ESO 96-11:MWSC 2119:OCL 899:Ruprecht 166"
 {
-	RA 13.608333
-	Dec -61.786389
-	Distance 3587
-	Radius 1.6
+	RA 13.42662268
+	Dec -63.45888976
+	Radius 125.083
+	Distance 20611.069
+}
+
+OpenCluster "HSC 2605"
+{
+	RA 13.42765993
+	Dec -47.33690133
+	Radius 12.829
+	Distance 3457.06
+}
+
+OpenCluster "Theia 3272"
+{
+	RA 13.43045465
+	Dec -61.42031641
+	Radius 31.588
+	Distance 3708.574
+}
+
+OpenCluster "HSC 2617"
+{
+	RA 13.44241817
+	Dec -41.16044343
+	Radius 34.361
+	Distance 7212.479
+}
+
+OpenCluster "DSH J1326.5-6406:Teutsch 110"
+{
+	RA 13.44243932
+	Dec -64.10571068
+	Radius 38.755
+	Distance 18500.255
+}
+
+OpenCluster "Theia 2139:Theia 2523"
+{
+	RA 13.44335607
+	Dec -62.02358065
+	Radius 103.584
+	Distance 10100.884
+}
+
+OpenCluster "CWNU 1442"
+{
+	RA 13.44515537
+	Dec -60.91967481
+	Radius 74.369
+	Distance 9840.994
+}
+
+OpenCluster "HSC 2586"
+{
+	RA 13.45312741
+	Dec -63.35676133
+	Radius 14.299
+	Distance 7607.833
+}
+
+OpenCluster "NGC 5138:Collinder 270:ESO 132-7:MWSC 2121:OCL 902"
+{
+	RA 13.45558659
+	Dec -59.0245513
+	Radius 90.794
+	Distance 5963.058
+}
+
+OpenCluster "Basel 18:Theia 2139"
+{
+	RA 13.46325543
+	Dec -62.30282084
+	Radius 28.981
+	Distance 5627.802
+}
+
+OpenCluster "HSC 2590"
+{
+	RA 13.46526413
+	Dec -61.87892812
+	Radius 25.527
+	Distance 4037.904
+}
+
+OpenCluster "HSC 2584"
+{
+	RA 13.47642868
+	Dec -64.77739792
+	Radius 69.725
+	Distance 8274.734
+}
+
+OpenCluster "Theia 2541"
+{
+	RA 13.47950656
+	Dec -64.26563398
+	Radius 49.179
+	Distance 6148.067
+}
+
+OpenCluster "CWNU 1988"
+{
+	RA 13.48120006
+	Dec -63.26508161
+	Radius 49.817
+	Distance 10209.029
+}
+
+OpenCluster "HSC 2585"
+{
+	RA 13.48217997
+	Dec -64.76318609
+	Radius 206.053
+	Distance 981.323
+}
+
+OpenCluster "HSC 2568"
+{
+	RA 13.48983694
+	Dec -74.66716358
+	Radius 52.764
+	Distance 1884.384
+}
+
+OpenCluster "HSC 2594"
+{
+	RA 13.4957957
+	Dec -62.25033526
+	Radius 12.18
+	Distance 8775.335
+}
+
+OpenCluster "HSC 2592"
+{
+	RA 13.49647057
+	Dec -62.49538555
+	Radius 77.479
+	Distance 12024.759
+}
+
+OpenCluster "Collinder 271:ESO 96-14:MWSC 2126:OCL 900:Theia 2541"
+{
+	RA 13.49820976
+	Dec -64.20254763
+	Radius 31.934
+	Distance 8300.702
+}
+
+OpenCluster "Collinder 272:ESO 132-9:MWSC 2128:OCL 904:Theia 2234"
+{
+	RA 13.50498349
+	Dec -61.33041666
+	Radius 61.847
+	Distance 6760.853
+}
+
+OpenCluster "Theia 2284:Theia 3392:UBC 293"
+{
+	RA 13.51281357
+	Dec -61.80189294
+	Radius 68.599
+	Distance 9685.146
+}
+
+OpenCluster "CWNU 2420"
+{
+	RA 13.51597791
+	Dec -62.75985996
+	Radius 40.618
+	Distance 16410.688
+}
+
+OpenCluster "HSC 2595"
+{
+	RA 13.51672734
+	Dec -60.93816447
+	Radius 99.395
+	Distance 5751.115
+}
+
+OpenCluster "NGC 5168:Collinder 273:BH 147:ESO 132-10:FSR 1655:MWSC 2129:OCL 905"
+{
+	RA 13.51955663
+	Dec -60.94451653
+	Radius 66.127
+	Distance 9563.316
+}
+
+OpenCluster "CWNU 315:Theia 2450"
+{
+	RA 13.52324869
+	Dec -57.19874614
+	Radius 30.185
+	Distance 3581.022
+}
+
+OpenCluster "ESO 132-11:MWSC2132:OCL 907:Ruprecht 108:Theia 3276"
+{
+	RA 13.53411119
+	Dec -58.49467573
+	Radius 27.548
+	Distance 3123.126
+}
+
+OpenCluster "BH 148:Collinder 274:ESO 96-15:MWSC 2131:OCL 903:Theia 2377:Trumpler 21"
+{
+	RA 13.53698562
+	Dec -62.78093632
+	Radius 27.03
+	Distance 4232.167
+}
+
+OpenCluster "CWNU 2223"
+{
+	RA 13.54127321
+	Dec -62.29266989
+	Radius 79.147
+	Distance 12617.242
+}
+
+OpenCluster "CWNU 2573"
+{
+	RA 13.54565896
+	Dec -63.84646385
+	Radius 50.893
+	Distance 8811.2
+}
+
+OpenCluster "HIP 67014 Group:Loden 915:MWSC 2135:MWSC 2150:Platais 10:Theia 1460:Theia 737"
+{
+	RA 13.55821856
+	Dec -59.28316088
+	Radius 119.063
+	Distance 2294.996
+}
+
+OpenCluster "CWNU 1961"
+{
+	RA 13.56807485
+	Dec -62.91956655
+	Radius 32.44
+	Distance 8654.433
+}
+
+OpenCluster "CWNU 121"
+{
+	RA 13.57698776
+	Dec -66.54883389
+	Radius 34.905
+	Distance 4182.731
+}
+
+OpenCluster "Theia 1805:Theia 3381"
+{
+	RA 13.57896549
+	Dec -63.33423296
+	Radius 108.574
+	Distance 6549.861
+}
+
+OpenCluster "HSC 2626"
+{
+	RA 13.57918826
+	Dec -44.62055614
+	Radius 32.324
+	Distance 10120.184
+}
+
+OpenCluster "HSC 2598"
+{
+	RA 13.58128783
+	Dec -61.32917347
+	Radius 35.11
+	Distance 11466.027
+}
+
+OpenCluster "HSC 2610"
+{
+	RA 13.59715236
+	Dec -55.01699364
+	Radius 141.201
+	Distance 613.861
+}
+
+OpenCluster "UBC 1591"
+{
+	RA 13.60358408
+	Dec -64.64615486
+	Radius 44.643
+	Distance 7472.306
+}
+
+OpenCluster "HSC 2602"
+{
+	RA 13.61167278
+	Dec -61.35612937
+	Radius 45.033
+	Distance 6872.326
 }
 
 OpenCluster "Pismis 18"
 {
-	RA 13.615278
-	Dec -61.906667
-	Distance 7306
-	Radius 4.3
+	RA 13.61512716
+	Dec -62.09105821
+	Radius 60.793
+	Distance 8473.906
 }
 
-OpenCluster "BH 151"
+OpenCluster "HSC 2587"
 {
-	RA 13.670000
-	Dec -60.270833
-	Distance 12394
-	Radius 2.7
+	RA 13.61709444
+	Dec -69.51194061
+	Radius 34.559
+	Distance 2779.996
 }
 
-OpenCluster "Platais 10"
+OpenCluster "Theia 5319:UBC 294"
 {
-	RA 13.724444
-	Dec -58.878333
-	Distance 802
-	Radius 37.8
+	RA 13.61830645
+	Dec -58.08516607
+	Radius 41.341
+	Distance 4857.549
 }
 
-OpenCluster "Loden 1010"
+OpenCluster "HSC 2616"
 {
-	RA 13.746667
-	Dec -59.716667
-	Distance 3623
-	Radius 16.3
+	RA 13.62688123
+	Dec -52.73587916
+	Radius 38.408
+	Distance 9471.547
 }
 
-OpenCluster "NGC 5281"
+OpenCluster "HSC 2600"
 {
-	RA 13.776389
-	Dec -61.083333
-	Distance 3613
-	Radius 3.7
+	RA 13.63323215
+	Dec -62.83717132
+	Radius 58.699
+	Distance 7085.762
 }
 
-OpenCluster "ASCC 75"
+OpenCluster "BH 150:vdBergh-Hagen 150"
 {
-	RA 13.786111
-	Dec -61.580000
-	Distance 9785
-	Radius 29.0
+	RA 13.6344779
+	Dec -63.34404062
+	Radius 60.491
+	Distance 13258.724
 }
 
-OpenCluster "Platais 11"
+OpenCluster "UBC 527"
 {
-	RA 13.799167
-	Dec -65.980000
-	Distance 756
-	Radius 19.8
+	RA 13.63742084
+	Dec -66.64013057
+	Radius 26.032
+	Distance 5441.53
 }
 
-OpenCluster "Platais 12"
+OpenCluster "HSC 2599"
 {
-	RA 13.862222
-	Dec -62.546667
-	Distance 1311
-	Radius 22.9
+	RA 13.63841013
+	Dec -63.4180596
+	Radius 35.801
+	Distance 15153.714
 }
 
-OpenCluster "Loden 995"
+OpenCluster "UBC 528"
 {
-	RA 13.865556
-	Dec -63.125000
-	Distance 7828
-	Radius 30.2
+	RA 13.64193995
+	Dec -61.62120411
+	Radius 42.072
+	Distance 9918.12
 }
 
-OpenCluster "ASCC 76"
+OpenCluster "CWNU 2336"
 {
-	RA 13.871111
-	Dec -65.600000
-	Distance 1957
-	Radius 12.0
+	RA 13.64995449
+	Dec -61.67178093
+	Radius 47.859
+	Distance 8151.211
 }
 
-OpenCluster "NGC 5316"
+OpenCluster "HSC 2636"
 {
-	RA 13.899167
-	Dec -60.131667
-	Distance 3962
-	Radius 8.1
+	RA 13.65924575
+	Dec -44.48223215
+	Radius 61.899
+	Distance 436.654
 }
 
-OpenCluster "Loden 1171"
+OpenCluster "BH 151:vdBergh-Hagen 151"
 {
-	RA 13.990000
-	Dec -57.616667
-	Distance 2328
-	Radius 3.7
+	RA 13.66960942
+	Dec -61.72825146
+	Radius 29.218
+	Distance 12110.775
 }
 
-OpenCluster "Lynga 1"
+OpenCluster "HSC 2604"
 {
-	RA 14.000556
-	Dec -61.850000
-	Distance 6197
-	Radius 2.7
+	RA 13.67960379
+	Dec -62.20168599
+	Radius 89.548
+	Distance 10535.989
 }
 
-OpenCluster "NGC 5359"
+OpenCluster "FSR 1663:MWSC 2148:OC 0599:SAI 117"
 {
-	RA 14.002500
-	Dec -69.608333
-	Distance 8154
-	Radius 19.0
+	RA 13.68261831
+	Dec -60.20535393
+	Radius 84.603
+	Distance 9374.58
 }
 
-OpenCluster "Ruprecht 110"
+OpenCluster "HIP 67014 Group:MWSC 2150:Platais 10"
 {
-	RA 14.090556
-	Dec -66.533333
-	Distance 2609
-	Radius 6.8
+	RA 13.68526382
+	Dec -59.1564596
+	Radius 378.655
+	Distance 778.603
 }
 
-OpenCluster "Loden 1194"
+OpenCluster "CWNU 420:OC 0602"
 {
-	RA 14.095000
-	Dec -58.300000
-	Distance 1630
-	Radius 3.3
+	RA 13.68706329
+	Dec -56.650618
+	Radius 32.144
+	Distance 5210.743
 }
 
-OpenCluster "NGC 5460"
+OpenCluster "HSC 2583"
 {
-	RA 14.124167
-	Dec -47.656667
-	Distance 2211
-	Radius 11.3
+	RA 13.6926204
+	Dec -72.16017701
+	Radius 27.255
+	Distance 7060.206
 }
 
-OpenCluster "Loden 1225"
+OpenCluster "UBC 529"
 {
-	RA 14.150833
-	Dec -58.283333
-	Distance 4660
-	Radius 2.7
+	RA 13.69330566
+	Dec -61.92522673
+	Radius 72.54
+	Distance 10305.921
 }
 
-OpenCluster "ASCC 77"
+OpenCluster "Platais 11:Theia 3097"
 {
-	RA 14.180000
-	Dec -61.670000
-	Distance 7175
-	Radius 40.1
+	RA 13.69463387
+	Dec -66.08373087
+	Radius 74.517
+	Distance 5616.411
 }
 
-OpenCluster "Ruprecht 167"
+OpenCluster "HSC 2607"
 {
-	RA 14.303056
-	Dec -57.033333
-	Distance 4077
-	Radius 8.3
+	RA 13.6991262
+	Dec -60.33177194
+	Radius 73.039
+	Distance 8897.675
 }
 
-OpenCluster "Loden 1256"
+OpenCluster "MWSC 2153:SAI 118"
 {
-	RA 14.303333
-	Dec -60.566667
-	Distance 4077
-	Radius 5.9
+	RA 13.72036219
+	Dec -63.15174394
+	Radius 28.078
+	Distance 5753.867
 }
 
-OpenCluster "ESO 175-06"
+OpenCluster "Theia 24:UPK 599"
 {
-	RA 14.308889
-	Dec -55.081667
-	Distance 1793
-	Radius 4.7
+	RA 13.73927981
+	Dec -38.7697974
+	Radius 76.565
+	Distance 2166.01
 }
 
-OpenCluster "Lynga 2"
+OpenCluster "NGC 5269:ESO 97-4:MWSC 2156:Theia 1873:Theia 1948"
 {
-	RA 14.409722
-	Dec -60.669444
-	Distance 2935
-	Radius 5.6
+	RA 13.7444544
+	Dec -62.90551674
+	Radius 40.674
+	Distance 6294.843
 }
 
-OpenCluster "NGC 5593"
+OpenCluster "Theia 1873:Theia 2559"
 {
-	RA 14.427500
-	Dec -53.201667
-	Distance 4657
-	Radius 6.8
+	RA 13.77213522
+	Dec -62.68799065
+	Radius 141.627
+	Distance 3955.055
 }
 
-OpenCluster "NGC 5606"
+OpenCluster "NGC 5281:Melotte 120:Collinder 276:BH 152:ESO 97-5:MWSC 2161:OCL 911:Theia 1873:Theia 1948"
 {
-	RA 14.463056
-	Dec -58.368333
-	Distance 5887
-	Radius 2.6
+	RA 13.77322497
+	Dec -62.91610874
+	Radius 24.302
+	Distance 4800.644
 }
 
-OpenCluster "NGC 5617"
+OpenCluster "HSC 2611"
 {
-	RA 14.495556
-	Dec -59.288333
-	Distance 6523
-	Radius 9.5
+	RA 13.79402231
+	Dec -62.58523928
+	Radius 64.363
+	Distance 9671.259
 }
 
-OpenCluster "Pismis 19"
+OpenCluster "CWNU 1138:HIP 67014 Group:MWSC 2150:Platais 10:Theia 737"
 {
-	RA 14.511111
-	Dec -59.116667
-	Distance 4892
-	Radius 2.1
+	RA 13.79412596
+	Dec -59.63303562
+	Radius 225.263
+	Distance 1615.067
 }
 
-OpenCluster "Trumpler 22"
+OpenCluster "ASCC 75:CWNU 2237:MWSC 2163"
 {
-	RA 14.517222
-	Dec -60.833333
-	Distance 4944
-	Radius 7.2
+	RA 13.7954653
+	Dec -62.4524761
+	Radius 44.978
+	Distance 6445.348
 }
 
-OpenCluster "Hogg 17"
+OpenCluster "OC 0600"
 {
-	RA 14.566111
-	Dec -60.633333
-	Distance 4272
-	Radius 2.5
+	RA 13.7966697
+	Dec -63.42889453
+	Radius 102.507
+	Distance 9877.129
 }
 
-OpenCluster "NGC 5662"
+OpenCluster "Collinder 277:ESO 97-6:MWSC 2166:OCL 909:Platais 11:Theia 4887"
 {
-	RA 14.593611
-	Dec -55.381667
-	Distance 2172
-	Radius 9.2
+	RA 13.80432028
+	Dec -66.05912886
+	Radius 44.589
+	Distance 5197.128
 }
 
-OpenCluster "Collinder 285"
+OpenCluster "OC 0601"
 {
-	RA 14.685000
-	Dec 69.566667
-	Distance 81
-	Radius 16.6
+	RA 13.80554496
+	Dec -62.74798217
+	Radius 29.697
+	Distance 8337.418
 }
 
-OpenCluster "NGC 5715"
+OpenCluster "CWNU 2412"
 {
-	RA 14.725000
-	Dec -56.423056
-	Distance 4892
-	Radius 4.3
+	RA 13.80855128
+	Dec -61.67393005
+	Radius 32.781
+	Distance 6270.161
 }
 
-OpenCluster "BH 164"
+OpenCluster "FSR 1666"
 {
-	RA 14.803889
-	Dec -65.663333
-	Distance 1764
-	Radius 15.4
+	RA 13.81304063
+	Dec -61.43351591
+	Radius 64.611
+	Distance 10487.325
 }
 
-OpenCluster "NGC 5749"
+OpenCluster "NGC 5288:Collinder 278:BH 153:ESO 97-7:MWSC 2168:OCL 910"
 {
-	RA 14.814722
-	Dec -53.501667
-	Distance 3362
-	Radius 4.9
+	RA 13.81335549
+	Dec -64.67058084
+	Radius 33.562
+	Distance 7806.632
 }
 
-OpenCluster "Hogg 18"
+OpenCluster "HXHWL 34"
 {
-	RA 14.845278
-	Dec -51.733333
-	Distance 5006
-	Radius 3.6
+	RA 13.81544199
+	Dec -60.81265907
+	Radius 36.692
+	Distance 4032.93
 }
 
-OpenCluster "Teutsch 80"
+OpenCluster "HSC 2612"
 {
-	RA 14.890556
-	Dec -59.517500
-	Distance 8154
-	Radius 4.0
+	RA 13.82709426
+	Dec -62.87194858
+	Radius 84.852
+	Distance 9855.146
 }
 
-OpenCluster "NGC 5764"
+OpenCluster "CWNU 2764"
 {
-	RA 14.892222
-	Dec -51.330000
-	Distance 9132
-	Radius 4.0
+	RA 13.82802287
+	Dec -61.88257904
+	Radius 120.869
+	Distance 10073.734
 }
 
-OpenCluster "NGC 5822"
+OpenCluster "Theia 3999:UBC 295"
 {
-	RA 15.072500
-	Dec -53.603333
-	Distance 2990
-	Radius 15.2
+	RA 13.83908003
+	Dec -60.41050153
+	Radius 46.348
+	Distance 5273.048
 }
 
-OpenCluster "ASCC 78"
+OpenCluster "HSC 2596"
 {
-	RA 15.085000
-	Dec -67.610000
-	Distance 7828
-	Radius 21.9
+	RA 13.8398823
+	Dec -70.53550612
+	Radius 100.886
+	Distance 20830.683
 }
 
-OpenCluster "NGC 5823"
+OpenCluster "CWNU 1353"
 {
-	RA 15.091667
-	Dec -54.396667
-	Distance 3887
-	Radius 6.8
+	RA 13.84941314
+	Dec -62.28915604
+	Radius 42.979
+	Distance 9217.509
+}
+
+OpenCluster "HIP 67440 Group:MWSC 2173:OCSN 90:Platais 12"
+{
+	RA 13.86129735
+	Dec -63.45382482
+	Radius 150.582
+	Distance 1449.186
+}
+
+OpenCluster "HIP 67440 Group:MWSC 2173:Platais 12:Theia 2702:Theia 2884:Theia 3319:Theia 3666"
+{
+	RA 13.86365248
+	Dec -63.71413837
+	Radius 95.369
+	Distance 6141.645
+}
+
+OpenCluster "NGC 5316:Melotte 122:Collinder 279:BH 154:ESO 133-6:MWSC 2175:OCL 913:OC 0603:Theia 2235"
+{
+	RA 13.9018315
+	Dec -61.86619635
+	Radius 37.676
+	Distance 4611.512
+}
+
+OpenCluster "CWNU 2631:HIP 67440 Group:MWSC 2173:Platais 12:Theia 1792:Theia 1866:Theia 2003:Theia 2251:Theia 2300:Theia 2651:Theia 2702:Theia 2884:Theia 3319:Theia 3666"
+{
+	RA 13.90607238
+	Dec -63.07980631
+	Radius 199.965
+	Distance 9901.367
+}
+
+OpenCluster "CWNU 426"
+{
+	RA 13.91281008
+	Dec -57.70630678
+	Radius 72.519
+	Distance 5572.884
+}
+
+OpenCluster "Loden 1002:MWSC 2177:OCL 911.2:Theia 4621"
+{
+	RA 13.91822255
+	Dec -65.39600907
+	Radius 33.422
+	Distance 4135.25
+}
+
+OpenCluster "CWNU 2740:FSR 1668"
+{
+	RA 13.920051
+	Dec -61.67722081
+	Radius 88.118
+	Distance 7990.581
+}
+
+OpenCluster "Loden 995:MWSC 2176"
+{
+	RA 13.92938689
+	Dec -64.94863932
+	Radius 29.436
+	Distance 3249.2
+}
+
+OpenCluster "HSC 2625"
+{
+	RA 13.93170429
+	Dec -60.54102493
+	Radius 17.81
+	Distance 5954.074
+}
+
+OpenCluster "CWNU 2457:HIP 67440 Group:MWSC 2173:Platais 12:Theia 2651:Theia 2702:Theia 2884:Theia 3319:Theia 3666:Theia 5663"
+{
+	RA 13.94398467
+	Dec -63.31533005
+	Radius 55.519
+	Distance 6125.824
+}
+
+OpenCluster "HSC 2622"
+{
+	RA 13.94571249
+	Dec -61.61393861
+	Radius 27.29
+	Distance 9767.818
+}
+
+OpenCluster "HIP 67440 Group:MWSC 2173:Platais 12:Theia 1792:Theia 1866:Theia 2003:Theia 2021:Theia 2251:Theia 2300:Theia 2651:Theia 2702:Theia 2884:Theia 3319:Theia 3666"
+{
+	RA 13.95376646
+	Dec -63.06042514
+	Radius 168.754
+	Distance 9804.868
+}
+
+OpenCluster "Theia 5137:Theia 6680"
+{
+	RA 13.96265768
+	Dec -39.96400986
+	Radius 75.337
+	Distance 2184.6
+}
+
+OpenCluster "HSC 2627"
+{
+	RA 13.99246268
+	Dec -61.37399366
+	Radius 46.611
+	Distance 10093.327
+}
+
+OpenCluster "FoF 2309:Theia 1180:Theia 5663:UBC 530"
+{
+	RA 13.99752326
+	Dec -63.61052076
+	Radius 31.043
+	Distance 3072.288
+}
+
+OpenCluster "ESO 133-10:Lynga 1:MWSC 2193:OCL 914"
+{
+	RA 13.99987253
+	Dec -62.14854727
+	Radius 39.268
+	Distance 6777.231
+}
+
+OpenCluster "NGC 5381:BH 156:ESO 133-11:MWSC 2196:OCL 915:Ruprecht 109"
+{
+	RA 14.01468442
+	Dec -59.5779205
+	Radius 86.853
+	Distance 7698.706
+}
+
+OpenCluster "HSC 2620"
+{
+	RA 14.01847014
+	Dec -63.67564073
+	Radius 74.223
+	Distance 10340.01
+}
+
+OpenCluster "CWNU 1415"
+{
+	RA 14.02822231
+	Dec -60.34251308
+	Radius 52.003
+	Distance 9143.38
+}
+
+OpenCluster "HSC 2603"
+{
+	RA 14.03051729
+	Dec -71.84363539
+	Radius 73.512
+	Distance 776.745
+}
+
+OpenCluster "HSC 2630"
+{
+	RA 14.03912622
+	Dec -61.76821654
+	Radius 81.409
+	Distance 587.436
+}
+
+OpenCluster "UFMG 54"
+{
+	RA 14.04528267
+	Dec -61.95999017
+	Radius 17.479
+	Distance 10002.108
+}
+
+OpenCluster "CWNU 1677"
+{
+	RA 14.04580456
+	Dec -59.42339641
+	Radius 50.067
+	Distance 8806.255
+}
+
+OpenCluster "HSC 2629"
+{
+	RA 14.0458821
+	Dec -61.9527188
+	Radius 9.398
+	Distance 7758.197
+}
+
+OpenCluster "HSC 2635"
+{
+	RA 14.05515095
+	Dec -59.66941933
+	Radius 42.494
+	Distance 8709.628
+}
+
+OpenCluster "HSC 2621"
+{
+	RA 14.05710502
+	Dec -64.45800567
+	Radius 40.443
+	Distance 1522.996
+}
+
+OpenCluster "HSC 2618"
+{
+	RA 14.06470617
+	Dec -65.80257486
+	Radius 67.64
+	Distance 637.652
+}
+
+OpenCluster "CWNU 1674"
+{
+	RA 14.09040305
+	Dec -62.03650915
+	Radius 39.867
+	Distance 5722.557
+}
+
+OpenCluster "Theia 3609"
+{
+	RA 14.09147112
+	Dec -61.64874691
+	Radius 59.888
+	Distance 8309.478
+}
+
+OpenCluster "CWNU 308:OC 0604:Theia 5496"
+{
+	RA 14.09442738
+	Dec -64.15935265
+	Radius 63.485
+	Distance 5077.581
+}
+
+OpenCluster "Theia 2179"
+{
+	RA 14.09571286
+	Dec -62.64688467
+	Radius 85.282
+	Distance 7988.149
+}
+
+OpenCluster "CWNU 284:Theia 3609:UBC 1523"
+{
+	RA 14.12012221
+	Dec -61.70368804
+	Radius 54.196
+	Distance 5664.321
+}
+
+OpenCluster "Theia 1366"
+{
+	RA 14.12100312
+	Dec -63.01953531
+	Radius 139.118
+	Distance 1205.395
+}
+
+OpenCluster "NGC 5460:Melotte 123:Collinder 280:ESO 221-24:MWSC 2202:OCL 925:Theia 266"
+{
+	RA 14.12110757
+	Dec -48.30279566
+	Radius 105.178
+	Distance 2320.556
+}
+
+OpenCluster "UBC 531"
+{
+	RA 14.12233155
+	Dec -63.06610005
+	Radius 27.68
+	Distance 8031.672
+}
+
+OpenCluster "CWNU 2475"
+{
+	RA 14.13570702
+	Dec -60.49330394
+	Radius 40.283
+	Distance 8944.269
+}
+
+OpenCluster "ESO 133-12:Loden 1194:Loden 1225:MWSC 2200:MWSC 2204:OCL 915.3:OCL 915.5:Theia 129:Theia 447"
+{
+	RA 14.13788327
+	Dec -59.75878568
+	Radius 44.442
+	Distance 2363.105
+}
+
+OpenCluster "HSC 2634"
+{
+	RA 14.14082405
+	Dec -62.31919213
+	Radius 54.287
+	Distance 9863.238
+}
+
+OpenCluster "Theia 3167"
+{
+	RA 14.14120084
+	Dec -63.52241225
+	Radius 47.72
+	Distance 5328.69
+}
+
+OpenCluster "CWNU 1536"
+{
+	RA 14.15919334
+	Dec -61.6997615
+	Radius 31.1
+	Distance 10886.723
+}
+
+OpenCluster "UFMG 48"
+{
+	RA 14.1619632
+	Dec -59.31628519
+	Radius 69.573
+	Distance 8310.396
+}
+
+OpenCluster "HSC 2637"
+{
+	RA 14.16523661
+	Dec -62.30618784
+	Radius 50.742
+	Distance 4856.509
+}
+
+OpenCluster "Theia 264:UPK 585"
+{
+	RA 14.17395755
+	Dec -75.8519061
+	Radius 81.816
+	Distance 2277.042
+}
+
+OpenCluster "HSC 2619"
+{
+	RA 14.17507363
+	Dec -67.10430672
+	Radius 59.646
+	Distance 16302.175
+}
+
+OpenCluster "ASCC 77:Ferrero 15:MWSC 2205:Theia 2146"
+{
+	RA 14.17973598
+	Dec -62.36042349
+	Radius 53.042
+	Distance 3581.338
+}
+
+OpenCluster "CWNU 2363"
+{
+	RA 14.18786876
+	Dec -61.13645724
+	Radius 64.235
+	Distance 7995.306
+}
+
+OpenCluster "CWNU 2801"
+{
+	RA 14.19293978
+	Dec -61.70171472
+	Radius 52.829
+	Distance 9241.855
+}
+
+OpenCluster "CWNU 247:OC 0606"
+{
+	RA 14.19311799
+	Dec -63.1414657
+	Radius 40.8
+	Distance 5853.74
+}
+
+OpenCluster "HSC 2640"
+{
+	RA 14.19488034
+	Dec -61.71618405
+	Radius 34.463
+	Distance 12612.284
+}
+
+OpenCluster "HSC 2639"
+{
+	RA 14.20413317
+	Dec -62.0413928
+	Radius 99.467
+	Distance 11961.443
+}
+
+OpenCluster "CWNU 261:UBC 1592"
+{
+	RA 14.23817252
+	Dec -64.18959696
+	Radius 31.304
+	Distance 2894.852
+}
+
+OpenCluster "UBC 1530"
+{
+	RA 14.24669294
+	Dec -50.08180918
+	Radius 26.325
+	Distance 5577.231
+}
+
+OpenCluster "HSC 2631"
+{
+	RA 14.251624
+	Dec -65.69619154
+	Radius 88.777
+	Distance 1138.507
+}
+
+OpenCluster "HSC 2642"
+{
+	RA 14.25310218
+	Dec -61.85750953
+	Radius 144.318
+	Distance 10600.198
+}
+
+OpenCluster "HXHWL 25:Theia 339"
+{
+	RA 14.25801433
+	Dec -63.74025759
+	Radius 33.929
+	Distance 5862.608
+}
+
+OpenCluster "CWNU 379"
+{
+	RA 14.27354493
+	Dec -63.51263783
+	Radius 34.359
+	Distance 7185.116
+}
+
+OpenCluster "UBC 1524"
+{
+	RA 14.29881839
+	Dec -62.56236773
+	Radius 84.55
+	Distance 12380.737
+}
+
+OpenCluster "LISC 3170:Theia 2819:UFMG 60"
+{
+	RA 14.31219224
+	Dec -62.66499025
+	Radius 87.757
+	Distance 6623.864
+}
+
+OpenCluster "Loden 1256:OC 0608"
+{
+	RA 14.32294724
+	Dec -61.41859846
+	Radius 84.579
+	Distance 5280.455
+}
+
+OpenCluster "CWNU 1439"
+{
+	RA 14.32995651
+	Dec -62.20320374
+	Radius 79.04
+	Distance 9846.774
+}
+
+OpenCluster "CWNU 1478"
+{
+	RA 14.33127684
+	Dec -61.94488584
+	Radius 33.558
+	Distance 9994.968
+}
+
+OpenCluster "HSC 2632"
+{
+	RA 14.3359901
+	Dec -66.34893535
+	Radius 23.216
+	Distance 8616.882
+}
+
+OpenCluster "CWNU 356"
+{
+	RA 14.33717503
+	Dec -61.08103156
+	Radius 27.007
+	Distance 5259.91
+}
+
+OpenCluster "ESO 133-13:MWSC 2211:OCL 917:Ruprecht 167"
+{
+	RA 14.34037336
+	Dec -58.8705579
+	Radius 48.611
+	Distance 4970.54
+}
+
+OpenCluster "HXHWL 14:UBC 1526"
+{
+	RA 14.34755115
+	Dec -58.14533357
+	Radius 75.729
+	Distance 6108.531
+}
+
+OpenCluster "Theia 903"
+{
+	RA 14.3494947
+	Dec -58.07485565
+	Radius 81.741
+	Distance 3045.81
+}
+
+OpenCluster "HSC 2690"
+{
+	RA 14.35260599
+	Dec -38.89266754
+	Radius 12.357
+	Distance 479
+}
+
+OpenCluster "Theia 447"
+{
+	RA 14.35497595
+	Dec -61.10619672
+	Radius 120.263
+	Distance 2317.217
+}
+
+OpenCluster "Theia 1264:Theia 865"
+{
+	RA 14.36402914
+	Dec -66.62723035
+	Radius 204.583
+	Distance 2238.61
+}
+
+OpenCluster "UPK 606"
+{
+	RA 14.39272106
+	Dec -46.42378799
+	Radius 47.778
+	Distance 542.715
+}
+
+OpenCluster "Lynga 2:Theia 365"
+{
+	RA 14.40382251
+	Dec -61.33333393
+	Radius 28.361
+	Distance 3008.29
+}
+
+OpenCluster "LISC 3250:UBC 296"
+{
+	RA 14.41140297
+	Dec -61.05635081
+	Radius 36.007
+	Distance 6139.841
+}
+
+OpenCluster "CWNU 2797"
+{
+	RA 14.42108961
+	Dec -60.92221118
+	Radius 25.084
+	Distance 8747.189
+}
+
+OpenCluster "NGC 5593:ESO 175-8:MWSC 2217:OCL 926:Theia 422"
+{
+	RA 14.42928079
+	Dec -54.78317882
+	Radius 27.332
+	Distance 3305.322
+}
+
+OpenCluster "UBC 1525"
+{
+	RA 14.43042234
+	Dec -61.88902994
+	Radius 33.214
+	Distance 6671.136
+}
+
+OpenCluster "HSC 2647"
+{
+	RA 14.43145023
+	Dec -60.93397859
+	Radius 28.741
+	Distance 10346.504
+}
+
+OpenCluster "CWNU 2629"
+{
+	RA 14.43536985
+	Dec -59.04913629
+	Radius 61.737
+	Distance 8904.863
+}
+
+OpenCluster "Theia 365"
+{
+	RA 14.44708929
+	Dec -61.06642744
+	Radius 35.162
+	Distance 2360.633
+}
+
+OpenCluster "NGC 5606:OC 0612"
+{
+	RA 14.46372123
+	Dec -59.6301821
+	Radius 74.094
+	Distance 7476.762
+}
+
+OpenCluster "CWNU 1448:Theia 2166"
+{
+	RA 14.46569228
+	Dec -61.3640592
+	Radius 26.937
+	Distance 5375.889
+}
+
+OpenCluster "NGC 5617:Melotte 125:Collinder 282:BH 159:ESO 134-4:MWSC 2223:OCL 919:OC 0609"
+{
+	RA 14.49608827
+	Dec -60.71236266
+	Radius 29.405
+	Distance 7116.118
+}
+
+OpenCluster "HSC 2651"
+{
+	RA 14.49751692
+	Dec -61.14000895
+	Radius 24.916
+	Distance 6421.324
+}
+
+OpenCluster "HSC 2646"
+{
+	RA 14.49832739
+	Dec -62.53794261
+	Radius 80.896
+	Distance 3691.836
+}
+
+OpenCluster "UBC 298"
+{
+	RA 14.50193359
+	Dec -59.81146818
+	Radius 50.992
+	Distance 7875.221
+}
+
+OpenCluster "HSC 2655"
+{
+	RA 14.50950969
+	Dec -60.29006208
+	Radius 71.706
+	Distance 7029.936
+}
+
+OpenCluster "UBC 1528"
+{
+	RA 14.5101012
+	Dec -59.11488442
+	Radius 72.441
+	Distance 8136.739
+}
+
+OpenCluster "BH 160:ESO 134-5:FSR 1679:MWSC 2225:OCL 921:OC 0610:Pismis 19:Theia 1793:Theia 1823"
+{
+	RA 14.51117989
+	Dec -60.89144191
+	Radius 23.817
+	Distance 9894.396
+}
+
+OpenCluster "HSC 2641"
+{
+	RA 14.51157964
+	Dec -67.17642661
+	Radius 76.297
+	Distance 875.996
+}
+
+OpenCluster "CWNU 31:UBC 1527"
+{
+	RA 14.5151908
+	Dec -60.39758816
+	Radius 54.269
+	Distance 7102.005
+}
+
+OpenCluster "BH 161:Collinder 283:ESO 134-6:MWSC 2226:OCL 920:Theia 1823:Trumpler 22"
+{
+	RA 14.52047446
+	Dec -61.18250411
+	Radius 31.883
+	Distance 7383.356
+}
+
+OpenCluster "HSC 2704"
+{
+	RA 14.52548285
+	Dec -40.77665086
+	Radius 26.431
+	Distance 1351.606
+}
+
+OpenCluster "HSC 2649"
+{
+	RA 14.53243256
+	Dec -61.94457691
+	Radius 24.318
+	Distance 7400.284
+}
+
+OpenCluster "HXHWL 13:Theia 903"
+{
+	RA 14.53326313
+	Dec -58.73706994
+	Radius 78.821
+	Distance 3578.21
+}
+
+OpenCluster "LISC 1738:Theia 2731:UBC 297"
+{
+	RA 14.53745
+	Dec -62.21230945
+	Radius 28.149
+	Distance 8462.457
+}
+
+OpenCluster "HSC 2688"
+{
+	RA 14.54024849
+	Dec -44.79762938
+	Radius 37.515
+	Distance 6724.801
+}
+
+OpenCluster "UPK 595"
+{
+	RA 14.54167327
+	Dec -67.19171908
+	Radius 36.563
+	Distance 2704.04
+}
+
+OpenCluster "HSC 2669"
+{
+	RA 14.54676334
+	Dec -50.87940291
+	Radius 73.524
+	Distance 21062.074
+}
+
+OpenCluster "ESO 134-8:Loden 1339:MWSC 2230:OCL 918.1"
+{
+	RA 14.55573512
+	Dec -62.0836659
+	Radius 64.156
+	Distance 8603.244
+}
+
+OpenCluster "ESO 134-9:Hogg 17:MWSC 2232:OCL 923:Theia 2049:Theia 2746"
+{
+	RA 14.56453009
+	Dec -61.3131465
+	Radius 17.554
+	Distance 7204.846
+}
+
+OpenCluster "Theia 505:UPK 594"
+{
+	RA 14.58505133
+	Dec -67.93733589
+	Radius 80.188
+	Distance 3004.635
+}
+
+OpenCluster "NGC 5662:Melotte 127:Collinder 284:BH 162:ESO 175-10:MWSC 2234:OCL 928:Theia 353:Theia 60"
+{
+	RA 14.59515602
+	Dec -56.57511514
+	Radius 84.391
+	Distance 2449.488
+}
+
+OpenCluster "ESO 134-10:MWSC 2235:OCL 924:Ruprecht 111:Theia 5922"
+{
+	RA 14.60058566
+	Dec -59.98065652
+	Radius 65.194
+	Distance 4582.386
+}
+
+OpenCluster "OC 0615:UFMG 39"
+{
+	RA 14.60132675
+	Dec -57.87412569
+	Radius 34.254
+	Distance 4736.649
+}
+
+OpenCluster "CWNU 318"
+{
+	RA 14.60584668
+	Dec -61.91192113
+	Radius 30.523
+	Distance 5948.849
+}
+
+OpenCluster "Theia 2711:Theia 3274:Theia 3463"
+{
+	RA 14.60733653
+	Dec -61.47496455
+	Radius 90.843
+	Distance 5408.897
+}
+
+OpenCluster "CWNU 1616"
+{
+	RA 14.60904281
+	Dec -57.53596991
+	Radius 45.852
+	Distance 6319.42
+}
+
+OpenCluster "ESO 134-10:MWSC 2235:OCL 924:Ruprecht 111:Theia 502"
+{
+	RA 14.6124017
+	Dec -60.02755136
+	Radius 47.438
+	Distance 2860.154
+}
+
+OpenCluster "CWNU 1938"
+{
+	RA 14.61990205
+	Dec -60.26243762
+	Radius 78.91
+	Distance 8148.771
+}
+
+OpenCluster "HSC 2644"
+{
+	RA 14.62400793
+	Dec -66.48366445
+	Radius 35.263
+	Distance 10857.266
+}
+
+OpenCluster "CWNU 2431"
+{
+	RA 14.62510055
+	Dec -60.95949832
+	Radius 57.781
+	Distance 7303.527
+}
+
+OpenCluster "Theia 1896:Theia 3289:UBC 301"
+{
+	RA 14.63359848
+	Dec -58.9917273
+	Radius 26.746
+	Distance 5127.003
+}
+
+OpenCluster "CWNU 1910"
+{
+	RA 14.63625409
+	Dec -63.39504235
+	Radius 53.624
+	Distance 8857.815
+}
+
+OpenCluster "Theia 1070:Theia 1224"
+{
+	RA 14.63634895
+	Dec -55.1651686
+	Radius 103.46
+	Distance 1748.355
+}
+
+OpenCluster "UBC 299"
+{
+	RA 14.64533531
+	Dec -62.15250876
+	Radius 96.052
+	Distance 9385.485
+}
+
+OpenCluster "CWNU 2904"
+{
+	RA 14.65140675
+	Dec -60.05363045
+	Radius 52.655
+	Distance 5615.746
+}
+
+OpenCluster "HSC 2659"
+{
+	RA 14.66620898
+	Dec -58.80854211
+	Radius 88.575
+	Distance 6657.963
+}
+
+OpenCluster "HSC 2675"
+{
+	RA 14.66683256
+	Dec -52.91030957
+	Radius 82.297
+	Distance 1565.977
+}
+
+OpenCluster "CWNU 1333"
+{
+	RA 14.66706627
+	Dec -61.29004536
+	Radius 57.8
+	Distance 11804.236
+}
+
+OpenCluster "Alessi 6:MWSC 2240:Theia 996"
+{
+	RA 14.66741303
+	Dec -66.13669172
+	Radius 48.862
+	Distance 2809.463
+}
+
+OpenCluster "FSR 1686:Juchert 10:LS 167:La Serena 167:MWSC 2239:MWSC 2241:SAI 121"
+{
+	RA 14.67080763
+	Dec -60.37857653
+	Radius 43.126
+	Distance 10090.386
+}
+
+OpenCluster "UBC 302"
+{
+	RA 14.6805813
+	Dec -55.35238297
+	Radius 28.038
+	Distance 3794.578
+}
+
+OpenCluster "CWNU 1637"
+{
+	RA 14.6896197
+	Dec -57.65005315
+	Radius 41.031
+	Distance 6288.803
+}
+
+OpenCluster "CWNU 357:Theia 2524:Theia 3263:Theia 3926"
+{
+	RA 14.70298695
+	Dec -58.37858833
+	Radius 58.291
+	Distance 3242.927
+}
+
+OpenCluster "NGC 5715:Melotte 128:Collinder 286:BH 163:ESO 176-2:MWSC 2245:OCL 929:OC 0618:Theia 3842"
+{
+	RA 14.72467103
+	Dec -57.57794833
+	Radius 36.841
+	Distance 6605.892
+}
+
+OpenCluster "ESO 134-12:ESO 134 12:MWSC 2248:OC 0617"
+{
+	RA 14.7484225
+	Dec -59.1535143
+	Radius 83.237
+	Distance 6875.234
+}
+
+OpenCluster "UBC 1533"
+{
+	RA 14.75270628
+	Dec -58.61863917
+	Radius 65.409
+	Distance 8707.86
+}
+
+OpenCluster "CWNU 2752"
+{
+	RA 14.75855193
+	Dec -59.69757919
+	Radius 58.555
+	Distance 6163.503
+}
+
+OpenCluster "HSC 2657"
+{
+	RA 14.75881636
+	Dec -63.08834406
+	Radius 67.032
+	Distance 3519.679
+}
+
+OpenCluster "CWNU 1437"
+{
+	RA 14.76091808
+	Dec -60.99131757
+	Radius 27.197
+	Distance 9694.915
+}
+
+OpenCluster "UBC 1529"
+{
+	RA 14.76200003
+	Dec -61.06951765
+	Radius 34.529
+	Distance 9894.61
+}
+
+OpenCluster "Theia 4566:Theia 5380:Theia 5561:UBC 303"
+{
+	RA 14.7889392
+	Dec -56.26317041
+	Radius 37.1
+	Distance 5465.532
+}
+
+OpenCluster "Theia 436"
+{
+	RA 14.7912407
+	Dec -65.40126353
+	Radius 62.661
+	Distance 703.687
+}
+
+OpenCluster "HSC 2660"
+{
+	RA 14.81433648
+	Dec -61.15443244
+	Radius 53.914
+	Distance 5034.169
+}
+
+OpenCluster "NGC 5749:Collinder 287:BH 165:ESO 176-4:MWSC 2256:OCL 930:Theia 1986"
+{
+	RA 14.81473641
+	Dec -54.49089262
+	Radius 36.046
+	Distance 3515.193
+}
+
+OpenCluster "HSC 2648"
+{
+	RA 14.82026217
+	Dec -66.41084602
+	Radius 30.469
+	Distance 1020.813
+}
+
+OpenCluster "Alessi 7:BH 164:MWSC 2255:vdBergh-Hagen 164"
+{
+	RA 14.82159019
+	Dec -66.39249343
+	Radius 427.902
+	Distance 1344.512
+}
+
+OpenCluster "UBC 1531"
+{
+	RA 14.82483647
+	Dec -61.54241442
+	Radius 188.996
+	Distance 10345.203
+}
+
+OpenCluster "HSC 2661"
+{
+	RA 14.82513979
+	Dec -59.74924466
+	Radius 108.694
+	Distance 9904.269
+}
+
+OpenCluster "CWNU 2276"
+{
+	RA 14.82732453
+	Dec -59.73026461
+	Radius 25.467
+	Distance 7162.452
+}
+
+OpenCluster "HSC 2654"
+{
+	RA 14.82792077
+	Dec -65.35643106
+	Radius 36.229
+	Distance 5154.831
+}
+
+OpenCluster "LISC 1314:OC 0614:UBC 1532"
+{
+	RA 14.83774806
+	Dec -61.76039644
+	Radius 53.293
+	Distance 9873.499
+}
+
+OpenCluster "BH 166:ESO 223-1:Hogg 18:MWSC 2257:OCL 933"
+{
+	RA 14.84588648
+	Dec -52.27265671
+	Radius 88.884
+	Distance 5520.889
+}
+
+OpenCluster "UBC 1534"
+{
+	RA 14.863134
+	Dec -57.73895816
+	Radius 78.506
+	Distance 7528.487
+}
+
+OpenCluster "Theia 3861:UBC 300"
+{
+	RA 14.86351864
+	Dec -65.3129823
+	Radius 32.212
+	Distance 5761.151
+}
+
+OpenCluster "OC 0616:Theia 2325"
+{
+	RA 14.8742895
+	Dec -61.49012204
+	Radius 50.939
+	Distance 3364.827
+}
+
+OpenCluster "HSC 2656"
+{
+	RA 14.88081882
+	Dec -64.93217767
+	Radius 25.449
+	Distance 7463.697
+}
+
+OpenCluster "CWNU 2867"
+{
+	RA 14.88220817
+	Dec -60.89702367
+	Radius 64.973
+	Distance 8760.492
+}
+
+OpenCluster "CWNU 95:OC 0623:Theia 1986"
+{
+	RA 14.88648788
+	Dec -54.1115284
+	Radius 91.374
+	Distance 3409.286
+}
+
+OpenCluster "DSH J1453.4-6028:MWSC 2258:Teutsch 80"
+{
+	RA 14.89061335
+	Dec -60.47371563
+	Radius 40.446
+	Distance 8494.797
+}
+
+OpenCluster "NGC 5764:Collinder 288:BH 167:ESO 223-4:MWSC 2259:OCL 934"
+{
+	RA 14.89234902
+	Dec -52.66431501
+	Radius 26.757
+	Distance 6111.992
+}
+
+OpenCluster "HSC 2725"
+{
+	RA 14.89803357
+	Dec -41.30350828
+	Radius 22.566
+	Distance 7026.109
+}
+
+OpenCluster "HSC 2667"
+{
+	RA 14.90219686
+	Dec -58.09912763
+	Radius 188.705
+	Distance 10311.356
+}
+
+OpenCluster "HSC 2609"
+{
+	RA 14.90932941
+	Dec -78.13293429
+	Radius 76.025
+	Distance 1175.283
+}
+
+OpenCluster "CWNU 352:LISC-III 3411"
+{
+	RA 14.90945963
+	Dec -57.60472833
+	Radius 23.81
+	Distance 3518.74
+}
+
+OpenCluster "CWNU 2767"
+{
+	RA 14.91522682
+	Dec -60.23166593
+	Radius 67.519
+	Distance 8324.132
+}
+
+OpenCluster "OC 0619"
+{
+	RA 14.92514832
+	Dec -60.51992596
+	Radius 25.447
+	Distance 9335.042
+}
+
+OpenCluster "HSC 2615"
+{
+	RA 14.93482335
+	Dec -77.2159558
+	Radius 57.051
+	Distance 907.755
+}
+
+OpenCluster "ESO 135-1:MWSC 2261:OCL 927:Ruprecht 112"
+{
+	RA 14.94899441
+	Dec -62.58830392
+	Radius 62.255
+	Distance 8457.239
+}
+
+OpenCluster "CWNU 1528"
+{
+	RA 14.96600088
+	Dec -58.05514376
+	Radius 43.176
+	Distance 7130.519
+}
+
+OpenCluster "Theia 14:UPK 604"
+{
+	RA 14.96800522
+	Dec -59.66739171
+	Radius 42.702
+	Distance 2398.722
+}
+
+OpenCluster "HSC 2674"
+{
+	RA 14.98728309
+	Dec -58.59643222
+	Radius 41.937
+	Distance 9309.266
+}
+
+OpenCluster "HSC 2706"
+{
+	RA 14.99607946
+	Dec -50.69590258
+	Radius 152.177
+	Distance 2453.788
+}
+
+OpenCluster "Theia 16:Theia 1969:UPK 607"
+{
+	RA 15.00200183
+	Dec -57.15263824
+	Radius 28.796
+	Distance 2908.276
+}
+
+OpenCluster "CWNU 2263:SAI 122"
+{
+	RA 15.0045935
+	Dec -58.808793
+	Radius 48.218
+	Distance 8698.341
+}
+
+OpenCluster "CWNU 2792"
+{
+	RA 15.00607539
+	Dec -58.36049042
+	Radius 48.503
+	Distance 7280.408
+}
+
+OpenCluster "HSC 759"
+{
+	RA 15.00977882
+	Dec 59.38615478
+	Radius 286.642
+	Distance 312.966
+}
+
+OpenCluster "HSC 2687"
+{
+	RA 15.01390218
+	Dec -54.4450286
+	Radius 53.05
+	Distance 1326.699
+}
+
+OpenCluster "HSC 2653"
+{
+	RA 15.02195838
+	Dec -68.00522033
+	Radius 113.526
+	Distance 1262.536
+}
+
+OpenCluster "HSC 2668"
+{
+	RA 15.02850358
+	Dec -59.69058617
+	Radius 83.341
+	Distance 9593.09
+}
+
+OpenCluster "CWWL 1746"
+{
+	RA 15.03265462
+	Dec -60.02477019
+	Radius 21.5
+	Distance 9186.672
+}
+
+OpenCluster "CWNU 41"
+{
+	RA 15.03414764
+	Dec -71.03102814
+	Radius 104.933
+	Distance 2376.981
+}
+
+OpenCluster "Majaess 160"
+{
+	RA 15.05363724
+	Dec -63.38567283
+	Radius 36.927
+	Distance 2527.03
+}
+
+OpenCluster "OC 0621"
+{
+	RA 15.06160804
+	Dec -60.01601251
+	Radius 49.355
+	Distance 9932.443
+}
+
+OpenCluster "NGC 5822:Melotte 130:Collinder 289:BH 168:ESO 176-9:Loden 2104:MWSC 2269:OCL 937:Theia 1174:Theia 7059"
+{
+	RA 15.07134099
+	Dec -54.35650017
+	Radius 83.573
+	Distance 2636.365
+}
+
+OpenCluster "Theia 2140:Theia 2943:Theia 4020:UBC 664"
+{
+	RA 15.0744057
+	Dec -60.8499387
+	Radius 83.312
+	Distance 9673.083
+}
+
+OpenCluster "HSC 2666"
+{
+	RA 15.07610546
+	Dec -61.05784457
+	Radius 49.251
+	Distance 9713.192
+}
+
+OpenCluster "HSC 2679"
+{
+	RA 15.07726057
+	Dec -58.49517535
+	Radius 16.687
+	Distance 9803.316
+}
+
+OpenCluster "HSC 2680"
+{
+	RA 15.08161358
+	Dec -58.50853153
+	Radius 15.756
+	Distance 8491.137
+}
+
+OpenCluster "UPK 613"
+{
+	RA 15.08590458
+	Dec -49.16183157
+	Radius 26.149
+	Distance 2787.927
+}
+
+OpenCluster "NGC 5823:Melotte 131:Collinder 290:BH 169:ESO 176-11:MWSC 2273:OCL 936:Theia 2779"
+{
+	RA 15.09171511
+	Dec -55.6046507
+	Radius 76.34
+	Distance 5655.39
+}
+
+OpenCluster "HSC 2682"
+{
+	RA 15.09572797
+	Dec -56.63141755
+	Radius 120.602
+	Distance 6392.028
+}
+
+OpenCluster "UBC 532"
+{
+	RA 15.09871486
+	Dec -62.22693508
+	Radius 48.044
+	Distance 6393.133
+}
+
+OpenCluster "HSC 2678"
+{
+	RA 15.10022591
+	Dec -59.29145263
+	Radius 27.749
+	Distance 7290.536
+}
+
+OpenCluster "HSC 2882"
+{
+	RA 15.11340613
+	Dec -9.77527622
+	Radius 69.365
+	Distance 372.003
+}
+
+OpenCluster "HSC 2751"
+{
+	RA 15.11759083
+	Dec -35.47251396
+	Radius 34.979
+	Distance 6682.723
+}
+
+OpenCluster "HSC 2709"
+{
+	RA 15.12570483
+	Dec -52.19968953
+	Radius 32.438
+	Distance 8124.147
+}
+
+OpenCluster "HSC 2676"
+{
+	RA 15.1268937
+	Dec -59.74459911
+	Radius 59.643
+	Distance 281.838
+}
+
+OpenCluster "OC 0622"
+{
+	RA 15.12725629
+	Dec -60.40164924
+	Radius 100.273
+	Distance 9759.457
+}
+
+OpenCluster "HSC 2672"
+{
+	RA 15.13333625
+	Dec -60.63502908
+	Radius 38.382
+	Distance 647.795
+}
+
+OpenCluster "CWNU 1275"
+{
+	RA 15.14774178
+	Dec -59.64525362
+	Radius 49.926
+	Distance 8644.838
+}
+
+OpenCluster "HSC 524"
+{
+	RA 15.14824238
+	Dec 39.57394348
+	Radius 52.527
+	Distance 2046.909
+}
+
+OpenCluster "CWNU 458"
+{
+	RA 15.1711922
+	Dec -56.40155305
+	Radius 36.527
+	Distance 6239.29
+}
+
+OpenCluster "FoF 2100:UBC 305"
+{
+	RA 15.17256275
+	Dec -60.49918288
+	Radius 29.228
+	Distance 6268.042
+}
+
+OpenCluster "OC 0626"
+{
+	RA 15.18827787
+	Dec -57.95850948
+	Radius 54.998
+	Distance 8982.259
+}
+
+OpenCluster "CWNU 1560"
+{
+	RA 15.19959169
+	Dec -58.71826632
+	Radius 32.781
+	Distance 7339.493
+}
+
+OpenCluster "HSC 2726"
+{
+	RA 15.201579
+	Dec -46.98748975
+	Radius 26.679
+	Distance 8175.457
+}
+
+OpenCluster "CWNU 1488"
+{
+	RA 15.20357331
+	Dec -57.35663001
+	Radius 49.439
+	Distance 8394.842
+}
+
+OpenCluster "HSC 2733"
+{
+	RA 15.20431139
+	Dec -44.52913812
+	Radius 101.544
+	Distance 470.23
+}
+
+OpenCluster "CWNU 445"
+{
+	RA 15.22249977
+	Dec -59.15707938
+	Radius 20.356
+	Distance 5533.742
+}
+
+OpenCluster "HSC 2683"
+{
+	RA 15.22900147
+	Dec -58.18561483
+	Radius 24.51
+	Distance 9178.678
+}
+
+OpenCluster "CWNU 2812"
+{
+	RA 15.23093716
+	Dec -55.53126614
+	Radius 71.267
+	Distance 9495.962
+}
+
+OpenCluster "CWNU 19"
+{
+	RA 15.23424518
+	Dec -54.53554584
+	Radius 52.326
+	Distance 6086.745
+}
+
+OpenCluster "UBC 1535"
+{
+	RA 15.23999371
+	Dec -59.66749932
+	Radius 29.626
+	Distance 9725.578
+}
+
+OpenCluster "FSR 1694:OC 0620"
+{
+	RA 15.24864468
+	Dec -62.77845773
+	Radius 28.607
+	Distance 2577.462
 }
 
 OpenCluster "Pismis 20"
 {
-	RA 15.256389
-	Dec -58.933333
-	Distance 6582
-	Radius 3.8
+	RA 15.25685924
+	Dec -59.07092803
+	Radius 86.885
+	Distance 9556.203
 }
 
-OpenCluster "ASCC 79"
+OpenCluster "CWNU 1362"
 {
-	RA 15.320000
-	Dec -59.270000
-	Distance 2609
-	Radius 23.7
+	RA 15.258486
+	Dec -59.17691035
+	Radius 28.213
+	Distance 9309.006
 }
 
-OpenCluster "ASCC 80"
+OpenCluster "HSC 2686"
 {
-	RA 15.410000
-	Dec -59.860000
-	Distance 4892
-	Radius 21.3
+	RA 15.2780996
+	Dec -58.37352336
+	Radius 57.2
+	Distance 16989.909
 }
 
-OpenCluster "Alessi 8"
+OpenCluster "Pismis 21"
 {
-	RA 15.492500
-	Dec -50.766667
-	Distance 1875
-	Radius 6.5
+	RA 15.27957419
+	Dec -59.6601693
+	Radius 27.79
+	Distance 9478.663
 }
 
-OpenCluster "Lynga 4"
+OpenCluster "Lynga 3"
 {
-	RA 15.555278
-	Dec -54.763611
-	Distance 3587
-	Radius 3.1
+	RA 15.27980044
+	Dec -58.37499793
+	Radius 39.493
+	Distance 16491.923
 }
 
-OpenCluster "Loden 2313"
+OpenCluster "HSC 2710"
 {
-	RA 15.680278
-	Dec -51.566667
-	Distance 4598
-	Radius 14.0
+	RA 15.28088709
+	Dec -54.16512716
+	Radius 15.912
+	Distance 2852.112
 }
 
-OpenCluster "Loden 2326"
+OpenCluster "CWNU 395"
 {
-	RA 15.725833
-	Dec -51.525000
-	Distance 2935
-	Radius 0.7
+	RA 15.28247677
+	Dec -53.67702402
+	Radius 26.302
+	Distance 5591.692
 }
 
-OpenCluster "Johansson 1"
+OpenCluster "ASCC 79:Alessi 25:MWSC 2288:Theia 89"
 {
-	RA 15.772222
-	Dec -51.618333
-	Distance 1859
-	Radius 7.8
+	RA 15.29114764
+	Dec -61.07482263
+	Radius 51.607
+	Distance 2662.677
 }
 
-OpenCluster "ASCC 81"
+OpenCluster "HSC 46"
 {
-	RA 15.781944
-	Dec -49.020000
-	Distance 2283
-	Radius 10.4
+	RA 15.30739183
+	Dec 2.04961365
+	Radius 35.382
+	Distance 1322.389
 }
 
-OpenCluster "ASCC 82"
+OpenCluster "OCSN 91"
 {
-	RA 15.790000
-	Dec -63.590000
-	Distance 2609
-	Radius 13.7
+	RA 15.31220939
+	Dec -37.65242834
+	Radius 15.94
+	Distance 432.421
 }
 
-OpenCluster "Collinder 292"
+OpenCluster "CWNU 2285:Theia 3114"
 {
-	RA 15.835556
-	Dec -56.383333
-	Distance 5437
-	Radius 11.1
+	RA 15.3139751
+	Dec -60.00426763
+	Radius 29.327
+	Distance 9452.472
 }
 
-OpenCluster "ASCC 83"
+OpenCluster "CWNU 1435"
 {
-	RA 15.836944
-	Dec -51.200000
-	Distance 1957
-	Radius 7.2
+	RA 15.32292861
+	Dec -57.73426892
+	Radius 47.609
+	Distance 4779.378
 }
 
-OpenCluster "NGC 5999"
+OpenCluster "HSC 2701"
 {
-	RA 15.868889
-	Dec -55.526667
-	Distance 6686
-	Radius 2.9
+	RA 15.32325703
+	Dec -56.39504479
+	Radius 27.382
+	Distance 11088.853
 }
 
-OpenCluster "ASCC 84"
+OpenCluster "CWNU 6"
 {
-	RA 15.915000
-	Dec -59.260000
-	Distance 2935
-	Radius 12.8
+	RA 15.33493428
+	Dec -56.19170648
+	Radius 35.66
+	Distance 5304.026
 }
 
-OpenCluster "NGC 6005"
+OpenCluster "ASCC 79:Alessi 25:MWSC 2288:Theia 2606:Theia 89"
 {
-	RA 15.930000
-	Dec -56.563333
-	Distance 8773
-	Radius 6.4
+	RA 15.33830845
+	Dec -60.81901676
+	Radius 102.453
+	Distance 2372.248
 }
 
-OpenCluster "Ruprecht 113"
+OpenCluster "OC 0629"
 {
-	RA 15.950833
-	Dec -58.533333
-	Distance 2175
-	Radius 7.9
+	RA 15.34054324
+	Dec -57.16077404
+	Radius 69.513
+	Distance 7518.349
 }
 
-OpenCluster "Trumpler 23"
+OpenCluster "UFMG 37"
 {
-	RA 16.013611
-	Dec -52.463889
-	Distance 6197
-	Radius 4.5
+	RA 15.34354414
+	Dec -57.75468236
+	Radius 46.037
+	Distance 4172.813
 }
 
-OpenCluster "Moffat 1"
+OpenCluster "CWNU 1826"
 {
-	RA 16.025000
-	Dec -53.883333
-	Distance 6849
-	Radius 7.0
+	RA 15.34429584
+	Dec -54.48227611
+	Radius 15.567
+	Distance 5051.775
 }
 
-OpenCluster "NGC 6025"
+OpenCluster "FSR 1698"
 {
-	RA 16.054722
-	Dec -59.568333
-	Distance 2465
-	Radius 5.0
+	RA 15.34889401
+	Dec -59.62171016
+	Radius 39.564
+	Distance 10112.338
 }
 
-OpenCluster "Lynga 6"
+OpenCluster "HSC 2698"
 {
-	RA 16.081111
-	Dec -50.066667
-	Distance 5218
-	Radius 3.8
+	RA 15.35408115
+	Dec -57.09781073
+	Radius 32.786
+	Distance 8220.397
 }
 
-OpenCluster "NGC 6031"
+OpenCluster "Theia 2324:UBC 533"
 {
-	RA 16.126389
-	Dec -53.985000
-	Distance 5946
-	Radius 2.6
+	RA 15.3551982
+	Dec -53.17192183
+	Radius 51.762
+	Distance 3807.156
 }
 
-OpenCluster "Ruprecht 115"
+OpenCluster "HSC 2695"
 {
-	RA 16.214444
-	Dec -51.600000
-	Distance 7045
-	Radius 5.1
+	RA 15.3569912
+	Dec -57.41606774
+	Radius 79.262
+	Distance 9526.467
 }
 
-OpenCluster "NGC 6067"
+OpenCluster "HSC 2691"
 {
-	RA 16.219722
-	Dec -53.781667
-	Distance 4621
-	Radius 9.4
+	RA 15.36920165
+	Dec -58.16772668
+	Radius 39.652
+	Distance 3170.768
+}
+
+OpenCluster "HSC 2720"
+{
+	RA 15.37445315
+	Dec -52.3939166
+	Radius 20.334
+	Distance 3465.312
+}
+
+OpenCluster "CWNU 21:UBC 1536"
+{
+	RA 15.37486977
+	Dec -58.19269637
+	Radius 63.844
+	Distance 5007.7
+}
+
+OpenCluster "HSC 2662"
+{
+	RA 15.3876036
+	Dec -66.4370521
+	Radius 81.854
+	Distance 873.945
+}
+
+OpenCluster "HSC 2645"
+{
+	RA 15.39347696
+	Dec -72.8523015
+	Radius 125.698
+	Distance 2128.665
+}
+
+OpenCluster "CWNU 443:UBC 1628"
+{
+	RA 15.39598776
+	Dec -61.97825854
+	Radius 15.257
+	Distance 5816.314
+}
+
+OpenCluster "CWNU 1429"
+{
+	RA 15.40322948
+	Dec -58.4767942
+	Radius 23.719
+	Distance 6002.967
+}
+
+OpenCluster "Theia 2762:Theia 3370:UPK 614"
+{
+	RA 15.40989847
+	Dec -53.9785111
+	Radius 44.795
+	Distance 2883.395
+}
+
+OpenCluster "OCSN 92"
+{
+	RA 15.43701044
+	Dec -36.0620607
+	Radius 61.487
+	Distance 450.647
+}
+
+OpenCluster "HSC 2684"
+{
+	RA 15.44125944
+	Dec -60.58700875
+	Radius 26.869
+	Distance 3542.877
+}
+
+OpenCluster "HSC 2810"
+{
+	RA 15.44130885
+	Dec -30.59078381
+	Radius 163.629
+	Distance 1244.672
+}
+
+OpenCluster "Theia 292:Theia 7371"
+{
+	RA 15.44509295
+	Dec -64.5843337
+	Radius 149.51
+	Distance 2848.93
+}
+
+OpenCluster "NGC 5925:Collinder 291:BH 172:ESO 177-6:MWSC 2293:OCL 938:Theia 2978"
+{
+	RA 15.45573463
+	Dec -54.51802859
+	Radius 42.368
+	Distance 4491.156
+}
+
+OpenCluster "HSC 2703"
+{
+	RA 15.46263527
+	Dec -57.78440468
+	Radius 142.124
+	Distance 16621.151
+}
+
+OpenCluster "CWNU 2193"
+{
+	RA 15.47820056
+	Dec -56.58748311
+	Radius 55.941
+	Distance 9149.711
+}
+
+OpenCluster "HSC 2708"
+{
+	RA 15.4789649
+	Dec -57.12042986
+	Radius 78.811
+	Distance 3155.376
+}
+
+OpenCluster "Alessi 8:MWSC 2298:Theia 252:Theia 335"
+{
+	RA 15.48652935
+	Dec -51.31186297
+	Radius 63.68
+	Distance 2133.639
+}
+
+OpenCluster "UBC 1537"
+{
+	RA 15.52082378
+	Dec -57.98347357
+	Radius 31.814
+	Distance 6816.916
+}
+
+OpenCluster "CWNU 1726"
+{
+	RA 15.53845761
+	Dec -58.59550416
+	Radius 61.547
+	Distance 7336.322
+}
+
+OpenCluster "HSC 2715"
+{
+	RA 15.54122656
+	Dec -55.45242633
+	Radius 27.291
+	Distance 5257.828
+}
+
+OpenCluster "HSC 2713"
+{
+	RA 15.54375642
+	Dec -55.56165485
+	Radius 29.863
+	Distance 6804.348
+}
+
+OpenCluster "HSC 2717"
+{
+	RA 15.54652659
+	Dec -54.93110119
+	Radius 84.166
+	Distance 9461.759
+}
+
+OpenCluster "HSC 2722"
+{
+	RA 15.55420759
+	Dec -53.03136191
+	Radius 12.576
+	Distance 3356.046
+}
+
+OpenCluster "BH 174:ESO 147-7:Lynga 4:MWSC 2302:OCL 941"
+{
+	RA 15.55550922
+	Dec -55.23456758
+	Radius 49.805
+	Distance 7458.282
+}
+
+OpenCluster "Theia 3233:Theia 3857:Theia 4576:Theia 4679"
+{
+	RA 15.55882454
+	Dec -58.65820649
+	Radius 165.278
+	Distance 9677.718
+}
+
+OpenCluster "CWNU 1638"
+{
+	RA 15.56333906
+	Dec -59.68144988
+	Radius 23.629
+	Distance 6202.201
+}
+
+OpenCluster "HSC 2723"
+{
+	RA 15.57738157
+	Dec -52.9246922
+	Radius 17.931
+	Distance 7818.642
+}
+
+OpenCluster "UFMG 34"
+{
+	RA 15.58934346
+	Dec -57.65604883
+	Radius 93.345
+	Distance 7496.88
+}
+
+OpenCluster "CWNU 325"
+{
+	RA 15.58974075
+	Dec -55.454668
+	Radius 70.733
+	Distance 5994.812
+}
+
+OpenCluster "OC 0630"
+{
+	RA 15.59451662
+	Dec -56.45478794
+	Radius 27.463
+	Distance 2939.078
+}
+
+OpenCluster "HSC 2696"
+{
+	RA 15.62859456
+	Dec -60.33565618
+	Radius 94.382
+	Distance 16154.298
+}
+
+OpenCluster "CWNU 360"
+{
+	RA 15.6358559
+	Dec -57.09444945
+	Radius 47.388
+	Distance 7712.652
+}
+
+OpenCluster "Theia 181"
+{
+	RA 15.63639082
+	Dec -64.85695162
+	Radius 133.796
+	Distance 1787.448
+}
+
+OpenCluster "HSC 2711"
+{
+	RA 15.6368803
+	Dec -58.09308261
+	Radius 30.089
+	Distance 6256.975
+}
+
+OpenCluster "CWNU 2643"
+{
+	RA 15.63823117
+	Dec -57.33960509
+	Radius 87.102
+	Distance 8826.174
+}
+
+OpenCluster "Theia 270:UBC 304:UPK 605"
+{
+	RA 15.63920714
+	Dec -65.97631811
+	Radius 32.704
+	Distance 2390.935
+}
+
+OpenCluster "FSR 1700:MWSC 2307"
+{
+	RA 15.64626227
+	Dec -59.26407242
+	Radius 272.854
+	Distance 30858.336
+}
+
+OpenCluster "HSC 477"
+{
+	RA 15.64634712
+	Dec 36.62019434
+	Radius 74.733
+	Distance 509.359
+}
+
+OpenCluster "UPK 617"
+{
+	RA 15.65546489
+	Dec -55.37285621
+	Radius 35.307
+	Distance 2337.53
+}
+
+OpenCluster "CWNU 2650:Theia 4482"
+{
+	RA 15.6554747
+	Dec -58.53838002
+	Radius 54.335
+	Distance 9784.123
+}
+
+OpenCluster "OC 0631"
+{
+	RA 15.65693567
+	Dec -55.92715965
+	Radius 46.762
+	Distance 14590.736
+}
+
+OpenCluster "HSC 2681"
+{
+	RA 15.66472991
+	Dec -64.44384267
+	Radius 71.926
+	Distance 2941.443
+}
+
+OpenCluster "HXHWL 67:Theia 2227"
+{
+	RA 15.66792924
+	Dec -58.48864411
+	Radius 28.11
+	Distance 5492.785
+}
+
+OpenCluster "CWNU 2877"
+{
+	RA 15.67218231
+	Dec -56.26118228
+	Radius 35.044
+	Distance 8329.663
+}
+
+OpenCluster "UFMG 41"
+{
+	RA 15.67449658
+	Dec -55.75373524
+	Radius 26.832
+	Distance 5602.802
+}
+
+OpenCluster "CWNU 1340"
+{
+	RA 15.68028565
+	Dec -51.81675261
+	Radius 31.318
+	Distance 5114.531
+}
+
+OpenCluster "FSR 1703:OC 0635"
+{
+	RA 15.69136332
+	Dec -54.97472871
+	Radius 63.903
+	Distance 6224.72
+}
+
+OpenCluster "HSC 2724"
+{
+	RA 15.69346744
+	Dec -53.97615496
+	Radius 15.85
+	Distance 6661.938
+}
+
+OpenCluster "BH 177:ESO 177-9:Lynga 5:MWSC 2310:OCL 942"
+{
+	RA 15.69732207
+	Dec -56.66918374
+	Radius 71.854
+	Distance 8651.659
+}
+
+OpenCluster "UFMG 44"
+{
+	RA 15.7035723
+	Dec -55.4825455
+	Radius 37.507
+	Distance 5300.073
+}
+
+OpenCluster "LISC 2425:UFMG 43"
+{
+	RA 15.71421346
+	Dec -55.42593073
+	Radius 21.7
+	Distance 6990.582
+}
+
+OpenCluster "HSC 2784"
+{
+	RA 15.71686764
+	Dec -38.21179979
+	Radius 91.441
+	Distance 765.728
+}
+
+OpenCluster "OC 0634"
+{
+	RA 15.72384948
+	Dec -56.14118807
+	Radius 92.655
+	Distance 14775.207
+}
+
+OpenCluster "HSC 2728"
+{
+	RA 15.73063352
+	Dec -54.31003022
+	Radius 16.571
+	Distance 6802.025
+}
+
+OpenCluster "UFMG 42"
+{
+	RA 15.73585159
+	Dec -55.24891474
+	Radius 43.782
+	Distance 8018.277
+}
+
+OpenCluster "Theia 1156"
+{
+	RA 15.74950778
+	Dec -43.60452306
+	Radius 75.275
+	Distance 2483.68
+}
+
+OpenCluster "CWNU 2417"
+{
+	RA 15.76009393
+	Dec -58.24071134
+	Radius 48.754
+	Distance 8200.823
+}
+
+OpenCluster "CWNU 1455"
+{
+	RA 15.76104875
+	Dec -56.65773867
+	Radius 23.734
+	Distance 6941.843
+}
+
+OpenCluster "HSC 2719"
+{
+	RA 15.76294621
+	Dec -57.16526628
+	Radius 72.219
+	Distance 6967.622
+}
+
+OpenCluster "FoF 1180:OC 0633:UBC 306:UFMG 1"
+{
+	RA 15.77327321
+	Dec -56.79588299
+	Radius 86.587
+	Distance 7855.993
+}
+
+OpenCluster "CWNU 1849"
+{
+	RA 15.8114756
+	Dec -54.26775775
+	Radius 34.467
+	Distance 6216.586
+}
+
+OpenCluster "Theia 61:UPK 621"
+{
+	RA 15.81336741
+	Dec -54.41533875
+	Radius 46.485
+	Distance 2863.981
+}
+
+OpenCluster "CWNU 1398"
+{
+	RA 15.82484088
+	Dec -55.93028603
+	Radius 47.888
+	Distance 6069.171
+}
+
+OpenCluster "Collinder 292:OC 0632:Theia 3613"
+{
+	RA 15.82536606
+	Dec -57.59823688
+	Radius 32.4
+	Distance 5742.573
+}
+
+OpenCluster "HSC 2743"
+{
+	RA 15.83037668
+	Dec -49.76516991
+	Radius 20.452
+	Distance 3852.84
+}
+
+OpenCluster "UBC 308:UFMG 2"
+{
+	RA 15.83806102
+	Dec -55.95687381
+	Radius 40.194
+	Distance 7870.974
+}
+
+OpenCluster "UBC 535"
+{
+	RA 15.84000912
+	Dec -56.74716982
+	Radius 52.336
+	Distance 9500.16
+}
+
+OpenCluster "UBC 536"
+{
+	RA 15.84257879
+	Dec -55.62675271
+	Radius 52.056
+	Distance 5783.389
+}
+
+OpenCluster "HSC 2731"
+{
+	RA 15.84455687
+	Dec -55.07394643
+	Radius 34.764
+	Distance 8696.771
+}
+
+OpenCluster "NGC 5999:Melotte 137:Collinder 293:BH 178:ESO 178-1:FSR 1706:MWSC 2326:OCL 946"
+{
+	RA 15.86962828
+	Dec -56.47946487
+	Radius 32.809
+	Distance 8440.41
+}
+
+OpenCluster "FoF 1182:OC 0636:UBC 309:UFMG 3"
+{
+	RA 15.87152678
+	Dec -55.42275624
+	Radius 42.692
+	Distance 6164.613
+}
+
+OpenCluster "HSC 2739"
+{
+	RA 15.88743193
+	Dec -51.81830258
+	Radius 34.02
+	Distance 7210.748
+}
+
+OpenCluster "HSC 2732"
+{
+	RA 15.90439732
+	Dec -55.26373393
+	Radius 45.958
+	Distance 9215.348
+}
+
+OpenCluster "HSC 2782"
+{
+	RA 15.90450265
+	Dec -41.5769053
+	Radius 137.599
+	Distance 1519.026
+}
+
+OpenCluster "Theia 2008:Theia 4657:Theia 6192:UBC 534"
+{
+	RA 15.90520691
+	Dec -57.90009429
+	Radius 64.368
+	Distance 5327.764
+}
+
+OpenCluster "HSC 2831"
+{
+	RA 15.91209644
+	Dec -33.86613965
+	Radius 52.776
+	Distance 7325.828
+}
+
+OpenCluster "ASCC 84:MWSC 2333"
+{
+	RA 15.91218204
+	Dec -60.71272864
+	Radius 17.295
+	Distance 2775.704
+}
+
+OpenCluster "Teutsch 246:UBC 1538"
+{
+	RA 15.91338735
+	Dec -54.38362652
+	Radius 64.148
+	Distance 7340.313
+}
+
+OpenCluster "Alessi 190:Theia 950:UBC 5"
+{
+	RA 15.9165113
+	Dec -47.61920524
+	Radius 72.471
+	Distance 1806.677
+}
+
+OpenCluster "ESO 275-01:ESO 275-1:ESO 275-275:ESO 275 01:FSR 1723:MWSC 2334:MWSC 2335"
+{
+	RA 15.91876577
+	Dec -46.01076681
+	Radius 26.749
+	Distance 4910.895
+}
+
+OpenCluster "NGC 6005:Melotte 138:Collinder 294:BH 179:ESO 178-3:FSR 1704:MWSC 2336:OCL 945"
+{
+	RA 15.93004509
+	Dec -57.43535784
+	Radius 35.116
+	Distance 7788.985
+}
+
+OpenCluster "HXHWL 47"
+{
+	RA 15.93514207
+	Dec -55.24990768
+	Radius 31.428
+	Distance 5242.011
+}
+
+OpenCluster "CWNU 1143"
+{
+	RA 15.93806394
+	Dec -25.70113195
+	Radius 56.398
+	Distance 353.427
+}
+
+OpenCluster "CWNU 1491"
+{
+	RA 15.96095192
+	Dec -55.40422055
+	Radius 59.339
+	Distance 6351.515
+}
+
+OpenCluster "Theia 5332:UBC 307"
+{
+	RA 15.96106316
+	Dec -57.27077534
+	Radius 70.26
+	Distance 9088.307
+}
+
+OpenCluster "CWNU 256:OC 0637:Theia 2115"
+{
+	RA 15.9623514
+	Dec -53.05337902
+	Radius 18.265
+	Distance 4228.458
+}
+
+OpenCluster "HSC 2693"
+{
+	RA 15.96487861
+	Dec -63.82580484
+	Radius 56.817
+	Distance 4556.316
+}
+
+OpenCluster "Teutsch 247:UBC 1540"
+{
+	RA 15.97463299
+	Dec -53.65682963
+	Radius 33.122
+	Distance 8139.87
+}
+
+OpenCluster "CWNU 1004"
+{
+	RA 15.98202309
+	Dec -42.00794547
+	Radius 13.591
+	Distance 517.224
+}
+
+OpenCluster "HSC 2744"
+{
+	RA 15.98571113
+	Dec -50.36937921
+	Radius 46.838
+	Distance 734.276
+}
+
+OpenCluster "Theia 732:UPK 626"
+{
+	RA 15.98603341
+	Dec -50.4183432
+	Radius 117.793
+	Distance 1630.828
+}
+
+OpenCluster "Theia 3118:Theia 3469:Theia 3787:UFMG 45"
+{
+	RA 15.98697683
+	Dec -55.87040008
+	Radius 55.857
+	Distance 8911.705
+}
+
+OpenCluster "HSC 2763"
+{
+	RA 15.99237242
+	Dec -46.37059228
+	Radius 28.699
+	Distance 339.623
+}
+
+OpenCluster "CWNU 7"
+{
+	RA 16.00621606
+	Dec -59.10420463
+	Radius 22.8
+	Distance 4052.799
+}
+
+OpenCluster "CWNU 142:UBC 1542"
+{
+	RA 16.00716372
+	Dec -51.20548715
+	Radius 32.615
+	Distance 7529.649
+}
+
+OpenCluster "CWNU 2570"
+{
+	RA 16.00908988
+	Dec -55.06070101
+	Radius 42.434
+	Distance 12776.935
+}
+
+OpenCluster "HSC 2816"
+{
+	RA 16.00931402
+	Dec -38.43871237
+	Radius 39.354
+	Distance 449.286
+}
+
+OpenCluster "CWNU 2795"
+{
+	RA 16.01131244
+	Dec -53.11833136
+	Radius 48.922
+	Distance 8704.048
+}
+
+OpenCluster "BH 180:Collinder 295:ESO 178-6:MWSC 2343:OCL 950:Trumpler 23"
+{
+	RA 16.01425786
+	Dec -53.53703549
+	Radius 41.954
+	Distance 8060.277
+}
+
+OpenCluster "C1557-540:MWSC 2346:Moffat 1"
+{
+	RA 16.02657174
+	Dec -54.14635887
+	Radius 74.151
+	Distance 7350.36
+}
+
+OpenCluster "OC 0640:OC 0641"
+{
+	RA 16.02771064
+	Dec -52.11067999
+	Radius 36.106
+	Distance 6945.824
+}
+
+OpenCluster "OCSN 96"
+{
+	RA 16.02864365
+	Dec -22.70921448
+	Radius 31.78
+	Distance 458.604
+}
+
+OpenCluster "HSC 2737"
+{
+	RA 16.0294186
+	Dec -53.8670268
+	Radius 26.428
+	Distance 8309.437
+}
+
+OpenCluster "CWNU 2028"
+{
+	RA 16.0350155
+	Dec -54.01842744
+	Radius 66.386
+	Distance 8962.541
+}
+
+OpenCluster "HSC 2792"
+{
+	RA 16.03539282
+	Dec -40.69894485
+	Radius 59.607
+	Distance 1490.101
+}
+
+OpenCluster "HSC 2702"
+{
+	RA 16.03575748
+	Dec -63.33792426
+	Radius 32.566
+	Distance 9822.994
+}
+
+OpenCluster "CWNU 249"
+{
+	RA 16.03774001
+	Dec -54.87313776
+	Radius 19.646
+	Distance 3669.12
+}
+
+OpenCluster "NGC 6025:Melotte 139:Collinder 296:BH 181:ESO 136-14:MWSC 2347:OCL 939"
+{
+	RA 16.0528791
+	Dec -60.43212414
+	Radius 74.182
+	Distance 2478.425
+}
+
+OpenCluster "HSC 2771"
+{
+	RA 16.05902336
+	Dec -45.65629213
+	Radius 124.189
+	Distance 1721.376
+}
+
+OpenCluster "HSC 2740"
+{
+	RA 16.06409572
+	Dec -53.68549523
+	Radius 32.552
+	Distance 9998.94
+}
+
+OpenCluster "CWNU 2330"
+{
+	RA 16.06776614
+	Dec -51.8500521
+	Radius 43.419
+	Distance 7276.108
+}
+
+OpenCluster "HSC 2747"
+{
+	RA 16.0782086
+	Dec -50.92743237
+	Radius 20.964
+	Distance 5853.268
+}
+
+OpenCluster "HSC 2774"
+{
+	RA 16.07906037
+	Dec -45.52331349
+	Radius 45.806
+	Distance 7592.059
+}
+
+OpenCluster "BH 182:ESO 225-4:Lynga 6:MWSC 2348:OCL 955"
+{
+	RA 16.08140069
+	Dec -51.96463182
+	Radius 40.176
+	Distance 7878.689
+}
+
+OpenCluster "HSC 2745"
+{
+	RA 16.08552782
+	Dec -51.31519797
+	Radius 110.379
+	Distance 2087.608
+}
+
+OpenCluster "OCSN 98"
+{
+	RA 16.0867225
+	Dec -19.74287484
+	Radius 18.327
+	Distance 493.614
+}
+
+OpenCluster "UFMG 38"
+{
+	RA 16.09891039
+	Dec -52.67183452
+	Radius 91.809
+	Distance 9559.205
+}
+
+OpenCluster "OC 0644"
+{
+	RA 16.10438417
+	Dec -52.13443563
+	Radius 61.75
+	Distance 8030.296
+}
+
+OpenCluster "HSC 2748"
+{
+	RA 16.10961891
+	Dec -51.17085991
+	Radius 37.94
+	Distance 8051.36
+}
+
+OpenCluster "HSC 2673"
+{
+	RA 16.11217522
+	Dec -69.05361835
+	Radius 37.438
+	Distance 8564.103
+}
+
+OpenCluster "HSC 2815"
+{
+	RA 16.11474733
+	Dec -39.81732614
+	Radius 38.994
+	Distance 7438.946
+}
+
+OpenCluster "Theia 3333"
+{
+	RA 16.12123628
+	Dec -54.19781495
+	Radius 31.896
+	Distance 7568.392
+}
+
+OpenCluster "NGC 6031:Collinder 297:BH 183:ESO 178-9:MWSC 2352:OCL 951:Theia 3333"
+{
+	RA 16.12638411
+	Dec -54.01400318
+	Radius 53.82
+	Distance 5664.497
+}
+
+OpenCluster "CWNU 2468"
+{
+	RA 16.134442
+	Dec -53.14787694
+	Radius 18.748
+	Distance 9515.091
+}
+
+OpenCluster "SAI 123:UBC 1546"
+{
+	RA 16.13919311
+	Dec -50.52201071
+	Radius 61.881
+	Distance 9525.841
+}
+
+OpenCluster "CWNU 2741:Theia 2730"
+{
+	RA 16.13939744
+	Dec -53.50326765
+	Radius 69.34
+	Distance 11908.131
+}
+
+OpenCluster "UBC 1541"
+{
+	RA 16.14380847
+	Dec -54.22309242
+	Radius 16.058
+	Distance 8147.562
+}
+
+OpenCluster "UBC 665"
+{
+	RA 16.1453099
+	Dec -51.42632213
+	Radius 21.622
+	Distance 6181.425
+}
+
+OpenCluster "CWNU 1014:OC 0666"
+{
+	RA 16.14606608
+	Dec -39.08487376
+	Radius 10.189
+	Distance 513.076
+}
+
+OpenCluster "Theia 2443"
+{
+	RA 16.1487168
+	Dec -56.06290463
+	Radius 59.692
+	Distance 3139.892
+}
+
+OpenCluster "HSC 2760"
+{
+	RA 16.15391948
+	Dec -48.92884954
+	Radius 28.688
+	Distance 5637.498
+}
+
+OpenCluster "CWNU 2485"
+{
+	RA 16.16727925
+	Dec -52.74431113
+	Radius 47.909
+	Distance 7252.958
+}
+
+OpenCluster "UBC 538"
+{
+	RA 16.1728772
+	Dec -52.33490235
+	Radius 54.187
+	Distance 8593.068
+}
+
+OpenCluster "UBC 1545"
+{
+	RA 16.17436797
+	Dec -51.00766569
+	Radius 60.916
+	Distance 7431.308
+}
+
+OpenCluster "DBSB 101"
+{
+	RA 16.17447209
+	Dec -49.04044849
+	Radius 27.777
+	Distance 5770.758
+}
+
+OpenCluster "HSC 2769"
+{
+	RA 16.17525972
+	Dec -47.29476429
+	Radius 41.537
+	Distance 2559.095
+}
+
+OpenCluster "OCSN 100"
+{
+	RA 16.18142233
+	Dec -19.38334114
+	Radius 16.472
+	Distance 449.09
+}
+
+OpenCluster "BH 184:ESO 178-11:FSR 1711:Lynga 7:MWSC 2361:OCL 949"
+{
+	RA 16.18183566
+	Dec -55.35451103
+	Radius 39.738
+	Distance 3081.574
+}
+
+OpenCluster "Theia 3005"
+{
+	RA 16.19232055
+	Dec -54.32096596
+	Radius 102.19
+	Distance 6367.761
+}
+
+OpenCluster "LISC 1753:OC 0643:UBC 537"
+{
+	RA 16.19240839
+	Dec -53.0391537
+	Radius 39.33
+	Distance 9395.888
+}
+
+OpenCluster "HSC 2770"
+{
+	RA 16.19437487
+	Dec -47.21706805
+	Radius 34.274
+	Distance 9842.015
+}
+
+OpenCluster "DBSB 144:UBC 539"
+{
+	RA 16.20139982
+	Dec -51.46465852
+	Radius 25.425
+	Distance 6700.704
+}
+
+OpenCluster "UBC 541"
+{
+	RA 16.2018804
+	Dec -50.22793817
+	Radius 32.82
+	Distance 7133.251
+}
+
+OpenCluster "DBSB 157:UBC 1544"
+{
+	RA 16.20506657
+	Dec -51.72116541
+	Radius 60.297
+	Distance 8794.354
+}
+
+OpenCluster "CWNU 2479"
+{
+	RA 16.20835124
+	Dec -50.92467536
+	Radius 22.26
+	Distance 7929.908
+}
+
+OpenCluster "HSC 2754"
+{
+	RA 16.21156165
+	Dec -50.08786158
+	Radius 24.934
+	Distance 7426.247
+}
+
+OpenCluster "OC 0646:Ruprecht 115"
+{
+	RA 16.21428836
+	Dec -52.39698943
+	Radius 24.401
+	Distance 7658.612
+}
+
+OpenCluster "NGC 6067:Theia 2390:Theia 2993"
+{
+	RA 16.21967683
+	Dec -54.23182675
+	Radius 43.559
+	Distance 6383.407
+}
+
+OpenCluster "UBC 314"
+{
+	RA 16.22444631
+	Dec -50.12754011
+	Radius 68.985
+	Distance 4980.498
+}
+
+OpenCluster "CWNU 1374"
+{
+	RA 16.23220573
+	Dec -51.0992214
+	Radius 37.169
+	Distance 8958.456
+}
+
+OpenCluster "Theia 3669:UBC 1543:UFMG 11"
+{
+	RA 16.23316214
+	Dec -52.96521723
+	Radius 58.394
+	Distance 9455.902
+}
+
+OpenCluster "CWNU 1065:Theia 2062"
+{
+	RA 16.23401649
+	Dec -51.1835188
+	Radius 30.981
+	Distance 3789.341
 }
 
 OpenCluster "Pismis 22"
 {
-	RA 16.235833
-	Dec -50.133333
-	Distance 3261
-	Radius 1.9
+	RA 16.23623089
+	Dec -51.87286924
+	Radius 67.014
+	Distance 13919.315
 }
 
-OpenCluster "Harvard 10"
+OpenCluster "HSC 2847"
 {
-	RA 16.313333
-	Dec -53.066667
-	Distance 4279
-	Radius 15.6
+	RA 16.24246654
+	Dec -34.23163379
+	Radius 33.42
+	Distance 9522.507
 }
 
-OpenCluster "NGC 6087"
+OpenCluster "MWSC 2373:OCL 957.1:Ruprecht 176"
 {
-	RA 16.313889
-	Dec -56.065000
-	Distance 2906
-	Radius 5.9
+	RA 16.24474489
+	Dec -51.33293599
+	Radius 83.05
+	Distance 8122.227
 }
 
-OpenCluster "Lynga 8"
+OpenCluster "CWNU 1568:Theia 2096"
 {
-	RA 16.334444
-	Dec -49.766944
-	Distance 3424
-	Radius 1.5
+	RA 16.2469254
+	Dec -51.58007142
+	Radius 66.98
+	Distance 8228.69
 }
 
-OpenCluster "Lynga 9"
+OpenCluster "HSC 2729"
 {
-	RA 16.344722
-	Dec -47.471111
-	Distance 5544
-	Radius 4.8
+	RA 16.25077585
+	Dec -59.00179573
+	Radius 30.059
+	Distance 4769.062
 }
 
-OpenCluster "Ruprecht 116"
+OpenCluster "CWNU 1777"
 {
-	RA 16.388889
-	Dec -52.000000
-	Distance 2175
-	Radius 1.6
+	RA 16.25946672
+	Dec -50.36960801
+	Radius 35.375
+	Distance 6902.768
+}
+
+OpenCluster "HSC 2768"
+{
+	RA 16.26109532
+	Dec -48.64465408
+	Radius 80.839
+	Distance 12345.503
+}
+
+OpenCluster "UBC 312"
+{
+	RA 16.28267675
+	Dec -50.72278881
+	Radius 49.297
+	Distance 8156.667
+}
+
+OpenCluster "UBC 1547"
+{
+	RA 16.29341987
+	Dec -49.85638054
+	Radius 51.269
+	Distance 8166.008
+}
+
+OpenCluster "HSC 2787"
+{
+	RA 16.29445217
+	Dec -45.02647598
+	Radius 33.425
+	Distance 2629.231
+}
+
+OpenCluster "OC 0645:UBC 310"
+{
+	RA 16.2984318
+	Dec -53.52365574
+	Radius 52.209
+	Distance 8814.346
+}
+
+OpenCluster "UBC 542"
+{
+	RA 16.30449057
+	Dec -49.48971223
+	Radius 30.689
+	Distance 5277.023
+}
+
+OpenCluster "OC 0650"
+{
+	RA 16.30572275
+	Dec -51.53102777
+	Radius 47.805
+	Distance 15439.179
+}
+
+OpenCluster "HSC 2664"
+{
+	RA 16.30650215
+	Dec -71.66650401
+	Radius 108.779
+	Distance 1405.158
+}
+
+OpenCluster "S Normae Cluster:NGC 6087:Melotte 141:Collinder 300:Caldwell 89:BH 188:ESO 137-15:MWSC 2382:OCL 948:Theia 299"
+{
+	RA 16.31220393
+	Dec -57.91408543
+	Radius 47.056
+	Distance 3059.713
+}
+
+OpenCluster "CWNU 2656"
+{
+	RA 16.31318598
+	Dec -51.89855248
+	Radius 40.794
+	Distance 5784.87
+}
+
+OpenCluster "FoF 861:OC 0648:Theia 2259:Theia 2366:Theia 2763:Theia 2961:Theia 3503:Theia 3643:Theia 3846:Theia 3937:Theia 3960:Theia 4054:Theia 4098:Theia 4374:Theia 4489:Theia 4592:Theia 4750:Theia 5146:Theia 5151:Theia 5275:Theia 5305:Theia 5348:Theia 5619"
+{
+	RA 16.31376487
+	Dec -52.88355717
+	Radius 98.501
+	Distance 11098.908
+}
+
+OpenCluster "CWNU 1703"
+{
+	RA 16.31711226
+	Dec -51.25837207
+	Radius 24.411
+	Distance 6309.227
+}
+
+OpenCluster "HSC 2907"
+{
+	RA 16.31817734
+	Dec -24.45005866
+	Radius 77.261
+	Distance 504.174
+}
+
+OpenCluster "ESO 179-2:Harvard 10:MWSC 2381:OCL 954"
+{
+	RA 16.32087238
+	Dec -54.96574802
+	Radius 391.298
+	Distance 2198.377
+}
+
+OpenCluster "UBC 1539"
+{
+	RA 16.32261373
+	Dec -57.20759477
+	Radius 66.261
+	Distance 6394.151
+}
+
+OpenCluster "CWNU 218"
+{
+	RA 16.32675173
+	Dec -55.61674688
+	Radius 47.606
+	Distance 4311.829
+}
+
+OpenCluster "CWNU 220:UBC 1548"
+{
+	RA 16.32908715
+	Dec -49.9670215
+	Radius 58.287
+	Distance 7797.35
+}
+
+OpenCluster "Theia 1907:UFMG 16"
+{
+	RA 16.33776361
+	Dec -44.87774106
+	Radius 83.822
+	Distance 4050.734
+}
+
+OpenCluster "HSC 2765"
+{
+	RA 16.33908422
+	Dec -49.6730232
+	Radius 173.476
+	Distance 747.568
+}
+
+OpenCluster "HSC 2931"
+{
+	RA 16.34183146
+	Dec -21.67283134
+	Radius 14.123
+	Distance 432.693
+}
+
+OpenCluster "BH 189:ESO 226-2:FSR 1726:Lynga 9:MWSC 2389:OCL 966"
+{
+	RA 16.34512057
+	Dec -48.52444688
+	Radius 41.617
+	Distance 7572.37
+}
+
+OpenCluster "CWNU 2305:LS 343:La Serena 343"
+{
+	RA 16.34544561
+	Dec -49.6967921
+	Radius 27.679
+	Distance 13027.932
+}
+
+OpenCluster "CWNU 1648"
+{
+	RA 16.34936486
+	Dec -49.90516665
+	Radius 27.405
+	Distance 8294.155
+}
+
+OpenCluster "CWNU 351:LISC 3483:OC 0667:Theia 2501"
+{
+	RA 16.35029639
+	Dec -40.83473017
+	Radius 29.273
+	Distance 3407.43
+}
+
+OpenCluster "HSC 2761"
+{
+	RA 16.35352081
+	Dec -50.93255725
+	Radius 66.1
+	Distance 11578.154
+}
+
+OpenCluster "CWNU 1752"
+{
+	RA 16.35706705
+	Dec -52.67294306
+	Radius 21.805
+	Distance 7182.911
+}
+
+OpenCluster "UPK 627"
+{
+	RA 16.35799463
+	Dec -53.13273403
+	Radius 148.883
+	Distance 1693.946
+}
+
+OpenCluster "HSC 2779"
+{
+	RA 16.3614012
+	Dec -47.26761942
+	Radius 47.085
+	Distance 8631.268
+}
+
+OpenCluster "CWNU 282"
+{
+	RA 16.36334457
+	Dec -53.938664
+	Radius 29.18
+	Distance 4034.678
+}
+
+OpenCluster "HSC 2714"
+{
+	RA 16.38048363
+	Dec -63.03057819
+	Radius 37.127
+	Distance 2352.14
+}
+
+OpenCluster "FoF 273:UBC 543"
+{
+	RA 16.38164011
+	Dec -50.17729437
+	Radius 69.452
+	Distance 7574.662
+}
+
+OpenCluster "OC 0653:Ruprecht 116:Ruprecht 117"
+{
+	RA 16.39188819
+	Dec -51.87249325
+	Radius 39.459
+	Distance 9124.571
+}
+
+OpenCluster "NGC 6121:Collinder 302:ESO 517-1:FSR 1764:GCL 41:MWSC 2396"
+{
+	RA 16.39251423
+	Dec -26.52255707
+	Radius 36.707
+	Distance 1336.574
+}
+
+OpenCluster "Ruprecht 117"
+{
+	RA 16.39735231
+	Dec -51.87109695
+	Radius 32.921
+	Distance 5102.687
 }
 
 OpenCluster "Pismis 23"
 {
-	RA 16.399444
-	Dec -47.107500
-	Distance 8480
-	Radius 1.2
+	RA 16.39946784
+	Dec -48.89302206
+	Radius 56.958
+	Distance 14439.803
 }
 
-OpenCluster "Ruprecht 118"
+OpenCluster "ESO 226-06:ESO 226-226:ESO 226-6:ESO 226 06:MWSC 2400"
 {
-	RA 16.410000
-	Dec -50.033333
-	Distance 4380
-	Radius 1.9
+	RA 16.40370136
+	Dec -51.14227298
+	Radius 37.965
+	Distance 7773.991
 }
 
-OpenCluster "NGC 6124"
+OpenCluster "Ruprecht 118:UBC 313"
 {
-	RA 16.422222
-	Dec -39.346667
-	Distance 1669
-	Radius 9.5
+	RA 16.40821605
+	Dec -51.91772256
+	Radius 63.03
+	Distance 8357.543
 }
 
-OpenCluster "NGC 6134"
+OpenCluster "Theia 1749"
 {
-	RA 16.462778
-	Dec -48.848333
-	Distance 2977
-	Radius 2.6
+	RA 16.40839379
+	Dec -48.95607395
+	Radius 23.423
+	Distance 6151.542
 }
 
-OpenCluster "Ruprecht 119"
+OpenCluster "HSC 2776"
 {
-	RA 16.470833
-	Dec -50.500000
-	Distance 3118
-	Radius 3.6
+	RA 16.41098226
+	Dec -48.82421314
+	Radius 105.694
+	Distance 8346.167
 }
 
-OpenCluster "NGC 6152"
+OpenCluster "NGC 6124:Melotte 145:Collinder 301:ESO 331-3:MWSC 2403:OCL 990:Theia 848"
 {
-	RA 16.545833
-	Dec -51.356667
-	Distance 3359
-	Radius 12.2
+	RA 16.41971768
+	Dec -40.6728107
+	Radius 104.26
+	Distance 1996.532
 }
 
-OpenCluster "NGC 6167"
+OpenCluster "PHOC 19"
 {
-	RA 16.576111
-	Dec -48.228333
-	Distance 3613
-	Radius 3.7
+	RA 16.41985855
+	Dec -49.73998128
+	Radius 95.361
+	Distance 8136.01
+}
+
+OpenCluster "HSC 2762"
+{
+	RA 16.42490917
+	Dec -51.45934251
+	Radius 14.418
+	Distance 9065.969
+}
+
+OpenCluster "OC 0662:UBC 315"
+{
+	RA 16.42527491
+	Dec -47.9496192
+	Radius 58.371
+	Distance 6812.241
+}
+
+OpenCluster "CWNU 1071:OC 0652"
+{
+	RA 16.42537871
+	Dec -52.17381519
+	Radius 31.571
+	Distance 2800.653
+}
+
+OpenCluster "HSC 190"
+{
+	RA 16.42647978
+	Dec 1.8548371
+	Radius 49.864
+	Distance 359.272
+}
+
+OpenCluster "HSC 2796"
+{
+	RA 16.42850407
+	Dec -44.74739731
+	Radius 52.273
+	Distance 5568.506
+}
+
+OpenCluster "Theia 1306"
+{
+	RA 16.43319748
+	Dec -42.34372054
+	Radius 114.978
+	Distance 1793.56
+}
+
+OpenCluster "CWNU 2565"
+{
+	RA 16.43522792
+	Dec -49.91548841
+	Radius 36.299
+	Distance 9053.494
+}
+
+OpenCluster "CWNU 2464"
+{
+	RA 16.43545286
+	Dec -49.98934328
+	Radius 38.566
+	Distance 8131.322
+}
+
+OpenCluster "HSC 2919"
+{
+	RA 16.44011029
+	Dec -24.0848455
+	Radius 15.521
+	Distance 447.845
+}
+
+OpenCluster "NGC 6134:Melotte 146:Collinder 303:BH 191:ESO 226-9:MWSC 2412:OCL 968:Theia 1693:Theia 1707:Theia 1886:Theia 2956"
+{
+	RA 16.44418767
+	Dec -49.14504044
+	Radius 53.57
+	Distance 8158.874
+}
+
+OpenCluster "UBC 11"
+{
+	RA 16.44883098
+	Dec -59.704536
+	Radius 135.681
+	Distance 1468.883
+}
+
+OpenCluster "HSC 2716"
+{
+	RA 16.45352079
+	Dec -63.46090596
+	Radius 69.479
+	Distance 1908.121
+}
+
+OpenCluster "HSC 2777"
+{
+	RA 16.46010501
+	Dec -49.02915524
+	Radius 21.843
+	Distance 2966.31
+}
+
+OpenCluster "CWNU 2303:CWNU 2428"
+{
+	RA 16.46167389
+	Dec -51.14412294
+	Radius 60.038
+	Distance 8854.029
+}
+
+OpenCluster "NGC 6134:Melotte 146:Collinder 303:BH 191:ESO 226-9:MWSC 2412:OCL 968:Theia 4874"
+{
+	RA 16.46285275
+	Dec -49.15736399
+	Radius 74.372
+	Distance 3568.457
+}
+
+OpenCluster "ESO 226-10:MWSC 2413:OCL 963:OC 0655:Ruprecht 119"
+{
+	RA 16.46688782
+	Dec -51.49584125
+	Radius 50.633
+	Distance 6519.988
+}
+
+OpenCluster "OC 0657:UBC 1549"
+{
+	RA 16.46917872
+	Dec -49.61937512
+	Radius 28.269
+	Distance 9232.377
+}
+
+OpenCluster "CWNU 2266"
+{
+	RA 16.47072903
+	Dec -51.09228829
+	Radius 76.884
+	Distance 8754.031
+}
+
+OpenCluster "HSC 2906"
+{
+	RA 16.47655498
+	Dec -26.60595666
+	Radius 68.159
+	Distance 1909.362
+}
+
+OpenCluster "FoF 2210:UBC 311"
+{
+	RA 16.47894611
+	Dec -54.95184451
+	Radius 59.716
+	Distance 4355.197
+}
+
+OpenCluster "HSC 2789"
+{
+	RA 16.48245213
+	Dec -46.12067424
+	Radius 18.146
+	Distance 2840.14
+}
+
+OpenCluster "NGC 6134:Melotte 146:Collinder 303:BH 191:ESO 226-11:ESO 226-9:Hogg 19:MWSC 2412:MWSC 2415:OCL 968:OCL 969:Theia 1693:Theia 1842:Theia 1893:Theia 2030"
+{
+	RA 16.48321107
+	Dec -49.11944449
+	Radius 30.95
+	Distance 7338.265
+}
+
+OpenCluster "CWNU 215"
+{
+	RA 16.48447752
+	Dec -45.52108285
+	Radius 30.136
+	Distance 3780.366
+}
+
+OpenCluster "HSC 2802"
+{
+	RA 16.49367815
+	Dec -45.10941786
+	Radius 48.282
+	Distance 2989.054
+}
+
+OpenCluster "Theia 624"
+{
+	RA 16.4966711
+	Dec -44.5495528
+	Radius 48.939
+	Distance 2087.071
+}
+
+OpenCluster "HSC 2808"
+{
+	RA 16.49941582
+	Dec -45.0184287
+	Radius 23.77
+	Distance 5443.095
+}
+
+OpenCluster "FSR 1725:MWSC 2420"
+{
+	RA 16.51141642
+	Dec -50.13143031
+	Radius 96.897
+	Distance 13429.79
+}
+
+OpenCluster "HSC 2746"
+{
+	RA 16.51401294
+	Dec -55.17626539
+	Radius 141.039
+	Distance 2066.6
+}
+
+OpenCluster "DSH J1630.9-4823:Teutsch 82:UBC 667"
+{
+	RA 16.51589615
+	Dec -48.38730117
+	Radius 55.412
+	Distance 8077.349
+}
+
+OpenCluster "HSC 2818"
+{
+	RA 16.5163539
+	Dec -43.91788946
+	Radius 26.559
+	Distance 4315.944
+}
+
+OpenCluster "HSC 2826"
+{
+	RA 16.51896297
+	Dec -41.77628785
+	Radius 72.493
+	Distance 7590.268
+}
+
+OpenCluster "HSC 2752"
+{
+	RA 16.51998412
+	Dec -53.64881231
+	Radius 31.529
+	Distance 14464.89
+}
+
+OpenCluster "HSC 242"
+{
+	RA 16.52308707
+	Dec 9.21638164
+	Radius 124.299
+	Distance 390.178
+}
+
+OpenCluster "HSC 2727"
+{
+	RA 16.52353604
+	Dec -61.28462797
+	Radius 38.791
+	Distance 11733.065
+}
+
+OpenCluster "CWNU 1529"
+{
+	RA 16.52413395
+	Dec -50.23044627
+	Radius 62.69
+	Distance 5152.541
+}
+
+OpenCluster "CWNU 141"
+{
+	RA 16.52928992
+	Dec -52.88081719
+	Radius 54.145
+	Distance 5379.638
+}
+
+OpenCluster "HSC 2788"
+{
+	RA 16.5295411
+	Dec -47.29737117
+	Radius 31.072
+	Distance 2786.57
+}
+
+OpenCluster "HSC 2821"
+{
+	RA 16.53798788
+	Dec -43.14129259
+	Radius 46.08
+	Distance 2344.348
+}
+
+OpenCluster "NGC 6152:Collinder 304:ESO 179-9:MWSC 2423:OCL 961:Theia 2642"
+{
+	RA 16.54388854
+	Dec -52.62059537
+	Radius 49.328
+	Distance 5033.067
+}
+
+OpenCluster "HSC 2712"
+{
+	RA 16.54447944
+	Dec -64.69962474
+	Radius 84.339
+	Distance 830.655
+}
+
+OpenCluster "HSC 2793"
+{
+	RA 16.54864053
+	Dec -46.32942459
+	Radius 26.524
+	Distance 8916.353
+}
+
+OpenCluster "HSC 2794"
+{
+	RA 16.54882124
+	Dec -46.32987674
+	Radius 63.044
+	Distance 12213.422
+}
+
+OpenCluster "CWNU 1954"
+{
+	RA 16.54990425
+	Dec -48.58542501
+	Radius 40.514
+	Distance 9238.936
+}
+
+OpenCluster "HSC 2801"
+{
+	RA 16.56127481
+	Dec -45.81293504
+	Radius 38.535
+	Distance 13785.708
+}
+
+OpenCluster "UBC 545"
+{
+	RA 16.56868856
+	Dec -48.88299252
+	Radius 69.731
+	Distance 8108.246
+}
+
+OpenCluster "HSC 2924"
+{
+	RA 16.57251988
+	Dec -25.09420906
+	Radius 56.869
+	Distance 19747.284
+}
+
+OpenCluster "NGC 6167:Collinder 305:BH 192:ESO 226-16:Harvard 11:MWSC 2425:OCL 971:OC 0661:Theia 2387"
+{
+	RA 16.57817697
+	Dec -49.78405913
+	Radius 66.479
+	Distance 4582.038
+}
+
+OpenCluster "Theia 1770:UBC 316"
+{
+	RA 16.5830309
+	Dec -47.98470376
+	Radius 27.47
+	Distance 5366.349
+}
+
+OpenCluster "Collinder 307"
+{
+	RA 16.58616993
+	Dec -50.98533604
+	Radius 38.106
+	Distance 5944.388
 }
 
 OpenCluster "Ruprecht 120"
 {
-	RA 16.586111
-	Dec -47.716667
-	Distance 6523
-	Radius 2.8
+	RA 16.58715211
+	Dec -48.27710746
+	Radius 31.026
+	Distance 6296.551
 }
 
-OpenCluster "NGC 6178"
+OpenCluster "HSC 2798"
 {
-	RA 16.596389
-	Dec -44.356667
-	Distance 3307
-	Radius 2.4
+	RA 16.58728155
+	Dec -46.17952076
+	Radius 138.216
+	Distance 12254.483
 }
 
-OpenCluster "NGC 6192"
+OpenCluster "Theia 2032"
 {
-	RA 16.673056
-	Dec -42.633333
-	Distance 5045
-	Radius 6.6
+	RA 16.58931163
+	Dec -46.57580955
+	Radius 52.666
+	Distance 13435.275
 }
 
-OpenCluster "NGC 6193"
+OpenCluster "UBC 1553"
 {
-	RA 16.688889
-	Dec -47.236667
-	Distance 3767
-	Radius 7.7
+	RA 16.59212237
+	Dec -45.64595119
+	Radius 31.122
+	Distance 10802.54
 }
 
-OpenCluster "NGC 6200"
+OpenCluster "NGC 6178:Collinder 308:ESO 276-6:MWSC 2428:OCL 980"
 {
-	RA 16.735278
-	Dec -46.536667
-	Distance 6699
-	Radius 13.6
+	RA 16.59529064
+	Dec -45.65054322
+	Radius 57.762
+	Distance 2864.706
 }
 
-OpenCluster "Lynga 12"
+OpenCluster "CWNU 1538"
 {
-	RA 16.767778
-	Dec -49.236111
-	Distance 3261
-	Radius 3.8
+	RA 16.60184801
+	Dec -49.13984437
+	Radius 22.102
+	Distance 5170.682
 }
 
-OpenCluster "NGC 6204"
+OpenCluster "UBC 325:UPK 644"
 {
-	RA 16.769167
-	Dec -46.983333
-	Distance 3914
-	Radius 2.8
+	RA 16.60893188
+	Dec -31.33767814
+	Radius 189.638
+	Distance 2369.8
 }
 
-OpenCluster "Hogg 22"
+OpenCluster "Theia 207:UBC 544:UPK 630"
 {
-	RA 16.776944
-	Dec -46.916667
-	Distance 3966
-	Radius 1.7
+	RA 16.61162383
+	Dec -51.26514819
+	Radius 19.522
+	Distance 2926.356
 }
 
-OpenCluster "Westerlund 1"
+OpenCluster "HSC 2800"
 {
-	RA 16.784444
-	Dec -44.156667
-	Distance 17939
-	Radius 6.3
+	RA 16.6125173
+	Dec -46.32301492
+	Radius 38.89
+	Distance 9185.391
 }
 
-OpenCluster "ASCC 85"
+OpenCluster "UBC 1550"
 {
-	RA 16.791944
-	Dec -44.540000
-	Distance 3914
-	Radius 15.0
+	RA 16.61794603
+	Dec -48.44110709
+	Radius 69.059
+	Distance 7393.136
 }
 
-OpenCluster "NGC 6216"
+OpenCluster "HSC 369"
 {
-	RA 16.823333
-	Dec -43.271667
-	Distance 14025
-	Radius 8.2
+	RA 16.62162615
+	Dec 24.06561942
+	Radius 27.667
+	Distance 5710.646
 }
 
-OpenCluster "NGC 6208"
+OpenCluster "HSC 2898"
 {
-	RA 16.824444
-	Dec -52.271667
-	Distance 3062
-	Radius 8.0
+	RA 16.63081553
+	Dec -29.97330144
+	Radius 23.771
+	Distance 7716.772
 }
 
-OpenCluster "NGC 6231"
+OpenCluster "HSC 2880"
 {
-	RA 16.902778
-	Dec -40.175000
-	Distance 4054
-	Radius 8.3
+	RA 16.63110199
+	Dec -32.25425749
+	Radius 61.94
+	Distance 15999.134
 }
 
-OpenCluster "ESO 332-08"
+OpenCluster "HSC 2781"
 {
-	RA 16.911944
-	Dec -39.291667
-	Distance 3914
-	Radius 5.7
+	RA 16.63181676
+	Dec -49.52907512
+	Radius 24.54
+	Distance 7153.995
 }
 
-OpenCluster "Lynga 14"
+OpenCluster "HSC 2853"
 {
-	RA 16.917778
-	Dec -44.766667
-	Distance 2873
-	Radius 1.3
+	RA 16.63402175
+	Dec -37.30363238
+	Radius 23.725
+	Distance 3323.799
 }
 
-OpenCluster "Collinder 316"
+OpenCluster "HSC 2856"
 {
-	RA 16.925000
-	Dec -39.166667
-	Distance 3261
-	Radius 47.4
+	RA 16.63540836
+	Dec -36.3047277
+	Radius 40.658
+	Distance 8960.872
 }
 
-OpenCluster "NGC 6242"
+OpenCluster "HSC 2785"
 {
-	RA 16.925833
-	Dec -38.538333
-	Distance 3688
-	Radius 4.8
+	RA 16.63677746
+	Dec -48.8019231
+	Radius 36.503
+	Distance 3679.793
 }
 
-OpenCluster "BH 205"
+OpenCluster "HSC 2764"
 {
-	RA 16.936389
-	Dec -39.333333
-	Distance 1360
-	Radius 0.8
+	RA 16.63849811
+	Dec -52.37376529
+	Radius 55.388
+	Distance 4668.701
 }
 
-OpenCluster "Trumpler 24"
+OpenCluster "CWNU 244:UBC 1554"
 {
-	RA 16.950000
-	Dec -39.333333
-	Distance 3711
-	Radius 32.4
+	RA 16.64431288
+	Dec -45.66394338
+	Radius 40.142
+	Distance 5906.501
 }
 
-OpenCluster "NGC 6249"
+OpenCluster "FoF 2442:UPK 640"
 {
-	RA 16.961389
-	Dec -43.188333
-	Distance 3199
-	Radius 2.3
+	RA 16.64615935
+	Dec -39.50714301
+	Radius 141.337
+	Distance 567.064
 }
 
-OpenCluster "NGC 6250"
+OpenCluster "LISC 3355:Theia 2006:UBC 319"
 {
-	RA 16.965556
-	Dec -44.063333
-	Distance 2821
-	Radius 4.1
+	RA 16.64877194
+	Dec -44.75025649
+	Radius 29.867
+	Distance 4296.732
 }
 
-OpenCluster "NGC 6253"
+OpenCluster "1636-283:C1636-283:ESO 452-11:MWSC 2436"
 {
-	RA 16.984722
-	Dec -51.291667
-	Distance 4925
-	Radius 2.9
+	RA 16.65704953
+	Dec -28.39919379
+	Radius 78.185
+	Distance 19776.351
 }
 
-OpenCluster "NGC 6259"
+OpenCluster "HSC 188"
 {
-	RA 17.012500
-	Dec -43.345000
-	Distance 3362
-	Radius 6.8
+	RA 16.66678284
+	Dec -0.60389824
+	Radius 41.368
+	Distance 693.928
 }
 
-OpenCluster "Alessi-Teutsch 12"
+OpenCluster "NGC 6192:Melotte 149:Collinder 309:BH 194:ESO 277-3:MWSC 2440:OCL 988:Theia 3268"
 {
-	RA 17.029722
-	Dec -57.041667
-	Distance 2283
-	Radius 21.9
+	RA 16.67165624
+	Dec -43.35645653
+	Radius 54.263
+	Distance 5206.31
 }
 
-OpenCluster "NGC 6268"
+OpenCluster "DSH J1640.5-4527:Teutsch 83"
 {
-	RA 17.036111
-	Dec -38.271667
-	Distance 3522
-	Radius 3.1
+	RA 16.67615455
+	Dec -45.46786588
+	Radius 60.011
+	Distance 12126.047
 }
 
-OpenCluster "ASCC 87"
+OpenCluster "HSC 2850"
 {
-	RA 17.050000
-	Dec -27.550000
-	Distance 2935
-	Radius 28.2
+	RA 16.6875383
+	Dec -38.59822007
+	Radius 119.066
+	Distance 1233.631
 }
 
-OpenCluster "Teutsch 84"
+OpenCluster "NGC 6193:Theia 1643:Theia 2108"
 {
-	RA 17.072222
-	Dec -41.926667
-	Distance 7175
-	Radius 4.2
+	RA 16.68865041
+	Dec -49.05851166
+	Radius 76.937
+	Distance 3633.03
 }
 
-OpenCluster "NGC 6281"
+OpenCluster "ESO 277-6:MWSC 2446:OCL 983:Ruprecht 121:UBC 548"
 {
-	RA 17.078056
-	Dec -36.015000
-	Distance 1562
-	Radius 1.8
+	RA 16.68922718
+	Dec -46.09008103
+	Radius 87.503
+	Distance 7322.194
+}
+
+OpenCluster "NGC 6193:Theia 1643"
+{
+	RA 16.69037979
+	Dec -48.77152314
+	Radius 39.969
+	Distance 3715.724
+}
+
+OpenCluster "ESO 277-6:MWSC 2446:OCL 983:Ruprecht 121:Theia 3360"
+{
+	RA 16.69553162
+	Dec -46.160749
+	Radius 63.755
+	Distance 6194.024
+}
+
+OpenCluster "UBC 1551"
+{
+	RA 16.70323087
+	Dec -47.48079457
+	Radius 48.117
+	Distance 7936.715
+}
+
+OpenCluster "HSC 2791"
+{
+	RA 16.70536935
+	Dec -47.88351181
+	Radius 27.233
+	Distance 10884.288
+}
+
+OpenCluster "UBC 317"
+{
+	RA 16.70983517
+	Dec -47.88601536
+	Radius 31.546
+	Distance 6680.769
+}
+
+OpenCluster "HXHWL 27"
+{
+	RA 16.70996197
+	Dec -52.67306963
+	Radius 39.56
+	Distance 5093.465
+}
+
+OpenCluster "HSC 2778"
+{
+	RA 16.71008913
+	Dec -50.76346102
+	Radius 33.999
+	Distance 3686.828
+}
+
+OpenCluster "UBC 668"
+{
+	RA 16.71149751
+	Dec -48.01292403
+	Radius 35.687
+	Distance 8602.09
+}
+
+OpenCluster "HSC 2827"
+{
+	RA 16.71755361
+	Dec -43.62522734
+	Radius 28.978
+	Distance 3696.916
+}
+
+OpenCluster "Theia 1676"
+{
+	RA 16.7195172
+	Dec -46.58665033
+	Radius 25.217
+	Distance 9258.103
+}
+
+OpenCluster "Theia 2052:UBC 1552"
+{
+	RA 16.72976427
+	Dec -47.08870349
+	Radius 34.255
+	Distance 8299.942
+}
+
+OpenCluster "NGC 6200:Collinder 311:BH 196:ESO 277-8:MWSC 2450:OCL 978:UBC 318"
+{
+	RA 16.734877
+	Dec -47.46641217
+	Radius 54.614
+	Distance 8179.911
+}
+
+OpenCluster "OC 0668"
+{
+	RA 16.7363643
+	Dec -44.11285717
+	Radius 36.96
+	Distance 9787.766
+}
+
+OpenCluster "UBC 1557"
+{
+	RA 16.73667202
+	Dec -45.52480012
+	Radius 47.362
+	Distance 7576.118
+}
+
+OpenCluster "CWNU 304"
+{
+	RA 16.74192218
+	Dec -52.98813025
+	Radius 50.114
+	Distance 5958.259
+}
+
+OpenCluster "UBC 1555"
+{
+	RA 16.75000481
+	Dec -46.54046094
+	Radius 33.545
+	Distance 6548.416
+}
+
+OpenCluster "HSC 2819"
+{
+	RA 16.75645098
+	Dec -45.81699021
+	Radius 45.629
+	Distance 3345.854
+}
+
+OpenCluster "Teutsch 254:Teutsch J1645.6-4426:UBC 320"
+{
+	RA 16.76066329
+	Dec -44.44382253
+	Radius 58.152
+	Distance 8340.362
+}
+
+OpenCluster "ESO 226-21:Hogg 21:MWSC 2455:OCL 977"
+{
+	RA 16.76091979
+	Dec -47.74398498
+	Radius 37.358
+	Distance 7981.21
+}
+
+OpenCluster "NGC 6204:Theia 2147"
+{
+	RA 16.76903747
+	Dec -47.02563794
+	Radius 26.197
+	Distance 3768.887
+}
+
+OpenCluster "CWNU 2672"
+{
+	RA 16.77135292
+	Dec -45.20677011
+	Radius 36.464
+	Distance 9946.476
+}
+
+OpenCluster "NGC 6204:ESO 277-11:Hogg 22:MWSC 2459:OCL 981:Theia 1784:Theia 2473:UBC 547"
+{
+	RA 16.77673014
+	Dec -47.08875105
+	Radius 73.005
+	Distance 8265.031
+}
+
+OpenCluster "HXHWL 33:UBC 1561"
+{
+	RA 16.77840741
+	Dec -41.20197919
+	Radius 41.416
+	Distance 3476.161
+}
+
+OpenCluster "UBC 1556"
+{
+	RA 16.77882863
+	Dec -46.36684405
+	Radius 43.427
+	Distance 8450.697
+}
+
+OpenCluster "CWNU 1842"
+{
+	RA 16.77995207
+	Dec -48.82175922
+	Radius 28.712
+	Distance 3848.901
+}
+
+OpenCluster "ESO 518-03:ESO 518-3:ESO 518-518:ESO 518 03:MWSC 2462:Theia 5265:UBC 327"
+{
+	RA 16.78499186
+	Dec -25.80631881
+	Radius 78.595
+	Distance 5161.089
+}
+
+OpenCluster "LISC 1757:UBC 669"
+{
+	RA 16.78740913
+	Dec -46.67177279
+	Radius 25.179
+	Distance 7392.068
+}
+
+OpenCluster "UBC 321"
+{
+	RA 16.79286434
+	Dec -44.53450971
+	Radius 54.75
+	Distance 7642.858
+}
+
+OpenCluster "ASCC 85:MWSC 2465:Theia 156:Theia 3681:Theia 4023"
+{
+	RA 16.7949538
+	Dec -45.57210398
+	Radius 134.924
+	Distance 2780.475
+}
+
+OpenCluster "HSC 66"
+{
+	RA 16.79617309
+	Dec -13.93912501
+	Radius 44.365
+	Distance 991.128
+}
+
+OpenCluster "HSC 2658"
+{
+	RA 16.79749268
+	Dec -75.66623345
+	Radius 102.509
+	Distance 11650.963
+}
+
+OpenCluster "HSC 2759"
+{
+	RA 16.80649445
+	Dec -54.90859016
+	Radius 177.054
+	Distance 31037.8
+}
+
+OpenCluster "HSC 2915"
+{
+	RA 16.81280356
+	Dec -28.6700087
+	Radius 21.98
+	Distance 4465.846
+}
+
+OpenCluster "UBC 549"
+{
+	RA 16.81332404
+	Dec -46.89292194
+	Radius 21.989
+	Distance 8062.135
+}
+
+OpenCluster "NGC 6216:Melotte 152:Collinder 314:BH 199:ESO 277-14:MWSC 2469:OCL 989:Theia 2094"
+{
+	RA 16.82223215
+	Dec -44.73101479
+	Radius 64.897
+	Distance 7472.64
+}
+
+OpenCluster "NGC 6208:Collinder 313:BH 198:ESO 179-14:FSR 1724:MWSC 2470:OCL 964:Theia 5118"
+{
+	RA 16.82295275
+	Dec -53.71227946
+	Radius 56.876
+	Distance 3678.534
+}
+
+OpenCluster "HSC 2956"
+{
+	RA 16.82806438
+	Dec -24.37590014
+	Radius 43.422
+	Distance 12101.17
+}
+
+OpenCluster "HSC 2814"
+{
+	RA 16.83036362
+	Dec -47.30196471
+	Radius 23.025
+	Distance 4002.36
+}
+
+OpenCluster "BH 200:ESO 277-15:MWSC 2471:OC 0671:vdBergh-Hagen 200"
+{
+	RA 16.8321465
+	Dec -44.1923048
+	Radius 39.234
+	Distance 7228.49
+}
+
+OpenCluster "HSC 2749"
+{
+	RA 16.83767968
+	Dec -57.25816928
+	Radius 102.856
+	Distance 15568.584
+}
+
+OpenCluster "HSC 2813"
+{
+	RA 16.83886912
+	Dec -47.38492339
+	Radius 21.143
+	Distance 5888.171
+}
+
+OpenCluster "OC 0673"
+{
+	RA 16.84118773
+	Dec -41.60087665
+	Radius 13.336
+	Distance 4987.895
+}
+
+OpenCluster "OC 0669:UBC 550"
+{
+	RA 16.84144702
+	Dec -45.08031449
+	Radius 34.708
+	Distance 7612.828
+}
+
+OpenCluster "CWNU 2778"
+{
+	RA 16.84374034
+	Dec -41.82593323
+	Radius 29.82
+	Distance 8661.639
+}
+
+OpenCluster "CWNU 2481"
+{
+	RA 16.84447634
+	Dec -43.81957144
+	Radius 63.666
+	Distance 7521.322
+}
+
+OpenCluster "UBC 1558"
+{
+	RA 16.84706159
+	Dec -45.41447187
+	Radius 39.166
+	Distance 7610.125
+}
+
+OpenCluster "HSC 2817"
+{
+	RA 16.85071958
+	Dec -47.11842161
+	Radius 42.89
+	Distance 2416.49
+}
+
+OpenCluster "Theia 1822:UBC 1559"
+{
+	RA 16.85961144
+	Dec -44.49587978
+	Radius 55.093
+	Distance 7106.9
+}
+
+OpenCluster "FSR 1744:MWSC 2474:SAI 124:UBC 1560"
+{
+	RA 16.86489145
+	Dec -42.40853489
+	Radius 35.389
+	Distance 5240.848
+}
+
+OpenCluster "HSC 2833"
+{
+	RA 16.86629121
+	Dec -44.22068945
+	Radius 77.478
+	Distance 8100.507
+}
+
+OpenCluster "UFMG 47"
+{
+	RA 16.86888543
+	Dec -47.39069278
+	Radius 70.703
+	Distance 8446.067
+}
+
+OpenCluster "Theia 2612:UBC 670"
+{
+	RA 16.87378464
+	Dec -44.42315377
+	Radius 15.28
+	Distance 5477.915
+}
+
+OpenCluster "HSC 2971"
+{
+	RA 16.87954364
+	Dec -23.51813529
+	Radius 133.698
+	Distance 331.648
+}
+
+OpenCluster "CWNU 2560"
+{
+	RA 16.88048158
+	Dec -46.36501777
+	Radius 81.85
+	Distance 7303.836
+}
+
+OpenCluster "Ryu 089"
+{
+	RA 16.8829358
+	Dec -41.67876096
+	Radius 34.609
+	Distance 8407.039
+}
+
+OpenCluster "HSC 2830"
+{
+	RA 16.88612137
+	Dec -45.03599336
+	Radius 69.102
+	Distance 7849.873
+}
+
+OpenCluster "Theia 659"
+{
+	RA 16.89171833
+	Dec -42.5886901
+	Radius 138.913
+	Distance 2154.505
+}
+
+OpenCluster "CWNU 2389"
+{
+	RA 16.89803518
+	Dec -46.73646045
+	Radius 45.094
+	Distance 8140.298
+}
+
+OpenCluster "HSC 2848"
+{
+	RA 16.89962941
+	Dec -41.15606138
+	Radius 10.413
+	Distance 4939.38
+}
+
+OpenCluster "Northern Jewel Box:NGC 6231:Melotte 153:Collinder 315"
+{
+	RA 16.90473238
+	Dec -41.83645183
+	Radius 49.222
+	Distance 5066.451
+}
+
+OpenCluster "HSC 2842"
+{
+	RA 16.9055698
+	Dec -42.78770759
+	Radius 34.925
+	Distance 6471.718
+}
+
+OpenCluster "HSC 2849"
+{
+	RA 16.90987174
+	Dec -40.98504561
+	Radius 18.032
+	Distance 5083.867
+}
+
+OpenCluster "Theia 2688:UBC 546"
+{
+	RA 16.91381684
+	Dec -48.44660844
+	Radius 46.23
+	Distance 6034.099
+}
+
+OpenCluster "CWNU 2439"
+{
+	RA 16.91415118
+	Dec -43.86387147
+	Radius 27.283
+	Distance 5119.266
+}
+
+OpenCluster "ESO 277-18:Lynga 14:MWSC 2484:OCL 992:OC 0670"
+{
+	RA 16.91774533
+	Dec -45.2362453
+	Radius 84.923
+	Distance 8156.338
+}
+
+OpenCluster "Collinder 316:BH 202:ESO 332-9:MWSC 2486:Ruprecht 122:Theia 3570"
+{
+	RA 16.91914722
+	Dec -40.95669515
+	Radius 47.756
+	Distance 5338.699
+}
+
+OpenCluster "NGC 6242:Melotte 155:Collinder 317:BH 204:ESO 332-10:MWSC 2488:OCL 1001"
+{
+	RA 16.92517242
+	Dec -39.46565963
+	Radius 53.133
+	Distance 4042.127
+}
+
+OpenCluster "CWNU 1594"
+{
+	RA 16.93056929
+	Dec -43.65687989
+	Radius 37.522
+	Distance 8327.716
+}
+
+OpenCluster "UBC 671"
+{
+	RA 16.93299957
+	Dec -43.21663642
+	Radius 79.168
+	Distance 7292.715
+}
+
+OpenCluster "BH 205:Collinder 316:Trumpler 24"
+{
+	RA 16.93551127
+	Dec -40.65487212
+	Radius 13.428
+	Distance 3007.433
+}
+
+OpenCluster "Collinder 316:BH 205:ESO 332-13:ESO 332 13:Trumpler 24:UBC 323"
+{
+	RA 16.93683485
+	Dec -40.59734474
+	Radius 35.695
+	Distance 5194.896
+}
+
+OpenCluster "CWNU 317"
+{
+	RA 16.94417511
+	Dec -39.84789058
+	Radius 26.711
+	Distance 4488.396
+}
+
+OpenCluster "Collinder 316:OCSN 95:Trumpler 24"
+{
+	RA 16.94545929
+	Dec -40.47268038
+	Radius 97.808
+	Distance 1351.036
+}
+
+OpenCluster "CWNU 267"
+{
+	RA 16.95804675
+	Dec -48.46290808
+	Radius 30.912
+	Distance 5511.3
+}
+
+OpenCluster "Theia 119:UPK 624"
+{
+	RA 16.95847502
+	Dec -60.51874832
+	Radius 53.455
+	Distance 1023.757
+}
+
+OpenCluster "CWNU 1851"
+{
+	RA 16.96033641
+	Dec -41.46584135
+	Radius 38.776
+	Distance 5101.984
+}
+
+OpenCluster "HSC 2689"
+{
+	RA 16.96257694
+	Dec -69.83744689
+	Radius 71.004
+	Distance 9861.114
+}
+
+OpenCluster "NGC 6249:Collinder 319:ESO 277-19:MWSC 2499:OCL 994"
+{
+	RA 16.96311325
+	Dec -44.81869675
+	Radius 23.426
+	Distance 3756.785
+}
+
+OpenCluster "NGC 6250:Collinder 320:BH 206:ESO 277-20:MWSC 2500:OCL 991:Theia 132:Theia 354"
+{
+	RA 16.9651835
+	Dec -45.94860902
+	Radius 47.185
+	Distance 3080.829
+}
+
+OpenCluster "CWNU 2568"
+{
+	RA 16.97289888
+	Dec -42.61328646
+	Radius 40.959
+	Distance 5035.61
+}
+
+OpenCluster "UBC 552"
+{
+	RA 16.98202288
+	Dec -42.06659704
+	Radius 91.274
+	Distance 7606.208
+}
+
+OpenCluster "NGC 6253:Melotte 156:Collinder 321:BH 207:ESO 180-2:FSR 1730:MWSC 2502:OCL 972:Theia 7520"
+{
+	RA 16.98472898
+	Dec -52.7148023
+	Radius 44.926
+	Distance 5238.728
+}
+
+OpenCluster "UBC 560"
+{
+	RA 16.98839799
+	Dec -36.06768472
+	Radius 34.41
+	Distance 4594.608
+}
+
+OpenCluster "Theia 354"
+{
+	RA 16.98850608
+	Dec -46.50576646
+	Radius 19.198
+	Distance 3020.372
+}
+
+OpenCluster "CWNU 1934"
+{
+	RA 16.99677781
+	Dec -42.36379452
+	Radius 13.434
+	Distance 4993.197
+}
+
+OpenCluster "Theia 206:UPK 629"
+{
+	RA 16.99939227
+	Dec -56.41915513
+	Radius 59.007
+	Distance 2956.446
+}
+
+OpenCluster "HSC 2895"
+{
+	RA 17.00038786
+	Dec -34.44194905
+	Radius 41.436
+	Distance 2621.347
+}
+
+OpenCluster "HSC 89"
+{
+	RA 17.00075364
+	Dec -14.59238267
+	Radius 68.302
+	Distance 12930.91
+}
+
+OpenCluster "HSC 2837"
+{
+	RA 17.00240748
+	Dec -44.72960357
+	Radius 24.661
+	Distance 7054.022
+}
+
+OpenCluster "CWNU 355:OC 0677"
+{
+	RA 17.00373498
+	Dec -38.7816288
+	Radius 43.349
+	Distance 5675.638
+}
+
+OpenCluster "UPK 612"
+{
+	RA 17.00656896
+	Dec -68.52356218
+	Radius 89.958
+	Distance 739.385
+}
+
+OpenCluster "NGC 6259:Melotte 158:Collinder 322:BH 209:ESO 277-22:MWSC 2511:OCL 996:OC 0672:Theia 3505"
+{
+	RA 17.01284941
+	Dec -44.67651013
+	Radius 70.998
+	Distance 7041.685
+}
+
+OpenCluster "HSC 64"
+{
+	RA 17.01323244
+	Dec -16.22050864
+	Radius 148.849
+	Distance 20746.497
+}
+
+OpenCluster "HSC 2824"
+{
+	RA 17.01374405
+	Dec -46.68217681
+	Radius 146.825
+	Distance 3783.854
+}
+
+OpenCluster "HSC 2773"
+{
+	RA 17.01376712
+	Dec -54.02795886
+	Radius 83.084
+	Distance 934.906
+}
+
+OpenCluster "UBC 322"
+{
+	RA 17.01440328
+	Dec -44.19047753
+	Radius 86.559
+	Distance 8534.649
+}
+
+OpenCluster "HSC 2829"
+{
+	RA 17.01688124
+	Dec -46.18254329
+	Radius 20.843
+	Distance 3156.39
+}
+
+OpenCluster "CWNU 1427"
+{
+	RA 17.01832105
+	Dec -39.59152233
+	Radius 37.771
+	Distance 7103.993
+}
+
+OpenCluster "HSC 2780"
+{
+	RA 17.0193496
+	Dec -52.60653898
+	Radius 158.108
+	Distance 11204.255
+}
+
+OpenCluster "HSC 2863"
+{
+	RA 17.01941057
+	Dec -38.77766216
+	Radius 22.263
+	Distance 5037.131
+}
+
+OpenCluster "CWNU 291:Theia 3329"
+{
+	RA 17.0271152
+	Dec -25.70565598
+	Radius 24.058
+	Distance 3093.234
+}
+
+OpenCluster "ASCC 86:AT 12:Alessi-Teutsch 12:Alessi J1701.7-5857:Alessi Teutsch 12:MWSC 2513:Theia 257"
+{
+	RA 17.02743032
+	Dec -59.00764117
+	Radius 112.062
+	Distance 1944.197
+}
+
+OpenCluster "FSR 1750:MWSC 2514"
+{
+	RA 17.03467543
+	Dec -38.8791165
+	Radius 49.395
+	Distance 10810.424
+}
+
+OpenCluster "BH 211:ESO 332-16:MWSC 2518:vdBergh-Hagen 211"
+{
+	RA 17.03514331
+	Dec -41.1121459
+	Radius 30.126
+	Distance 5418.319
+}
+
+OpenCluster "NGC 6268:Collinder 323:BH 212:ESO 332-17:MWSC 2516:OCL 1002"
+{
+	RA 17.03516144
+	Dec -39.72252922
+	Radius 44.713
+	Distance 4705.328
+}
+
+OpenCluster "Theia 643"
+{
+	RA 17.03749837
+	Dec -48.92391645
+	Radius 213.492
+	Distance 1847.277
+}
+
+OpenCluster "CWNU 285:Theia 2341"
+{
+	RA 17.04086963
+	Dec -42.8986738
+	Radius 21.886
+	Distance 3354.975
+}
+
+OpenCluster "ASCC 87:MWSC 2520:Theia 330"
+{
+	RA 17.04652347
+	Dec -28.45807211
+	Radius 54.756
+	Distance 2450.8
+}
+
+OpenCluster "HSC 2877"
+{
+	RA 17.05079355
+	Dec -36.90805559
+	Radius 18.893
+	Distance 3059.548
+}
+
+OpenCluster "HSC 16"
+{
+	RA 17.05085434
+	Dec -20.69443082
+	Radius 40.732
+	Distance 9326.043
+}
+
+OpenCluster "Theia 1888:Theia 3116:Theia 4045:UBC 324"
+{
+	RA 17.06257115
+	Dec -38.4694724
+	Radius 47.218
+	Distance 5761.405
+}
+
+OpenCluster "DBSB 104"
+{
+	RA 17.06463394
+	Dec -51.09238842
+	Radius 17.014
+	Distance 3474.304
+}
+
+OpenCluster "ESO 227-3:Harvard 13:MWSC 2523:OCL 986:Theia 4391"
+{
+	RA 17.06736897
+	Dec -48.1184281
+	Radius 90.153
+	Distance 3758.26
+}
+
+OpenCluster "HSC 2917"
+{
+	RA 17.06882104
+	Dec -31.22294738
+	Radius 20.833
+	Distance 5489.277
+}
+
+OpenCluster "HSC 229"
+{
+	RA 17.0720754
+	Dec 1.6253259
+	Radius 59.64
+	Distance 715.333
+}
+
+OpenCluster "DSH J1704.3-4204:MWSC 2526:Teutsch 84"
+{
+	RA 17.07261101
+	Dec -42.07025604
+	Radius 67.937
+	Distance 7838.23
+}
+
+OpenCluster "HSC 2878"
+{
+	RA 17.07346234
+	Dec -37.01072829
+	Radius 272.662
+	Distance 23552.012
+}
+
+OpenCluster "Theia 1704:UBC 554"
+{
+	RA 17.07608954
+	Dec -41.66349221
+	Radius 26.64
+	Distance 5218.126
+}
+
+OpenCluster "CWNU 1151:Theia 2460"
+{
+	RA 17.07719336
+	Dec -51.40135421
+	Radius 48.055
+	Distance 3548.292
+}
+
+OpenCluster "NGC 6281:Melotte 161:Collinder 324:BH 213:ESO 332-19:MWSC 2530:OCL 1003"
+{
+	RA 17.07925185
+	Dec -37.94068257
+	Radius 128.497
+	Distance 1698.5
+}
+
+OpenCluster "UBC 557"
+{
+	RA 17.07995397
+	Dec -38.92151381
+	Radius 33.99
+	Distance 4705.347
+}
+
+OpenCluster "HSC 2890"
+{
+	RA 17.08413095
+	Dec -35.48443524
+	Radius 108.398
+	Distance 25616.742
+}
+
+OpenCluster "HSC 2864"
+{
+	RA 17.08579355
+	Dec -39.09143375
+	Radius 100.27
+	Distance 10863.888
+}
+
+OpenCluster "HXHWL 10"
+{
+	RA 17.09007974
+	Dec -48.38776664
+	Radius 48.9
+	Distance 2854.426
+}
+
+OpenCluster "HSC 2832"
+{
+	RA 17.09057329
+	Dec -46.11479172
+	Radius 24.302
+	Distance 3240.92
+}
+
+OpenCluster "HSC 2861"
+{
+	RA 17.09698289
+	Dec -40.00158613
+	Radius 30.756
+	Distance 4968.279
+}
+
+OpenCluster "UBC 1562"
+{
+	RA 17.09896137
+	Dec -43.45465892
+	Radius 57.199
+	Distance 7200.947
+}
+
+OpenCluster "CWNU 1619"
+{
+	RA 17.10454549
+	Dec -42.42769267
+	Radius 23.521
+	Distance 7917.418
+}
+
+OpenCluster "Theia 1662:Theia 1704:UBC 555"
+{
+	RA 17.1057477
+	Dec -41.58248499
+	Radius 18.282
+	Distance 5231.957
+}
+
+OpenCluster "CWNU 62"
+{
+	RA 17.11336854
+	Dec -41.56450675
+	Radius 56.079
+	Distance 4850.249
+}
+
+OpenCluster "UBC 563"
+{
+	RA 17.11640279
+	Dec -30.68685803
+	Radius 26.678
+	Distance 3511.507
+}
+
+OpenCluster "ASCC 88:Gulliver 29:OC 0684:Theia 1690"
+{
+	RA 17.11818023
+	Dec -35.80406861
+	Radius 85.887
+	Distance 3466.428
 }
 
 OpenCluster "ASCC 88"
 {
-	RA 17.113056
-	Dec -34.400000
-	Distance 6197
-	Radius 59.5
+	RA 17.1233749
+	Dec -35.55640977
+	Radius 22.328
+	Distance 2847.174
 }
 
-OpenCluster "NGC 6318"
+OpenCluster "ESO 332-22:ESO 332 22:MWSC 2537"
 {
-	RA 17.269722
-	Dec -38.575000
-	Distance 6849
-	Radius 4.0
+	RA 17.12521767
+	Dec -40.84179213
+	Radius 17.48
+	Distance 5062.456
 }
 
-OpenCluster "Bochum 13"
+OpenCluster "CWNU 2714"
 {
-	RA 17.290000
-	Dec -34.450000
-	Distance 3512
-	Radius 7.2
+	RA 17.12780295
+	Dec -42.64872622
+	Radius 49.016
+	Distance 4884.525
+}
+
+OpenCluster "HSC 2767"
+{
+	RA 17.13140238
+	Dec -55.73243692
+	Radius 25.319
+	Distance 3484.386
+}
+
+OpenCluster "FoF 145:UBC 551"
+{
+	RA 17.13236977
+	Dec -44.15646643
+	Radius 45.836
+	Distance 5646.822
+}
+
+OpenCluster "CWNU 1922"
+{
+	RA 17.13655022
+	Dec -42.46533823
+	Radius 22.754
+	Distance 6572.947
+}
+
+OpenCluster "HSC 2879"
+{
+	RA 17.1369339
+	Dec -37.5472595
+	Radius 219.726
+	Distance 10552.91
+}
+
+OpenCluster "HSC 2858"
+{
+	RA 17.13806623
+	Dec -40.96610397
+	Radius 76.729
+	Distance 7986.658
+}
+
+OpenCluster "OCSN 2:Theia 70"
+{
+	RA 17.14112163
+	Dec -18.20906584
+	Radius 51.281
+	Distance 681.905
+}
+
+OpenCluster "HSC 322"
+{
+	RA 17.14498967
+	Dec 12.20013196
+	Radius 51.523
+	Distance 1654.093
+}
+
+OpenCluster "HSC 2860"
+{
+	RA 17.15312221
+	Dec -40.61033582
+	Radius 85.57
+	Distance 10576.262
+}
+
+OpenCluster "HSC 2836"
+{
+	RA 17.15371971
+	Dec -46.20288278
+	Radius 61.268
+	Distance 3506.488
+}
+
+OpenCluster "CWNU 1347"
+{
+	RA 17.16449873
+	Dec -40.49008658
+	Radius 45.063
+	Distance 7248.444
+}
+
+OpenCluster "CWNU 1559"
+{
+	RA 17.16726005
+	Dec -40.86546981
+	Radius 25
+	Distance 9863.506
+}
+
+OpenCluster "HSC 334"
+{
+	RA 17.17163725
+	Dec 14.54451052
+	Radius 59.562
+	Distance 2235.985
+}
+
+OpenCluster "HSC 2886"
+{
+	RA 17.17292687
+	Dec -36.65657763
+	Radius 47.419
+	Distance 5037.742
+}
+
+OpenCluster "Theia 1649:Theia 1673:Theia 1875"
+{
+	RA 17.17548295
+	Dec -41.61455782
+	Radius 12.905
+	Distance 7325.797
+}
+
+OpenCluster "CWNU 1832"
+{
+	RA 17.17946639
+	Dec -36.02914769
+	Radius 38.596
+	Distance 5317.54
+}
+
+OpenCluster "CWNU 2507:Theia 1746"
+{
+	RA 17.18043767
+	Dec -41.85395455
+	Radius 51.755
+	Distance 7984.018
+}
+
+OpenCluster "HSC 2795"
+{
+	RA 17.18244214
+	Dec -51.27400147
+	Radius 26.538
+	Distance 5438.519
+}
+
+OpenCluster "HSC 67"
+{
+	RA 17.18313889
+	Dec -17.76926401
+	Radius 22.97
+	Distance 433.958
+}
+
+OpenCluster "HSC 2963"
+{
+	RA 17.18393118
+	Dec -27.43951891
+	Radius 22.874
+	Distance 518.859
+}
+
+OpenCluster "Theia 1891:UFMG 30"
+{
+	RA 17.18417094
+	Dec -48.73053968
+	Radius 57.878
+	Distance 3661.701
+}
+
+OpenCluster "CWNU 2606"
+{
+	RA 17.19229225
+	Dec -41.74866111
+	Radius 42.313
+	Distance 4749.294
+}
+
+OpenCluster "CWNU 85"
+{
+	RA 17.19681868
+	Dec -41.34274609
+	Radius 24.969
+	Distance 7156.018
+}
+
+OpenCluster "CWNU 513"
+{
+	RA 17.19876176
+	Dec -71.62002998
+	Radius 44.956
+	Distance 1062.014
+}
+
+OpenCluster "HSC 2976"
+{
+	RA 17.19956209
+	Dec -25.63922466
+	Radius 35.003
+	Distance 335.655
+}
+
+OpenCluster "UFMG 24"
+{
+	RA 17.20037123
+	Dec -35.94076739
+	Radius 13.563
+	Distance 4355.559
+}
+
+OpenCluster "HSC 2854"
+{
+	RA 17.20604425
+	Dec -42.39736341
+	Radius 163.389
+	Distance 1635.587
+}
+
+OpenCluster "UBC 326"
+{
+	RA 17.20956421
+	Dec -36.05017139
+	Radius 33.069
+	Distance 5095.925
+}
+
+OpenCluster "HSC 2893"
+{
+	RA 17.21028608
+	Dec -36.52838084
+	Radius 27.286
+	Distance 4343.579
+}
+
+OpenCluster "HSC 2866"
+{
+	RA 17.21259949
+	Dec -39.99793473
+	Radius 77.143
+	Distance 11890.824
+}
+
+OpenCluster "CWNU 2622"
+{
+	RA 17.21745275
+	Dec -41.79878139
+	Radius 33.926
+	Distance 6750.112
+}
+
+OpenCluster "DSH J1713.2-3942:MWSC 2547:Teutsch 85"
+{
+	RA 17.22062498
+	Dec -39.70893094
+	Radius 43.042
+	Distance 16549.671
+}
+
+OpenCluster "HSC 2911"
+{
+	RA 17.22134568
+	Dec -33.26737592
+	Radius 70.19
+	Distance 3504.568
+}
+
+OpenCluster "CWNU 1702"
+{
+	RA 17.22644804
+	Dec -38.86765065
+	Radius 50.218
+	Distance 10845.042
+}
+
+OpenCluster "HSC 2869"
+{
+	RA 17.22701091
+	Dec -39.84118813
+	Radius 34.504
+	Distance 4220.984
+}
+
+OpenCluster "HSC 2730"
+{
+	RA 17.22734291
+	Dec -64.66624836
+	Radius 23.521
+	Distance 6000.595
+}
+
+OpenCluster "HSC 2862"
+{
+	RA 17.22946684
+	Dec -40.78777671
+	Radius 67.116
+	Distance 9554.919
+}
+
+OpenCluster "HSC 2899"
+{
+	RA 17.23704748
+	Dec -35.89847388
+	Radius 62.105
+	Distance 8228.218
+}
+
+OpenCluster "HSC 2870"
+{
+	RA 17.24163901
+	Dec -39.8088886
+	Radius 33.943
+	Distance 7665.946
+}
+
+OpenCluster "CWNU 2516"
+{
+	RA 17.24809674
+	Dec -46.63736819
+	Radius 27.544
+	Distance 4484.728
+}
+
+OpenCluster "Theia 1777:UFMG 29"
+{
+	RA 17.25425274
+	Dec -36.57530092
+	Radius 25.237
+	Distance 4865.346
+}
+
+OpenCluster "HSC 2868"
+{
+	RA 17.25459276
+	Dec -40.1966962
+	Radius 29.25
+	Distance 9534.939
+}
+
+OpenCluster "OC 0687:UFMG 65"
+{
+	RA 17.26344746
+	Dec -33.74291875
+	Radius 18.839
+	Distance 3376.28
+}
+
+OpenCluster "UBC 1564"
+{
+	RA 17.26363155
+	Dec -38.72147122
+	Radius 67.032
+	Distance 10088.283
+}
+
+OpenCluster "OC 0680"
+{
+	RA 17.26570901
+	Dec -39.04236802
+	Radius 38.852
+	Distance 7777.874
+}
+
+OpenCluster "CWNU 1535"
+{
+	RA 17.2663638
+	Dec -42.28952941
+	Radius 72.898
+	Distance 6805.386
+}
+
+OpenCluster "NGC 6318:Melotte 166:Collinder 325:BH 218:ESO 333-1:MWSC 2552:OCL 1004:OC 0679:Theia 1708:Theia 1766:Theia 2037:Theia 2225"
+{
+	RA 17.26988516
+	Dec -39.42755711
+	Radius 28.495
+	Distance 7151.208
+}
+
+OpenCluster "BH 217:ESO 333-2:MWSC 2553:vdBergh-Hagen 217"
+{
+	RA 17.27154181
+	Dec -40.81763023
+	Radius 32.307
+	Distance 8835.584
+}
+
+OpenCluster "CWNU 1758"
+{
+	RA 17.27215707
+	Dec -39.91447859
+	Radius 11.488
+	Distance 8284.288
+}
+
+OpenCluster "HSC 2874"
+{
+	RA 17.27371745
+	Dec -39.314365
+	Radius 20.993
+	Distance 7556.686
+}
+
+OpenCluster "Theia 1699:Theia 1766:Theia 2037:UBC 559"
+{
+	RA 17.27404499
+	Dec -39.74719455
+	Radius 58.859
+	Distance 7304.18
+}
+
+OpenCluster "HSC 2790"
+{
+	RA 17.27553746
+	Dec -52.30833693
+	Radius 49.41
+	Distance 7984.262
+}
+
+OpenCluster "HSC 2897"
+{
+	RA 17.27580719
+	Dec -36.37596234
+	Radius 31.221
+	Distance 5329.848
+}
+
+OpenCluster "CWNU 1294"
+{
+	RA 17.27833408
+	Dec -41.87503655
+	Radius 62.897
+	Distance 5771.086
+}
+
+OpenCluster "HSC 2872"
+{
+	RA 17.28108054
+	Dec -39.86395784
+	Radius 45.881
+	Distance 10402.006
+}
+
+OpenCluster "HSC 172"
+{
+	RA 17.28207086
+	Dec -8.73995437
+	Radius 146.386
+	Distance 19551.209
+}
+
+OpenCluster "CWNU 1:UBC 1563"
+{
+	RA 17.28488194
+	Dec -41.697642
+	Radius 24.554
+	Distance 5068.467
+}
+
+OpenCluster "LISC 3180:UBC 556"
+{
+	RA 17.28590575
+	Dec -41.52161938
+	Radius 35.077
+	Distance 5531.146
+}
+
+OpenCluster "HSC 2909"
+{
+	RA 17.28707143
+	Dec -34.29048903
+	Radius 72.664
+	Distance 26632.609
+}
+
+OpenCluster "Bochum 13:Theia 1642"
+{
+	RA 17.28885344
+	Dec -35.53377806
+	Radius 50.108
+	Distance 5327.966
+}
+
+OpenCluster "CWNU 2611"
+{
+	RA 17.29004409
+	Dec -40.13587908
+	Radius 13.929
+	Distance 6827.91
+}
+
+OpenCluster "Theia 2496:UBC 558"
+{
+	RA 17.29145734
+	Dec -40.27691862
+	Radius 38.75
+	Distance 8410.412
+}
+
+OpenCluster "HSC 2881"
+{
+	RA 17.29896938
+	Dec -38.56901285
+	Radius 18.147
+	Distance 6718.757
+}
+
+OpenCluster "BH 221:ESO 454-6:MWSC 2563:OC 0691:vdBergh-Hagen 221"
+{
+	RA 17.30623578
+	Dec -32.38955234
+	Radius 33.76
+	Distance 3488.038
 }
 
 OpenCluster "NGC 6322"
 {
-	RA 17.306944
-	Dec -41.066667
-	Distance 3248
-	Radius 2.4
+	RA 17.30749059
+	Dec -42.93991801
+	Radius 44.727
+	Distance 4058.059
 }
 
-OpenCluster "BH 221"
+OpenCluster "CWNU 170"
 {
-	RA 17.310833
-	Dec -31.683333
-	Distance 2716
-	Radius 4.0
+	RA 17.3086192
+	Dec -30.94531171
+	Radius 15.265
+	Distance 3451.806
 }
 
-OpenCluster "BH 222"
+OpenCluster "BH 222:CWNU 2715:ESO 333-4:MWSC 2564:vdBergh-Hagen 222"
 {
-	RA 17.313056
-	Dec -37.716667
-	Distance 19570
-	Radius 5.7
+	RA 17.30968851
+	Dec -38.42510941
+	Radius 55.065
+	Distance 7002.419
 }
 
-OpenCluster "Havlen-Moffat 1"
+OpenCluster "HSC 2914"
 {
-	RA 17.315000
-	Dec -37.183333
-	Distance 10763
-	Radius 7.8
+	RA 17.31206013
+	Dec -33.54879961
+	Radius 21.932
+	Distance 3902.141
 }
 
-OpenCluster "Ruprecht 123"
+OpenCluster "Havlen-Moffat 1:Havlen Moffat 1"
 {
-	RA 17.390556
-	Dec -36.100000
-	Distance 2328
-	Radius 4.1
+	RA 17.3174056
+	Dec -38.81612463
+	Radius 133.191
+	Distance 11256.716
 }
 
-OpenCluster "Alessi 24"
+OpenCluster "CWNU 2621"
 {
-	RA 17.400278
-	Dec -61.136667
-	Distance 1630
-	Radius 31.3
+	RA 17.31893697
+	Dec -42.355712
+	Radius 57.87
+	Distance 10682.999
 }
 
-OpenCluster "Pismis 24"
+OpenCluster "HSC 2960"
 {
-	RA 17.411944
-	Dec -33.793611
-	Distance 6507
-	Radius 1.9
+	RA 17.31894225
+	Dec -28.75967306
+	Radius 60.565
+	Distance 13230.223
 }
 
-OpenCluster "IC 4651"
+OpenCluster "Havlen-Moffat 1:Havlen Moffat 1:UBC 1565"
 {
-	RA 17.413611
-	Dec -48.066667
-	Distance 2896
-	Radius 4.2
+	RA 17.31905088
+	Dec -38.72208549
+	Radius 66.44
+	Distance 8317.091
 }
 
-OpenCluster "Trumpler 26"
+OpenCluster "HSC 2855"
 {
-	RA 17.475556
-	Dec -28.502778
-	Distance 3261
-	Radius 2.4
+	RA 17.32123901
+	Dec -42.62888394
+	Radius 37.109
+	Distance 9975.486
 }
 
-OpenCluster "Antalova 1"
+OpenCluster "HSC 98"
 {
-	RA 17.481667
-	Dec -30.450000
-	Distance 4077
-	Radius 20.8
+	RA 17.32338235
+	Dec -17.07128889
+	Radius 68.021
+	Distance 6743.04
 }
 
-OpenCluster "Ruprecht 125"
+OpenCluster "CWNU 4:OC 0681"
 {
-	RA 17.493889
-	Dec -39.533333
-	Distance 2508
-	Radius 7.3
+	RA 17.32395516
+	Dec -39.05772266
+	Radius 77.497
+	Distance 5292.877
 }
 
-OpenCluster "Collinder 333"
+OpenCluster "CWNU 2430"
 {
-	RA 17.525278
-	Dec -33.983333
-	Distance 2788
-	Radius 2.8
+	RA 17.32868716
+	Dec -34.18180123
+	Radius 27.798
+	Distance 6343.892
+}
+
+OpenCluster "Gulliver 14"
+{
+	RA 17.32970684
+	Dec -36.70777429
+	Radius 36.89
+	Distance 4088.157
+}
+
+OpenCluster "NGC 6334:OC 0685:Theia 1682"
+{
+	RA 17.33007385
+	Dec -36.08493852
+	Radius 40.857
+	Distance 5380.129
+}
+
+OpenCluster "CWNU 1920"
+{
+	RA 17.34012266
+	Dec -40.65896486
+	Radius 96.158
+	Distance 7616.418
+}
+
+OpenCluster "HSC 2983"
+{
+	RA 17.34630298
+	Dec -26.28280249
+	Radius 21.973
+	Distance 2569.046
+}
+
+OpenCluster "HSC 2885"
+{
+	RA 17.34804789
+	Dec -38.22538018
+	Radius 32.296
+	Distance 2798.25
+}
+
+OpenCluster "HSC 283"
+{
+	RA 17.35023945
+	Dec 6.35716452
+	Radius 78.278
+	Distance 1371.28
+}
+
+OpenCluster "CWNU 2870"
+{
+	RA 17.35039346
+	Dec -38.0368158
+	Radius 67.159
+	Distance 10220.995
+}
+
+OpenCluster "HSC 2902"
+{
+	RA 17.3553317
+	Dec -36.43594401
+	Radius 43.141
+	Distance 4615.431
+}
+
+OpenCluster "OCSN 1:Theia 67"
+{
+	RA 17.35571536
+	Dec -25.0590264
+	Radius 36.159
+	Distance 477.845
+}
+
+OpenCluster "CWNU 2676"
+{
+	RA 17.37445604
+	Dec -31.31764448
+	Radius 107.184
+	Distance 4378.886
+}
+
+OpenCluster "HSC 2937"
+{
+	RA 17.37846357
+	Dec -32.00798996
+	Radius 134.463
+	Distance 30806.119
+}
+
+OpenCluster "HSC 2936"
+{
+	RA 17.38043932
+	Dec -32.03535151
+	Radius 26.418
+	Distance 6025.955
+}
+
+OpenCluster "CWNU 316:OC 0675"
+{
+	RA 17.38468593
+	Dec -44.37768132
+	Radius 53.46
+	Distance 3696.496
+}
+
+OpenCluster "HSC 2916"
+{
+	RA 17.38495359
+	Dec -34.09908908
+	Radius 15.635
+	Distance 3216.365
+}
+
+OpenCluster "HSC 2894"
+{
+	RA 17.38537682
+	Dec -37.88006124
+	Radius 30.242
+	Distance 5323.52
+}
+
+OpenCluster "HSC 2939"
+{
+	RA 17.38644208
+	Dec -32.0231894
+	Radius 80.982
+	Distance 11630.363
+}
+
+OpenCluster "HSC 474"
+{
+	RA 17.3869991
+	Dec 34.70830494
+	Radius 143.325
+	Distance 1028.764
+}
+
+OpenCluster "HSC 59"
+{
+	RA 17.38783099
+	Dec -20.39529687
+	Radius 88.986
+	Distance 16627.096
+}
+
+OpenCluster "ESO 333-6:MWSC 2584:OCL 1008:Ruprecht 123"
+{
+	RA 17.39064508
+	Dec -37.91581756
+	Radius 23.974
+	Distance 4749.441
+}
+
+OpenCluster "OC 0696:UFMG 66"
+{
+	RA 17.39068798
+	Dec -32.04667945
+	Radius 38.521
+	Distance 5148.519
+}
+
+OpenCluster "HSC 2889"
+{
+	RA 17.39558027
+	Dec -38.21595722
+	Radius 14.067
+	Distance 7036.324
+}
+
+OpenCluster "ASCC 89:Alessi 24:LISC-III 3249:MWSC 2582:OC 0638"
+{
+	RA 17.3985624
+	Dec -62.81755799
+	Radius 90.382
+	Distance 1554.876
+}
+
+OpenCluster "UPK 639"
+{
+	RA 17.40260386
+	Dec -46.63192349
+	Radius 231.117
+	Distance 2252.504
+}
+
+OpenCluster "BH 225:Collinder 329:ESO 333-7:Harvard 14:MWSC 2587:OCL 1007:OC 0683:Theia 1997:Theia 3280:Trumpler 25"
+{
+	RA 17.40765167
+	Dec -39.0111805
+	Radius 42.093
+	Distance 7201.073
+}
+
+OpenCluster "CWNU 2342"
+{
+	RA 17.40985419
+	Dec -37.05203424
+	Radius 45.45
+	Distance 7129.956
+}
+
+OpenCluster "CWNU 2765"
+{
+	RA 17.4102066
+	Dec -38.58062047
+	Radius 38.215
+	Distance 8127.466
+}
+
+OpenCluster "PHOC 17:UFMG 76"
+{
+	RA 17.41166079
+	Dec -34.70468583
+	Radius 17.69
+	Distance 5159.235
+}
+
+OpenCluster "NGC 6357:Pismis 24"
+{
+	RA 17.41216647
+	Dec -34.20262752
+	Radius 43.749
+	Distance 5453.926
+}
+
+OpenCluster "IC 4651:Melotte 169:Collinder 327:BH 224:ESO 228-2:FSR 1738:MWSC 2590:OCL 987:Theia 1343"
+{
+	RA 17.41277011
+	Dec -49.92855832
+	Radius 44.962
+	Distance 2970.579
+}
+
+OpenCluster "HSC 2903"
+{
+	RA 17.41293165
+	Dec -36.84011743
+	Radius 22.563
+	Distance 6044.23
+}
+
+OpenCluster "UBC 561"
+{
+	RA 17.41356448
+	Dec -37.48962962
+	Radius 53.107
+	Distance 5098.044
+}
+
+OpenCluster "CWNU 1303"
+{
+	RA 17.41579398
+	Dec -37.7413772
+	Radius 34.916
+	Distance 7072.953
+}
+
+OpenCluster "HSC 7"
+{
+	RA 17.42648365
+	Dec -25.13485632
+	Radius 67.346
+	Distance 7123.592
+}
+
+OpenCluster "CWNU 1279"
+{
+	RA 17.428424
+	Dec -36.46342112
+	Radius 28.406
+	Distance 5249.204
+}
+
+OpenCluster "PHOC 18:UFMG 86"
+{
+	RA 17.43982081
+	Dec -37.74707476
+	Radius 48.403
+	Distance 6941.743
+}
+
+OpenCluster "HSC 2929"
+{
+	RA 17.44390859
+	Dec -33.47088367
+	Radius 25.276
+	Distance 5186.215
+}
+
+OpenCluster "ESO 392-13:ESO 392 13"
+{
+	RA 17.44550211
+	Dec -34.74404524
+	Radius 48.626
+	Distance 3409.613
+}
+
+OpenCluster "HSC 2947"
+{
+	RA 17.44824977
+	Dec -31.34469838
+	Radius 37.861
+	Distance 4963.585
+}
+
+OpenCluster "HSC 2918"
+{
+	RA 17.45072678
+	Dec -34.60113587
+	Radius 20.966
+	Distance 3292.839
+}
+
+OpenCluster "FoF 866:Theia 4124"
+{
+	RA 17.45105797
+	Dec -39.41737672
+	Radius 44.752
+	Distance 7342.842
+}
+
+OpenCluster "HSC 2930"
+{
+	RA 17.45516456
+	Dec -33.38785573
+	Radius 102.85
+	Distance 12099.47
+}
+
+OpenCluster "HSC 2962"
+{
+	RA 17.45743241
+	Dec -29.9460389
+	Radius 35.705
+	Distance 16353.499
+}
+
+OpenCluster "CWNU 2729"
+{
+	RA 17.46097386
+	Dec -38.35307956
+	Radius 44.224
+	Distance 4927.635
+}
+
+OpenCluster "HSC 2910"
+{
+	RA 17.46659939
+	Dec -35.52126149
+	Radius 67.005
+	Distance 4206.635
+}
+
+OpenCluster "HSC 2935"
+{
+	RA 17.46770106
+	Dec -32.83255458
+	Radius 27.674
+	Distance 5366.068
+}
+
+OpenCluster "HSC 2867"
+{
+	RA 17.47014379
+	Dec -41.97063905
+	Radius 91.925
+	Distance 14790.818
+}
+
+OpenCluster "Theia 2517:UFMG 85"
+{
+	RA 17.47109635
+	Dec -37.82397624
+	Radius 55.66
+	Distance 3887.6
+}
+
+OpenCluster "Collinder 331:ESO 454-33:Harvard 15:MWSC 2604:OCL 1032:Theia 2599:Trumpler 26:UBC 332"
+{
+	RA 17.47509083
+	Dec -29.48885363
+	Radius 39.379
+	Distance 4854.139
+}
+
+OpenCluster "Antalova 1:MWSC 2605:OCL 1027.1"
+{
+	RA 17.48075715
+	Dec -31.61441196
+	Radius 16.098
+	Distance 4698.538
+}
+
+OpenCluster "HSC 2904"
+{
+	RA 17.48265242
+	Dec -36.97663715
+	Radius 23.736
+	Distance 5619.287
+}
+
+OpenCluster "Theia 2122:UFMG 67"
+{
+	RA 17.48467711
+	Dec -30.93303507
+	Radius 28.207
+	Distance 3313.372
+}
+
+OpenCluster "HSC 2876"
+{
+	RA 17.48980705
+	Dec -40.97130777
+	Radius 47.443
+	Distance 4144.369
+}
+
+OpenCluster "HSC 2799"
+{
+	RA 17.49312751
+	Dec -52.9120432
+	Radius 43.552
+	Distance 9907.494
+}
+
+OpenCluster "CWNU 2890"
+{
+	RA 17.49486871
+	Dec -34.32119433
+	Radius 29.007
+	Distance 5040.398
+}
+
+OpenCluster "HSC 2944"
+{
+	RA 17.49601757
+	Dec -31.87871587
+	Radius 20.514
+	Distance 5432.7
+}
+
+OpenCluster "Antalova 2:MWSC 2610:OCL 1021.1"
+{
+	RA 17.49627932
+	Dec -32.55098917
+	Radius 33.322
+	Distance 3649.965
+}
+
+OpenCluster "Theia 290"
+{
+	RA 17.49768387
+	Dec -35.7499802
+	Radius 44.309
+	Distance 2741.905
+}
+
+OpenCluster "HSC 2825"
+{
+	RA 17.49850415
+	Dec -49.7949683
+	Radius 17.41
+	Distance 2604.244
+}
+
+OpenCluster "CWNU 1466"
+{
+	RA 17.50137081
+	Dec -30.59872064
+	Radius 15.274
+	Distance 5001.449
+}
+
+OpenCluster "CWNU 32"
+{
+	RA 17.50204272
+	Dec -38.21613811
+	Radius 18.694
+	Distance 5600.301
+}
+
+OpenCluster "HSC 2913"
+{
+	RA 17.50539136
+	Dec -35.47553667
+	Radius 35.838
+	Distance 10099.728
+}
+
+OpenCluster "HSC 2692"
+{
+	RA 17.50555891
+	Dec -71.0288077
+	Radius 92.231
+	Distance 22133.266
+}
+
+OpenCluster "Theia 1645:UFMG 77"
+{
+	RA 17.51721205
+	Dec -33.4679238
+	Radius 43.535
+	Distance 3507.213
+}
+
+OpenCluster "Collinder 332:BH 230:ESO 393-2:ESO 393-3:Harvard 16:MWSC 2616:OCL 1010:OCL 1012:Theia 1728"
+{
+	RA 17.51746926
+	Dec -36.82218172
+	Radius 29.595
+	Distance 4805.229
+}
+
+OpenCluster "UBC 562"
+{
+	RA 17.51854644
+	Dec -37.89335929
+	Radius 32.885
+	Distance 7430.568
+}
+
+OpenCluster "Collinder 333:CWNU 1798:ESO 393-4:MWSC 2618:OCL 1017"
+{
+	RA 17.51917261
+	Dec -33.99795544
+	Radius 37.788
+	Distance 7487.182
+}
+
+OpenCluster "BH 231:MWSC 2620:UBC 568:vdBergh-Hagen 231"
+{
+	RA 17.52970706
+	Dec -31.91502594
+	Radius 43.928
+	Distance 8666.539
+}
+
+OpenCluster "HSC 2952"
+{
+	RA 17.52980896
+	Dec -31.58625369
+	Radius 25.663
+	Distance 4408.004
+}
+
+OpenCluster "HSC 2958"
+{
+	RA 17.53298076
+	Dec -30.85651978
+	Radius 49.395
+	Distance 5421.958
+}
+
+OpenCluster "CWNU 1797"
+{
+	RA 17.53312271
+	Dec -35.65943915
+	Radius 21.3
+	Distance 8178.878
+}
+
+OpenCluster "Theia 288:UPK 642"
+{
+	RA 17.53509633
+	Dec -44.3206738
+	Radius 56.281
+	Distance 3036.604
+}
+
+OpenCluster "HSC 99"
+{
+	RA 17.53691091
+	Dec -18.97601786
+	Radius 39.87
+	Distance 13506.219
+}
+
+OpenCluster "HSC 2966"
+{
+	RA 17.53950599
+	Dec -30.37403148
+	Radius 40.204
+	Distance 12540.365
+}
+
+OpenCluster "CWNU 1627"
+{
+	RA 17.54309309
+	Dec -36.22983842
+	Radius 18.327
+	Distance 4674.796
+}
+
+OpenCluster "Theia 1726:Theia 2803:UFMG 68"
+{
+	RA 17.54353828
+	Dec -30.85468307
+	Radius 52.058
+	Distance 4901.823
+}
+
+OpenCluster "UFMG 22"
+{
+	RA 17.54668252
+	Dec -37.61172386
+	Radius 44.239
+	Distance 7522.646
+}
+
+OpenCluster "HSC 2851"
+{
+	RA 17.54671548
+	Dec -45.48968547
+	Radius 31.487
+	Distance 8883.33
+}
+
+OpenCluster "HSC 590"
+{
+	RA 17.54722422
+	Dec 48.63573254
+	Radius 148.287
+	Distance 385.323
+}
+
+OpenCluster "Theia 2505"
+{
+	RA 17.5497589
+	Dec -30.02441477
+	Radius 53.512
+	Distance 4852.539
+}
+
+OpenCluster "HSC 120"
+{
+	RA 17.55300081
+	Dec -16.59125821
+	Radius 56.534
+	Distance 19303.608
+}
+
+OpenCluster "UFMG 87"
+{
+	RA 17.5532445
+	Dec -35.13609154
+	Radius 29.676
+	Distance 10168.65
+}
+
+OpenCluster "HSC 333"
+{
+	RA 17.55381871
+	Dec 12.0302157
+	Radius 29.545
+	Distance 5597.43
+}
+
+OpenCluster "HSC 2912"
+{
+	RA 17.55550178
+	Dec -35.98075795
+	Radius 25.28
+	Distance 7433.174
+}
+
+OpenCluster "OC 0002:UFMG 63"
+{
+	RA 17.55884605
+	Dec -25.01063574
+	Radius 25.718
+	Distance 3865.043
+}
+
+OpenCluster "OC 0692"
+{
+	RA 17.56021708
+	Dec -34.44156031
+	Radius 30.052
+	Distance 10143.396
+}
+
+OpenCluster "HSC 2921"
+{
+	RA 17.56202911
+	Dec -35.02042265
+	Radius 21.052
+	Distance 7428.001
+}
+
+OpenCluster "CWNU 2274"
+{
+	RA 17.56739693
+	Dec -34.54051468
+	Radius 18.025
+	Distance 7595.737
+}
+
+OpenCluster "OC 0689"
+{
+	RA 17.56842302
+	Dec -35.06514535
+	Radius 20.667
+	Distance 6031.423
+}
+
+OpenCluster "HSC 2959"
+{
+	RA 17.57021115
+	Dec -31.1179703
+	Radius 43.456
+	Distance 6382.366
+}
+
+OpenCluster "HSC 2934"
+{
+	RA 17.57157072
+	Dec -33.75218145
+	Radius 31.266
+	Distance 7777.401
+}
+
+OpenCluster "HSC 2926"
+{
+	RA 17.57177853
+	Dec -34.62782426
+	Radius 24.246
+	Distance 7751.96
 }
 
 OpenCluster "NGC 6383"
 {
-	RA 17.580000
-	Dec -31.433333
-	Distance 3212
-	Radius 9.3
+	RA 17.57819474
+	Dec -32.57715247
+	Radius 35.239
+	Distance 3590.549
 }
 
-OpenCluster "Trumpler 27"
+OpenCluster "Bica 631"
 {
-	RA 17.605556
-	Dec -32.483333
-	Distance 3949
-	Radius 3.4
+	RA 17.57857632
+	Dec -33.47853905
+	Radius 78.274
+	Distance 10301.623
 }
 
-OpenCluster "Trumpler 28"
+OpenCluster "UBC 566"
 {
-	RA 17.616667
-	Dec -31.516667
-	Distance 4380
-	Radius 3.2
+	RA 17.57867949
+	Dec -33.09909825
+	Radius 68.409
+	Distance 7583.122
 }
 
-OpenCluster "NGC 6396"
+OpenCluster "CWNU 229"
 {
-	RA 17.626667
-	Dec -34.973333
-	Distance 3887
-	Radius 1.7
+	RA 17.58176519
+	Dec -43.01598244
+	Radius 53.565
+	Distance 3426.308
 }
 
-OpenCluster "ESO 139-13"
+OpenCluster "ESO 393-8:MWSC 32:OCL 1019:OC 0694:Ruprecht 126"
 {
-	RA 17.628056
-	Dec -57.870000
-	Distance 4892
-	Radius 3.6
+	RA 17.58502172
+	Dec -34.32550132
+	Radius 43.493
+	Distance 10132.197
 }
 
-OpenCluster "Ruprecht 127"
+OpenCluster "CWNU 1543"
 {
-	RA 17.630833
-	Dec -35.700000
-	Distance 4781
-	Radius 3.5
+	RA 17.58909351
+	Dec -34.23125887
+	Radius 16.05
+	Distance 4093.419
 }
 
-OpenCluster "Mamajek 2"
+OpenCluster "HSC 205"
 {
-	RA 17.633333
-	Dec -7.888333
-	Distance 525
-	Radius 0.8
+	RA 17.58914586
+	Dec -6.08280617
+	Radius 91.538
+	Distance 8113.51
 }
 
-OpenCluster "Collinder 338"
+OpenCluster "Trumpler 27:UFMG 82"
 {
-	RA 17.639167
-	Dec -36.283333
-	Distance 1630
-	Radius 4.7
+	RA 17.59259468
+	Dec -33.41102484
+	Radius 26.512
+	Distance 5056.142
 }
 
-OpenCluster "ASCC 90"
+OpenCluster "Theia 1980:UBC 565"
 {
-	RA 17.651944
-	Dec -33.200000
-	Distance 1630
-	Radius 10.2
+	RA 17.59346797
+	Dec -33.93605127
+	Radius 55.946
+	Distance 7564.056
 }
 
-OpenCluster "NGC 6404"
+OpenCluster "CWNU 1939"
 {
-	RA 17.660278
-	Dec -32.753333
-	Distance 7828
-	Radius 5.7
+	RA 17.59742193
+	Dec -35.68017314
+	Radius 19.497
+	Distance 4103.658
 }
 
-OpenCluster "NGC 6400"
+OpenCluster "HSC 2946"
 {
-	RA 17.670000
-	Dec -35.051667
-	Distance 3261
-	Radius 5.7
+	RA 17.60026689
+	Dec -32.62914685
+	Radius 41.123
+	Distance 8203.96
 }
 
-OpenCluster "NGC 6405"
+OpenCluster "UBC 564"
 {
-	RA 17.672222
-	Dec -31.746667
-	Distance 1588
-	Radius 4.6
+	RA 17.60065665
+	Dec -34.63558101
+	Radius 35.391
+	Distance 7330.056
 }
 
-OpenCluster "Trumpler 29"
+OpenCluster "CWNU 2377"
 {
-	RA 17.691944
-	Dec -39.850000
-	Distance 1630
-	Radius 2.8
+	RA 17.60205632
+	Dec -34.84390806
+	Radius 41.657
+	Distance 6658.745
 }
 
-OpenCluster "Alessi 9"
+OpenCluster "BH 236:ESO 333-16:FSR 1762:GCL 71:MWSC 2637:Pismis 26:Ton 2:Tonantzintla 2"
 {
-	RA 17.725000
-	Dec -45.033333
-	Distance 688
-	Radius 15.0
+	RA 17.60302631
+	Dec -38.55213902
+	Radius 157.883
+	Distance 23951.536
 }
 
-OpenCluster "NGC 6416"
+OpenCluster "OC 0697:Trumpler 27"
 {
-	RA 17.738611
-	Dec -31.638333
-	Distance 2416
-	Radius 4.9
+	RA 17.60399937
+	Dec -33.49322414
+	Radius 37.703
+	Distance 7442.658
 }
 
-OpenCluster "BH 245"
+OpenCluster "HSC 2967"
 {
-	RA 17.771111
-	Dec -28.300000
-	Distance 3261
-	Radius 0.5
+	RA 17.61053738
+	Dec -30.7146863
+	Radius 51.777
+	Distance 9384.041
 }
 
-OpenCluster "IC 4665"
+OpenCluster "Collinder 337:BH 238:ESO 455-25:MWSC 2641:OCL 1029:Theia 2013:Trumpler 28:UBC 569"
 {
-	RA 17.771667
-	Dec 5.716667
-	Distance 1148
-	Radius 11.7
+	RA 17.61548046
+	Dec -32.47638442
+	Radius 17.812
+	Distance 4671.019
+}
+
+OpenCluster "HSC 2950"
+{
+	RA 17.61801611
+	Dec -32.49631894
+	Radius 60.463
+	Distance 9343.321
+}
+
+OpenCluster "OC 0695"
+{
+	RA 17.6181237
+	Dec -33.98458148
+	Radius 26.722
+	Distance 8496.368
+}
+
+OpenCluster "UFMG 70"
+{
+	RA 17.61857307
+	Dec -29.90604894
+	Radius 36.693
+	Distance 5814.836
+}
+
+OpenCluster "Theia 1813"
+{
+	RA 17.6225438
+	Dec -33.83842202
+	Radius 28.994
+	Distance 11001.543
+}
+
+OpenCluster "CWNU 50"
+{
+	RA 17.62348556
+	Dec -34.79626703
+	Radius 32.671
+	Distance 7181.072
+}
+
+OpenCluster "HSC 37"
+{
+	RA 17.62366692
+	Dec -24.40572095
+	Radius 152.44
+	Distance 22026.169
+}
+
+OpenCluster "HSC 199"
+{
+	RA 17.62399691
+	Dec -8.01569742
+	Radius 148.126
+	Distance 666.594
+}
+
+OpenCluster "NGC 6396:Collinder 339:BH 239:ESO 393-10:MWSC 2644:OCL 1018"
+{
+	RA 17.62649981
+	Dec -35.02163408
+	Radius 37.968
+	Distance 8083.457
+}
+
+OpenCluster "UFMG 96"
+{
+	RA 17.62817595
+	Dec -29.77170532
+	Radius 24.922
+	Distance 7133.69
+}
+
+OpenCluster "ESO 393-11:MWSC 2649:OCL 1015:Ruprecht 127"
+{
+	RA 17.63026
+	Dec -36.31201579
+	Radius 45.427
+	Distance 7534.234
+}
+
+OpenCluster "HSC 2980"
+{
+	RA 17.63417875
+	Dec -29.12211124
+	Radius 33.409
+	Distance 5832.525
+}
+
+OpenCluster "UFMG 69"
+{
+	RA 17.63448352
+	Dec -29.50507398
+	Radius 92.032
+	Distance 10199.847
+}
+
+OpenCluster "HXHWL 6"
+{
+	RA 17.63839775
+	Dec -33.94985036
+	Radius 19.756
+	Distance 3081.02
+}
+
+OpenCluster "Collinder 338:ESO 334-3:MWSC 2651:Mamajek 1732:Mamajek J1732.0-3712:OCL 1013:Theia 334"
+{
+	RA 17.63865718
+	Dec -37.63440311
+	Radius 271.919
+	Distance 2123.523
+}
+
+OpenCluster "CWNU 1467"
+{
+	RA 17.644876
+	Dec -33.69795856
+	Radius 38.085
+	Distance 5565.952
+}
+
+OpenCluster "ASCC 90:Alessi 41:MWSC 2655:Theia 948"
+{
+	RA 17.6507978
+	Dec -34.81736389
+	Radius 196.464
+	Distance 1862.465
+}
+
+OpenCluster "HSC 232"
+{
+	RA 17.65123475
+	Dec -2.73125361
+	Radius 37.238
+	Distance 4123.595
+}
+
+OpenCluster "HSC 2982"
+{
+	RA 17.65386338
+	Dec -29.00875009
+	Radius 23.147
+	Distance 7246.861
+}
+
+OpenCluster "HSC 263"
+{
+	RA 17.65481785
+	Dec 2.42586823
+	Radius 62.355
+	Distance 1641.426
+}
+
+OpenCluster "HSC 125"
+{
+	RA 17.65745908
+	Dec -16.81024381
+	Radius 64.834
+	Distance 12811.04
+}
+
+OpenCluster "OC 0693:UFMG 91"
+{
+	RA 17.65775184
+	Dec -35.08432719
+	Radius 34.432
+	Distance 9243.249
+}
+
+OpenCluster "HSC 2871"
+{
+	RA 17.65842662
+	Dec -42.8742027
+	Radius 60.979
+	Distance 933.054
+}
+
+OpenCluster "NGC 6404:Collinder 340:BH 240:ESO 393-13:MWSC 2658:OCL 1024:UBC 567"
+{
+	RA 17.66075008
+	Dec -33.22916455
+	Radius 19.143
+	Distance 8201.235
+}
+
+OpenCluster "NGC 6400:Melotte 177:Collinder 342:BH 241:ESO 393-14:MWSC 2660:OCL 1014:Theia 1860"
+{
+	RA 17.67022053
+	Dec -36.9565231
+	Radius 49.522
+	Distance 3881.487
+}
+
+OpenCluster "Butterfly Cluster:M 6:NGC 6405:Melotte 178:Collinder 341:Theia 122"
+{
+	RA 17.67115001
+	Dec -32.22806085
+	Radius 133.282
+	Distance 1473.802
+}
+
+OpenCluster "FoF 282"
+{
+	RA 17.6840631
+	Dec -33.26861925
+	Radius 20.325
+	Distance 8072.749
+}
+
+OpenCluster "Collinder 343:ESO 334-4:Harvard 17:MWSC 2663:OCL 1009:Trumpler 29"
+{
+	RA 17.69035662
+	Dec -40.1472071
+	Radius 34.698
+	Distance 4516.429
+}
+
+OpenCluster "HSC 25"
+{
+	RA 17.69276949
+	Dec -25.70159807
+	Radius 153.486
+	Distance 32264.173
+}
+
+OpenCluster "CWNU 1707"
+{
+	RA 17.70256514
+	Dec -37.37333232
+	Radius 30.648
+	Distance 4671.471
+}
+
+OpenCluster "UFMG 71"
+{
+	RA 17.70353475
+	Dec -27.33554733
+	Radius 22.856
+	Distance 4639.382
+}
+
+OpenCluster "HSC 20"
+{
+	RA 17.70437546
+	Dec -26.1112651
+	Radius 33.835
+	Distance 8935.723
+}
+
+OpenCluster "HSC 2945"
+{
+	RA 17.70624599
+	Dec -33.49499942
+	Radius 34.835
+	Distance 4719.012
+}
+
+OpenCluster "Theia 1653:UBC 334"
+{
+	RA 17.70754764
+	Dec -30.72249013
+	Radius 65.965
+	Distance 4924.628
+}
+
+OpenCluster "Alessi 9:MWSC 2670"
+{
+	RA 17.70949247
+	Dec -46.74400774
+	Radius 102.4
+	Distance 679.671
+}
+
+OpenCluster "HSC 2901"
+{
+	RA 17.71319876
+	Dec -39.41400407
+	Radius 56.887
+	Distance 19354.749
+}
+
+OpenCluster "HSC 2972"
+{
+	RA 17.71833314
+	Dec -31.04265482
+	Radius 18.379
+	Distance 3968.062
+}
+
+OpenCluster "HSC 2928"
+{
+	RA 17.71988863
+	Dec -35.7426199
+	Radius 30.732
+	Distance 3801.602
+}
+
+OpenCluster "ESO 393-15:ESO 393 15:MWSC 2667:OC 0698:UBC 328"
+{
+	RA 17.7251523
+	Dec -34.21859831
+	Radius 76.406
+	Distance 7765.179
+}
+
+OpenCluster "NGC 6416:Collinder 344:ESO 455-32:MWSC 2673:OCL 1031:Theia 3310:UBC 331"
+{
+	RA 17.73384765
+	Dec -32.3369589
+	Radius 94.707
+	Distance 3404.351
+}
+
+OpenCluster "BH 243:ESO 393-17:MWSC 2672:OCL 1020:Ruprecht 128:Theia 3213"
+{
+	RA 17.7377535
+	Dec -34.87673694
+	Radius 36.4
+	Distance 6028.13
+}
+
+OpenCluster "CWNU 1932"
+{
+	RA 17.74511397
+	Dec -33.06003536
+	Radius 22.344
+	Distance 7525.839
+}
+
+OpenCluster "HSC 2964"
+{
+	RA 17.75473112
+	Dec -32.12931827
+	Radius 21.118
+	Distance 3544.847
+}
+
+OpenCluster "HSC 65"
+{
+	RA 17.75670536
+	Dec -23.09481333
+	Radius 45.883
+	Distance 13378.052
+}
+
+OpenCluster "CWNU 275:Theia 1889:Theia 5705"
+{
+	RA 17.75800795
+	Dec -40.81569408
+	Radius 129.522
+	Distance 3788.911
+}
+
+OpenCluster "CWNU 151"
+{
+	RA 17.76500301
+	Dec -33.443433
+	Radius 18.297
+	Distance 5310.979
+}
+
+OpenCluster "HSC 2978"
+{
+	RA 17.76570824
+	Dec -30.29983319
+	Radius 28.559
+	Distance 8129.784
+}
+
+OpenCluster "HSC 2974"
+{
+	RA 17.76664204
+	Dec -31.0283073
+	Radius 29.838
+	Distance 5989.742
+}
+
+OpenCluster "FoF 1624"
+{
+	RA 17.76741383
+	Dec -29.19169293
+	Radius 24.794
+	Distance 5589.314
+}
+
+OpenCluster "IC 4665:Melotte 179:Collinder 349:MWSC 2689:OCL 85:Theia 76"
+{
+	RA 17.76882964
+	Dec 5.63474291
+	Radius 77.409
+	Distance 1119.842
+}
+
+OpenCluster "BH 245:ESO 455-35:MWSC 2687:vdBergh-Hagen 245"
+{
+	RA 17.77096344
+	Dec -29.706056
+	Radius 41.634
+	Distance 8781.539
+}
+
+OpenCluster "FoF 1624:OC 0704:Theia 2163:UBC 335"
+{
+	RA 17.77168196
+	Dec -29.17432694
+	Radius 49.888
+	Distance 6244.455
 }
 
 OpenCluster "Collinder 347"
 {
-	RA 17.771667
-	Dec -28.666667
-	Distance 4938
-	Radius 7.2
+	RA 17.77205678
+	Dec -29.34500866
+	Radius 55.781
+	Distance 8641.804
 }
 
-OpenCluster "NGC 6425"
+OpenCluster "HSC 2900"
 {
-	RA 17.783611
-	Dec -30.470000
-	Distance 2537
-	Radius 3.7
+	RA 17.77207251
+	Dec -40.05263847
+	Radius 25.184
+	Distance 463.224
 }
 
-OpenCluster "Ruprecht 130"
+OpenCluster "HSC 31"
 {
-	RA 17.792222
-	Dec -29.900000
-	Distance 6849
-	Radius 3.0
+	RA 17.77238573
+	Dec -26.04071152
+	Radius 146.393
+	Distance 9687.151
 }
 
-OpenCluster "Collinder 350"
+OpenCluster "HSC 34"
 {
-	RA 17.801667
-	Dec 1.300000
-	Distance 932
-	Radius 5.3
+	RA 17.77485185
+	Dec -25.93021104
+	Radius 25.767
+	Distance 4380.257
 }
 
-OpenCluster "ASCC 91"
+OpenCluster "HSC 325"
 {
-	RA 17.815000
-	Dec -36.640000
-	Distance 2609
-	Radius 13.7
+	RA 17.77557153
+	Dec 8.94370799
+	Radius 79.705
+	Distance 12141.894
 }
 
-OpenCluster "Ruprecht 131"
+OpenCluster "PHOC 10"
 {
-	RA 17.821111
-	Dec -28.750000
-	Distance 1957
-	Radius 2.0
+	RA 17.77649574
+	Dec -30.35308762
+	Radius 15.263
+	Distance 4034.883
 }
 
-OpenCluster "NGC 6444"
+OpenCluster "HSC 2750"
 {
-	RA 17.826389
-	Dec -33.180000
-	Distance 3261
-	Radius 1.4
+	RA 17.78113069
+	Dec -61.49057881
+	Radius 24.412
+	Distance 5297.143
 }
 
-OpenCluster "Collinder 351"
+OpenCluster "NGC 6425:Collinder 384:BH 246:ESO 455-38:MWSC 2691:OCL 1033:Theia 892:UBC 333"
 {
-	RA 17.816667
-	Dec -27.264167
-	Distance 4272
-	Radius 5.2
+	RA 17.78275674
+	Dec -31.50730963
+	Radius 51.208
+	Distance 3194.295
 }
 
-OpenCluster "NGC 6451"
+OpenCluster "UBC 1566"
 {
-	RA 17.844722
-	Dec -29.790000
-	Distance 6784
-	Radius 6.9
+	RA 17.78628653
+	Dec -30.29383529
+	Radius 47.018
+	Distance 8064.54
 }
 
-OpenCluster "Alessi 31"
+OpenCluster "Theia 5705"
 {
-	RA 17.845000
-	Dec -11.998333
-	Distance 2120
-	Radius 11.1
+	RA 17.78812817
+	Dec -42.39424104
+	Radius 53.978
+	Distance 4481.894
 }
 
-OpenCluster "Basel 5"
+OpenCluster "BH 247:ESO 455-41:MWSC 2698:OCL 1034:Ruprecht 130"
 {
-	RA 17.874167
-	Dec -29.900000
-	Distance 2498
-	Radius 1.8
+	RA 17.7929886
+	Dec -30.09793423
+	Radius 25.747
+	Distance 7764.533
 }
 
-OpenCluster "NGC 6481"
+OpenCluster "HSC 86"
 {
-	RA 17.880000
-	Dec 4.166667
-	Distance 3848
-	Radius 1.7
+	RA 17.79617563
+	Dec -22.18554732
+	Radius 57.747
+	Distance 4616.997
 }
 
-OpenCluster "NGC 6469"
+OpenCluster "HSC 2985"
 {
-	RA 17.886667
-	Dec -21.725000
-	Distance 3587
-	Radius 3.7
+	RA 17.79718974
+	Dec -29.53628704
+	Radius 35.383
+	Distance 8618.598
 }
 
-OpenCluster "Czernik 37"
+OpenCluster "HSC 35"
 {
-	RA 17.888056
-	Dec -26.630556
-	Distance 5544
-	Radius 4.0
+	RA 17.7991231
+	Dec -26.12444269
+	Radius 45.636
+	Distance 5734.463
 }
 
-OpenCluster "NGC 6475"
+OpenCluster "Casado 7:UBC 1593"
 {
-	RA 17.897500
-	Dec -33.206667
-	Distance 981
-	Radius 11.4
+	RA 17.80195407
+	Dec -29.00461186
+	Radius 15.95
+	Distance 5338.884
 }
 
-OpenCluster "Trumpler 30"
+OpenCluster "Theia 5015"
 {
-	RA 17.946111
-	Dec -34.733333
-	Distance 2038
-	Radius 2.1
+	RA 17.80391677
+	Dec -24.20982045
+	Radius 56.558
+	Distance 3703.829
 }
 
-OpenCluster "NGC 6494"
+OpenCluster "HSC 2979"
 {
-	RA 17.951111
-	Dec -17.015000
-	Distance 2048
-	Radius 8.6
+	RA 17.80417856
+	Dec -30.5986737
+	Radius 18.136
+	Distance 8355.482
 }
 
-OpenCluster "Ruprecht 135"
+OpenCluster "Collinder 350:MWSC 2700:OCL 75:Theia 919"
 {
-	RA 17.970000
-	Dec -10.350000
-	Distance 6034
-	Radius 5.3
+	RA 17.80433085
+	Dec 1.41761766
+	Radius 108.954
+	Distance 1192.727
 }
 
-OpenCluster "Ruprecht 169"
+OpenCluster "CWNU 2210"
 {
-	RA 17.989444
-	Dec -23.233056
-	Distance 4533
-	Radius 3.4
+	RA 17.80515588
+	Dec -32.97410183
+	Radius 73.616
+	Distance 8559.354
 }
 
-OpenCluster "Trumpler 31"
+OpenCluster "CWNU 2569"
 {
-	RA 17.996944
-	Dec -27.833333
-	Distance 3216
-	Radius 2.3
+	RA 17.80801388
+	Dec -27.40923337
+	Radius 27.482
+	Distance 7182.909
 }
 
-OpenCluster "NGC 6507"
+OpenCluster "HSC 75"
 {
-	RA 17.997222
-	Dec -16.549444
-	Distance 4011
-	Radius 7.7
+	RA 17.81154568
+	Dec -23.08216024
+	Radius 93.43
+	Distance 2046.894
 }
 
-OpenCluster "Ruprecht 138"
+OpenCluster "HSC 2977"
 {
-	RA 17.998889
-	Dec -23.317500
-	Distance 3033
-	Radius 2.6
+	RA 17.8135291
+	Dec -30.9059562
+	Radius 31.699
+	Distance 7737.202
 }
 
-OpenCluster "Ruprecht 137"
+OpenCluster "HSC 27"
 {
-	RA 18.004444
-	Dec -24.772500
-	Distance 4729
-	Radius 3.9
+	RA 17.81818536
+	Dec -26.63021458
+	Radius 31.881
+	Distance 3298.665
 }
 
-OpenCluster "Ruprecht 139"
+OpenCluster "HSC 14"
 {
-	RA 18.017500
-	Dec -22.466667
-	Distance 2716
-	Radius 4.7
+	RA 17.81999132
+	Dec -28.00803909
+	Radius 36.565
+	Distance 7080.234
 }
 
-OpenCluster "Collinder 359"
+OpenCluster "NGC 6444:ESO 393-3:MWSC 2709:OCL 1023:Ruprecht 132:Theia 4790:UBC 329"
 {
-	RA 18.018333
-	Dec 2.900000
-	Distance 812
-	Radius 28.3
+	RA 17.82323733
+	Dec -34.81601734
+	Radius 47.855
+	Distance 5815.402
+}
+
+OpenCluster "HSC 2905"
+{
+	RA 17.8235533
+	Dec -39.29787183
+	Radius 20.802
+	Distance 2855.878
+}
+
+OpenCluster "DB 51:Dutra-Bica 51:Dutra Bica 51:MWSC 2708:OC 0701"
+{
+	RA 17.82500962
+	Dec -31.2739296
+	Radius 52.644
+	Distance 4266.782
+}
+
+OpenCluster "HSC 11"
+{
+	RA 17.82770323
+	Dec -28.34712185
+	Radius 11.543
+	Distance 4727.278
+}
+
+OpenCluster "HSC 2961"
+{
+	RA 17.82878269
+	Dec -32.97723537
+	Radius 35.069
+	Distance 4685.258
+}
+
+OpenCluster "Collinder 351:UBC 91"
+{
+	RA 17.82891183
+	Dec -28.75372102
+	Radius 29.433
+	Distance 6827.996
+}
+
+OpenCluster "CWNU 1998"
+{
+	RA 17.83107767
+	Dec -33.33538849
+	Radius 15.442
+	Distance 4651.65
+}
+
+OpenCluster "NGC 6451:Melotte 181:Collinder 352:BH 250:ESO 455-50:MWSC 2718:OCL 1035:Theia 2680:UBC 570"
+{
+	RA 17.84473727
+	Dec -30.2102535
+	Radius 74.543
+	Distance 8693.205
+}
+
+OpenCluster "HSC 8"
+{
+	RA 17.84486917
+	Dec -28.63475332
+	Radius 33.442
+	Distance 8479.559
+}
+
+OpenCluster "HSC 55"
+{
+	RA 17.84523837
+	Dec -24.71361397
+	Radius 30.816
+	Distance 5024.042
+}
+
+OpenCluster "HSC 6"
+{
+	RA 17.84714827
+	Dec -28.82464882
+	Radius 27.37
+	Distance 11033.44
+}
+
+OpenCluster "ASCC 92:Alessi 31:MWSC 2723:Theia 739"
+{
+	RA 17.84988406
+	Dec -11.85713699
+	Radius 109.793
+	Distance 2146.954
+}
+
+OpenCluster "CWNU 224"
+{
+	RA 17.85026729
+	Dec -38.44730867
+	Radius 32.87
+	Distance 3562.305
+}
+
+OpenCluster "OCSN 97:Theia 1023"
+{
+	RA 17.85992064
+	Dec -40.69386744
+	Radius 145.984
+	Distance 1449.556
+}
+
+OpenCluster "CWNU 1785"
+{
+	RA 17.86007022
+	Dec -27.74159686
+	Radius 32.559
+	Distance 8689.135
+}
+
+OpenCluster "OC 0700:Theia 3922:UFMG 94"
+{
+	RA 17.86392349
+	Dec -33.38520013
+	Radius 37.461
+	Distance 4048.814
+}
+
+OpenCluster "OC 0001:UBC 336"
+{
+	RA 17.86556545
+	Dec -27.85030482
+	Radius 57.437
+	Distance 8324.58
+}
+
+OpenCluster "HSC 2951"
+{
+	RA 17.86948747
+	Dec -34.36639983
+	Radius 34.134
+	Distance 2633.246
+}
+
+OpenCluster "Theia 2619"
+{
+	RA 17.87135007
+	Dec -25.20516059
+	Radius 97.629
+	Distance 3403.426
+}
+
+OpenCluster "HXHWL 29"
+{
+	RA 17.87171003
+	Dec -27.03502437
+	Radius 78.327
+	Distance 1934.675
+}
+
+OpenCluster "UBC 1002:UFMG 83"
+{
+	RA 17.87400096
+	Dec -28.18207317
+	Radius 43.653
+	Distance 9919.849
+}
+
+OpenCluster "Alessi 80B"
+{
+	RA 17.87543787
+	Dec -38.67051789
+	Radius 46.054
+	Distance 3839.713
+}
+
+OpenCluster "BH 252:ESO 456-1:MWSC 2730:OCL 4:Ruprecht 134"
+{
+	RA 17.87835599
+	Dec -29.53457502
+	Radius 34.831
+	Distance 7490.638
+}
+
+OpenCluster "HSC 39"
+{
+	RA 17.87896818
+	Dec -26.37854966
+	Radius 31.544
+	Distance 6332.191
+}
+
+OpenCluster "BH 252:ESO 456-1:MWSC 2730:OCL 4:Ruprecht 134:UFMG 88"
+{
+	RA 17.87985805
+	Dec -29.52604293
+	Radius 24.242
+	Distance 4699.035
+}
+
+OpenCluster "HSC 10"
+{
+	RA 17.881702
+	Dec -28.79674558
+	Radius 17.317
+	Distance 8493.107
+}
+
+OpenCluster "NGC 6469:Melotte 182:Collinder 353:ESO 589-18:MWSC 2735:OCL 21:Theia 2906:UBC 95"
+{
+	RA 17.88296106
+	Dec -22.16164311
+	Radius 26.898
+	Distance 5973.269
+}
+
+OpenCluster "NGC 6469:Melotte 182:Collinder 353:ESO 589-18:MWSC 2735:OCL 21:Theia 2040"
+{
+	RA 17.88450763
+	Dec -22.30486423
+	Radius 74.968
+	Distance 5269.193
+}
+
+OpenCluster "Theia 1421:UPK 25"
+{
+	RA 17.88492112
+	Dec -2.72474939
+	Radius 57.635
+	Distance 1994.392
+}
+
+OpenCluster "BH 253:Czernik 37:ESO 521-3:MWSC 2737:OCL 8"
+{
+	RA 17.88789844
+	Dec -27.36555412
+	Radius 28.506
+	Distance 7826.334
+}
+
+OpenCluster "HSC 56"
+{
+	RA 17.89526309
+	Dec -25.1053462
+	Radius 62.19
+	Distance 9108.922
+}
+
+OpenCluster "Theia 1038"
+{
+	RA 17.89767715
+	Dec -24.29022583
+	Radius 92.256
+	Distance 1645.841
+}
+
+OpenCluster "Ptolemy Cluster:M 7:NGC 6475:Melotte 183:Collinder 354:BH 254:ESO 394-9:MWSC 2739:OCL 1028:Theia 692"
+{
+	RA 17.89840369
+	Dec -34.82833007
+	Radius 76.569
+	Distance 900.151
+}
+
+OpenCluster "HSC 63"
+{
+	RA 17.89931171
+	Dec -24.36923185
+	Radius 33.773
+	Distance 9641.394
+}
+
+OpenCluster "UBC 93 "
+{
+	RA 17.90512937
+	Dec -25.40388985
+	Radius 49.425
+	Distance 9073.138
+}
+
+OpenCluster "UBC 1003:UFMG 78"
+{
+	RA 17.90661182
+	Dec -24.89289791
+	Radius 38.256
+	Distance 7438.142
+}
+
+OpenCluster "Theia 1761:UFMG 72"
+{
+	RA 17.90681893
+	Dec -23.10872833
+	Radius 32.453
+	Distance 4366.24
+}
+
+OpenCluster "HSC 26"
+{
+	RA 17.90766735
+	Dec -27.38502038
+	Radius 96.598
+	Distance 8094.32
+}
+
+OpenCluster "HSC 2"
+{
+	RA 17.90849558
+	Dec -29.53106019
+	Radius 23.554
+	Distance 4821.761
+}
+
+OpenCluster "HSC 2925"
+{
+	RA 17.90915635
+	Dec -37.20056623
+	Radius 21.256
+	Distance 5154.876
+}
+
+OpenCluster "Theia 589"
+{
+	RA 17.91046011
+	Dec -22.00677558
+	Radius 38.655
+	Distance 2901.841
+}
+
+OpenCluster "HSC 36"
+{
+	RA 17.9161522
+	Dec -27.00148638
+	Radius 22.68
+	Distance 6047.921
+}
+
+OpenCluster "HSC 17"
+{
+	RA 17.91791267
+	Dec -28.22565051
+	Radius 28.213
+	Distance 4016.31
+}
+
+OpenCluster "Theia 5347"
+{
+	RA 17.91862866
+	Dec 9.84164499
+	Radius 81.115
+	Distance 1683.807
+}
+
+OpenCluster "HSC 248"
+{
+	RA 17.92092082
+	Dec -0.96469952
+	Radius 59.785
+	Distance 14280.24
+}
+
+OpenCluster "OC 0007"
+{
+	RA 17.92741604
+	Dec -22.69195704
+	Radius 29.589
+	Distance 8354.209
+}
+
+OpenCluster "HSC 40"
+{
+	RA 17.9314143
+	Dec -26.72565082
+	Radius 33.922
+	Distance 8271.984
+}
+
+OpenCluster "UBC 1567:UFMG 92"
+{
+	RA 17.93460055
+	Dec -29.51069294
+	Radius 38.087
+	Distance 7586.841
+}
+
+OpenCluster "HSC 13"
+{
+	RA 17.93658004
+	Dec -28.94250223
+	Radius 29.122
+	Distance 7175.976
+}
+
+OpenCluster "HSC 9"
+{
+	RA 17.93694004
+	Dec -29.33439782
+	Radius 48.235
+	Distance 5497.72
+}
+
+OpenCluster "HSC 4"
+{
+	RA 17.93814772
+	Dec -29.63809868
+	Radius 87.193
+	Distance 18503.902
+}
+
+OpenCluster "UFMG 73"
+{
+	RA 17.93892592
+	Dec -21.87303567
+	Radius 33.484
+	Distance 6400.541
+}
+
+OpenCluster "HSC 2943"
+{
+	RA 17.94221036
+	Dec -35.72584609
+	Radius 32.714
+	Distance 4015.846
+}
+
+OpenCluster "CWNU 2379"
+{
+	RA 17.94253271
+	Dec -25.634563
+	Radius 45.431
+	Distance 8981.989
+}
+
+OpenCluster "Collinder 355:ESO 394-12:Harvard 18:MWSC 2755:OCL 1025:Theia 3241:Trumpler 30:UBC 330"
+{
+	RA 17.94570118
+	Dec -35.28412624
+	Radius 40.639
+	Distance 4431.655
+}
+
+OpenCluster "HSC 103"
+{
+	RA 17.94734852
+	Dec -22.05030987
+	Radius 40.734
+	Distance 325.615
+}
+
+OpenCluster "M 23:NGC 6494:Melotte 184:Collinder 356:ESO 589-22:MWSC 2757:OCL 30:Theia 653"
+{
+	RA 17.9487972
+	Dec -18.99911774
+	Radius 89.72
+	Distance 2326.817
+}
+
+OpenCluster "HSC 213"
+{
+	RA 17.94906964
+	Dec -7.38452727
+	Radius 19.134
+	Distance 4988.825
+}
+
+OpenCluster "Theia 1854"
+{
+	RA 17.94922456
+	Dec -20.31423543
+	Radius 26.29
+	Distance 4588.384
+}
+
+OpenCluster "CWNU 1391"
+{
+	RA 17.95024321
+	Dec -26.05599433
+	Radius 21.234
+	Distance 6921.239
+}
+
+OpenCluster "UFMG 89"
+{
+	RA 17.95195492
+	Dec -27.60697013
+	Radius 15.208
+	Distance 8108.294
+}
+
+OpenCluster "HSC 73"
+{
+	RA 17.95235608
+	Dec -24.30498415
+	Radius 50.868
+	Distance 6073.145
+}
+
+OpenCluster "HSC 38"
+{
+	RA 17.9528749
+	Dec -27.02527134
+	Radius 82.098
+	Distance 8515.228
+}
+
+OpenCluster "HSC 110"
+{
+	RA 17.95757354
+	Dec -21.76285513
+	Radius 19.141
+	Distance 5330.038
+}
+
+OpenCluster "UFMG 93"
+{
+	RA 17.96566098
+	Dec -29.15342797
+	Radius 32.165
+	Distance 9007.428
+}
+
+OpenCluster "HSC 92"
+{
+	RA 17.9664359
+	Dec -23.29243771
+	Radius 62.717
+	Distance 9920.733
+}
+
+OpenCluster "MWSC 2759:OCL 49:Ruprecht 135:Theia 3040"
+{
+	RA 17.96665503
+	Dec -11.64239945
+	Radius 49.509
+	Distance 3539.374
+}
+
+OpenCluster "CWNU 488"
+{
+	RA 17.97123236
+	Dec -25.25832776
+	Radius 21.409
+	Distance 7590.101
+}
+
+OpenCluster "HSC 72"
+{
+	RA 17.97289234
+	Dec -24.55712493
+	Radius 32.841
+	Distance 9211.247
+}
+
+OpenCluster "Theia 2302:UBC 94 "
+{
+	RA 17.97561679
+	Dec -24.60897916
+	Radius 43.227
+	Distance 4130.274
+}
+
+OpenCluster "HSC 156"
+{
+	RA 17.97924646
+	Dec -16.20407121
+	Radius 49.317
+	Distance 5209.745
+}
+
+OpenCluster "HSC 305"
+{
+	RA 17.98107293
+	Dec 4.10488602
+	Radius 60.917
+	Distance 1342.294
+}
+
+OpenCluster "OC 0012:UFMG 74"
+{
+	RA 17.98269443
+	Dec -20.58279325
+	Radius 68.764
+	Distance 8879.06
+}
+
+OpenCluster "HSC 62"
+{
+	RA 17.98839035
+	Dec -25.07628698
+	Radius 45.31
+	Distance 10273.559
+}
+
+OpenCluster "Theia 1984:UBC 92 "
+{
+	RA 17.99159098
+	Dec -26.65467458
+	Radius 94.656
+	Distance 7310.451
+}
+
+OpenCluster "CWNU 1719"
+{
+	RA 17.99718108
+	Dec -21.55760456
+	Radius 45.791
+	Distance 8970.428
+}
+
+OpenCluster "HSC 106"
+{
+	RA 17.99735955
+	Dec -22.37753092
+	Radius 19.398
+	Distance 3867.842
+}
+
+OpenCluster "HSC 196"
+{
+	RA 17.99896593
+	Dec -11.68227142
+	Radius 40.927
+	Distance 5708.605
+}
+
+OpenCluster "NGC 6506:ESO 521-6:MWSC 2771:OCL 16:Ruprecht 138"
+{
+	RA 17.99948297
+	Dec -24.66250853
+	Radius 35.399
+	Distance 7553.457
+}
+
+OpenCluster "ESO 521-8:MWSC 2772:OCL 13:Ruprecht 137"
+{
+	RA 18.00356968
+	Dec -25.10918957
+	Radius 26.16
+	Distance 6896.176
+}
+
+OpenCluster "HSC 79"
+{
+	RA 18.00451197
+	Dec -24.28845129
+	Radius 21.715
+	Distance 6279.247
+}
+
+OpenCluster "HSC 76"
+{
+	RA 18.00691761
+	Dec -24.45817391
+	Radius 42.356
+	Distance 4584.377
+}
+
+OpenCluster "CWNU 230"
+{
+	RA 18.00897954
+	Dec -13.37309446
+	Radius 26.479
+	Distance 3191.814
+}
+
+OpenCluster "CWNU 2884"
+{
+	RA 18.00918069
+	Dec -20.50287173
+	Radius 60.089
+	Distance 5652.401
+}
+
+OpenCluster "Theia 337:UPK 645"
+{
+	RA 18.00931466
+	Dec -42.83973747
+	Radius 96.168
+	Distance 2243.619
+}
+
+OpenCluster "UFMG 81"
+{
+	RA 18.00940069
+	Dec -22.43568443
+	Radius 35.246
+	Distance 7119.46
+}
+
+OpenCluster "UFMG 80"
+{
+	RA 18.01234957
+	Dec -22.1818115
+	Radius 35.292
+	Distance 6830.449
+}
+
+OpenCluster "OC 0016:UFMG 75"
+{
+	RA 18.01511061
+	Dec -20.22274602
+	Radius 32.717
+	Distance 8018.195
+}
+
+OpenCluster "ESO 521-10:MWSC 2776:OCL 20:Ruprecht 139"
+{
+	RA 18.01570544
+	Dec -23.544639
+	Radius 25.874
+	Distance 9769.628
+}
+
+OpenCluster "HSC 80"
+{
+	RA 18.01698083
+	Dec -24.33497311
+	Radius 24.108
+	Distance 8381.962
+}
+
+OpenCluster "HSC 70"
+{
+	RA 18.0208416
+	Dec -24.95714343
+	Radius 21.014
+	Distance 8753.068
+}
+
+OpenCluster "Bull of Poniatowski:Melotte 186:Collinder 359:MWSC 2773:OCL 84"
+{
+	RA 18.02118249
+	Dec 3.19263569
+	Radius 118.247
+	Distance 1763.966
+}
+
+OpenCluster "HSC 94"
+{
+	RA 18.02190701
+	Dec -23.61920684
+	Radius 23.196
+	Distance 4052.688
+}
+
+OpenCluster "HSC 71"
+{
+	RA 18.02316196
+	Dec -24.9526974
+	Radius 29.792
+	Distance 5420.889
+}
+
+OpenCluster "CWNU 1465:ESO 521-10:MWSC 2776:OCL 20:Ruprecht 139"
+{
+	RA 18.02431798
+	Dec -23.54559616
+	Radius 17.154
+	Distance 8507.276
+}
+
+OpenCluster "Theia 766"
+{
+	RA 18.02545996
+	Dec -38.01199022
+	Radius 199.485
+	Distance 2212.105
+}
+
+OpenCluster "CWNU 2530"
+{
+	RA 18.03287561
+	Dec -22.75823455
+	Radius 12.993
+	Distance 8469.157
 }
 
 OpenCluster "Bochum 14"
 {
-	RA 18.033333
-	Dec -22.316667
-	Distance 1885
-	Radius 0.5
+	RA 18.03335762
+	Dec -23.69697077
+	Radius 38.057
+	Distance 9251.674
 }
 
-OpenCluster "NGC 6514"
+OpenCluster "HSC 104"
 {
-	RA 18.045000
-	Dec -21.028333
-	Distance 2661
-	Radius 10.8
+	RA 18.03442391
+	Dec -22.72959219
+	Radius 15.553
+	Distance 7026.413
 }
 
-OpenCluster "NGC 6520"
+OpenCluster "CWNU 1494"
 {
-	RA 18.056667
-	Dec -26.111667
-	Distance 6197
-	Radius 1.8
+	RA 18.03442578
+	Dec -28.28897905
+	Radius 21.141
+	Distance 5136.32
 }
 
-OpenCluster "NGC 6531"
+OpenCluster "HSC 162"
 {
-	RA 18.070278
-	Dec -21.510000
-	Distance 3930
-	Radius 8.0
+	RA 18.03587678
+	Dec -16.23085959
+	Radius 32.715
+	Distance 4644.815
 }
 
-OpenCluster "NGC 6530"
+OpenCluster "UBC 1004"
 {
-	RA 18.075278
-	Dec -23.641667
-	Distance 4338
-	Radius 8.8
+	RA 18.03637102
+	Dec -25.07846647
+	Radius 54.698
+	Distance 7738.421
 }
 
-OpenCluster "NGC 6546"
+OpenCluster "ESO 589-26:ESO 589 26:MW"
 {
-	RA 18.122778
-	Dec -22.703333
-	Distance 3059
-	Radius 6.2
+	RA 18.03734386
+	Dec -21.91794774
+	Radius 29.988
+	Distance 8736.199
 }
 
-OpenCluster "ASCC 93"
+OpenCluster "CWNU 2859:UFMG 90"
 {
-	RA 18.136944
-	Dec -21.740000
-	Distance 8154
-	Radius 38.4
+	RA 18.0426347
+	Dec -25.81611163
+	Radius 69.498
+	Distance 6520.638
 }
 
-OpenCluster "vdBergh 113"
+OpenCluster "HSC 129"
 {
-	RA 18.143333
-	Dec -20.583333
-	Distance 5437
-	Radius 11.1
+	RA 18.0455085
+	Dec -19.76123414
+	Radius 46.557
+	Distance 8013.312
 }
 
-OpenCluster "ESO 521-38"
+OpenCluster "UFMG 95"
 {
-	RA 18.156944
-	Dec -23.470000
-	Distance 5871
-	Radius 2.6
+	RA 18.04588159
+	Dec -29.38407019
+	Radius 19.766
+	Distance 3650.553
 }
 
-OpenCluster "Collinder 367"
+OpenCluster "HSC 2984"
 {
-	RA 18.164167
-	Dec -22.171667
-	Distance 4077
-	Radius 23.7
+	RA 18.05025511
+	Dec -31.64607401
+	Radius 98.877
+	Distance 31385.767
+}
+
+OpenCluster "CWNU 1476:Theia 1647"
+{
+	RA 18.05072911
+	Dec -23.68864564
+	Radius 28.392
+	Distance 9085.638
+}
+
+OpenCluster "UBC 340:XDOCC 8"
+{
+	RA 18.05075826
+	Dec -22.66040633
+	Radius 46.227
+	Distance 4279.348
+}
+
+OpenCluster "HSC 297"
+{
+	RA 18.05242781
+	Dec 2.73645795
+	Radius 29.783
+	Distance 1452.279
+}
+
+OpenCluster "HSC 159"
+{
+	RA 18.05341915
+	Dec -16.63427519
+	Radius 18.422
+	Distance 5434.016
+}
+
+OpenCluster "CWNU 179:UBC 1007"
+{
+	RA 18.05539924
+	Dec -19.3333189
+	Radius 22.216
+	Distance 4681.511
+}
+
+OpenCluster "NGC 6520:Melotte 187:Collinder 361:BH 255:ESO 456-42:MWSC 2790:OCL 10"
+{
+	RA 18.0571737
+	Dec -27.8856225
+	Radius 67.603
+	Distance 5570.808
+}
+
+OpenCluster "DSH J1803.5-2207:MWSC 2791:Teutsch 14a:Teutsch J1803.5-2207"
+{
+	RA 18.05855214
+	Dec -22.12603415
+	Radius 71.834
+	Distance 9114.415
+}
+
+OpenCluster "HSC 12"
+{
+	RA 18.06652226
+	Dec -30.01874129
+	Radius 19.622
+	Distance 3288.893
+}
+
+OpenCluster "Webb's Cross:M 21:NGC 6531:Melotte 188:Collinder 363:ESO 521-19:MWSC 2796:OCL 26"
+{
+	RA 18.06948134
+	Dec -22.49964912
+	Radius 20.156
+	Distance 3919.854
+}
+
+OpenCluster "CWNU 1717:CWWL 2457"
+{
+	RA 18.07176719
+	Dec -21.22040742
+	Radius 68.468
+	Distance 10561.855
+}
+
+OpenCluster "HSC 318"
+{
+	RA 18.07290783
+	Dec 5.45172928
+	Radius 45.781
+	Distance 9659.313
+}
+
+OpenCluster "HSC 19"
+{
+	RA 18.07315419
+	Dec -29.07542033
+	Radius 58.237
+	Distance 19786.513
+}
+
+OpenCluster "NGC 6530:OC 0006"
+{
+	RA 18.07345913
+	Dec -24.37047848
+	Radius 37.258
+	Distance 4010.098
+}
+
+OpenCluster "CWNU 1615"
+{
+	RA 18.0755022
+	Dec -26.02776012
+	Radius 34.899
+	Distance 4757.117
+}
+
+OpenCluster "OC 0015"
+{
+	RA 18.08483866
+	Dec -21.21635053
+	Radius 44.871
+	Distance 8888.931
+}
+
+OpenCluster "HSC 97"
+{
+	RA 18.08570725
+	Dec -23.8027007
+	Radius 24.949
+	Distance 8809.775
+}
+
+OpenCluster "HSC 208"
+{
+	RA 18.08727065
+	Dec -9.77796581
+	Radius 101.027
+	Distance 15742.204
+}
+
+OpenCluster "CWNU 2598"
+{
+	RA 18.08738071
+	Dec -22.16919044
+	Radius 29.078
+	Distance 7053.61
+}
+
+OpenCluster "UBC 339"
+{
+	RA 18.08754298
+	Dec -23.30832307
+	Radius 27.254
+	Distance 7408.304
+}
+
+OpenCluster "HSC 108"
+{
+	RA 18.08843908
+	Dec -22.92801652
+	Radius 74.05
+	Distance 9178.14
+}
+
+OpenCluster "HSC 381"
+{
+	RA 18.09238381
+	Dec 17.77089873
+	Radius 123.672
+	Distance 1021.341
+}
+
+OpenCluster "HSC 145"
+{
+	RA 18.0925514
+	Dec -18.77060297
+	Radius 24.351
+	Distance 3511.609
+}
+
+OpenCluster "CWNU 1468"
+{
+	RA 18.09326907
+	Dec -22.79348253
+	Radius 13.497
+	Distance 6953.674
+}
+
+OpenCluster "HSC 142"
+{
+	RA 18.09363918
+	Dec -18.94524995
+	Radius 21.436
+	Distance 5258.9
+}
+
+OpenCluster "OC 0008"
+{
+	RA 18.09807077
+	Dec -23.80834008
+	Radius 26.846
+	Distance 5864.972
+}
+
+OpenCluster "UBC 338"
+{
+	RA 18.10227938
+	Dec -24.26440236
+	Radius 23.655
+	Distance 4833.81
+}
+
+OpenCluster "HSC 2705"
+{
+	RA 18.10502217
+	Dec -71.37806446
+	Radius 163.057
+	Distance 338.507
+}
+
+OpenCluster "FSR 0031:OC 0014"
+{
+	RA 18.10724754
+	Dec -21.40226666
+	Radius 14.506
+	Distance 6377.916
+}
+
+OpenCluster "Theia 1739:UBC 337"
+{
+	RA 18.11254717
+	Dec -24.68408946
+	Radius 66.961
+	Distance 5578.622
+}
+
+OpenCluster "CWNU 1180:Theia 696"
+{
+	RA 18.11460584
+	Dec -73.99257142
+	Radius 106.916
+	Distance 937.819
+}
+
+OpenCluster "CWNU 2288"
+{
+	RA 18.11526661
+	Dec -18.25209844
+	Radius 33.677
+	Distance 6074.941
+}
+
+OpenCluster "HSC 135"
+{
+	RA 18.11594349
+	Dec -19.76358173
+	Radius 65.979
+	Distance 4171.167
+}
+
+OpenCluster "CWNU 1664"
+{
+	RA 18.12397569
+	Dec -21.66952199
+	Radius 47.563
+	Distance 10027.996
+}
+
+OpenCluster "HSC 160"
+{
+	RA 18.12526364
+	Dec -17.19599946
+	Radius 26.98
+	Distance 5473.36
+}
+
+OpenCluster "NGC 6544:Melotte 192:Collinder 366:CWNU 1446:ESO 521-28:GCL 87:MWSC 2810:OCL 17"
+{
+	RA 18.12598636
+	Dec -25.11906804
+	Radius 21.555
+	Distance 4667.278
+}
+
+OpenCluster "ASCC 93:MWSC 2814"
+{
+	RA 18.12750715
+	Dec -22.28335608
+	Radius 72.982
+	Distance 5941.539
+}
+
+OpenCluster "CWNU 2480"
+{
+	RA 18.12827063
+	Dec -17.88796604
+	Radius 32.536
+	Distance 4815.202
+}
+
+OpenCluster "HSC 127"
+{
+	RA 18.12963275
+	Dec -20.47842167
+	Radius 13.623
+	Distance 3776.963
+}
+
+OpenCluster "HSC 469"
+{
+	RA 18.12968134
+	Dec 31.0196817
+	Radius 53.099
+	Distance 1573.392
+}
+
+OpenCluster "OC 0017"
+{
+	RA 18.13397867
+	Dec -19.48751414
+	Radius 36.724
+	Distance 8762.555
+}
+
+OpenCluster "CWNU 1409"
+{
+	RA 18.1352632
+	Dec -18.56186845
+	Radius 57.99
+	Distance 5865.788
+}
+
+OpenCluster "OC 0018"
+{
+	RA 18.13537061
+	Dec -19.4081346
+	Radius 18.96
+	Distance 5729.449
+}
+
+OpenCluster "OCSN 4:Theia 227"
+{
+	RA 18.13935795
+	Dec -16.47280525
+	Radius 128.99
+	Distance 1532.773
+}
+
+OpenCluster "LISC-III 3629:Theia 5731"
+{
+	RA 18.13939106
+	Dec -60.28967471
+	Radius 80.205
+	Distance 1802.123
+}
+
+OpenCluster "CWNU 2825"
+{
+	RA 18.1397358
+	Dec -21.06153572
+	Radius 26.004
+	Distance 8615.754
+}
+
+OpenCluster "CWNU 1284"
+{
+	RA 18.14327945
+	Dec -21.07079735
+	Radius 24.705
+	Distance 7781.182
+}
+
+OpenCluster "UBC 1005:UFMG 84:vdBergh 113"
+{
+	RA 18.14436615
+	Dec -21.4414776
+	Radius 47.42
+	Distance 4603.028
+}
+
+OpenCluster "CWNU 2708"
+{
+	RA 18.14586459
+	Dec -21.57414431
+	Radius 19.35
+	Distance 7800.319
+}
+
+OpenCluster "HSC 236"
+{
+	RA 18.14629129
+	Dec -5.10307995
+	Radius 47.097
+	Distance 1320.582
+}
+
+OpenCluster "NGC 6554"
+{
+	RA 18.15547176
+	Dec -18.39536921
+	Radius 27.014
+	Distance 4578.781
+}
+
+OpenCluster "HSC 179"
+{
+	RA 18.156247
+	Dec -15.24975983
+	Radius 286.013
+	Distance 21298.965
+}
+
+OpenCluster "HSC 422"
+{
+	RA 18.15820235
+	Dec 24.81434709
+	Radius 61.957
+	Distance 11581.535
+}
+
+OpenCluster "ESO 521-38:ESO 521 38:MWSC 2825"
+{
+	RA 18.15994483
+	Dec -24.54340896
+	Radius 36.371
+	Distance 3855.203
+}
+
+OpenCluster "HSC 100"
+{
+	RA 18.16171377
+	Dec -24.04988447
+	Radius 57.183
+	Distance 7594.383
+}
+
+OpenCluster "HSC 152"
+{
+	RA 18.16263851
+	Dec -18.64624965
+	Radius 32.818
+	Distance 5151.329
+}
+
+OpenCluster "UBC 1006"
+{
+	RA 18.16358328
+	Dec -21.461423
+	Radius 52.628
+	Distance 8472.067
+}
+
+OpenCluster "Collinder 367:CWNU 1222:OC 0010"
+{
+	RA 18.16372885
+	Dec -23.65170031
+	Radius 47.945
+	Distance 3975.387
+}
+
+OpenCluster "HSC 2981"
+{
+	RA 18.16467986
+	Dec -33.00817546
+	Radius 24.676
+	Distance 5616.555
+}
+
+OpenCluster "CWNU 482"
+{
+	RA 18.16548844
+	Dec -22.28253555
+	Radius 19.185
+	Distance 4695.1
+}
+
+OpenCluster "HSC 87"
+{
+	RA 18.16701459
+	Dec -25.09089627
+	Radius 30.18
+	Distance 3588.613
+}
+
+OpenCluster "CWNU 2597"
+{
+	RA 18.17174444
+	Dec -21.22362256
+	Radius 14.969
+	Distance 4605.34
+}
+
+OpenCluster "NGC 6561:Gulliver 15"
+{
+	RA 18.17320362
+	Dec -16.72264169
+	Radius 40.112
+	Distance 5856.708
+}
+
+OpenCluster "HSC 193"
+{
+	RA 18.17494202
+	Dec -13.48973345
+	Radius 26.197
+	Distance 4882.69
 }
 
 OpenCluster "NGC 6561"
 {
-	RA 18.175000
-	Dec -15.275000
-	Distance 11089
-	Radius 24.2
+	RA 18.17634044
+	Dec -16.73066204
+	Radius 19.76
+	Distance 4597.774
 }
 
-OpenCluster "NGC 6568"
+OpenCluster "HSC 118"
 {
-	RA 18.212222
-	Dec -20.395000
-	Distance 2508
-	Radius 4.4
+	RA 18.17720283
+	Dec -22.46953955
+	Radius 64.498
+	Distance 4570.089
 }
 
-OpenCluster "ESO 522-05"
+OpenCluster "IC 1276:FSR 66:GCL 90:MWSC 2835:Pal 7:Palomar 7"
 {
-	RA 18.214722
-	Dec -23.636111
-	Distance 2152
-	Radius 1.4
+	RA 18.1789763
+	Dec -7.21174394
+	Radius 218.314
+	Distance 15969.832
+}
+
+OpenCluster "HSC 388"
+{
+	RA 18.18490698
+	Dec 18.22433698
+	Radius 28.038
+	Distance 1154.232
+}
+
+OpenCluster "CWNU 2188"
+{
+	RA 18.18601122
+	Dec -19.41373868
+	Radius 15.63
+	Distance 5795.732
+}
+
+OpenCluster "CWNU 2894"
+{
+	RA 18.18620896
+	Dec -22.91517354
+	Radius 40.146
+	Distance 7386.383
+}
+
+OpenCluster "Theia 551"
+{
+	RA 18.18712164
+	Dec -41.49851415
+	Radius 53.056
+	Distance 2079.902
+}
+
+OpenCluster "CWNU 1841"
+{
+	RA 18.18851696
+	Dec -20.88377846
+	Radius 34.662
+	Distance 8118.168
+}
+
+OpenCluster "HSC 2932"
+{
+	RA 18.19775728
+	Dec -38.36477453
+	Radius 38.728
+	Distance 9848.155
+}
+
+OpenCluster "OC 0011:Theia 1927"
+{
+	RA 18.19952281
+	Dec -22.97135671
+	Radius 44.946
+	Distance 4960.25
+}
+
+OpenCluster "HSC 197"
+{
+	RA 18.20046048
+	Dec -12.99210675
+	Radius 51.339
+	Distance 6447.888
+}
+
+OpenCluster "CWNU 477"
+{
+	RA 18.20099438
+	Dec -15.69424152
+	Radius 38.364
+	Distance 4685.107
+}
+
+OpenCluster "CWNU 2459"
+{
+	RA 18.20240511
+	Dec -19.18030757
+	Radius 18.053
+	Distance 8881.791
+}
+
+OpenCluster "UBC 1012"
+{
+	RA 18.2025051
+	Dec -15.98595334
+	Radius 76.434
+	Distance 7223.966
+}
+
+OpenCluster "Theia 1927"
+{
+	RA 18.20513505
+	Dec -22.90878609
+	Radius 13.001
+	Distance 3344.259
+}
+
+OpenCluster "CWNU 183"
+{
+	RA 18.2058357
+	Dec -21.14331974
+	Radius 16.397
+	Distance 5380.237
+}
+
+OpenCluster "HSC 175"
+{
+	RA 18.20612298
+	Dec -16.48882379
+	Radius 50.55
+	Distance 5106.179
+}
+
+OpenCluster "HSC 115"
+{
+	RA 18.20716725
+	Dec -23.02799015
+	Radius 32.276
+	Distance 7629.457
+}
+
+OpenCluster "HXHWL 66:UBC 1013"
+{
+	RA 18.20765458
+	Dec -15.38079323
+	Radius 42.044
+	Distance 5254.032
+}
+
+OpenCluster "OC 0025"
+{
+	RA 18.209774
+	Dec -16.40356547
+	Radius 20.819
+	Distance 5748.73
+}
+
+OpenCluster "CWNU 1770:ESO 522-05:ESO 522-5:ESO 522-522:ESO 522 05:MWSC 284:Theia 273"
+{
+	RA 18.21214864
+	Dec -24.36273083
+	Radius 15.311
+	Distance 4203.136
+}
+
+OpenCluster "NGC 6568:Collinder 369:ESO 590-6:MWSC 2841:OCL 28:Theia 674"
+{
+	RA 18.21292877
+	Dec -21.615491
+	Radius 25.79
+	Distance 3382.797
+}
+
+OpenCluster "HSC 138"
+{
+	RA 18.21380572
+	Dec -20.22983227
+	Radius 31.025
+	Distance 9391.131
+}
+
+OpenCluster "Theia 184:UPK 5"
+{
+	RA 18.21401263
+	Dec -18.32609813
+	Radius 147.505
+	Distance 1801.596
+}
+
+OpenCluster "HSC 187"
+{
+	RA 18.21666938
+	Dec -14.46653302
+	Radius 18.042
+	Distance 5283.75
+}
+
+OpenCluster "CWNU 534"
+{
+	RA 18.21713855
+	Dec 27.47491804
+	Radius 34.828
+	Distance 940.554
+}
+
+OpenCluster "CWNU 293:Theia 1914"
+{
+	RA 18.21918261
+	Dec -20.41201108
+	Radius 22.659
+	Distance 3828.703
+}
+
+OpenCluster "UBC 1008"
+{
+	RA 18.22096202
+	Dec -19.02049838
+	Radius 24.483
+	Distance 8582.844
+}
+
+OpenCluster "CWNU 2314"
+{
+	RA 18.22648211
+	Dec -21.37720748
+	Radius 47.583
+	Distance 5641.695
+}
+
+OpenCluster "CWNU 155"
+{
+	RA 18.2307875
+	Dec -21.06213951
+	Radius 24.067
+	Distance 4000.926
+}
+
+OpenCluster "HSC 158"
+{
+	RA 18.23200309
+	Dec -18.06627228
+	Radius 34.955
+	Distance 8945.57
+}
+
+OpenCluster "HSC 149"
+{
+	RA 18.23334058
+	Dec -19.50420289
+	Radius 8.918
+	Distance 7395.977
+}
+
+OpenCluster "HSC 148"
+{
+	RA 18.23361593
+	Dec -19.52203394
+	Radius 15.334
+	Distance 8135.962
+}
+
+OpenCluster "HSC 161"
+{
+	RA 18.2342162
+	Dec -17.98918143
+	Radius 37.816
+	Distance 7509.639
+}
+
+OpenCluster "CWNU 2693:Theia 2045"
+{
+	RA 18.23675984
+	Dec -18.88628992
+	Radius 23.425
+	Distance 4714.394
+}
+
+OpenCluster "Theia 1871:UBC 1009"
+{
+	RA 18.23700789
+	Dec -18.98538914
+	Radius 46.373
+	Distance 8720.577
+}
+
+OpenCluster "Theia 2045"
+{
+	RA 18.24358158
+	Dec -18.79146075
+	Radius 84.228
+	Distance 5789.793
+}
+
+OpenCluster "HSC 184"
+{
+	RA 18.24869129
+	Dec -14.98552326
+	Radius 13.283
+	Distance 5226.667
+}
+
+OpenCluster "CWNU 1630"
+{
+	RA 18.24885662
+	Dec -20.41511648
+	Radius 28.46
+	Distance 4235.812
+}
+
+OpenCluster "HSC 3"
+{
+	RA 18.24899764
+	Dec -31.87471566
+	Radius 52.309
+	Distance 4746.86
+}
+
+OpenCluster "OC 0023"
+{
+	RA 18.25086079
+	Dec -17.01244303
+	Radius 34.396
+	Distance 8729.21
+}
+
+OpenCluster "CWNU 493:OC 0030"
+{
+	RA 18.25308171
+	Dec -12.55134418
+	Radius 44.031
+	Distance 5261.083
+}
+
+OpenCluster "Theia 2240:UBC 96 "
+{
+	RA 18.25389979
+	Dec -16.34187682
+	Radius 27.239
+	Distance 5015.359
 }
 
 OpenCluster "Markarian 38"
 {
-	RA 18.254722
-	Dec -19.000000
-	Distance 4797
-	Radius 1.4
+	RA 18.25430719
+	Dec -18.99430649
+	Radius 17.143
+	Distance 5397.649
 }
 
-OpenCluster "ASCC 94"
+OpenCluster "HSC 295"
 {
-	RA 18.260000
-	Dec -13.010000
-	Distance 2772
-	Radius 12.1
+	RA 18.25518821
+	Dec 1.01936775
+	Radius 128.007
+	Distance 1253.995
 }
 
-OpenCluster "NGC 6583"
+OpenCluster "Gulliver 20:Theia 623"
 {
-	RA 18.263611
-	Dec -21.863333
-	Distance 6653
-	Radius 4.8
+	RA 18.25598171
+	Dec 11.43775178
+	Radius 55.745
+	Distance 1368.079
 }
 
-OpenCluster "ASCC 95"
+OpenCluster "CWNU 2669"
 {
-	RA 18.268056
-	Dec -24.290000
-	Distance 4892
-	Radius 27.3
+	RA 18.25848222
+	Dec -18.66530593
+	Radius 32.951
+	Distance 7260.727
 }
 
-OpenCluster "Collinder 469"
+OpenCluster "HSC 155"
 {
-	RA 18.276111
-	Dec -17.688333
-	Distance 4830
-	Radius 2.1
+	RA 18.25986216
+	Dec -18.75782206
+	Radius 38.244
+	Distance 8563.483
 }
 
-OpenCluster "Turner 4"
+OpenCluster "ASCC 94:MWSC 2858:UBC 342"
 {
-	RA 18.285556
-	Dec -17.300000
-	Distance 7599
-	Radius 3.9
+	RA 18.26147747
+	Dec -14.90845919
+	Radius 53.502
+	Distance 5062.877
 }
 
-OpenCluster "Turner 2"
+OpenCluster "NGC 6583:Collinder 370:ESO 590-11:FSR 32:MWSC 2860:OCL 27:Theia 5571"
 {
-	RA 18.286389
-	Dec -17.175833
-	Distance 3881
-	Radius 4.3
+	RA 18.26412914
+	Dec -22.14464589
+	Radius 60.114
+	Distance 7308.708
 }
 
-OpenCluster "Trumpler 32"
+OpenCluster "FoF 1218"
 {
-	RA 18.291667
-	Dec -12.650000
-	Distance 5610
-	Radius 4.1
+	RA 18.26534145
+	Dec -18.10377131
+	Radius 45.904
+	Distance 8101.466
 }
 
-OpenCluster "NGC 6596"
+OpenCluster "Theia 1666:Theia 1697:Theia 1756:Theia 2365"
 {
-	RA 18.292500
-	Dec -15.350000
-	Distance 4073
-	Radius 5.9
+	RA 18.26800374
+	Dec -16.41036125
+	Radius 119.671
+	Distance 8794.179
 }
 
-OpenCluster "Turner 3"
+OpenCluster "HSC 176"
 {
-	RA 18.292778
-	Dec -17.136111
-	Distance 5838
-	Radius 1.7
+	RA 18.27018214
+	Dec -16.53805472
+	Radius 49.436
+	Distance 5378.812
+}
+
+OpenCluster "ASCC 95:MWSC 2861"
+{
+	RA 18.27047329
+	Dec -25.8321451
+	Radius 53.953
+	Distance 3731.796
+}
+
+OpenCluster "CWNU 2848"
+{
+	RA 18.27216356
+	Dec -19.39356747
+	Radius 20.687
+	Distance 6064.092
+}
+
+OpenCluster "UBC 1011"
+{
+	RA 18.27379937
+	Dec -18.09617406
+	Radius 43.74
+	Distance 8333.207
+}
+
+OpenCluster "CWNU 191:OC 0019"
+{
+	RA 18.2738002
+	Dec -20.14435311
+	Radius 50.997
+	Distance 5882.688
+}
+
+OpenCluster "CWNU 367"
+{
+	RA 18.27456652
+	Dec -12.7180933
+	Radius 23.309
+	Distance 4464.752
+}
+
+OpenCluster "Collinder 469:MWSC 2865:OCL 35"
+{
+	RA 18.27611475
+	Dec -18.30720569
+	Radius 24.12
+	Distance 7437.469
+}
+
+OpenCluster "OC 0024"
+{
+	RA 18.27834121
+	Dec -16.99651562
+	Radius 33.587
+	Distance 5189.121
+}
+
+OpenCluster "HSC 144"
+{
+	RA 18.27882154
+	Dec -20.32101038
+	Radius 53.323
+	Distance 5075.453
+}
+
+OpenCluster "UBC 1019"
+{
+	RA 18.27976343
+	Dec -11.99928618
+	Radius 36.794
+	Distance 6187.709
+}
+
+OpenCluster "Theia 1666:Theia 2365"
+{
+	RA 18.28260828
+	Dec -15.86188637
+	Radius 79.46
+	Distance 8594.407
+}
+
+OpenCluster "HXHWL 7"
+{
+	RA 18.28510467
+	Dec -20.34530094
+	Radius 24.599
+	Distance 3990.579
+}
+
+OpenCluster "Collinder 372:Harvard 19:MWSC 2873:OCL 55:Theia 4347:Trumpler 32"
+{
+	RA 18.28611631
+	Dec -13.35565421
+	Radius 53.715
+	Distance 5261.227
+}
+
+OpenCluster "HSC 355"
+{
+	RA 18.28931281
+	Dec 11.32978422
+	Radius 58.907
+	Distance 9362.015
+}
+
+OpenCluster "OC 0021:Turner 2:Turner 3"
+{
+	RA 18.28943583
+	Dec -19.09624246
+	Radius 37.286
+	Distance 5507
+}
+
+OpenCluster "HSC 143"
+{
+	RA 18.29011819
+	Dec -20.41499421
+	Radius 17.514
+	Distance 4150.049
 }
 
 OpenCluster "Dias 5"
 {
-	RA 18.294444
-	Dec -18.330000
-	Distance 5740
-	Radius 2.5
+	RA 18.29166699
+	Dec -19.70749321
+	Radius 51.288
+	Distance 4109.901
 }
 
-OpenCluster "NGC 6604"
+OpenCluster "HSC 178"
 {
-	RA 18.300833
-	Dec -11.758333
-	Distance 5531
-	Radius 4.0
+	RA 18.29439319
+	Dec -16.35895169
+	Radius 25.778
+	Distance 9233.642
 }
 
-OpenCluster "NGC 6603"
+OpenCluster "UBC 1010"
 {
-	RA 18.307222
-	Dec -17.593333
-	Distance 11742
-	Radius 10.2
+	RA 18.29895068
+	Dec -18.54998841
+	Radius 45.916
+	Distance 8109.554
 }
 
-OpenCluster "Alessi 19"
+OpenCluster "CWNU 1917"
 {
-	RA 18.307778
-	Dec 12.166667
-	Distance 1793
-	Radius 23.0
+	RA 18.30046142
+	Dec -19.70882493
+	Radius 24.307
+	Distance 7330.009
+}
+
+OpenCluster "Teutsch 262"
+{
+	RA 18.30133885
+	Dec -18.97234585
+	Radius 11.739
+	Distance 5028.79
+}
+
+OpenCluster "NGC 6604:Theia 1650"
+{
+	RA 18.30175991
+	Dec -12.25326391
+	Radius 17.706
+	Distance 6579.198
+}
+
+OpenCluster "Alessi 19:LeDrew 5:MWSC 2887:OC 0068"
+{
+	RA 18.30227623
+	Dec 11.89734723
+	Radius 116.329
+	Distance 1873.952
+}
+
+OpenCluster "Theia 1650:UBC 344"
+{
+	RA 18.30280642
+	Dec -11.90543355
+	Radius 32.467
+	Distance 6360.338
+}
+
+OpenCluster "UFMG 46"
+{
+	RA 18.303896
+	Dec -25.06475626
+	Radius 45.124
+	Distance 7880.353
+}
+
+OpenCluster "CWNU 2719"
+{
+	RA 18.30620526
+	Dec -19.36022771
+	Radius 32.651
+	Distance 6191.362
+}
+
+OpenCluster "NGC 6603:Melotte 197:Collinder 374:FSR 45:MWSC 2883:OCL 36"
+{
+	RA 18.30755082
+	Dec -18.40916824
+	Radius 47.828
+	Distance 9044.62
+}
+
+OpenCluster "OC 0028:Theia 1709"
+{
+	RA 18.30935536
+	Dec -15.17364825
+	Radius 104.064
+	Distance 5225.583
+}
+
+OpenCluster "HSC 2839"
+{
+	RA 18.31067839
+	Dec -52.23939371
+	Radius 10.146
+	Distance 3039.875
 }
 
 OpenCluster "NGC 6611"
 {
-	RA 18.313333
-	Dec -12.193333
-	Distance 5871
-	Radius 5.1
+	RA 18.31168438
+	Dec -13.78958993
+	Radius 61.333
+	Distance 5539.601
 }
 
-OpenCluster "NGC 6613"
+OpenCluster "Theia 1656"
 {
-	RA 18.332778
-	Dec -16.898333
-	Distance 4227
-	Radius 3.1
+	RA 18.31807339
+	Dec -12.41537792
+	Radius 29.032
+	Distance 6752.417
 }
 
-OpenCluster "Ferrero 1"
+OpenCluster "LISC 3356:Theia 1709:UBC 97 "
 {
-	RA 18.336944
-	Dec -31.648333
-	Distance 2446
-	Radius 10.7
+	RA 18.32091665
+	Dec -15.73440317
+	Radius 25.639
+	Distance 4306.77
 }
 
-OpenCluster "NGC 6618"
+OpenCluster "HSC 2820"
 {
-	RA 18.346389
-	Dec -15.828333
-	Distance 4240
-	Radius 15.4
+	RA 18.32421021
+	Dec -55.10281802
+	Radius 34.296
+	Distance 5250.897
 }
 
-OpenCluster "Kharchenko 2"
+OpenCluster "HSC 409"
 {
-	RA 18.371389
-	Dec -13.410000
-	Distance 6490
-	Radius 2.6
+	RA 18.32568723
+	Dec 21.25419953
+	Radius 42.643
+	Distance 9203.972
 }
 
-OpenCluster "Kharchenko 3"
+OpenCluster "OC 0026"
 {
-	RA 18.379722
-	Dec -13.366667
-	Distance 6947
-	Radius 8.1
+	RA 18.32799134
+	Dec -16.54132637
+	Radius 20.014
+	Distance 5450.89
 }
 
-OpenCluster "NGC 6625"
+OpenCluster "Theia 817"
 {
-	RA 18.380556
-	Dec -10.038333
-	Distance 4354
-	Radius 9.8
+	RA 18.33003007
+	Dec 24.60625816
+	Radius 90.636
+	Distance 1173.964
 }
 
-OpenCluster "Trumpler 33"
+OpenCluster "OC 0027"
 {
-	RA 18.411667
-	Dec -18.283333
-	Distance 5724
-	Radius 4.2
+	RA 18.33066475
+	Dec -15.70178884
+	Radius 36.313
+	Distance 7064.856
 }
 
-OpenCluster "Mamajek 4"
+OpenCluster "HSC 109"
 {
-	RA 18.433333
-	Dec -51.000000
-	Distance 1255
-	Radius 15.3
+	RA 18.33092936
+	Dec -24.66315793
+	Radius 79.428
+	Distance 23981.567
 }
 
-OpenCluster "Bica 3"
+OpenCluster "Black Swan Cluster:M 18:NGC 6613:Collinder 376:MWSC 2892:OCL 40:Theia 1931"
 {
-	RA 18.434444
-	Dec -12.941111
-	Distance 5349
-	Radius 2.7
+	RA 18.33241332
+	Dec -17.09207751
+	Radius 86.392
+	Distance 4894.708
 }
 
-OpenCluster "NGC 6631"
+OpenCluster "HSC 131"
 {
-	RA 18.453056
-	Dec -11.970000
-	Distance 8480
-	Radius 7.4
+	RA 18.3324879
+	Dec -21.89475593
+	Radius 37.975
+	Distance 2504.155
 }
 
-OpenCluster "NGC 6633"
+OpenCluster "ASCC 96:Ferrero 1:MWSC 2893:Slotegraaf 61"
 {
-	RA 18.454167
-	Dec 6.508333
-	Distance 1226
-	Radius 3.6
+	RA 18.33521424
+	Dec -32.35056497
+	Radius 71.505
+	Distance 2777.646
 }
 
-OpenCluster "Dias 6"
+OpenCluster "UBC 573"
 {
-	RA 18.508333
-	Dec -11.683611
-	Distance 5153
-	Radius 4.5
+	RA 18.33529184
+	Dec -9.47673971
+	Radius 31.551
+	Distance 5319.739
 }
 
-OpenCluster "NGC 6639"
+OpenCluster "HSC 214"
 {
-	RA 18.516389
-	Dec -12.845000
-	Distance 2283
-	Radius 1.7
+	RA 18.33663551
+	Dec -10.46468426
+	Radius 38.774
+	Distance 6023.328
 }
 
-OpenCluster "Ruprecht 141"
+OpenCluster "HSC 174"
 {
-	RA 18.521667
-	Dec -11.683333
-	Distance 4660
-	Radius 3.4
+	RA 18.33695989
+	Dec -17.53998857
+	Radius 12.719
+	Distance 6035.496
 }
 
-OpenCluster "IC 4725"
+OpenCluster "Theia 1471:UBC 348:UPK 27"
 {
-	RA 18.529722
-	Dec -18.883333
-	Distance 2022
-	Radius 8.5
+	RA 18.3373419
+	Dec -5.14613535
+	Radius 32.521
+	Distance 2887.315
 }
 
-OpenCluster "Ruprecht 142"
+OpenCluster "NGC 6618:Theia 846"
 {
-	RA 18.536389
-	Dec -11.770278
-	Distance 5658
-	Radius 5.4
+	RA 18.33763738
+	Dec -15.98198483
+	Radius 133.751
+	Distance 1974.913
 }
 
-OpenCluster "Ruprecht 171"
+OpenCluster "Theia 1694"
 {
-	RA 18.536389
-	Dec -15.950278
-	Distance 3718
-	Radius 6.2
+	RA 18.33882882
+	Dec -15.01761125
+	Radius 64.737
+	Distance 4843.364
 }
 
-OpenCluster "NGC 6645"
+OpenCluster "HSC 204"
 {
-	RA 18.543611
-	Dec -15.114444
-	Distance 4060
-	Radius 8.7
+	RA 18.34247673
+	Dec -12.3711663
+	Radius 72.109
+	Distance 2157.141
 }
 
-OpenCluster "NGC 6649"
+OpenCluster "HSC 44"
 {
-	RA 18.557500
-	Dec -9.596667
-	Distance 4465
-	Radius 3.2
+	RA 18.3425249
+	Dec -29.27220598
+	Radius 49.081
+	Distance 17648.486
 }
 
-OpenCluster "Alessi 40"
+OpenCluster "HSC 153"
 {
-	RA 18.609722
-	Dec -18.535000
-	Distance 2609
-	Radius 19.6
+	RA 18.3473858
+	Dec -19.99353689
+	Radius 21.099
+	Distance 5394.122
 }
 
-OpenCluster "NGC 6664"
+OpenCluster "HSC 415"
 {
-	RA 18.610278
-	Dec -6.186667
-	Distance 3796
-	Radius 6.6
+	RA 18.34996663
+	Dec 22.77173921
+	Radius 66.014
+	Distance 984.41
 }
 
-OpenCluster "IC 4756"
+OpenCluster "UBC 1017"
 {
-	RA 18.650000
-	Dec 5.450000
-	Distance 1578
-	Radius 9.0
+	RA 18.35818697
+	Dec -12.64748948
+	Radius 29.25
+	Distance 5469.338
 }
 
-OpenCluster "NGC 6683"
+OpenCluster "HSC 186"
 {
-	RA 18.703611
-	Dec -5.788333
-	Distance 3904
-	Radius 1.7
+	RA 18.36165647
+	Dec -15.79271552
+	Radius 48.704
+	Distance 9174.843
 }
 
-OpenCluster "ASCC 98"
+OpenCluster "CWNU 1877:DSH J1821.3-1417:Kronberger 2:MWSC 2898"
 {
-	RA 18.710000
-	Dec -32.370000
-	Distance 2609
-	Radius 29.6
+	RA 18.36172993
+	Dec -14.28671253
+	Radius 17.696
+	Distance 4997.637
 }
 
-OpenCluster "Trumpler 35"
+OpenCluster "OC 0029:Teutsch 263"
 {
-	RA 18.715000
-	Dec -3.866667
-	Distance 3933
-	Radius 2.9
+	RA 18.36386302
+	Dec -13.89670489
+	Radius 39.537
+	Distance 6495.765
 }
 
-OpenCluster "Berkeley 79"
+OpenCluster "HSC 183"
 {
-	RA 18.753333
-	Dec -0.783333
-	Distance 7501
-	Radius 6.5
+	RA 18.37584137
+	Dec -16.00257103
+	Radius 39.324
+	Distance 8912.174
 }
 
-OpenCluster "NGC 6694"
+OpenCluster "J1822.6-1443:Kronberger 25:MWSC 2901"
 {
-	RA 18.755000
-	Dec -8.616667
-	Distance 5218
-	Radius 5.3
+	RA 18.37780823
+	Dec -14.72427797
+	Radius 20.761
+	Distance 9957.301
 }
 
-OpenCluster "Basel 1"
+OpenCluster "HSC 194"
 {
-	RA 18.803333
-	Dec -4.150000
-	Distance 7103
-	Radius 5.2
+	RA 18.38232497
+	Dec -15.02687037
+	Radius 22.815
+	Distance 4265.019
 }
 
-OpenCluster "ASCC 99"
+OpenCluster "CWNU 1853:Kharchenko 3"
 {
-	RA 18.818056
-	Dec -17.270000
-	Distance 913
-	Radius 3.7
+	RA 18.38308424
+	Dec -14.65050353
+	Radius 25.037
+	Distance 8619.252
 }
 
-OpenCluster "Ruprecht 145"
+OpenCluster "HSC 202"
 {
-	RA 18.843333
-	Dec -17.750000
-	Distance 2172
-	Radius 11.1
+	RA 18.38487882
+	Dec -13.45228083
+	Radius 27.064
+	Distance 5693.311
 }
 
-OpenCluster "NGC 6704"
+OpenCluster "CWNU 2470"
 {
-	RA 18.845833
-	Dec -4.795000
-	Distance 9700
-	Radius 7.1
+	RA 18.39243297
+	Dec -13.31113374
+	Radius 17.278
+	Distance 5623.068
 }
 
-OpenCluster "NGC 6705"
+OpenCluster "UBC 1018"
 {
-	RA 18.851389
-	Dec -5.730000
-	Distance 6122
-	Radius 28.5
+	RA 18.39421348
+	Dec -12.9181301
+	Radius 61.543
+	Distance 7518.571
 }
 
-OpenCluster "NGC 6709"
+OpenCluster "UBC 1024"
 {
-	RA 18.855000
-	Dec 10.318333
-	Distance 3506
-	Radius 7.1
+	RA 18.39659879
+	Dec -11.52538885
+	Radius 47.009
+	Distance 7767.845
 }
 
-OpenCluster "Collinder 394"
+OpenCluster "CWNU 98"
 {
-	RA 18.871111
-	Dec -19.796667
-	Distance 2250
-	Radius 7.2
+	RA 18.39753516
+	Dec -9.88809063
+	Radius 19.786
+	Distance 4658.624
 }
 
-OpenCluster "Stephenson 1"
+OpenCluster "HSC 2957"
 {
-	RA 18.891667
-	Dec 36.916667
-	Distance 1272
-	Radius 3.7
+	RA 18.40008807
+	Dec -37.18943458
+	Radius 34.368
+	Distance 2326.286
 }
 
-OpenCluster "Berkeley 80"
+OpenCluster "Theia 3300:UBC 346"
 {
-	RA 18.906111
-	Dec -0.783333
-	Distance 4713
-	Radius 2.7
+	RA 18.40271241
+	Dec -10.5728508
+	Radius 33.068
+	Distance 5037.947
 }
 
-OpenCluster "NGC 6716"
+OpenCluster "OCSN 10"
 {
-	RA 18.909444
-	Dec -18.098333
-	Distance 2573
-	Radius 3.7
+	RA 18.40595905
+	Dec 15.68969843
+	Radius 304.564
+	Distance 1201.913
 }
 
-OpenCluster "ESO 524-01"
+OpenCluster "HSC 198"
 {
-	RA 18.943611
-	Dec -25.039167
-	Distance 9132
-	Radius 8.0
+	RA 18.40668502
+	Dec -14.49021398
+	Radius 44.293
+	Distance 10076.651
 }
 
-OpenCluster "NGC 6728"
+OpenCluster "HSC 238"
 {
-	RA 18.978889
-	Dec -7.030000
-	Distance 3261
-	Radius 7.4
+	RA 18.40669637
+	Dec -6.58233157
+	Radius 53.366
+	Distance 1196.375
 }
 
-OpenCluster "NGC 6738"
+OpenCluster "CWNU 1308"
 {
-	RA 19.022500
-	Dec 11.615000
-	Distance 2283
-	Radius 5.0
+	RA 18.40846247
+	Dec -14.05245963
+	Radius 40.289
+	Distance 8920.071
 }
 
-OpenCluster "ASCC 100"
+OpenCluster "UBC 1025"
 {
-	RA 19.026944
-	Dec 33.570000
-	Distance 1141
-	Radius 6.2
+	RA 18.40854654
+	Dec -10.56568079
+	Radius 39.483
+	Distance 7788.425
 }
 
-OpenCluster "Berkeley 81"
+OpenCluster "Collinder 378:ESO 590-20:MWSC 2910:OCL 34:Theia 1816:Trumpler 33"
 {
-	RA 19.027778
-	Dec 0.456111
-	Distance 9785
-	Radius 7.1
+	RA 18.41054638
+	Dec -19.70919957
+	Radius 50.922
+	Distance 4474.964
 }
 
-OpenCluster "NGC 6737"
+OpenCluster "HSC 2638"
 {
-	RA 19.038889
-	Dec -17.450278
-	Distance 6914
-	Radius 8.9
+	RA 18.41765357
+	Dec -81.82341955
+	Radius 44.338
+	Distance 817.41
 }
 
-OpenCluster "Alessi 56"
+OpenCluster "CWNU 2051"
 {
-	RA 19.114444
-	Dec 9.583333
-	Distance 12720
-	Radius 4.1
+	RA 18.41932629
+	Dec -14.41803287
+	Radius 61.077
+	Distance 9855.765
 }
 
-OpenCluster "NGC 6755"
+OpenCluster "OC 0031"
 {
-	RA 19.130278
-	Dec 4.266667
-	Distance 4634
-	Radius 9.4
+	RA 18.41933167
+	Dec -13.28017276
+	Radius 43.876
+	Distance 6289.137
 }
 
-OpenCluster "NGC 6756"
+OpenCluster "CWNU 2590"
 {
-	RA 19.145000
-	Dec 4.705000
-	Distance 4915
-	Radius 2.9
+	RA 18.42255349
+	Dec -12.12534512
+	Radius 62.345
+	Distance 8475.842
 }
 
-OpenCluster "Berkeley 82"
+OpenCluster "MWSC 2912:OCL 64:Ruprecht 170:Theia 1818"
 {
-	RA 19.188889
-	Dec 13.118333
-	Distance 2805
-	Radius 0.8
+	RA 18.42259209
+	Dec -10.01277374
+	Radius 42.258
+	Distance 6353.32
 }
 
-OpenCluster "ASCC 101"
+OpenCluster "Alessi 71:MWSC 2914:Mamajek 4"
 {
-	RA 19.226944
-	Dec 36.330000
-	Distance 1141
-	Radius 7.2
+	RA 18.42473176
+	Dec -50.63734376
+	Radius 340.035
+	Distance 1448.75
 }
 
-OpenCluster "ESO 282-26"
+OpenCluster "CWNU 2723"
 {
-	RA 19.231111
-	Dec -41.351667
-	Distance 4566
-	Radius 10.0
+	RA 18.42591672
+	Dec -17.65195318
+	Radius 17.723
+	Distance 4272.385
 }
 
-OpenCluster "Ruprecht 147"
+OpenCluster "HSC 227"
 {
-	RA 19.278333
-	Dec -15.716667
-	Distance 567
-	Radius 2.1
+	RA 18.42769887
+	Dec -9.74681471
+	Radius 41.528
+	Distance 6622.908
 }
 
-OpenCluster "Berkeley 44"
+OpenCluster "HSC 200"
 {
-	RA 19.286667
-	Dec 19.550000
-	Distance 5871
-	Radius 8.5
+	RA 18.42821918
+	Dec -13.93978103
+	Radius 29.669
+	Distance 11331.726
 }
 
-OpenCluster "NGC 6791"
+OpenCluster "OCSN 3"
 {
-	RA 19.348056
-	Dec 37.771667
-	Distance 19090
-	Radius 27.8
+	RA 18.43040035
+	Dec -21.0374784
+	Radius 41.015
+	Distance 493.095
 }
 
-OpenCluster "Alessi 57"
+OpenCluster "Dolidze 52a:Teutsch 265:Teutsch J1825.8-1704:UBC 341"
 {
-	RA 19.348333
-	Dec 15.676667
-	Distance 12720
-	Radius 4.6
+	RA 18.43164702
+	Dec -17.07951053
+	Radius 50.336
+	Distance 6150.925
 }
 
-OpenCluster "NGC 6793"
+OpenCluster "UBC 1594"
 {
-	RA 19.387222
-	Dec 22.141667
-	Distance 2964
-	Radius 2.6
+	RA 18.43231787
+	Dec -13.73429056
+	Radius 31.933
+	Distance 8427.72
 }
 
-OpenCluster "ASCC 102"
+OpenCluster "CWNU 132"
 {
-	RA 19.413889
-	Dec 29.950000
-	Distance 4892
-	Radius 15.4
+	RA 18.43263498
+	Dec -15.05271234
+	Radius 24.555
+	Distance 5580.304
 }
 
-OpenCluster "NGC 6800"
+OpenCluster "CWNU 2698"
 {
-	RA 19.451944
-	Dec 25.140000
-	Distance 3261
-	Radius 2.4
+	RA 18.43362389
+	Dec -14.77707707
+	Radius 45.396
+	Distance 8902.12
 }
 
-OpenCluster "ESO 525-08"
+OpenCluster "OCSN 12"
 {
-	RA 19.454444
-	Dec -22.423611
-	Distance 5349
-	Radius 4.7
+	RA 18.43423996
+	Dec 21.42100709
+	Radius 97.042
+	Distance 1504.721
 }
 
-OpenCluster "Teutsch 42"
+OpenCluster "BBD 4:Bica 3:FSR 57:MWSC 2915"
 {
-	RA 19.503611
-	Dec 18.535833
-	Distance 5218
-	Radius 0.9
+	RA 18.43449454
+	Dec -13.06040475
+	Radius 38.836
+	Distance 8668.693
 }
 
-OpenCluster "NGC 6802"
+OpenCluster "HSC 157"
 {
-	RA 19.509722
-	Dec 20.261667
-	Distance 3666
-	Radius 2.7
+	RA 18.44072531
+	Dec -19.71429058
+	Radius 113.657
+	Distance 524.562
 }
 
-OpenCluster "Kronberger 79"
+OpenCluster "LISC-III 3755:Teutsch 179:UBC 9"
 {
-	RA 19.565278
-	Dec 18.520000
-	Distance 8806
-	Radius 2.7
+	RA 18.44162672
+	Dec 26.40809359
+	Radius 32.743
+	Distance 1114.049
 }
 
-OpenCluster "Stock 1"
+OpenCluster "CWNU 1995"
 {
-	RA 19.596667
-	Dec 25.216667
-	Distance 1037
-	Radius 7.8
+	RA 18.44273063
+	Dec -16.17934792
+	Radius 24.391
+	Distance 5787.191
 }
 
-OpenCluster "Teutsch 35"
+OpenCluster "CWNU 2518"
 {
-	RA 19.598889
-	Dec 35.668333
-	Distance 2283
-	Radius 14.3
+	RA 18.44678787
+	Dec -14.92210922
+	Radius 40.599
+	Distance 5972.016
 }
 
-OpenCluster "NGC 6811"
+OpenCluster "CWNU 37"
 {
-	RA 19.621389
-	Dec 46.388333
-	Distance 3962
-	Radius 8.1
+	RA 18.44761588
+	Dec -12.47995047
+	Radius 38.787
+	Distance 6603.736
+}
+
+OpenCluster "Teutsch 268:UBC 1015"
+{
+	RA 18.44906985
+	Dec -14.10478902
+	Radius 75.004
+	Distance 9487.052
+}
+
+OpenCluster "UBC 347"
+{
+	RA 18.44954703
+	Dec -10.97881507
+	Radius 34.012
+	Distance 4206.63
+}
+
+OpenCluster "HSC 5"
+{
+	RA 18.45216135
+	Dec -33.09355306
+	Radius 24.159
+	Distance 4725.191
+}
+
+OpenCluster "NGC 6631:Collinder 379:MWSC 2916:OCL 59:OC 0033"
+{
+	RA 18.4523383
+	Dec -12.03939583
+	Radius 26.53
+	Distance 8103.984
+}
+
+OpenCluster "Theia 351:UPK 7"
+{
+	RA 18.45340784
+	Dec -17.34635758
+	Radius 30.003
+	Distance 2538.938
+}
+
+OpenCluster "NGC 6633:Melotte 201:Collinder 380:MWSC 2917:OCL 90:Theia 924"
+{
+	RA 18.45369857
+	Dec 6.55920048
+	Radius 73.315
+	Distance 1270.471
+}
+
+OpenCluster "OC 0035"
+{
+	RA 18.45581388
+	Dec -10.96335984
+	Radius 46.059
+	Distance 9447.486
+}
+
+OpenCluster "HSC 234"
+{
+	RA 18.45919101
+	Dec -8.10792682
+	Radius 54.024
+	Distance 3462.825
+}
+
+OpenCluster "CWNU 2331"
+{
+	RA 18.45942251
+	Dec -13.38944456
+	Radius 25.454
+	Distance 8856.506
+}
+
+OpenCluster "CWNU 1968"
+{
+	RA 18.45992677
+	Dec -14.03450943
+	Radius 21.039
+	Distance 6069.964
+}
+
+OpenCluster "Theia 1651:Theia 1678:Theia 2117:Theia 2741:Theia 3353:Theia 4383:UBC 343"
+{
+	RA 18.46679251
+	Dec -14.71796155
+	Radius 96.369
+	Distance 6315.575
+}
+
+OpenCluster "CWNU 2718"
+{
+	RA 18.46712814
+	Dec -12.16282841
+	Radius 22.729
+	Distance 8767.417
+}
+
+OpenCluster "HXHWL 57:PHOC 20:Theia 2510"
+{
+	RA 18.46930152
+	Dec -15.33139666
+	Radius 30.386
+	Distance 3606.484
+}
+
+OpenCluster "HSC 215"
+{
+	RA 18.4712061
+	Dec -11.458311
+	Radius 35.986
+	Distance 8913.838
+}
+
+OpenCluster "OC 0036"
+{
+	RA 18.47978622
+	Dec -10.42142492
+	Radius 91.334
+	Distance 8948.842
+}
+
+OpenCluster "CWNU 2574"
+{
+	RA 18.48081759
+	Dec -12.9465881
+	Radius 24.833
+	Distance 5593.963
+}
+
+OpenCluster "CWNU 296"
+{
+	RA 18.48321265
+	Dec -14.23548401
+	Radius 32.077
+	Distance 5855.565
+}
+
+OpenCluster "CWNU 44:CWNU 506:OC 0032:UBC 1020"
+{
+	RA 18.48332594
+	Dec -12.71001315
+	Radius 69.192
+	Distance 6523.853
+}
+
+OpenCluster "HSC 181"
+{
+	RA 18.48484931
+	Dec -17.03748063
+	Radius 58.565
+	Distance 1937.462
+}
+
+OpenCluster "HSC 207"
+{
+	RA 18.485958
+	Dec -13.10581908
+	Radius 49.297
+	Distance 1457.674
+}
+
+OpenCluster "HSC 210"
+{
+	RA 18.4894243
+	Dec -12.66959183
+	Radius 14.661
+	Distance 4548.921
+}
+
+OpenCluster "UBC 351:UPK 28"
+{
+	RA 18.49079759
+	Dec -4.98161784
+	Radius 42.538
+	Distance 2878.866
+}
+
+OpenCluster "CWNU 2406"
+{
+	RA 18.4957205
+	Dec -10.56946803
+	Radius 45.879
+	Distance 8606.972
+}
+
+OpenCluster "HSC 140"
+{
+	RA 18.49825999
+	Dec -22.15558323
+	Radius 63.192
+	Distance 20349.547
+}
+
+OpenCluster "UPK 39"
+{
+	RA 18.49851458
+	Dec 1.07627007
+	Radius 37.016
+	Distance 1417.246
+}
+
+OpenCluster "HSC 219"
+{
+	RA 18.50567698
+	Dec -10.91094866
+	Radius 114.357
+	Distance 1938.596
+}
+
+OpenCluster "HSC 139"
+{
+	RA 18.50759871
+	Dec -22.36743412
+	Radius 80.97
+	Distance 1645.43
+}
+
+OpenCluster "BBD 5:Dias 6:MWSC 2932"
+{
+	RA 18.50764699
+	Dec -12.33178382
+	Radius 40.091
+	Distance 8827.41
+}
+
+OpenCluster "HSC 226"
+{
+	RA 18.50807718
+	Dec -10.45025603
+	Radius 43.559
+	Distance 6444.198
+}
+
+OpenCluster "Theia 828"
+{
+	RA 18.51005445
+	Dec -21.71483961
+	Radius 230.25
+	Distance 1224.187
+}
+
+OpenCluster "HSC 225"
+{
+	RA 18.51591312
+	Dec -10.53336579
+	Radius 86.794
+	Distance 11687.523
+}
+
+OpenCluster "OC 0044"
+{
+	RA 18.51902887
+	Dec -6.12049738
+	Radius 35.38
+	Distance 9502.481
+}
+
+OpenCluster "HSC 221"
+{
+	RA 18.51904752
+	Dec -10.87545852
+	Radius 44.947
+	Distance 8220.51
+}
+
+OpenCluster "HSC 230"
+{
+	RA 18.52823399
+	Dec -10.16943298
+	Radius 124.433
+	Distance 9254.878
+}
+
+OpenCluster "CWWL 3567:PHOC 39:Theia 23"
+{
+	RA 18.5292173
+	Dec -3.92511013
+	Radius 34.24
+	Distance 1228.696
+}
+
+OpenCluster "HXHWL 37"
+{
+	RA 18.52930773
+	Dec -11.45950107
+	Radius 23.735
+	Distance 3506.697
+}
+
+OpenCluster "M 25:IC 4725:Melotte 204:Collinder 382:ESO 591-6:MWSC 2940:OCL 38:Theia 650"
+{
+	RA 18.52949901
+	Dec -19.13084298
+	Radius 87.583
+	Distance 2103.498
+}
+
+OpenCluster "CWNU 70"
+{
+	RA 18.53084287
+	Dec -10.14528617
+	Radius 41.728
+	Distance 6663.909
+}
+
+OpenCluster "HSC 233"
+{
+	RA 18.53108922
+	Dec -8.79048766
+	Radius 18.33
+	Distance 6197.29
+}
+
+OpenCluster "HSC 239"
+{
+	RA 18.53229046
+	Dec -7.50761149
+	Radius 44.065
+	Distance 7546.572
+}
+
+OpenCluster "CWNU 2920:Theia 4013"
+{
+	RA 18.53316706
+	Dec -13.38605828
+	Radius 61.457
+	Distance 8715.57
+}
+
+OpenCluster "MWSC 2944:OCL 50:Ruprecht 171:Theia 5903"
+{
+	RA 18.53426962
+	Dec -16.06068488
+	Radius 121.12
+	Distance 4832.865
+}
+
+OpenCluster "HSC 254"
+{
+	RA 18.53884938
+	Dec -5.37004719
+	Radius 59.291
+	Distance 17248.375
+}
+
+OpenCluster "UBC 1033"
+{
+	RA 18.53928538
+	Dec -6.8744608
+	Radius 33.184
+	Distance 6807.466
+}
+
+OpenCluster "CWNU 43:OC 0037"
+{
+	RA 18.53934676
+	Dec -10.59429197
+	Radius 21.28
+	Distance 6137.267
+}
+
+OpenCluster "HSC 134"
+{
+	RA 18.54094324
+	Dec -23.1122733
+	Radius 128.466
+	Distance 38207.568
+}
+
+OpenCluster "HSC 2823"
+{
+	RA 18.54224992
+	Dec -55.32202991
+	Radius 91.869
+	Distance 13097.715
+}
+
+OpenCluster "NGC 6645:Melotte 205:Collinder 383:MWSC 2946:OCL 48"
+{
+	RA 18.54302752
+	Dec -16.92596539
+	Radius 62.979
+	Distance 5534.271
+}
+
+OpenCluster "HSC 235"
+{
+	RA 18.54321688
+	Dec -8.45098405
+	Radius 86.51
+	Distance 3766.913
+}
+
+OpenCluster "MWSC 1408:MWSC 2945:OCL 62:Ruprecht 143"
+{
+	RA 18.54496253
+	Dec -12.15145355
+	Radius 38.966
+	Distance 8364.618
+}
+
+OpenCluster "Theia 1829:Theia 590"
+{
+	RA 18.54757431
+	Dec -13.01876428
+	Radius 23.188
+	Distance 3318.636
+}
+
+OpenCluster "HSC 195"
+{
+	RA 18.54889313
+	Dec -16.07118922
+	Radius 63.749
+	Distance 4761.541
+}
+
+OpenCluster "HSC 133"
+{
+	RA 18.54892804
+	Dec -23.36693405
+	Radius 127.843
+	Distance 32288.567
+}
+
+OpenCluster "UBC 1028"
+{
+	RA 18.55014636
+	Dec -9.40371902
+	Radius 64.881
+	Distance 8565.815
+}
+
+OpenCluster "UBC 1016"
+{
+	RA 18.55366765
+	Dec -14.29696424
+	Radius 52.17
+	Distance 5548.857
+}
+
+OpenCluster "CWNU 494:OC 0041"
+{
+	RA 18.55412106
+	Dec -7.98591825
+	Radius 23.641
+	Distance 5947.064
+}
+
+OpenCluster "CWNU 397:Theia 1976:UBC 1022"
+{
+	RA 18.55469243
+	Dec -13.05339569
+	Radius 49.894
+	Distance 7602.008
+}
+
+OpenCluster "NGC 6649:Melotte 206:Collinder 384:MWSC 2949:OCL 66:Theia 1835"
+{
+	RA 18.55724466
+	Dec -10.40202685
+	Radius 33.009
+	Distance 6394.314
+}
+
+OpenCluster "CWNU 400:UBC 1026"
+{
+	RA 18.55776149
+	Dec -10.72587767
+	Radius 33.694
+	Distance 6142.509
+}
+
+OpenCluster "CWNU 2660"
+{
+	RA 18.5584876
+	Dec -10.79227676
+	Radius 55.041
+	Distance 4908.201
+}
+
+OpenCluster "MWSC 2950:OCL 63:Ruprecht 144"
+{
+	RA 18.56072665
+	Dec -11.42147823
+	Radius 26.376
+	Distance 5298.744
+}
+
+OpenCluster "HSC 267"
+{
+	RA 18.56112661
+	Dec -4.5522319
+	Radius 43.445
+	Distance 4119.843
+}
+
+OpenCluster "HSC 258"
+{
+	RA 18.56153115
+	Dec -4.87384263
+	Radius 35.569
+	Distance 7506.391
+}
+
+OpenCluster "HSC 257"
+{
+	RA 18.56438357
+	Dec -4.95492108
+	Radius 29.011
+	Distance 6794.876
+}
+
+OpenCluster "HSC 222"
+{
+	RA 18.56784353
+	Dec -11.2086311
+	Radius 34.46
+	Distance 10395.932
+}
+
+OpenCluster "Theia 984"
+{
+	RA 18.56888886
+	Dec -13.1468569
+	Radius 26.096
+	Distance 3370.522
+}
+
+OpenCluster "Theia 1138:UPK 29"
+{
+	RA 18.57240413
+	Dec -5.42592458
+	Radius 67.844
+	Distance 2138.806
+}
+
+OpenCluster "HSC 166"
+{
+	RA 18.57606768
+	Dec -20.24130206
+	Radius 65.79
+	Distance 18095.416
+}
+
+OpenCluster "HSC 101"
+{
+	RA 18.57692618
+	Dec -26.87364187
+	Radius 49.189
+	Distance 8156.859
+}
+
+OpenCluster "CWNU 492:OC 0056:UPK 34"
+{
+	RA 18.57744685
+	Dec -1.84649431
+	Radius 23.841
+	Distance 2738.335
+}
+
+OpenCluster "HXHWL 51:UBC 1023"
+{
+	RA 18.57747596
+	Dec -13.03084983
+	Radius 18.618
+	Distance 5211.462
+}
+
+OpenCluster "HSC 250"
+{
+	RA 18.57868596
+	Dec -5.99598865
+	Radius 49.39
+	Distance 6900.212
+}
+
+OpenCluster "CWNU 1994"
+{
+	RA 18.57943941
+	Dec -11.6257466
+	Radius 19.96
+	Distance 5887.169
+}
+
+OpenCluster "CWNU 2547"
+{
+	RA 18.57957045
+	Dec -12.00869279
+	Radius 50.304
+	Distance 9120.233
+}
+
+OpenCluster "CWNU 2626"
+{
+	RA 18.58434836
+	Dec -10.6865031
+	Radius 58.98
+	Distance 8517.119
+}
+
+OpenCluster "CWNU 2540"
+{
+	RA 18.58534092
+	Dec -8.10407348
+	Radius 19.143
+	Distance 6971.519
+}
+
+OpenCluster "CWNU 2716"
+{
+	RA 18.58984654
+	Dec -8.50295043
+	Radius 46.938
+	Distance 7587.96
+}
+
+OpenCluster "CWNU 101"
+{
+	RA 18.59155646
+	Dec -9.78345735
+	Radius 29.959
+	Distance 3339.949
+}
+
+OpenCluster "HSC 479"
+{
+	RA 18.59254591
+	Dec 30.12896414
+	Radius 50.002
+	Distance 1232.974
+}
+
+OpenCluster "HSC 290"
+{
+	RA 18.59772682
+	Dec -2.3345193
+	Radius 127.255
+	Distance 15904.482
+}
+
+OpenCluster "HSC 15"
+{
+	RA 18.5981466
+	Dec -33.29082913
+	Radius 73.973
+	Distance 24069.856
+}
+
+OpenCluster "OC 0034"
+{
+	RA 18.59902012
+	Dec -12.80044266
+	Radius 19.345
+	Distance 5864.088
+}
+
+OpenCluster "HSC 271"
+{
+	RA 18.60028907
+	Dec -4.61108282
+	Radius 34.212
+	Distance 8848.429
+}
+
+OpenCluster "HSC 189"
+{
+	RA 18.60436166
+	Dec -16.99601034
+	Radius 112.34
+	Distance 1600.902
+}
+
+OpenCluster "HSC 243"
+{
+	RA 18.60488441
+	Dec -6.76277586
+	Radius 73.395
+	Distance 8142.688
+}
+
+OpenCluster "HSC 253"
+{
+	RA 18.60653588
+	Dec -5.99965923
+	Radius 23.465
+	Distance 6010.855
+}
+
+OpenCluster "HSC 128"
+{
+	RA 18.60704716
+	Dec -23.95327177
+	Radius 54.43
+	Distance 10147.149
+}
+
+OpenCluster "CWNU 1388"
+{
+	RA 18.60717868
+	Dec -8.55018621
+	Radius 45.862
+	Distance 9354.947
+}
+
+OpenCluster "NGC 6664:Collinder 385:Alessi 153:MWSC 2962:OCL 68:Theia 2336"
+{
+	RA 18.60787597
+	Dec -8.20615841
+	Radius 52.547
+	Distance 6503.536
+}
+
+OpenCluster "HSC 130"
+{
+	RA 18.60859458
+	Dec -23.92242894
+	Radius 29.301
+	Distance 2467.962
+}
+
+OpenCluster "CWNU 337"
+{
+	RA 18.61055282
+	Dec -8.90895379
+	Radius 20.184
+	Distance 5720.01
+}
+
+OpenCluster "Theia 240"
+{
+	RA 18.61282462
+	Dec -20.35702564
+	Radius 82.65
+	Distance 1340.553
+}
+
+OpenCluster "OC 0038"
+{
+	RA 18.61313782
+	Dec -10.88187239
+	Radius 29.34
+	Distance 5589.391
+}
+
+OpenCluster "Theia 403"
+{
+	RA 18.61475835
+	Dec -6.50764711
+	Radius 58.636
+	Distance 1520.495
+}
+
+OpenCluster "ASCC 97:Alessi 40:MWSC 2963:Theia 462"
+{
+	RA 18.61804723
+	Dec -19.16822916
+	Radius 51.067
+	Distance 1838.547
+}
+
+OpenCluster "DSH J1837.1-1013:OC 0039:Teutsch 117:UBC 1027"
+{
+	RA 18.61940225
+	Dec -10.23447844
+	Radius 74.803
+	Distance 10916.283
+}
+
+OpenCluster "Theia 223:UBC 32:UPK 19"
+{
+	RA 18.62145049
+	Dec -14.00302676
+	Radius 156.094
+	Distance 920.032
+}
+
+OpenCluster "HSC 251"
+{
+	RA 18.62212382
+	Dec -6.2970265
+	Radius 68.631
+	Distance 8378.068
+}
+
+OpenCluster "OC 0043"
+{
+	RA 18.62320937
+	Dec -7.56976714
+	Radius 29.82
+	Distance 8103.864
+}
+
+OpenCluster "OC 0062:Theia 37:UPK 41"
+{
+	RA 18.63080003
+	Dec 0.46068881
+	Radius 54.566
+	Distance 1523.187
+}
+
+OpenCluster "CWNU 407"
+{
+	RA 18.63314324
+	Dec -6.46585344
+	Radius 66.038
+	Distance 6540.207
+}
+
+OpenCluster "UBC 101"
+{
+	RA 18.63369809
+	Dec -7.13775997
+	Radius 63.141
+	Distance 7209.981
+}
+
+OpenCluster "UBC 1034"
+{
+	RA 18.63758828
+	Dec -6.98599361
+	Radius 23.973
+	Distance 6171.428
+}
+
+OpenCluster "UBC 1032"
+{
+	RA 18.63831847
+	Dec -9.27372827
+	Radius 33.858
+	Distance 9881.746
+}
+
+OpenCluster "HSC 349"
+{
+	RA 18.6397092
+	Dec 7.44103693
+	Radius 67.987
+	Distance 9181.466
+}
+
+OpenCluster "IC 4756:Melotte 210:Collinder 386:Graff 1:LISC-III 3449:MWSC 2967:OCL 94:Theia 1115"
+{
+	RA 18.64183122
+	Dec 5.43708948
+	Radius 86.337
+	Distance 1522.348
+}
+
+OpenCluster "HSC 261"
+{
+	RA 18.64467427
+	Dec -5.40192615
+	Radius 30.193
+	Distance 11537.427
+}
+
+OpenCluster "HSC 249"
+{
+	RA 18.64628356
+	Dec -6.56767885
+	Radius 38.899
+	Distance 6905.907
+}
+
+OpenCluster "HSC 231"
+{
+	RA 18.64732001
+	Dec -10.93304208
+	Radius 20.449
+	Distance 4416.178
+}
+
+OpenCluster "Theia 1048:UPK 17"
+{
+	RA 18.64771535
+	Dec -15.04179346
+	Radius 72.955
+	Distance 2152.322
+}
+
+OpenCluster "CWNU 1425"
+{
+	RA 18.64814993
+	Dec -6.90913837
+	Radius 68.618
+	Distance 5477.887
+}
+
+OpenCluster "Teutsch 271:UBC 1035"
+{
+	RA 18.64861073
+	Dec -6.43342831
+	Radius 53.673
+	Distance 7638.907
+}
+
+OpenCluster "UBC 1038"
+{
+	RA 18.65025343
+	Dec -5.37615091
+	Radius 26.092
+	Distance 9123.055
+}
+
+OpenCluster "UBC 107"
+{
+	RA 18.65118401
+	Dec -4.7974583
+	Radius 31.741
+	Distance 8844.167
+}
+
+OpenCluster "HSC 113"
+{
+	RA 18.65141297
+	Dec -26.55669048
+	Radius 54.074
+	Distance 19760.016
+}
+
+OpenCluster "CWNU 236"
+{
+	RA 18.65541148
+	Dec 1.15130489
+	Radius 42.202
+	Distance 1993.52
+}
+
+OpenCluster "HSC 265"
+{
+	RA 18.65564733
+	Dec -5.37947806
+	Radius 25.527
+	Distance 9885.67
+}
+
+OpenCluster "HSC 245"
+{
+	RA 18.65897787
+	Dec -7.05988378
+	Radius 19.043
+	Distance 6850.709
+}
+
+OpenCluster "Collinder 387:CWNU 2277:MWSC 2970:OCL 69:Trumpler 34"
+{
+	RA 18.66005187
+	Dec -8.42329986
+	Radius 42.599
+	Distance 9261.578
+}
+
+OpenCluster "CWNU 2543"
+{
+	RA 18.66023206
+	Dec -7.03879287
+	Radius 53.353
+	Distance 9537.939
+}
+
+OpenCluster "HSC 18"
+{
+	RA 18.66184511
+	Dec -32.96086031
+	Radius 36.29
+	Distance 14268.491
+}
+
+OpenCluster "HSC 278"
+{
+	RA 18.66375109
+	Dec -4.36897412
+	Radius 32.926
+	Distance 5211.94
+}
+
+OpenCluster "Collinder 387:MWSC 2970:OCL 69:Trumpler 34"
+{
+	RA 18.66378524
+	Dec -8.42949979
+	Radius 24.215
+	Distance 8970.64
+}
+
+OpenCluster "OC 0061"
+{
+	RA 18.66630953
+	Dec -0.33990334
+	Radius 39.015
+	Distance 5361.898
+}
+
+OpenCluster "HSC 289"
+{
+	RA 18.66797717
+	Dec -2.88903589
+	Radius 68.624
+	Distance 7309.966
+}
+
+OpenCluster "UBC 349"
+{
+	RA 18.67075273
+	Dec -7.02462853
+	Radius 52.766
+	Distance 7458.071
+}
+
+OpenCluster "PHOC 2"
+{
+	RA 18.67273867
+	Dec -3.71811101
+	Radius 37.372
+	Distance 7635.686
+}
+
+OpenCluster "UBC 1052"
+{
+	RA 18.67274887
+	Dec 7.65867915
+	Radius 88.138
+	Distance 9766.676
+}
+
+OpenCluster "HSC 272"
+{
+	RA 18.67445049
+	Dec -5.13622613
+	Radius 61.018
+	Distance 10573.197
+}
+
+OpenCluster "UPK 33"
+{
+	RA 18.67449418
+	Dec -4.36040519
+	Radius 117.251
+	Distance 1641.879
+}
+
+OpenCluster "CWNU 2221"
+{
+	RA 18.67614905
+	Dec -6.93115023
+	Radius 19.859
+	Distance 9677.305
+}
+
+OpenCluster "HSC 268"
+{
+	RA 18.67640164
+	Dec -5.32521643
+	Radius 87.162
+	Distance 10389.049
+}
+
+OpenCluster "CWNU 432:UBC 1036"
+{
+	RA 18.67650895
+	Dec -6.50602758
+	Radius 41.01
+	Distance 8749.064
+}
+
+OpenCluster "HSC 308"
+{
+	RA 18.68004336
+	Dec -0.7694449
+	Radius 19.037
+	Distance 7140.745
+}
+
+OpenCluster "CWNU 404:UBC 1031"
+{
+	RA 18.68176354
+	Dec -9.664517
+	Radius 103.614
+	Distance 7604.88
+}
+
+OpenCluster "HSC 224"
+{
+	RA 18.68190816
+	Dec -11.80396617
+	Radius 85.819
+	Distance 5517.469
+}
+
+OpenCluster "Dolidze 32:Theia 1899"
+{
+	RA 18.68287372
+	Dec -4.07938363
+	Radius 67.754
+	Distance 6510.279
+}
+
+OpenCluster "HSC 262"
+{
+	RA 18.68332306
+	Dec -5.64531231
+	Radius 101.129
+	Distance 12473.914
+}
+
+OpenCluster "HSC 284"
+{
+	RA 18.68685204
+	Dec -3.91097827
+	Radius 46.921
+	Distance 10481.285
+}
+
+OpenCluster "Dolidze 33:UBC 1041"
+{
+	RA 18.68685218
+	Dec -4.37609522
+	Radius 29.2
+	Distance 9499.935
+}
+
+OpenCluster "OC 0047:UBC 105"
+{
+	RA 18.68831101
+	Dec -5.42523305
+	Radius 22.391
+	Distance 6268.149
+}
+
+OpenCluster "ESO 591-12:FSR 48:GCL 100:MWSC 2974:Pal 8:Palomar 8"
+{
+	RA 18.69177263
+	Dec -19.82804001
+	Radius 102.081
+	Distance 29169.529
+}
+
+OpenCluster "CWNU 28:UBC 1037"
+{
+	RA 18.69248216
+	Dec -6.01036464
+	Radius 30.454
+	Distance 8240.963
+}
+
+OpenCluster "CWNU 2847:Dolidze 32"
+{
+	RA 18.69270186
+	Dec -4.1784827
+	Radius 35.145
+	Distance 6666.871
+}
+
+OpenCluster "CWNU 2310"
+{
+	RA 18.69426426
+	Dec -6.46598082
+	Radius 56.43
+	Distance 11625.148
+}
+
+OpenCluster "Theia 4208"
+{
+	RA 18.69445201
+	Dec -19.64690405
+	Radius 64.386
+	Distance 4856.943
+}
+
+OpenCluster "UBC 572"
+{
+	RA 18.69463311
+	Dec -21.98614981
+	Radius 41.495
+	Distance 4694.569
+}
+
+OpenCluster "Theia 4850:UBC 106"
+{
+	RA 18.6994762
+	Dec -5.41714154
+	Radius 69.415
+	Distance 7413.252
+}
+
+OpenCluster "HSC 552"
+{
+	RA 18.6999287
+	Dec 40.46436627
+	Radius 90.32
+	Distance 1743.127
+}
+
+OpenCluster "Theia 622"
+{
+	RA 18.70075788
+	Dec 8.58714274
+	Radius 73.257
+	Distance 1762.21
+}
+
+OpenCluster "HSC 304"
+{
+	RA 18.70218551
+	Dec -1.54590303
+	Radius 134.717
+	Distance 9512.755
+}
+
+OpenCluster "HSC 483"
+{
+	RA 18.70303378
+	Dec 29.94071615
+	Radius 60.018
+	Distance 1049.85
+}
+
+OpenCluster "NGC 6683:MWSC 2977:OCL 74"
+{
+	RA 18.70439536
+	Dec -6.22456335
+	Radius 37.581
+	Distance 9932.916
+}
+
+OpenCluster "PHOC 6"
+{
+	RA 18.70537259
+	Dec -7.23578723
+	Radius 80.716
+	Distance 7702.143
+}
+
+OpenCluster "HSC 264"
+{
+	RA 18.70550699
+	Dec -5.78375409
+	Radius 12.121
+	Distance 13054.74
+}
+
+OpenCluster "UBC 102"
+{
+	RA 18.70593608
+	Dec -6.90871489
+	Radius 42.195
+	Distance 5889.495
+}
+
+OpenCluster "DSH J1842.4-0515:MWSC 2978:Teutsch 145"
+{
+	RA 18.70817614
+	Dec -5.24969155
+	Radius 21.237
+	Distance 12159.666
+}
+
+OpenCluster "OC 0046:Theia 1953:UBC 103"
+{
+	RA 18.70826146
+	Dec -6.58592043
+	Radius 50.277
+	Distance 9757.072
+}
+
+OpenCluster "UBC 104"
+{
+	RA 18.71320454
+	Dec -6.24983203
+	Radius 47.143
+	Distance 8825.348
+}
+
+OpenCluster "CWNU 2584"
+{
+	RA 18.71523552
+	Dec -2.49985189
+	Radius 38.677
+	Distance 7408.516
+}
+
+OpenCluster "CWNU 431:UBC 1030"
+{
+	RA 18.71603435
+	Dec -10.00803869
+	Radius 34.756
+	Distance 6573.987
+}
+
+OpenCluster "OC 0050:Trumpler 35"
+{
+	RA 18.71647728
+	Dec -4.22762761
+	Radius 44.99
+	Distance 8722.563
+}
+
+OpenCluster "HSC 220"
+{
+	RA 18.7168744
+	Dec -12.48672168
+	Radius 22.788
+	Distance 5304.8
+}
+
+OpenCluster "Theia 479:UPK 18"
+{
+	RA 18.71807239
+	Dec -15.31688289
+	Radius 42.263
+	Distance 2449.836
+}
+
+OpenCluster "HSC 266"
+{
+	RA 18.71929443
+	Dec -5.78762459
+	Radius 86.139
+	Distance 17059.1
+}
+
+OpenCluster "BDSB 124"
+{
+	RA 18.72010063
+	Dec -3.62580196
+	Radius 43.229
+	Distance 9986.924
+}
+
+OpenCluster "UPK 38"
+{
+	RA 18.72136479
+	Dec -1.64276074
+	Radius 41.919
+	Distance 1884.954
+}
+
+OpenCluster "OC 0051:UBC 353"
+{
+	RA 18.72183466
+	Dec -3.73069901
+	Radius 22.038
+	Distance 6376.514
+}
+
+OpenCluster "HSC 281"
+{
+	RA 18.72299158
+	Dec -4.38196396
+	Radius 53.183
+	Distance 10829.686
+}
+
+OpenCluster "CWNU 328:UBC 1021"
+{
+	RA 18.72647078
+	Dec -14.4266316
+	Radius 48.407
+	Distance 5134.275
+}
+
+OpenCluster "HSC 285"
+{
+	RA 18.72712431
+	Dec -3.8143722
+	Radius 16.153
+	Distance 9363.605
+}
+
+OpenCluster "CWNU 387:UBC 1046"
+{
+	RA 18.72736685
+	Dec -1.01100516
+	Radius 45.761
+	Distance 6573.186
+}
+
+OpenCluster "Theia 1140"
+{
+	RA 18.72795978
+	Dec 5.6272468
+	Radius 58.042
+	Distance 2188.813
+}
+
+OpenCluster "UBC 1045"
+{
+	RA 18.73026908
+	Dec -2.87345531
+	Radius 62.646
+	Distance 6709.106
+}
+
+OpenCluster "UBC 1029"
+{
+	RA 18.73337233
+	Dec -10.79603949
+	Radius 27.732
+	Distance 5038.724
+}
+
+OpenCluster "Theia 1203"
+{
+	RA 18.73434021
+	Dec -57.17799269
+	Radius 141.78
+	Distance 1309.972
+}
+
+OpenCluster "CWNU 2666"
+{
+	RA 18.7348154
+	Dec -11.9060545
+	Radius 49.029
+	Distance 5486.802
+}
+
+OpenCluster "CWNU 1292"
+{
+	RA 18.73618195
+	Dec -3.7967969
+	Radius 45.909
+	Distance 9241.335
+}
+
+OpenCluster "Andrews-Lindsay 5:Andrews Lindsay 5"
+{
+	RA 18.73854476
+	Dec -4.92992738
+	Radius 39.651
+	Distance 12582.424
+}
+
+OpenCluster "HSC 302"
+{
+	RA 18.73910903
+	Dec -2.1220746
+	Radius 61.102
+	Distance 8465.364
+}
+
+OpenCluster "HSC 273"
+{
+	RA 18.74046605
+	Dec -5.44458045
+	Radius 67.123
+	Distance 11418.869
+}
+
+OpenCluster "Theia 627:UBC 32:UPK 20"
+{
+	RA 18.74124542
+	Dec -14.37412033
+	Radius 49.831
+	Distance 1502.9
+}
+
+OpenCluster "OC 0063"
+{
+	RA 18.74264685
+	Dec -0.29324248
+	Radius 25.571
+	Distance 8759.125
+}
+
+OpenCluster "UBC 352"
+{
+	RA 18.74820181
+	Dec -5.82320027
+	Radius 36.113
+	Distance 10497.767
+}
+
+OpenCluster "HSC 93"
+{
+	RA 18.74868915
+	Dec -28.72036583
+	Radius 87.545
+	Distance 25869.914
+}
+
+OpenCluster "Berkeley 79:MWSC 2986:OCL 86"
+{
+	RA 18.74990024
+	Dec -1.140767
+	Radius 54.725
+	Distance 7669.049
+}
+
+OpenCluster "HSC 594"
+{
+	RA 18.75031159
+	Dec 46.12301837
+	Radius 101.036
+	Distance 737.528
+}
+
+OpenCluster "CWNU 497:UBC 1043"
+{
+	RA 18.75155972
+	Dec -4.1806155
+	Radius 23.562
+	Distance 6683.492
+}
+
+OpenCluster "HSC 279"
+{
+	RA 18.75175422
+	Dec -4.85880952
+	Radius 35.107
+	Distance 12601.381
+}
+
+OpenCluster "OC 0057:Theia 1841"
+{
+	RA 18.75460948
+	Dec -2.58425221
+	Radius 52.978
+	Distance 4128.274
+}
+
+OpenCluster "M 26:NGC 6694:Melotte 212:Collinder 389:FSR 71:MWSC 2987:OCL 67"
+{
+	RA 18.75461488
+	Dec -9.38617151
+	Radius 60.331
+	Distance 5986.426
+}
+
+OpenCluster "UBC 100"
+{
+	RA 18.75589507
+	Dec -11.06920037
+	Radius 45.948
+	Distance 4180.154
+}
+
+OpenCluster "Theia 575:UPK 4"
+{
+	RA 18.75910964
+	Dec -23.76637843
+	Radius 45.765
+	Distance 2509.219
+}
+
+OpenCluster "FSR 0087:FSR 87:MWSC 2989:OC 0052"
+{
+	RA 18.76034801
+	Dec -3.60182997
+	Radius 98.417
+	Distance 7564.878
+}
+
+OpenCluster "FSR 0069:FSR 69:MWSC 2988"
+{
+	RA 18.76229505
+	Dec -10.51914482
+	Radius 25.184
+	Distance 5724.966
+}
+
+OpenCluster "HSC 137"
+{
+	RA 18.77133842
+	Dec -24.35032782
+	Radius 116.754
+	Distance 1709.403
+}
+
+OpenCluster "UBC 108"
+{
+	RA 18.77310753
+	Dec -5.17978373
+	Radius 33.952
+	Distance 4885.409
+}
+
+OpenCluster "UBC 110"
+{
+	RA 18.77676042
+	Dec -4.98542363
+	Radius 50.206
+	Distance 10379.782
+}
+
+OpenCluster "HSC 425"
+{
+	RA 18.77830763
+	Dec 21.54590802
+	Radius 54.932
+	Distance 10020.084
+}
+
+OpenCluster "CWNU 1387"
+{
+	RA 18.77979572
+	Dec -2.91740991
+	Radius 27.209
+	Distance 7036.604
+}
+
+OpenCluster "UBC 1042"
+{
+	RA 18.78787033
+	Dec -4.74307912
+	Radius 46.272
+	Distance 10772.35
+}
+
+OpenCluster "HSC 339"
+{
+	RA 18.7897252
+	Dec 3.99421132
+	Radius 15.571
+	Distance 8318.662
+}
+
+OpenCluster "FoF 1235:Theia 4017:UBC 109"
+{
+	RA 18.79053442
+	Dec -5.22444291
+	Radius 92.475
+	Distance 6421.63
+}
+
+OpenCluster "UPK 24"
+{
+	RA 18.79195786
+	Dec -11.7013855
+	Radius 157.185
+	Distance 1623.483
+}
+
+OpenCluster "HSC 23"
+{
+	RA 18.79199901
+	Dec -33.33870929
+	Radius 26.956
+	Distance 9730.856
+}
+
+OpenCluster "OC 0053:UBC 355"
+{
+	RA 18.79450997
+	Dec -3.8226527
+	Radius 60.212
+	Distance 6630.56
+}
+
+OpenCluster "CWNU 1857"
+{
+	RA 18.79753911
+	Dec -6.07645236
+	Radius 45.109
+	Distance 4646.822
+}
+
+OpenCluster "UBC 99 :UPK 13"
+{
+	RA 18.79974005
+	Dec -18.28577898
+	Radius 23.69
+	Distance 2980.094
+}
+
+OpenCluster "Apriamaswili 1:Basel 1:MWSC 2996:OCL 77"
+{
+	RA 18.80176851
+	Dec -5.86988899
+	Radius 33.78
+	Distance 5806.677
+}
+
+OpenCluster "HSC 321"
+{
+	RA 18.80290562
+	Dec 0.04259551
+	Radius 39.259
+	Distance 6710.522
+}
+
+OpenCluster "OCSN 7:Theia 711"
+{
+	RA 18.80626403
+	Dec -7.74377648
+	Radius 96.902
+	Distance 1402.632
+}
+
+OpenCluster "CWNU 1245:Theia 12"
+{
+	RA 18.80677707
+	Dec -2.38187257
+	Radius 88.71
+	Distance 2015.986
+}
+
+OpenCluster "FoF 597:UBC 117"
+{
+	RA 18.80761763
+	Dec 8.70887241
+	Radius 64.035
+	Distance 6888.473
+}
+
+OpenCluster "Alessi 191:UBC 577"
+{
+	RA 18.80899839
+	Dec 22.06131497
+	Radius 110.11
+	Distance 3206.18
+}
+
+OpenCluster "ASCC 99:MWSC 2999:Theia 518"
+{
+	RA 18.81145463
+	Dec -18.38406542
+	Radius 131.895
+	Distance 975.087
+}
+
+OpenCluster "HSC 2920"
+{
+	RA 18.81202007
+	Dec -42.59017461
+	Radius 96.949
+	Distance 1185.393
+}
+
+OpenCluster "UBC 1047"
+{
+	RA 18.81314264
+	Dec -1.0077712
+	Radius 39.645
+	Distance 8785.647
+}
+
+OpenCluster "UPK 23"
+{
+	RA 18.81331456
+	Dec -12.8825766
+	Radius 39.326
+	Distance 3131.229
+}
+
+OpenCluster "CWNU 2694:Theia 3455"
+{
+	RA 18.81453336
+	Dec 9.38324557
+	Radius 58.625
+	Distance 5870.929
+}
+
+OpenCluster "UBC 1569"
+{
+	RA 18.81792208
+	Dec -7.1242942
+	Radius 82.818
+	Distance 8441.306
+}
+
+OpenCluster "HSC 475"
+{
+	RA 18.82215202
+	Dec 28.58196541
+	Radius 90.348
+	Distance 1554.185
+}
+
+OpenCluster "FoF 2117:FoF 2118:Theia 2821:UBC 111:UBC 354"
+{
+	RA 18.8228636
+	Dec -4.48655151
+	Radius 53.399
+	Distance 5001.642
+}
+
+OpenCluster "CWNU 245:OC 0065"
+{
+	RA 18.82401341
+	Dec 3.35010015
+	Radius 66.567
+	Distance 5183.332
+}
+
+OpenCluster "Czernik 38:FSR 109:MWSC 3002:OCL 95"
+{
+	RA 18.83017227
+	Dec 4.96240739
+	Radius 31.475
+	Distance 7627.346
+}
+
+OpenCluster "OC 0064"
+{
+	RA 18.83104982
+	Dec -0.33109172
+	Radius 68.495
+	Distance 6628.974
+}
+
+OpenCluster "HSC 294"
+{
+	RA 18.83252929
+	Dec -3.48927681
+	Radius 33.737
+	Distance 6154.961
+}
+
+OpenCluster "HSC 512"
+{
+	RA 18.83526831
+	Dec 34.11555576
+	Radius 83.888
+	Distance 1135.938
+}
+
+OpenCluster "HSC 291"
+{
+	RA 18.83569106
+	Dec -4.1002288
+	Radius 37.122
+	Distance 9859.608
+}
+
+OpenCluster "CWWL 3595:Gaia 8:PHOC 41"
+{
+	RA 18.83620934
+	Dec 33.39282363
+	Radius 80.927
+	Distance 943.379
+}
+
+OpenCluster "HSC 316"
+{
+	RA 18.8364491
+	Dec -0.52407186
+	Radius 25.26
+	Distance 10255.806
+}
+
+OpenCluster "CWNU 1577"
+{
+	RA 18.8418173
+	Dec 4.2421817
+	Radius 21.847
+	Distance 4292.604
+}
+
+OpenCluster "ESO 592-2:MWSC 3005:OCL 52:Ruprecht 145:Theia 1134"
+{
+	RA 18.8438352
+	Dec -18.29345369
+	Radius 214.239
+	Distance 1927.184
+}
+
+OpenCluster "FSR 0088:FSR 88:MWSC 3006:OC 0054:OC 0055"
+{
+	RA 18.84407489
+	Dec -4.18294874
+	Radius 103.806
+	Distance 11318.716
+}
+
+OpenCluster "LISC 3301:Theia 3171:Theia 3375:UBC 118"
+{
+	RA 18.84457498
+	Dec 9.76941922
+	Radius 43.38
+	Distance 4798.795
+}
+
+OpenCluster "NGC 6704:Collinder 390:OCL 82:mWSC 3007"
+{
+	RA 18.84586011
+	Dec -5.19949634
+	Radius 28.465
+	Distance 7118.764
+}
+
+OpenCluster "HSC 192"
+{
+	RA 18.8494364
+	Dec -18.55244057
+	Radius 47.857
+	Distance 9325.674
+}
+
+OpenCluster "Wild Duck Cluster:M 11:NGC 6705:Melotte 213:Collinder 391:FSR 82:MWSC 3008:OCL 76:OC 0048:Theia 1776:Theia 2170:Theia 2622"
+{
+	RA 18.851066
+	Dec -6.2752533
+	Radius 62.162
+	Distance 7283.288
+}
+
+OpenCluster "HSC 345"
+{
+	RA 18.85284893
+	Dec 5.18125841
+	Radius 52.185
+	Distance 9592.313
+}
+
+OpenCluster "HSC 327"
+{
+	RA 18.85430613
+	Dec 1.04062905
+	Radius 21.972
+	Distance 4410.123
+}
+
+OpenCluster "NGC 6709:Melotte 214:Collinder 392:MWSC 3009:OCL 100:Theia 2542"
+{
+	RA 18.85557179
+	Dec 10.32271245
+	Radius 55.112
+	Distance 3418.301
+}
+
+OpenCluster "HSC 223"
+{
+	RA 18.8588226
+	Dec -13.35482559
+	Radius 34.936
+	Distance 10213.99
+}
+
+OpenCluster "Theia 1234:UPK 21"
+{
+	RA 18.86135451
+	Dec -15.17411159
+	Radius 224.836
+	Distance 1894.512
+}
+
+OpenCluster "UBC 1048"
+{
+	RA 18.86291087
+	Dec -1.0061957
+	Radius 37.987
+	Distance 11386.495
+}
+
+OpenCluster "Theia 242"
+{
+	RA 18.86301261
+	Dec 16.34005524
+	Radius 92.269
+	Distance 1290.208
+}
+
+OpenCluster "HSC 269"
+{
+	RA 18.8645991
+	Dec -6.72618358
+	Radius 17.42
+	Distance 5816.976
+}
+
+OpenCluster "HSC 320"
+{
+	RA 18.86513971
+	Dec -0.43656104
+	Radius 46.956
+	Distance 11187.764
+}
+
+OpenCluster "Collinder 394:ESO 592-3:MWSC 3011:OCL 42:Theia 407"
+{
+	RA 18.87054825
+	Dec -20.27190837
+	Radius 72.718
+	Distance 2294.827
+}
+
+OpenCluster "UBC 358:UPK 50"
+{
+	RA 18.88658308
+	Dec 8.19707992
+	Radius 30.489
+	Distance 3224.123
+}
+
+OpenCluster "Theia 7028:UBC 1054"
+{
+	RA 18.8874794
+	Dec 10.8655005
+	Radius 38.962
+	Distance 9302.39
+}
+
+OpenCluster "CWNU 86"
+{
+	RA 18.89065168
+	Dec -4.71655023
+	Radius 34.297
+	Distance 5248.098
+}
+
+OpenCluster "UBC 1050"
+{
+	RA 18.89129778
+	Dec -0.71198057
+	Radius 30.435
+	Distance 9820.038
+}
+
+OpenCluster "HSC 429"
+{
+	RA 18.89572677
+	Dec 21.11695646
+	Radius 127.982
+	Distance 2030.004
+}
+
+OpenCluster "CWNU 63:UBC 1044"
+{
+	RA 18.89755884
+	Dec -4.64921141
+	Radius 69.427
+	Distance 6980.319
+}
+
+OpenCluster "UPK 26"
+{
+	RA 18.89812238
+	Dec -9.83146811
+	Radius 53.54
+	Distance 2901.85
+}
+
+OpenCluster "MWSC 3018:OCL 137:Stephenson 1:delta Lyr"
+{
+	RA 18.90522297
+	Dec 36.88066358
+	Radius 66.734
+	Distance 1156.816
+}
+
+OpenCluster "Berkeley 80:MWSC 3019:OCL 87"
+{
+	RA 18.90599554
+	Dec -1.21571479
+	Radius 23.705
+	Distance 7438.677
+}
+
+OpenCluster "CWNU 2320"
+{
+	RA 18.90722464
+	Dec -5.57469628
+	Radius 31.511
+	Distance 4726.042
+}
+
+OpenCluster "NGC 6716:Collinder 393:ESO 592-5:MWSC 3020:OCL 46:Theia 407"
+{
+	RA 18.90803352
+	Dec -19.8921073
+	Radius 58.414
+	Distance 2294.827
+}
+
+OpenCluster "HSC 338"
+{
+	RA 18.90907299
+	Dec 2.90215723
+	Radius 230.499
+	Distance 5961.508
+}
+
+OpenCluster "HSC 313"
+{
+	RA 18.91251136
+	Dec -2.40737519
+	Radius 14.738
+	Distance 3489.349
+}
+
+OpenCluster "Archinal 1:MWSC 3021"
+{
+	RA 18.91390153
+	Dec 5.54980035
+	Radius 47.94
+	Distance 5555.268
+}
+
+OpenCluster "Alessi 161:UBC 3"
+{
+	RA 18.91926347
+	Dec 12.32006789
+	Radius 58.825
+	Distance 5353.871
+}
+
+OpenCluster "CWNU 448"
+{
+	RA 18.92127336
+	Dec -17.53858032
+	Radius 52.468
+	Distance 3375.251
+}
+
+OpenCluster "HSC 323"
+{
+	RA 18.92337857
+	Dec 0.23798193
+	Radius 20.389
+	Distance 9209.492
+}
+
+OpenCluster "UBC 1049"
+{
+	RA 18.9241729
+	Dec -1.25118769
+	Radius 46.37
+	Distance 9336.37
+}
+
+OpenCluster "HSC 277"
+{
+	RA 18.92696072
+	Dec -6.46175483
+	Radius 13.128
+	Distance 3236.618
+}
+
+OpenCluster "Alessi 62:MWSC 3025:Theia 1131"
+{
+	RA 18.93083785
+	Dec 21.60735561
+	Radius 121.553
+	Distance 1977.627
+}
+
+OpenCluster "FoF 2068:UBC 112"
+{
+	RA 18.93088686
+	Dec -5.10079877
+	Radius 63.603
+	Distance 6238.602
+}
+
+OpenCluster "HSC 347"
+{
+	RA 18.93576017
+	Dec 4.74272114
+	Radius 43.622
+	Distance 5943.52
+}
+
+OpenCluster "HSC 336"
+{
+	RA 18.93934447
+	Dec 2.51660893
+	Radius 23.495
+	Distance 3558.199
+}
+
+OpenCluster "Theia 4064:UBC 120"
+{
+	RA 18.94180927
+	Dec 13.25283903
+	Radius 32.482
+	Distance 3687.864
+}
+
+OpenCluster "HSC 363"
+{
+	RA 18.95220881
+	Dec 8.55187932
+	Radius 26.727
+	Distance 8087.833
+}
+
+OpenCluster "HSC 359"
+{
+	RA 18.95456654
+	Dec 8.29918362
+	Radius 107.085
+	Distance 24151.339
+}
+
+OpenCluster "UBC 350"
+{
+	RA 18.95885607
+	Dec -8.95649937
+	Radius 62.031
+	Distance 5472.062
+}
+
+OpenCluster "PHOC 38"
+{
+	RA 18.95935498
+	Dec -1.55315723
+	Radius 40.008
+	Distance 7363.171
+}
+
+OpenCluster "HSC 307"
+{
+	RA 18.96020731
+	Dec -2.96947137
+	Radius 45.169
+	Distance 12116.032
+}
+
+OpenCluster "HSC 201"
+{
+	RA 18.9685468
+	Dec -17.82773452
+	Radius 108.96
+	Distance 30590.696
+}
+
+OpenCluster "HSC 350"
+{
+	RA 18.9722937
+	Dec 5.04603347
+	Radius 36.984
+	Distance 3686.843
+}
+
+OpenCluster "HSC 164"
+{
+	RA 18.97334765
+	Dec -22.99486528
+	Radius 56.799
+	Distance 11526.792
+}
+
+OpenCluster "CWNU 2810"
+{
+	RA 18.97852889
+	Dec 0.69614453
+	Radius 45.312
+	Distance 4914.605
+}
+
+OpenCluster "HXHWL 30"
+{
+	RA 18.97885455
+	Dec -9.86199357
+	Radius 34.038
+	Distance 3411.352
+}
+
+OpenCluster "NGC 6728:MWSC 3032:Theia 3529"
+{
+	RA 18.97936712
+	Dec -8.95614536
+	Radius 43.213
+	Distance 5726.113
+}
+
+OpenCluster "UBC 576"
+{
+	RA 18.97957488
+	Dec 0.43235452
+	Radius 14.766
+	Distance 4143.519
+}
+
+OpenCluster "HSC 105"
+{
+	RA 18.98011505
+	Dec -29.09380917
+	Radius 91.584
+	Distance 14311.584
+}
+
+OpenCluster "UBC 357"
+{
+	RA 18.98344031
+	Dec -0.22827199
+	Radius 74.011
+	Distance 9263.182
+}
+
+OpenCluster "UBC 359"
+{
+	RA 18.98520022
+	Dec 10.36409622
+	Radius 60.258
+	Distance 10549.342
+}
+
+OpenCluster "HSC 782"
+{
+	RA 18.98929491
+	Dec 69.61145656
+	Radius 67.771
+	Distance 634.264
+}
+
+OpenCluster "HSC 351"
+{
+	RA 18.99461891
+	Dec 5.0846215
+	Radius 44.907
+	Distance 4261.362
+}
+
+OpenCluster "HSC 315"
+{
+	RA 18.99510841
+	Dec -1.8087212
+	Radius 80.472
+	Distance 7557.906
+}
+
+OpenCluster "UPK 72"
+{
+	RA 18.99918866
+	Dec 27.29271719
+	Radius 102.79
+	Distance 1461.383
+}
+
+OpenCluster "HSC 324"
+{
+	RA 19.00010396
+	Dec -0.30611152
+	Radius 32.422
+	Distance 9361.769
+}
+
+OpenCluster "HSC 476"
+{
+	RA 19.00126887
+	Dec 27.54252596
+	Radius 65.204
+	Distance 12709.042
+}
+
+OpenCluster "OCSN 15"
+{
+	RA 19.00661725
+	Dec 27.18952386
+	Radius 71.428
+	Distance 808.095
+}
+
+OpenCluster "Theia 3072:UBC 113"
+{
+	RA 19.00937347
+	Dec -1.55948354
+	Radius 79.357
+	Distance 7408.643
+}
+
+OpenCluster "NGC 6735:WSC 3034"
+{
+	RA 19.0093808
+	Dec -0.51193738
+	Radius 91.136
+	Distance 7157.102
+}
+
+OpenCluster "HSC 240"
+{
+	RA 19.01166435
+	Dec -10.62643938
+	Radius 34.796
+	Distance 2262.187
+}
+
+OpenCluster "CWNU 307:UBC 1058"
+{
+	RA 19.01547465
+	Dec 15.82722897
+	Radius 41.631
+	Distance 6751.234
+}
+
+OpenCluster "HSC 387"
+{
+	RA 19.01868477
+	Dec 12.43320989
+	Radius 78.06
+	Distance 7635.373
+}
+
+OpenCluster "CWNU 2753"
+{
+	RA 19.02068131
+	Dec 0.93007962
+	Radius 80.36
+	Distance 5745.727
+}
+
+OpenCluster "HSC 2986"
+{
+	RA 19.02114066
+	Dec -36.88340157
+	Radius 64.317
+	Distance 482.861
+}
+
+OpenCluster "ASCC 100:MWSC 3038"
+{
+	RA 19.02687251
+	Dec 33.60094346
+	Radius 69.067
+	Distance 1175.375
+}
+
+OpenCluster "UBC 1055"
+{
+	RA 19.02709566
+	Dec 11.73036171
+	Radius 81.541
+	Distance 10943.502
+}
+
+OpenCluster "HSC 570"
+{
+	RA 19.0277319
+	Dec 42.07868629
+	Radius 73.307
+	Distance 790.668
+}
+
+OpenCluster "Berkeley 81:MWSC 3039:OCL 88:Theia 4178"
+{
+	RA 19.02779192
+	Dec -0.45703407
+	Radius 76.58
+	Distance 11314.298
+}
+
+OpenCluster "Theia 148:UBC 26"
+{
+	RA 19.02842323
+	Dec 22.11339879
+	Radius 128.473
+	Distance 1935.806
+}
+
+OpenCluster "HSC 340"
+{
+	RA 19.03276664
+	Dec 2.32162468
+	Radius 24.867
+	Distance 6359.351
+}
+
+OpenCluster "HSC 727"
+{
+	RA 19.03466756
+	Dec 61.38158559
+	Radius 41.933
+	Distance 1176.461
+}
+
+OpenCluster "PHOC 7"
+{
+	RA 19.05180626
+	Dec 14.62616636
+	Radius 38.669
+	Distance 6095.681
+}
+
+OpenCluster "Theia 640:UPK 31"
+{
+	RA 19.06148953
+	Dec -8.48316594
+	Radius 82.594
+	Distance 1747.378
+}
+
+OpenCluster "HSC 74"
+{
+	RA 19.06925253
+	Dec -31.59649709
+	Radius 54.26
+	Distance 5460.954
+}
+
+OpenCluster "HSC 358"
+{
+	RA 19.07215751
+	Dec 6.72258116
+	Radius 143.584
+	Distance 9803.849
+}
+
+OpenCluster "HSC 353"
+{
+	RA 19.07340757
+	Dec 4.61333999
+	Radius 28.434
+	Distance 7602.87
+}
+
+OpenCluster "CWNU 235:UBC 1056"
+{
+	RA 19.07713213
+	Dec 13.40868816
+	Radius 30.978
+	Distance 5803.437
+}
+
+OpenCluster "Theia 495:UPK 54"
+{
+	RA 19.08362802
+	Dec 15.72187119
+	Radius 38.021
+	Distance 2649.618
+}
+
+OpenCluster "HSC 298"
+{
+	RA 19.08706365
+	Dec -5.21450582
+	Radius 57.853
+	Distance 10327.004
+}
+
+OpenCluster "HSC 380"
+{
+	RA 19.09488368
+	Dec 10.71352567
+	Radius 18.128
+	Distance 7168.222
+}
+
+OpenCluster "Theia 1902:UBC 114"
+{
+	RA 19.09499654
+	Dec -0.39369743
+	Radius 34.262
+	Distance 4788.661
+}
+
+OpenCluster "Theia 875:UPK 65"
+{
+	RA 19.10169779
+	Dec 23.2965751
+	Radius 61.873
+	Distance 2449.53
+}
+
+OpenCluster "Theia 1954:Theia 1957:Theia 2426:UBC 1051"
+{
+	RA 19.10371816
+	Dec 3.34192113
+	Radius 79.37
+	Distance 8703.877
+}
+
+OpenCluster "OCSN 5:Theia 222"
+{
+	RA 19.10459284
+	Dec -15.60780356
+	Radius 69.064
+	Distance 807.772
+}
+
+OpenCluster "HSC 346"
+{
+	RA 19.10559636
+	Dec 3.39767234
+	Radius 16.245
+	Distance 6398.626
+}
+
+OpenCluster "FSR 0124:FSR 124:MWSC 3066:OC 0074:SAI 127:UBC 1057"
+{
+	RA 19.11476792
+	Dec 13.25030997
+	Radius 32.284
+	Distance 9901.027
+}
+
+OpenCluster "HSC 373"
+{
+	RA 19.11993696
+	Dec 9.95696538
+	Radius 29.861
+	Distance 10386.398
+}
+
+OpenCluster "HSC 434"
+{
+	RA 19.12169588
+	Dec 20.10659994
+	Radius 76.48
+	Distance 4462.954
+}
+
+OpenCluster "HSC 177"
+{
+	RA 19.12177245
+	Dec -22.37657083
+	Radius 99.615
+	Distance 16614.02
+}
+
+OpenCluster "HSC 32"
+{
+	RA 19.12549541
+	Dec -34.67970405
+	Radius 28.373
+	Distance 7427.063
+}
+
+OpenCluster "DSH J1907.5+0617:FSR 115:Juchert 3:MWSC 3049:Masgomas 5"
+{
+	RA 19.12581885
+	Dec 6.28039948
+	Radius 38.399
+	Distance 9992.279
+}
+
+OpenCluster "NGC 6755:Collinder 397:Cernik 39:Czernik 39:DSH J1908.1+0414:FSR 0111:FSR 111:MWSC 3050:MWSC 3051:OCL 96:OCL 97:Teutsch 118"
+{
+	RA 19.12824143
+	Dec 4.34428181
+	Radius 71.804
+	Distance 10346.836
+}
+
+OpenCluster "NGC 6755:Collinder 397:MWSC 3051:OCL 96"
+{
+	RA 19.1290211
+	Dec 4.22813176
+	Radius 48.907
+	Distance 7445.985
+}
+
+OpenCluster "HSC 343"
+{
+	RA 19.13048573
+	Dec 2.33054736
+	Radius 64.312
+	Distance 1993.43
+}
+
+OpenCluster "CWNU 2581"
+{
+	RA 19.14013745
+	Dec 10.17591523
+	Radius 47.819
+	Distance 10255.619
+}
+
+OpenCluster "HSC 455"
+{
+	RA 19.14051184
+	Dec 23.38451057
+	Radius 36.446
+	Distance 2944.702
+}
+
+OpenCluster "Theia 291"
+{
+	RA 19.14477397
+	Dec -7.65297354
+	Radius 95.466
+	Distance 3364.319
+}
+
+OpenCluster "NGC 6756:Collinder 398:FSR 113:MWSC 3052:OCL 99"
+{
+	RA 19.14539841
+	Dec 4.71112861
+	Radius 47.024
+	Distance 9447.734
+}
+
+OpenCluster "HSC 332"
+{
+	RA 19.14956208
+	Dec 0.09405799
+	Radius 26.366
+	Distance 6763.139
+}
+
+OpenCluster "HSC 147"
+{
+	RA 19.15185692
+	Dec -26.02120676
+	Radius 77.089
+	Distance 1779.19
+}
+
+OpenCluster "CWNU 1518:Juchert 2"
+{
+	RA 19.15711219
+	Dec 10.33261833
+	Radius 49.406
+	Distance 10978.875
+}
+
+OpenCluster "UPK 16"
+{
+	RA 19.15771041
+	Dec -19.06890383
+	Radius 38.638
+	Distance 2628.194
+}
+
+OpenCluster "Theia 236"
+{
+	RA 19.15824512
+	Dec 13.51103158
+	Radius 41.251
+	Distance 1113.775
+}
+
+OpenCluster "HSC 276"
+{
+	RA 19.16129742
+	Dec -8.39386569
+	Radius 60.511
+	Distance 2888.863
+}
+
+OpenCluster "TRSG 4:Theia 520:UBC 1"
+{
+	RA 19.17971026
+	Dec 56.52277694
+	Radius 98.093
+	Distance 1051.596
+}
+
+OpenCluster "PHOC 40"
+{
+	RA 19.18142652
+	Dec 14.0045922
+	Radius 54.461
+	Distance 1064.18
+}
+
+OpenCluster "HSC 399"
+{
+	RA 19.1852737
+	Dec 13.87004835
+	Radius 39.213
+	Distance 9529.403
+}
+
+OpenCluster "Berkeley 82:MWSC 3065:OCL 103:Theia 2838"
+{
+	RA 19.18919601
+	Dec 13.11651856
+	Radius 24.891
+	Distance 4339.945
+}
+
+OpenCluster "CWNU 2024"
+{
+	RA 19.18956799
+	Dec 10.52460235
+	Radius 24.506
+	Distance 9098.805
+}
+
+OpenCluster "HSC 558"
+{
+	RA 19.19148982
+	Dec 38.80934537
+	Radius 64.711
+	Distance 817.166
+}
+
+OpenCluster "FSR 0123:FSR 0124:FSR 123:FSR 124:MWSC 3066:MWSC 3067:OC 0072:SAI 127"
+{
+	RA 19.19440466
+	Dec 12.04565189
+	Radius 65.114
+	Distance 13021.983
+}
+
+OpenCluster "HSC 416"
+{
+	RA 19.19508055
+	Dec 17.35726073
+	Radius 41.081
+	Distance 12903.83
+}
+
+OpenCluster "HSC 401"
+{
+	RA 19.20106071
+	Dec 13.92589801
+	Radius 32.509
+	Distance 11928.211
+}
+
+OpenCluster "HSC 180"
+{
+	RA 19.20809666
+	Dec -22.1809088
+	Radius 88.173
+	Distance 723.546
+}
+
+OpenCluster "HSC 386"
+{
+	RA 19.20915295
+	Dec 10.51295829
+	Radius 37.312
+	Distance 10079.239
+}
+
+OpenCluster "UBC 122"
+{
+	RA 19.20917519
+	Dec 15.73061229
+	Radius 80.682
+	Distance 8057.462
+}
+
+OpenCluster "CWNU 314"
+{
+	RA 19.21043616
+	Dec -9.63329176
+	Radius 61.661
+	Distance 1194.875
+}
+
+OpenCluster "OC 0073"
+{
+	RA 19.21199272
+	Dec 12.00171575
+	Radius 34.631
+	Distance 11857.199
+}
+
+OpenCluster "HSC 365"
+{
+	RA 19.21266095
+	Dec 6.93418268
+	Radius 22.029
+	Distance 5131.769
+}
+
+OpenCluster "HSC 370"
+{
+	RA 19.21774256
+	Dec 8.54293483
+	Radius 93.793
+	Distance 9262.991
+}
+
+OpenCluster "HSC 384"
+{
+	RA 19.22171379
+	Dec 9.98065698
+	Radius 73.735
+	Distance 1418.807
+}
+
+OpenCluster "ASCC 101:Alessi J1913.6+3619:LeDrew 6:MWSC 3070:Theia 445"
+{
+	RA 19.22297884
+	Dec 36.35990257
+	Radius 156.269
+	Distance 1295.805
+}
+
+OpenCluster "HSC 151"
+{
+	RA 19.22378373
+	Dec -25.89773304
+	Radius 94.317
+	Distance 1534.495
+}
+
+OpenCluster "HSC 385"
+{
+	RA 19.22600803
+	Dec 10.33261559
+	Radius 28.768
+	Distance 6608.798
+}
+
+OpenCluster "HSC 361"
+{
+	RA 19.22645761
+	Dec 6.40431079
+	Radius 26.143
+	Distance 4147.196
+}
+
+OpenCluster "CWNU 2647"
+{
+	RA 19.22951627
+	Dec 6.45347063
+	Radius 37.022
+	Distance 7712.586
+}
+
+OpenCluster "HSC 296"
+{
+	RA 19.22967925
+	Dec -6.3435325
+	Radius 36.283
+	Distance 3092.118
+}
+
+OpenCluster "Theia 952:UPK 53"
+{
+	RA 19.23529628
+	Dec 14.2690892
+	Radius 55.669
+	Distance 1906.917
+}
+
+OpenCluster "HSC 171"
+{
+	RA 19.24343696
+	Dec -23.86749095
+	Radius 40.741
+	Distance 1240.026
+}
+
+OpenCluster "HSC 462"
+{
+	RA 19.24972675
+	Dec 23.93343699
+	Radius 49.18
+	Distance 8047.211
+}
+
+OpenCluster "UBC 1053"
+{
+	RA 19.25066903
+	Dec 5.9690211
+	Radius 57.29
+	Distance 10569.344
+}
+
+OpenCluster "PHOC 8:Theia 1928"
+{
+	RA 19.25530159
+	Dec 14.4417978
+	Radius 36.484
+	Distance 8120.167
+}
+
+OpenCluster "Theia 7543:UBC 98 :UPK 12"
+{
+	RA 19.25817101
+	Dec -22.07779372
+	Radius 159.856
+	Distance 2122.977
+}
+
+OpenCluster "Theia 2011:UBC 121"
+{
+	RA 19.25859843
+	Dec 12.84732991
+	Radius 39.125
+	Distance 5181.817
+}
+
+OpenCluster "Berkeley 43:FSR 122:MWSC 3075:OCL 102:OC 0071"
+{
+	RA 19.25866629
+	Dec 11.26878748
+	Radius 114.331
+	Distance 11195.986
+}
+
+OpenCluster "CWNU 2603"
+{
+	RA 19.25962132
+	Dec 5.81637253
+	Radius 53.82
+	Distance 6286.354
+}
+
+OpenCluster "CWNU 120"
+{
+	RA 19.25983915
+	Dec 7.31046206
+	Radius 32.801
+	Distance 5345.896
+}
+
+OpenCluster "Theia 2217:UBC 125"
+{
+	RA 19.26158426
+	Dec 22.93813985
+	Radius 40.183
+	Distance 4008.739
+}
+
+OpenCluster "LISC 3404:UBC 356"
+{
+	RA 19.26160484
+	Dec -4.27933884
+	Radius 59.414
+	Distance 3378.859
+}
+
+OpenCluster "NGC 6774:MWSC 3078:OCL 65:Ruprecht 147:Theia 1531"
+{
+	RA 19.27605213
+	Dec -16.26885181
+	Radius 199.709
+	Distance 987.229
+}
+
+OpenCluster "CWNU 181"
+{
+	RA 19.27716687
+	Dec 5.81571754
+	Radius 34.327
+	Distance 3653.207
+}
+
+OpenCluster "HSC 379"
+{
+	RA 19.2794111
+	Dec 9.05773677
+	Radius 22.485
+	Distance 7908.601
+}
+
+OpenCluster "HSC 407"
+{
+	RA 19.28030415
+	Dec 14.17781624
+	Radius 179.608
+	Distance 13271.157
+}
+
+OpenCluster "HSC 375"
+{
+	RA 19.28117821
+	Dec 8.75445726
+	Radius 38.971
+	Distance 12337.595
+}
+
+OpenCluster "HSC 329"
+{
+	RA 19.28527875
+	Dec -2.22300068
+	Radius 42.639
+	Distance 5207.988
+}
+
+OpenCluster "HSC 354"
+{
+	RA 19.286075
+	Dec 3.83569888
+	Radius 25.7
+	Distance 8123.176
+}
+
+OpenCluster "Theia 836"
+{
+	RA 19.28688676
+	Dec 18.41974533
+	Radius 162.957
+	Distance 1794.717
+}
+
+OpenCluster "Berkeley 44:FSR 138:MWSC 3082:OCL 110"
+{
+	RA 19.28762972
+	Dec 19.54819668
+	Radius 81.907
+	Distance 8774.56
+}
+
+OpenCluster "HSC 569"
+{
+	RA 19.28953612
+	Dec 40.61551245
+	Radius 43.908
+	Distance 937.6
+}
+
+OpenCluster "Theia 268:UPK 56"
+{
+	RA 19.28980136
+	Dec 17.64928626
+	Radius 59.606
+	Distance 2496.416
+}
+
+OpenCluster "HSC 411"
+{
+	RA 19.2921339
+	Dec 15.30110535
+	Radius 70.591
+	Distance 18220.013
+}
+
+OpenCluster "HSC 374"
+{
+	RA 19.29499527
+	Dec 8.63162324
+	Radius 97.72
+	Distance 16501.772
+}
+
+OpenCluster "PHOC 35"
+{
+	RA 19.29559142
+	Dec 8.72019888
+	Radius 39.134
+	Distance 5148.456
+}
+
+OpenCluster "HSC 405"
+{
+	RA 19.29589847
+	Dec 13.93805328
+	Radius 34.883
+	Distance 9355.469
+}
+
+OpenCluster "Theia 625"
+{
+	RA 19.296471
+	Dec -13.77499718
+	Radius 318.791
+	Distance 1670.454
+}
+
+OpenCluster "FSR 137:GCL 111:MWSC 3084:Pal 10:Palomar 10"
+{
+	RA 19.30054498
+	Dec 18.57335345
+	Radius 130.4
+	Distance 25398.206
+}
+
+OpenCluster "CWNU 1893"
+{
+	RA 19.30142815
+	Dec 10.68485086
+	Radius 38.188
+	Distance 6601.581
+}
+
+OpenCluster "HSC 408"
+{
+	RA 19.30452849
+	Dec 14.45675871
+	Radius 38.643
+	Distance 14537.143
+}
+
+OpenCluster "HSC 252"
+{
+	RA 19.30599912
+	Dec -11.32991985
+	Radius 124.788
+	Distance 2097.372
+}
+
+OpenCluster "HSC 433"
+{
+	RA 19.30725866
+	Dec 18.74049175
+	Radius 25.304
+	Distance 4391.592
+}
+
+OpenCluster "CWNU 206"
+{
+	RA 19.30735675
+	Dec 13.19956535
+	Radius 22.384
+	Distance 6632.4
+}
+
+OpenCluster "HSC 551"
+{
+	RA 19.31126877
+	Dec 37.3319885
+	Radius 42.497
+	Distance 12108.14
+}
+
+OpenCluster "UPK 62"
+{
+	RA 19.31540541
+	Dec 20.81743833
+	Radius 28.932
+	Distance 2853.298
+}
+
+OpenCluster "HSC 493"
+{
+	RA 19.31741062
+	Dec 27.98967154
+	Radius 48.788
+	Distance 10531.305
+}
+
+OpenCluster "HSC 366"
+{
+	RA 19.31764787
+	Dec 6.12328306
+	Radius 49.512
+	Distance 14251.697
+}
+
+OpenCluster "Berkeley 45:MWSC 3086:OCL 107"
+{
+	RA 19.31835039
+	Dec 15.71689671
+	Radius 120.574
+	Distance 11596.674
+}
+
+OpenCluster "HSC 393"
+{
+	RA 19.31925172
+	Dec 11.10295618
+	Radius 47.849
+	Distance 7284.905
+}
+
+OpenCluster "HSC 403"
+{
+	RA 19.32267648
+	Dec 13.3389216
+	Radius 62.058
+	Distance 2636.577
+}
+
+OpenCluster "Juchert J1919.4+1453"
+{
+	RA 19.32434565
+	Dec 14.90344931
+	Radius 91.444
+	Distance 27929.966
+}
+
+OpenCluster "Theia 494:UPK 52"
+{
+	RA 19.32927181
+	Dec 9.64433894
+	Radius 16.323
+	Distance 2631.124
+}
+
+OpenCluster "HSC 398"
+{
+	RA 19.32949886
+	Dec 12.52812146
+	Radius 40.949
+	Distance 7865.082
+}
+
+OpenCluster "UBC 1595"
+{
+	RA 19.33005591
+	Dec -1.87229396
+	Radius 40.82
+	Distance 2964.794
+}
+
+OpenCluster "HSC 310"
+{
+	RA 19.33111087
+	Dec -5.68417585
+	Radius 259.367
+	Distance 974.878
+}
+
+OpenCluster "LISC 3279:UBC 361"
+{
+	RA 19.33343735
+	Dec 15.14706021
+	Radius 28.962
+	Distance 5000.651
+}
+
+OpenCluster "HSC 446"
+{
+	RA 19.33506956
+	Dec 20.82297762
+	Radius 33.628
+	Distance 2539.231
+}
+
+OpenCluster "CWNU 165"
+{
+	RA 19.33880916
+	Dec 4.33004471
+	Radius 29.743
+	Distance 4551.232
+}
+
+OpenCluster "HSC 534"
+{
+	RA 19.34361243
+	Dec 34.14721798
+	Radius 33.896
+	Distance 1197.531
+}
+
+OpenCluster "HSC 348"
+{
+	RA 19.34539819
+	Dec 1.64394572
+	Radius 40.151
+	Distance 3602.013
+}
+
+OpenCluster "NGC 6791:Berkeley 46:FSR 186:MWSC 3088:OCL 142:Theia 7859"
+{
+	RA 19.34799729
+	Dec 37.77428119
+	Radius 165.036
+	Distance 13664.105
+}
+
+OpenCluster "CWNU 1556"
+{
+	RA 19.34941985
+	Dec 13.29968328
+	Radius 66.079
+	Distance 11605.54
+}
+
+OpenCluster "HSC 406"
+{
+	RA 19.35258927
+	Dec 13.58830678
+	Radius 59.77
+	Distance 9161.994
+}
+
+OpenCluster "HSC 402"
+{
+	RA 19.35281686
+	Dec 12.86478998
+	Radius 33.313
+	Distance 5136.522
+}
+
+OpenCluster "OC 0070"
+{
+	RA 19.36012011
+	Dec 9.08245591
+	Radius 40.29
+	Distance 2785.582
+}
+
+OpenCluster "Theia 978"
+{
+	RA 19.36139864
+	Dec 22.34119629
+	Radius 92.659
+	Distance 2421.78
+}
+
+OpenCluster "HSC 438"
+{
+	RA 19.36586584
+	Dec 19.26881421
+	Radius 66.53
+	Distance 14753.945
+}
+
+OpenCluster "HSC 397"
+{
+	RA 19.36681956
+	Dec 11.53148145
+	Radius 61.719
+	Distance 10971.213
+}
+
+OpenCluster "HSC 711"
+{
+	RA 19.36975903
+	Dec 58.87125328
+	Radius 22.697
+	Distance 4786.221
+}
+
+OpenCluster "HSC 412"
+{
+	RA 19.3730747
+	Dec 15.14049161
+	Radius 38.173
+	Distance 11930.867
+}
+
+OpenCluster "LISC 3121:UBC 119"
+{
+	RA 19.37376051
+	Dec 8.42229883
+	Radius 42.409
+	Distance 5429.454
+}
+
+OpenCluster "HSC 437"
+{
+	RA 19.37460723
+	Dec 19.14004166
+	Radius 21.375
+	Distance 2635.279
+}
+
+OpenCluster "DSH J1922.5+1240:Juchert 1:MWSC 3095"
+{
+	RA 19.37571702
+	Dec 12.66951185
+	Radius 48.749
+	Distance 10642.555
+}
+
+OpenCluster "HSC 572"
+{
+	RA 19.37880677
+	Dec 40.62193951
+	Radius 55.656
+	Distance 1032.966
+}
+
+OpenCluster "Theia 1796"
+{
+	RA 19.38084004
+	Dec 18.70896024
+	Radius 42.963
+	Distance 3489.839
+}
+
+OpenCluster "HSC 532"
+{
+	RA 19.38144506
+	Dec 33.69080976
+	Radius 49.005
+	Distance 1782.01
+}
+
+OpenCluster "NGC 6793:MWSC 3098:OCL 115:Theia 738"
+{
+	RA 19.38218368
+	Dec 22.15477741
+	Radius 18.263
+	Distance 1510.056
+}
+
+OpenCluster "NGC 6793:MWSC 3098:OCL 115:Theia 738"
+{
+	RA 19.38783595
+	Dec 22.16406267
+	Radius 154.715
+	Distance 1911.803
+}
+
+OpenCluster "HSC 413"
+{
+	RA 19.38950507
+	Dec 15.41023957
+	Radius 34.283
+	Distance 9554.568
+}
+
+OpenCluster "HSC 466"
+{
+	RA 19.39217683
+	Dec 23.32930436
+	Radius 46.326
+	Distance 7257.582
+}
+
+OpenCluster "HSC 368"
+{
+	RA 19.39290401
+	Dec 5.96870531
+	Radius 30.666
+	Distance 7109.55
+}
+
+OpenCluster "HSC 191"
+{
+	RA 19.3944928
+	Dec -22.08912514
+	Radius 75.599
+	Distance 916.706
+}
+
+OpenCluster "UBC 575"
+{
+	RA 19.39558095
+	Dec -5.09339179
+	Radius 72.975
+	Distance 3320.972
+}
+
+OpenCluster "CWNU 1187:Theia 708"
+{
+	RA 19.39657447
+	Dec 53.29107345
+	Radius 66.335
+	Distance 1477.407
+}
+
+OpenCluster "Theia 202"
+{
+	RA 19.39850156
+	Dec -2.98846339
+	Radius 93.057
+	Distance 2678.381
+}
+
+OpenCluster "CWNU 2325"
+{
+	RA 19.40274969
+	Dec -7.85648752
+	Radius 50.053
+	Distance 4224.727
+}
+
+OpenCluster "HSC 471"
+{
+	RA 19.40552228
+	Dec 23.81098585
+	Radius 56.469
+	Distance 4388.404
+}
+
+OpenCluster "FSR 0134:FSR 134:MWSC 3112"
+{
+	RA 19.40856858
+	Dec 16.88624079
+	Radius 94.537
+	Distance 13376.87
+}
+
+OpenCluster "FSR 127:King 25:MWSC 3113:OCL 106"
+{
+	RA 19.40890724
+	Dec 13.69719937
+	Radius 41.31
+	Distance 9110.487
+}
+
+OpenCluster "HSC 255"
+{
+	RA 19.41241555
+	Dec -11.72044989
+	Radius 82.996
+	Distance 1582.315
+}
+
+OpenCluster "HSC 212"
+{
+	RA 19.41497775
+	Dec -18.37633376
+	Radius 59.224
+	Distance 7565.14
+}
+
+OpenCluster "HSC 431"
+{
+	RA 19.41623005
+	Dec 17.54328518
+	Radius 166.533
+	Distance 28160.515
+}
+
+OpenCluster "HSC 436"
+{
+	RA 19.42061741
+	Dec 18.72450673
+	Radius 95.991
+	Distance 14016.982
+}
+
+OpenCluster "DSH J1925.2+1356:Kronberger 13:MWSC 3116:UBC 1059"
+{
+	RA 19.42070045
+	Dec 13.94836826
+	Radius 53.573
+	Distance 9673.126
+}
+
+OpenCluster "CWNU 2630:Dolidze 35"
+{
+	RA 19.42477796
+	Dec 11.63683287
+	Radius 59.337
+	Distance 7440.95
+}
+
+OpenCluster "HSC 443"
+{
+	RA 19.42647355
+	Dec 19.7211932
+	Radius 63.669
+	Distance 3362.317
+}
+
+OpenCluster "HSC 510"
+{
+	RA 19.43452627
+	Dec 29.96327021
+	Radius 47.282
+	Distance 1819.117
+}
+
+OpenCluster "HSC 300"
+{
+	RA 19.44045319
+	Dec -7.68659521
+	Radius 120.533
+	Distance 1867.434
+}
+
+OpenCluster "CWNU 1285"
+{
+	RA 19.44407841
+	Dec 17.81131887
+	Radius 88.687
+	Distance 8436.652
+}
+
+OpenCluster "UBC 116:UPK 45"
+{
+	RA 19.44663831
+	Dec 0.22629784
+	Radius 80.106
+	Distance 2820.919
+}
+
+OpenCluster "OC 0078"
+{
+	RA 19.44732302
+	Dec 19.62792097
+	Radius 26.42
+	Distance 5213.385
+}
+
+OpenCluster "OCSN 13:OC 0083:Theia 38"
+{
+	RA 19.44967948
+	Dec 21.11655537
+	Radius 159.975
+	Distance 1627.136
+}
+
+OpenCluster "NGC 6800:MWSC 3123:OCL 123:Theia 3363"
+{
+	RA 19.45070078
+	Dec 25.16316113
+	Radius 66.599
+	Distance 3335.252
+}
+
+OpenCluster "Gulliver 37:Theia 3585:Theia 6281"
+{
+	RA 19.47161326
+	Dec 25.35755037
+	Radius 34.636
+	Distance 4827.073
+}
+
+OpenCluster "Berkeley 47:MWSC 3126:OCL 109"
+{
+	RA 19.47509671
+	Dec 17.36091091
+	Radius 48.974
+	Distance 7557.928
+}
+
+OpenCluster "King 26:MWSC 3128:OCL 108"
+{
+	RA 19.48236334
+	Dec 14.88064152
+	Radius 57.193
+	Distance 7359.774
+}
+
+OpenCluster "HSC 330"
+{
+	RA 19.48532269
+	Dec -3.0789282
+	Radius 46.039
+	Distance 2565.05
+}
+
+OpenCluster "Theia 3721"
+{
+	RA 19.49121918
+	Dec 23.11600496
+	Radius 42.138
+	Distance 4404.282
+}
+
+OpenCluster "UBC 1063"
+{
+	RA 19.49449767
+	Dec 19.44177077
+	Radius 51.862
+	Distance 13169.081
+}
+
+OpenCluster "FSR 0133:FSR 133:MWSC 3130:OC 0076:SAI 128"
+{
+	RA 19.49649039
+	Dec 15.56009999
+	Radius 90.416
+	Distance 11228.638
+}
+
+OpenCluster "HSC 394"
+{
+	RA 19.49766717
+	Dec 10.19647281
+	Radius 12.815
+	Distance 3881.059
+}
+
+OpenCluster "UBC 360"
+{
+	RA 19.49915295
+	Dec 10.6489788
+	Radius 70.465
+	Distance 9566.159
+}
+
+OpenCluster "HSC 441"
+{
+	RA 19.5058234
+	Dec 18.27863179
+	Radius 44.359
+	Distance 4030.741
+}
+
+OpenCluster "UPK 40"
+{
+	RA 19.50605326
+	Dec -7.20116827
+	Radius 68.501
+	Distance 2082.168
+}
+
+OpenCluster "HSC 389"
+{
+	RA 19.50621051
+	Dec 8.86838474
+	Radius 69.66
+	Distance 10666.245
+}
+
+OpenCluster "NGC 6802:Collinder 400:FSR 141:MWSC 3134:OCL 114"
+{
+	RA 19.50975654
+	Dec 20.25833681
+	Radius 41.04
+	Distance 9030.555
+}
+
+OpenCluster "CWNU 2674"
+{
+	RA 19.51660313
+	Dec 22.03490429
+	Radius 32.805
+	Distance 7505.552
+}
+
+OpenCluster "HSC 430"
+{
+	RA 19.51909685
+	Dec 16.71924907
+	Radius 38.699
+	Distance 8546.287
+}
+
+OpenCluster "HSC 426"
+{
+	RA 19.52747273
+	Dec 16.16175425
+	Radius 60.537
+	Distance 3312.374
+}
+
+OpenCluster "HSC 371"
+{
+	RA 19.52803123
+	Dec 6.38014292
+	Radius 32.821
+	Distance 7812.571
+}
+
+OpenCluster "CWNU 122:UBC 1060"
+{
+	RA 19.53145378
+	Dec 16.53911651
+	Radius 25.585
+	Distance 6628.469
+}
+
+OpenCluster "Theia 333"
+{
+	RA 19.5328085
+	Dec 26.86307371
+	Radius 76.542
+	Distance 2032.008
+}
+
+OpenCluster "Theia 171"
+{
+	RA 19.53871752
+	Dec 31.99509981
+	Radius 296.593
+	Distance 1674.101
+}
+
+OpenCluster "HSC 449"
+{
+	RA 19.54702232
+	Dec 19.37218138
+	Radius 82.98
+	Distance 13654.44
+}
+
+OpenCluster "UBC 1597"
+{
+	RA 19.55272666
+	Dec 16.87436021
+	Radius 58.314
+	Distance 8752.527
+}
+
+OpenCluster "UBC 1062"
+{
+	RA 19.55732318
+	Dec 18.26181181
+	Radius 59.673
+	Distance 10231.36
+}
+
+OpenCluster "CWNU 2713"
+{
+	RA 19.55994578
+	Dec 17.4181454
+	Radius 66.324
+	Distance 11577.005
+}
+
+OpenCluster "HSC 451"
+{
+	RA 19.56078091
+	Dec 19.44429451
+	Radius 25.529
+	Distance 8664.744
+}
+
+OpenCluster "Alessi J1933.7+1147"
+{
+	RA 19.56221461
+	Dec 11.79094954
+	Radius 18.164
+	Distance 3075.533
+}
+
+OpenCluster "DSH J1933.9+1831:Kronberger 79"
+{
+	RA 19.56508048
+	Dec 18.51844051
+	Radius 68.777
+	Distance 15621.995
+}
+
+OpenCluster "CWNU 1521"
+{
+	RA 19.56687756
+	Dec 18.98345183
+	Radius 42.661
+	Distance 8902.392
+}
+
+OpenCluster "XDOCC 9"
+{
+	RA 19.57435953
+	Dec 24.77284997
+	Radius 59.84
+	Distance 1791.488
+}
+
+OpenCluster "Gulliver 28:Theia 955"
+{
+	RA 19.57694968
+	Dec 18.16389907
+	Radius 99.207
+	Distance 2053.354
+}
+
+OpenCluster "CWNU 347:Theia 253"
+{
+	RA 19.57898389
+	Dec 32.1221016
+	Radius 89.204
+	Distance 1363.776
+}
+
+OpenCluster "HSC 482"
+{
+	RA 19.58573737
+	Dec 24.13322028
+	Radius 68.706
+	Distance 2702.774
+}
+
+OpenCluster "HSC 432"
+{
+	RA 19.58866706
+	Dec 16.47687572
+	Radius 70.18
+	Distance 8570.371
+}
+
+OpenCluster "UPK 80"
+{
+	RA 19.58953981
+	Dec 28.12820997
+	Radius 58.314
+	Distance 2915.979
+}
+
+OpenCluster "LISC-III 3263:Theia 1041:Theia 329:UBC 115:UPK 42"
+{
+	RA 19.59451004
+	Dec -3.66617345
+	Radius 63.403
+	Distance 1893.409
+}
+
+OpenCluster "OCL 127:Stock 1:Theia 821"
+{
+	RA 19.59896908
+	Dec 25.18832336
+	Radius 119.191
+	Distance 1312.7
+}
+
+OpenCluster "OC 0084"
+{
+	RA 19.60187431
+	Dec 20.55185785
+	Radius 49.882
+	Distance 8319.109
+}
+
+OpenCluster "HSC 301"
+{
+	RA 19.60264502
+	Dec -8.81347501
+	Radius 41.939
+	Distance 7661.339
+}
+
+OpenCluster "HSC 470"
+{
+	RA 19.60273442
+	Dec 22.30107545
+	Radius 48.647
+	Distance 11691.398
+}
+
+OpenCluster "OCSN 19"
+{
+	RA 19.60320578
+	Dec 29.61483271
+	Radius 77.366
+	Distance 988.804
+}
+
+OpenCluster "ASCC 103:Teutsch 35:Teutsch J1935.9+3540:Theia 457"
+{
+	RA 19.6056139
+	Dec 35.70828544
+	Radius 98.124
+	Distance 1597.722
+}
+
+OpenCluster "Theia 4877"
+{
+	RA 19.61106806
+	Dec 45.12656983
+	Radius 71.981
+	Distance 4137.25
+}
+
+OpenCluster "UBC 123"
+{
+	RA 19.61160576
+	Dec 18.23682211
+	Radius 25.771
+	Distance 7533.97
+}
+
+OpenCluster "HSC 428"
+{
+	RA 19.61203559
+	Dec 15.79040653
+	Radius 15.15
+	Distance 5374.119
+}
+
+OpenCluster "HSC 458"
+{
+	RA 19.61837046
+	Dec 20.49131976
+	Radius 50.477
+	Distance 13271.918
+}
+
+OpenCluster "Theia 2592:UBC 27"
+{
+	RA 19.62252182
+	Dec 15.59541497
+	Radius 24.863
+	Distance 3613.847
+}
+
+OpenCluster "NGC 6811:Melotte 222:Collinder 402:FSR 228:OCL 185:Theia 5603"
+{
+	RA 19.62292608
+	Dec 46.36411472
+	Radius 41.969
+	Distance 3620.605
+}
+
+OpenCluster "DSH J1937.3+1841:Teutsch 27"
+{
+	RA 19.6229431
+	Dec 18.70133847
+	Radius 27.931
+	Distance 11241.882
+}
+
+OpenCluster "HSC 454"
+{
+	RA 19.62440695
+	Dec 19.74966419
+	Radius 38.086
+	Distance 5965.575
+}
+
+OpenCluster "HSC 491"
+{
+	RA 19.63871404
+	Dec 25.4469054
+	Radius 34.267
+	Distance 3740.448
+}
+
+OpenCluster "Theia 329:UPK 46"
+{
+	RA 19.64174839
+	Dec -1.31249267
+	Radius 110.214
+	Distance 2179.076
+}
+
+OpenCluster "UBC 1067"
+{
+	RA 19.64377724
+	Dec 23.95014628
+	Radius 61.779
+	Distance 14412.243
+}
+
+OpenCluster "HSC 447"
+{
+	RA 19.64397254
+	Dec 18.55095559
+	Radius 47.852
+	Distance 2989.223
+}
+
+OpenCluster "HSC 744"
+{
+	RA 19.64512586
+	Dec 63.34558372
+	Radius 37.084
+	Distance 11607.185
 }
 
 OpenCluster "ASCC 104"
 {
-	RA 19.648056
-	Dec 18.690000
-	Distance 2609
-	Radius 21.9
+	RA 19.64638903
+	Dec 18.61877529
+	Radius 104.998
+	Distance 1330.63
 }
 
-OpenCluster "Kronberger 31"
+OpenCluster "CWNU 373:Theia 2921"
 {
-	RA 19.669722
-	Dec 26.263333
-	Distance 38813
-	Radius 7.3
+	RA 19.65344391
+	Dec 23.80282525
+	Radius 39.12
+	Distance 4171.013
 }
 
-OpenCluster "NGC 6819"
+OpenCluster "ASCC 106:Alessi 44:MWSC 3164:OC 0069"
 {
-	RA 19.688333
-	Dec 40.186667
-	Distance 7697
-	Radius 5.6
+	RA 19.65354772
+	Dec 2.33100921
+	Radius 93.385
+	Distance 2086.711
 }
 
-OpenCluster "ASCC 105"
+OpenCluster "HSC 489"
 {
-	RA 19.696111
-	Dec 27.380000
-	Distance 1630
-	Radius 17.1
+	RA 19.65392948
+	Dec 24.83974234
+	Radius 88.382
+	Distance 18030.77
 }
 
-OpenCluster "Alessi 44"
+OpenCluster "HSC 457"
 {
-	RA 19.709167
-	Dec 1.523056
-	Distance 1630
-	Radius 18.8
+	RA 19.65448722
+	Dec 20.17282904
+	Radius 54.002
+	Distance 11204.437
 }
 
-OpenCluster "Czernik 40"
+OpenCluster "OC 0077"
 {
-	RA 19.710000
-	Dec 21.153889
-	Distance 10078
-	Radius 21.1
+	RA 19.6580763
+	Dec 16.44927587
+	Radius 66.42
+	Distance 2941.317
 }
 
-OpenCluster "Teutsch 43"
+OpenCluster "HSC 392"
 {
-	RA 19.713056
-	Dec 29.855556
-	Distance 26419
-	Radius 5.0
+	RA 19.66191259
+	Dec 8.26762595
+	Radius 26.233
+	Distance 6542.45
 }
 
-OpenCluster "NGC 6823"
+OpenCluster "Theia 2395:UBC 1069"
 {
-	RA 19.719167
-	Dec 23.300000
-	Distance 10359
-	Radius 9.0
+	RA 19.6646101
+	Dec 24.78435976
+	Radius 71.713
+	Distance 9613.859
 }
 
-OpenCluster "Turner 9"
+OpenCluster "UBC 126"
 {
-	RA 19.746944
-	Dec 29.265000
-	Distance 2778
-	Radius 13.3
+	RA 19.66527625
+	Dec 20.05289383
+	Radius 19.524
+	Distance 8069.299
 }
 
-OpenCluster "Roslund 1"
+OpenCluster "HSC 456"
 {
-	RA 19.750000
-	Dec 17.516667
-	Distance 2716
-	Radius 1.2
+	RA 19.66957241
+	Dec 19.97614065
+	Radius 47.118
+	Distance 4969.428
 }
 
-OpenCluster "Kronberger 4"
+OpenCluster "Theia 745:UBC 27"
 {
-	RA 19.753056
-	Dec 28.161111
-	Distance 25767
-	Radius 4.9
+	RA 19.67218561
+	Dec 15.81573193
+	Radius 74.443
+	Distance 2333.011
 }
 
-OpenCluster "Roslund 2"
+OpenCluster "HSC 486"
 {
-	RA 19.756667
-	Dec 23.916667
-	Distance 5437
-	Radius 11.1
+	RA 19.67382107
+	Dec 24.24729093
+	Radius 58.616
+	Distance 12622.77
 }
 
-OpenCluster "Turner 1"
+OpenCluster "CWNU 2258:Theia 2395"
 {
-	RA 19.806944
-	Dec 27.293056
-	Distance 5463
-	Radius 3.2
+	RA 19.67392131
+	Dec 24.2444203
+	Radius 151.07
+	Distance 12601.567
 }
 
-OpenCluster "ASCC 107"
+OpenCluster "HSC 444"
 {
-	RA 19.808889
-	Dec 21.960000
-	Distance 2283
-	Radius 4.4
+	RA 19.67511926
+	Dec 17.78522837
+	Radius 109.68
+	Distance 9829.682
 }
 
-OpenCluster "NGC 6827"
+OpenCluster "CWNU 313"
 {
-	RA 19.814722
-	Dec 21.215000
-	Distance 13372
-	Radius 5.8
+	RA 19.67586495
+	Dec -1.99248423
+	Radius 120.6
+	Distance 1858.658
 }
 
-OpenCluster "NGC 6828"
+OpenCluster "HSC 2908"
 {
-	RA 19.838056
-	Dec 7.903333
-	Distance 1957
-	Radius 2.6
+	RA 19.6772393
+	Dec -46.60048281
+	Radius 92.985
+	Distance 12852.119
 }
 
-OpenCluster "NGC 6830"
+OpenCluster "HSC 450"
 {
-	RA 19.849722
-	Dec 23.100000
-	Distance 5345
-	Radius 3.9
+	RA 19.67761425
+	Dec 18.48038203
+	Radius 59.984
+	Distance 2853.324
 }
 
-OpenCluster "Czernik 41"
+OpenCluster "UPK 74"
 {
-	RA 19.850278
-	Dec 25.268611
-	Distance 4435
-	Radius 2.8
+	RA 19.68074838
+	Dec 22.48085634
+	Radius 32.925
+	Distance 1820.837
 }
 
-OpenCluster "Saurer 6"
+OpenCluster "HSC 480"
 {
-	RA 19.850556
-	Dec 32.243056
-	Distance 30431
-	Radius 8.0
+	RA 19.68217115
+	Dec 23.03590698
+	Radius 152.938
+	Distance 12477.676
 }
 
-OpenCluster "NGC 6834"
+OpenCluster "CWNU 1813"
 {
-	RA 19.870000
-	Dec 29.408333
-	Distance 6741
-	Radius 4.9
+	RA 19.68218822
+	Dec 22.62540779
+	Radius 38.007
+	Distance 11834.459
 }
 
-OpenCluster "Harvard 20"
+OpenCluster "NGC 6819:Melotte 223:Collinder 403:FSR 202:MWSC 3155:OCL 155:Theia 7522:Theia 8171"
 {
-	RA 19.885000
-	Dec 18.333333
-	Distance 5022
-	Radius 5.1
+	RA 19.68811717
+	Dec 40.18986975
+	Radius 108.232
+	Distance 8187.505
 }
 
-OpenCluster "ASCC 108"
+OpenCluster "HSC 2741"
 {
-	RA 19.896944
-	Dec 39.370000
-	Distance 3587
-	Radius 13.8
+	RA 19.69049615
+	Dec -66.83647395
+	Radius 23.354
+	Distance 4140.651
 }
 
-OpenCluster "ASCC 109"
+OpenCluster "Theia 316"
 {
-	RA 19.900000
-	Dec 34.580000
-	Distance 1467
-	Radius 12.8
+	RA 19.69083655
+	Dec 21.29799567
+	Radius 87.328
+	Distance 3366.638
 }
 
-OpenCluster "Loiano 1"
+OpenCluster "OC 0082:Theia 4913:Theia 5174:UBC 124"
 {
-	RA 19.970556
-	Dec 32.545000
-	Distance 8806
-	Radius 7.7
+	RA 19.69441927
+	Dec 19.04061905
+	Radius 63.14
+	Distance 8644.879
 }
 
-OpenCluster "Roslund 3"
+OpenCluster "CWNU 2758"
 {
-	RA 19.978333
-	Dec 20.483333
-	Distance 4784
-	Radius 3.5
+	RA 19.69483253
+	Dec 26.15034893
+	Radius 107.281
+	Distance 13648.391
 }
 
-OpenCluster "Teutsch 8"
+OpenCluster "HSC 497"
 {
-	RA 20.039722
-	Dec 35.311389
-	Distance 5218
-	Radius 0.8
+	RA 19.69630441
+	Dec 25.48664993
+	Radius 68.354
+	Distance 4537.234
 }
 
-OpenCluster "Dolidze 36"
+OpenCluster "ASCC 105:MWSC 3157:Theia 165:Theia 544"
 {
-	RA 20.041667
-	Dec 42.100000
-	Distance 2935
-	Radius 6.0
+	RA 19.69810681
+	Dec 27.38609425
+	Radius 84.821
+	Distance 1804.816
 }
 
-OpenCluster "ASCC 110"
+OpenCluster "CWNU 2364"
 {
-	RA 20.050000
-	Dec 33.570000
-	Distance 2609
-	Radius 10.5
+	RA 19.7010461
+	Dec 24.19336869
+	Radius 97.995
+	Distance 12729.481
 }
 
-OpenCluster "NGC 6866"
+OpenCluster "HSC 461"
 {
-	RA 20.065278
-	Dec 44.158333
-	Distance 4729
-	Radius 9.6
+	RA 19.70399455
+	Dec 20.18389646
+	Radius 100.057
+	Distance 15241.571
 }
 
-OpenCluster "Alessi 10"
+OpenCluster "Theia 553"
 {
-	RA 20.079444
-	Dec -9.521667
-	Distance 1673
-	Radius 4.4
+	RA 19.70465681
+	Dec 17.83098897
+	Radius 147.039
+	Distance 2299.8
+}
+
+OpenCluster "CWNU 440"
+{
+	RA 19.70614063
+	Dec 22.31141016
+	Radius 36.384
+	Distance 3697.733
+}
+
+OpenCluster "MWSC 3159:Skiff J1942+38.6"
+{
+	RA 19.7071462
+	Dec 38.64520544
+	Radius 40.079
+	Distance 8063.11
+}
+
+OpenCluster "CWNU 1183:Theia 540:Theia 833"
+{
+	RA 19.70737874
+	Dec 38.27214217
+	Radius 158.954
+	Distance 1538.444
+}
+
+OpenCluster "HSC 564"
+{
+	RA 19.7080237
+	Dec 37.09491842
+	Radius 23.32
+	Distance 3691.796
+}
+
+OpenCluster "Czernik 40:King 27:MWSC 3161:OCL 118"
+{
+	RA 19.71077122
+	Dec 21.15493064
+	Radius 74.435
+	Distance 14405.139
+}
+
+OpenCluster "HSC 511"
+{
+	RA 19.71137512
+	Dec 28.306066
+	Radius 221.691
+	Distance 41790.688
+}
+
+OpenCluster "PHOC 13:Theia 1754"
+{
+	RA 19.71257418
+	Dec 23.65337951
+	Radius 25.493
+	Distance 5684.982
+}
+
+OpenCluster "UBC 1061"
+{
+	RA 19.71305065
+	Dec 15.7060351
+	Radius 81.739
+	Distance 10828.269
+}
+
+OpenCluster "HSC 391"
+{
+	RA 19.71524409
+	Dec 7.61084835
+	Radius 24.482
+	Distance 4152.897
+}
+
+OpenCluster "HSC 463"
+{
+	RA 19.71773189
+	Dec 20.49189051
+	Radius 43.025
+	Distance 9784.494
+}
+
+OpenCluster "HSC 404"
+{
+	RA 19.7182607
+	Dec 10.36514048
+	Radius 31.549
+	Distance 3141.268
+}
+
+OpenCluster "ASCC 106:Alessi 44:MWSC 3164"
+{
+	RA 19.71943761
+	Dec 1.56308576
+	Radius 46.06
+	Distance 2407.54
+}
+
+OpenCluster "NGC 6823:OC 0087"
+{
+	RA 19.71948356
+	Dec 23.29445427
+	Radius 32.859
+	Distance 6655.32
+}
+
+OpenCluster "HSC 464"
+{
+	RA 19.7194912
+	Dec 20.52018546
+	Radius 25.108
+	Distance 6241.227
+}
+
+OpenCluster "CWNU 412:UBC 1066"
+{
+	RA 19.72144227
+	Dec 22.14632401
+	Radius 36.078
+	Distance 7983.997
+}
+
+OpenCluster "HSC 641"
+{
+	RA 19.72331004
+	Dec 48.90737567
+	Radius 47.741
+	Distance 717.461
+}
+
+OpenCluster "HSC 560"
+{
+	RA 19.72623468
+	Dec 35.83954226
+	Radius 23.16
+	Distance 6363.155
+}
+
+OpenCluster "CWNU 1074"
+{
+	RA 19.72688482
+	Dec 6.41261684
+	Radius 192.228
+	Distance 2370.593
+}
+
+OpenCluster "PHOC 14"
+{
+	RA 19.72764583
+	Dec 24.43940974
+	Radius 51.572
+	Distance 7200.71
+}
+
+OpenCluster "CWNU 2106"
+{
+	RA 19.73129292
+	Dec 21.89818794
+	Radius 31.257
+	Distance 11657.012
+}
+
+OpenCluster "HSC 505"
+{
+	RA 19.73229499
+	Dec 26.95052267
+	Radius 78.372
+	Distance 2158.173
+}
+
+OpenCluster "HSC 553"
+{
+	RA 19.73827838
+	Dec 34.90241141
+	Radius 79.459
+	Distance 7231.083
+}
+
+OpenCluster "CWNU 1564"
+{
+	RA 19.74375192
+	Dec 24.0238456
+	Radius 52.597
+	Distance 7227.225
+}
+
+OpenCluster "Theia 4035:Turner 9"
+{
+	RA 19.74549279
+	Dec 29.49765874
+	Radius 60.615
+	Distance 5606.417
+}
+
+OpenCluster "CWNU 134"
+{
+	RA 19.75059119
+	Dec 18.99833813
+	Radius 30.649
+	Distance 3799.634
+}
+
+OpenCluster "MWSC 3169:OCL 112:OC 0079:Roslund 1"
+{
+	RA 19.75093806
+	Dec 17.549167
+	Radius 27.733
+	Distance 2815.699
+}
+
+OpenCluster "Roslund 2:Theia 1717:Theia 2554"
+{
+	RA 19.75160793
+	Dec 23.97426814
+	Radius 74.337
+	Distance 6503.521
+}
+
+OpenCluster "Gulliver 43"
+{
+	RA 19.75192647
+	Dec 24.59555408
+	Radius 36.622
+	Distance 9120.269
+}
+
+OpenCluster "HSC 563"
+{
+	RA 19.75246565
+	Dec 36.50006599
+	Radius 55.049
+	Distance 18852.008
+}
+
+OpenCluster "DSH J1945.1+2809:Kronberger 4:MWSC 3170"
+{
+	RA 19.75278214
+	Dec 28.16268435
+	Radius 86.641
+	Distance 20363.938
+}
+
+OpenCluster "HSC 496"
+{
+	RA 19.75327979
+	Dec 24.95040834
+	Radius 76.973
+	Distance 13474.475
+}
+
+OpenCluster "GCL 114:MWSC 3171:Pal 11:Palomar 11"
+{
+	RA 19.75411282
+	Dec -8.00954967
+	Radius 337.204
+	Distance 36772.321
+}
+
+OpenCluster "FoF 321:OC 0085:Theia 3403:UBC 127"
+{
+	RA 19.75908642
+	Dec 21.16279383
+	Radius 40.607
+	Distance 6801.465
+}
+
+OpenCluster "CWNU 1634:Theia 3886"
+{
+	RA 19.75919172
+	Dec 14.68836828
+	Radius 49.396
+	Distance 5721.654
+}
+
+OpenCluster "CWNU 1918"
+{
+	RA 19.77043446
+	Dec 24.89343619
+	Radius 88.462
+	Distance 13850.36
+}
+
+OpenCluster "Dolidze 53"
+{
+	RA 19.77304198
+	Dec 24.61843568
+	Radius 34.927
+	Distance 6372.233
+}
+
+OpenCluster "CWNU 2247"
+{
+	RA 19.77307211
+	Dec 19.34913293
+	Radius 41.281
+	Distance 4249.257
+}
+
+OpenCluster "HSC 506"
+{
+	RA 19.77494871
+	Dec 26.62553838
+	Radius 63.852
+	Distance 13217.566
+}
+
+OpenCluster "Theia 278:UPK 55"
+{
+	RA 19.77790328
+	Dec 10.43288729
+	Radius 55.111
+	Distance 2556.329
+}
+
+OpenCluster "Sh2 88B"
+{
+	RA 19.77884822
+	Dec 25.23397997
+	Radius 61.741
+	Distance 5584.827
+}
+
+OpenCluster "HSC 485"
+{
+	RA 19.78268009
+	Dec 23.06644638
+	Radius 46.76
+	Distance 4841.571
+}
+
+OpenCluster "CWNU 1558"
+{
+	RA 19.78336517
+	Dec 28.81031684
+	Radius 23.146
+	Distance 8657.156
+}
+
+OpenCluster "HSC 581"
+{
+	RA 19.78337854
+	Dec 38.91139451
+	Radius 126.324
+	Distance 23508.113
+}
+
+OpenCluster "HSC 498"
+{
+	RA 19.78892323
+	Dec 24.77425079
+	Radius 19.979
+	Distance 6647.97
+}
+
+OpenCluster "DSH J1947.7+2415:FSR 155:MWSC 3180:Teutsch 7"
+{
+	RA 19.79561324
+	Dec 24.26048359
+	Radius 79.612
+	Distance 15238.214
+}
+
+OpenCluster "FSR 0158:FSR 158:MWSC 3182:SAI 130"
+{
+	RA 19.79926543
+	Dec 26.04064773
+	Radius 159.043
+	Distance 15519.931
+}
+
+OpenCluster "HSC 490"
+{
+	RA 19.799946
+	Dec 23.90534562
+	Radius 185.726
+	Distance 2127.655
+}
+
+OpenCluster "FSR 0154:FSR 154:MWSC 3181:SAI 131"
+{
+	RA 19.80075977
+	Dec 23.35257192
+	Radius 70.891
+	Distance 12123.418
+}
+
+OpenCluster "HSC 419"
+{
+	RA 19.80077116
+	Dec 13.29314345
+	Radius 61.159
+	Distance 4772.541
+}
+
+OpenCluster "HSC 467"
+{
+	RA 19.80819092
+	Dec 20.14149712
+	Radius 48.543
+	Distance 2474.319
+}
+
+OpenCluster "ASCC 107:MWSC 3185:Teutsch J1948.5+2157"
+{
+	RA 19.81011789
+	Dec 21.97962092
+	Radius 45.861
+	Distance 2828.802
+}
+
+OpenCluster "HSC 492"
+{
+	RA 19.81101065
+	Dec 24.28786679
+	Radius 43.633
+	Distance 3408.386
+}
+
+OpenCluster "HSC 537"
+{
+	RA 19.81388249
+	Dec 31.3592615
+	Radius 41.809
+	Distance 9325.037
+}
+
+OpenCluster "NGC 6827:Berkeley 48:FSR 152:MWSC 3186:OCL 120"
+{
+	RA 19.81482824
+	Dec 21.21407056
+	Radius 97.201
+	Distance 20754.145
+}
+
+OpenCluster "Theia 8068:UBC 1082"
+{
+	RA 19.81607065
+	Dec 34.08612057
+	Radius 46.164
+	Distance 17519.758
+}
+
+OpenCluster "CWNU 393"
+{
+	RA 19.81653848
+	Dec 24.64647919
+	Radius 29.395
+	Distance 3879.153
+}
+
+OpenCluster "HSC 522"
+{
+	RA 19.82393768
+	Dec 29.30319091
+	Radius 49.053
+	Distance 4535.498
+}
+
+OpenCluster "Theia 833"
+{
+	RA 19.82601656
+	Dec 38.56881269
+	Radius 50.553
+	Distance 2234.111
+}
+
+OpenCluster "Theia 5724:UBC 1071"
+{
+	RA 19.82622373
+	Dec 29.08570583
+	Radius 53.316
+	Distance 9814.341
+}
+
+OpenCluster "HSC 507"
+{
+	RA 19.8301384
+	Dec 26.20107308
+	Radius 94.271
+	Distance 428.158
+}
+
+OpenCluster "HSC 513"
+{
+	RA 19.83049012
+	Dec 27.89485917
+	Radius 138.181
+	Distance 24543.702
+}
+
+OpenCluster "UBC 1064"
+{
+	RA 19.84469536
+	Dec 19.71322575
+	Radius 72.101
+	Distance 10976.42
+}
+
+OpenCluster "CWNU 2592"
+{
+	RA 19.84587074
+	Dec 22.65881877
+	Radius 62.716
+	Distance 12317.045
+}
+
+OpenCluster "HSC 541"
+{
+	RA 19.84672511
+	Dec 31.69146562
+	Radius 50.185
+	Distance 6506.766
+}
+
+OpenCluster "HSC 528"
+{
+	RA 19.84697716
+	Dec 30.21118661
+	Radius 67.923
+	Distance 23952.075
+}
+
+OpenCluster "NGC 6830:Melotte 224:Collinder 406:MWSC 3191:OCL 125:Theia 1933"
+{
+	RA 19.84811707
+	Dec 23.09835798
+	Radius 40.584
+	Distance 7129.88
+}
+
+OpenCluster "CWNU 1753"
+{
+	RA 19.84845891
+	Dec 27.43225151
+	Radius 106.143
+	Distance 6713.931
+}
+
+OpenCluster "Czernik 41:FSR 157:MWSC 3192:OCL 130"
+{
+	RA 19.85072452
+	Dec 25.28133795
+	Radius 74.416
+	Distance 8103.841
+}
+
+OpenCluster "HSC 488"
+{
+	RA 19.85478005
+	Dec 23.13672176
+	Radius 38.514
+	Distance 13533.602
+}
+
+OpenCluster "Gulliver 55"
+{
+	RA 19.85536402
+	Dec 18.67501344
+	Radius 67.047
+	Distance 8724.695
+}
+
+OpenCluster "UBC 1068"
+{
+	RA 19.85613826
+	Dec 22.7292756
+	Radius 54.16
+	Distance 10091.285
+}
+
+OpenCluster "UBC 1072"
+{
+	RA 19.8585553
+	Dec 29.84671323
+	Radius 75.363
+	Distance 13525.56
+}
+
+OpenCluster "FoF 2123:Theia 3305:UBC 128"
+{
+	RA 19.86368539
+	Dec 22.10011513
+	Radius 32.82
+	Distance 5193.964
+}
+
+OpenCluster "FSR 0182:FSR 182:MWSC 3194:UBC 1081"
+{
+	RA 19.86378905
+	Dec 33.51648206
+	Radius 87.73
+	Distance 17046.745
+}
+
+OpenCluster "HSC 410"
+{
+	RA 19.86801376
+	Dec 10.45650855
+	Radius 36.73
+	Distance 9720.406
+}
+
+OpenCluster "CWNU 359:Theia 2421"
+{
+	RA 19.86961153
+	Dec 24.84368942
+	Radius 70.093
+	Distance 4858.815
+}
+
+OpenCluster "NGC 6834:Theia 1903"
+{
+	RA 19.87026695
+	Dec 29.39515657
+	Radius 47.469
+	Distance 10707.759
+}
+
+OpenCluster "UBC 130"
+{
+	RA 19.87073463
+	Dec 27.44890648
+	Radius 53.211
+	Distance 7689.584
+}
+
+OpenCluster "UBC 1108"
+{
+	RA 19.87230177
+	Dec 44.79365646
+	Radius 89.987
+	Distance 13544.542
+}
+
+OpenCluster "HSC 494"
+{
+	RA 19.87512383
+	Dec 23.82130152
+	Radius 58.307
+	Distance 5007.535
+}
+
+OpenCluster "CWNU 517:UBC 1570"
+{
+	RA 19.87634163
+	Dec 32.55803808
+	Radius 39.746
+	Distance 7662.776
+}
+
+OpenCluster "HSC 519"
+{
+	RA 19.8811964
+	Dec 28.64268368
+	Radius 56.814
+	Distance 20241.352
+}
+
+OpenCluster "CWNU 319:UBC 1073"
+{
+	RA 19.88436163
+	Dec 30.80654933
+	Radius 104.452
+	Distance 11330.359
+}
+
+OpenCluster "HXHWL 46:UBC 1079"
+{
+	RA 19.88769411
+	Dec 32.6533718
+	Radius 52.396
+	Distance 6593.357
+}
+
+OpenCluster "NGC 6838:Melotte 226:Collinder 408:Collinder 409:FSR 144:FSR 147:GCL 115:Harvard 20:MWSC 3198:MWSC 3200:OCL 116:OCL 117:Theia 4117:Theia 6074:Theia 6500:Theia 7156:Theia 7398:Theia 7437:Theia 8028:UBC 362"
+{
+	RA 19.88827229
+	Dec 18.35954525
+	Radius 114.812
+	Distance 6994.556
+}
+
+OpenCluster "Theia 6593:Theia 8014"
+{
+	RA 19.89194454
+	Dec 37.65994124
+	Radius 78.746
+	Distance 2025.385
+}
+
+OpenCluster "CWNU 2415"
+{
+	RA 19.89195462
+	Dec 29.86914263
+	Radius 74.019
+	Distance 17401.357
+}
+
+OpenCluster "ASCC 108:MWSC 3201:Theia 3446"
+{
+	RA 19.89248135
+	Dec 39.34259987
+	Radius 101.56
+	Distance 3757.579
+}
+
+OpenCluster "CWNU 370:UBC 1070"
+{
+	RA 19.89398352
+	Dec 27.55040373
+	Radius 79.711
+	Distance 6397.68
+}
+
+OpenCluster "FoF 2417:UPK 82"
+{
+	RA 19.89757507
+	Dec 26.20195077
+	Radius 67.573
+	Distance 1754.288
+}
+
+OpenCluster "CWNU 326"
+{
+	RA 19.90221472
+	Dec 29.1153083
+	Radius 32.053
+	Distance 6628.33
+}
+
+OpenCluster "HSC 478"
+{
+	RA 19.90251413
+	Dec 21.01786103
+	Radius 120.118
+	Distance 3699.826
+}
+
+OpenCluster "HSC 536"
+{
+	RA 19.90292213
+	Dec 30.53883197
+	Radius 70.173
+	Distance 3488.58
+}
+
+OpenCluster "UBC 1065"
+{
+	RA 19.90342149
+	Dec 19.88932528
+	Radius 55.638
+	Distance 8410.563
+}
+
+OpenCluster "HSC 514"
+{
+	RA 19.91078973
+	Dec 27.7256274
+	Radius 34.806
+	Distance 7744.907
+}
+
+OpenCluster "HSC 533"
+{
+	RA 19.91108978
+	Dec 30.07731926
+	Radius 81.046
+	Distance 2492.584
+}
+
+OpenCluster "HSC 592"
+{
+	RA 19.91110454
+	Dec 40.25270963
+	Radius 59.132
+	Distance 1780.631
+}
+
+OpenCluster "HSC 529"
+{
+	RA 19.91123124
+	Dec 29.80023571
+	Radius 46.373
+	Distance 12475.876
+}
+
+OpenCluster "HSC 499"
+{
+	RA 19.91400986
+	Dec 23.8602772
+	Radius 34.054
+	Distance 8609.384
+}
+
+OpenCluster "UBC 1075"
+{
+	RA 19.91820676
+	Dec 30.62601808
+	Radius 50.537
+	Distance 11765.46
+}
+
+OpenCluster "HD 226540 Group:OC 0096"
+{
+	RA 19.91943105
+	Dec 33.49971607
+	Radius 36.868
+	Distance 8253.469
+}
+
+OpenCluster "HSC 504"
+{
+	RA 19.92648209
+	Dec 25.00958162
+	Radius 32.507
+	Distance 10100.458
+}
+
+OpenCluster "HSC 535"
+{
+	RA 19.93285489
+	Dec 30.24762161
+	Radius 44.607
+	Distance 13354.11
+}
+
+OpenCluster "HSC 603"
+{
+	RA 19.93400601
+	Dec 41.60476953
+	Radius 138.88
+	Distance 3288.754
+}
+
+OpenCluster "HSC 567"
+{
+	RA 19.93477454
+	Dec 35.98541795
+	Radius 156.062
+	Distance 24143.622
+}
+
+OpenCluster "Theia 332"
+{
+	RA 19.93548843
+	Dec 32.90336024
+	Radius 52.597
+	Distance 2164.984
+}
+
+OpenCluster "UBC 129"
+{
+	RA 19.93563699
+	Dec 26.44524868
+	Radius 70.531
+	Distance 3677.887
+}
+
+OpenCluster "CWNU 2414"
+{
+	RA 19.93646451
+	Dec 26.06888582
+	Radius 64.529
+	Distance 10094.916
+}
+
+OpenCluster "CWNU 1397"
+{
+	RA 19.93946382
+	Dec 34.23068604
+	Radius 36.397
+	Distance 7727.376
+}
+
+OpenCluster "NGC 6846:Collinder 410:OCL 139"
+{
+	RA 19.94098224
+	Dec 32.34975571
+	Radius 270.052
+	Distance 25602.974
+}
+
+OpenCluster "CWNU 2326"
+{
+	RA 19.94198152
+	Dec 29.79752735
+	Radius 32.202
+	Distance 11903.851
+}
+
+OpenCluster "NGC 6847:CWNU 2345"
+{
+	RA 19.94604176
+	Dec 30.27711925
+	Radius 45.776
+	Distance 13873.383
+}
+
+OpenCluster "OC 0093:SAI 132"
+{
+	RA 19.94973089
+	Dec 31.61293894
+	Radius 59.352
+	Distance 10802.503
+}
+
+OpenCluster "OC 0088:OC 0089:UBC 132"
+{
+	RA 19.95148519
+	Dec 28.44522802
+	Radius 41.891
+	Distance 10145.393
+}
+
+OpenCluster "UBC 363"
+{
+	RA 19.95182627
+	Dec 31.87044189
+	Radius 48.323
+	Distance 12714.619
+}
+
+OpenCluster "HSC 544"
+{
+	RA 19.95327656
+	Dec 31.24228796
+	Radius 52.788
+	Distance 1127.668
+}
+
+OpenCluster "HSC 527"
+{
+	RA 19.95463124
+	Dec 29.19153664
+	Radius 108.612
+	Distance 12150.323
+}
+
+OpenCluster "CWNU 1286"
+{
+	RA 19.9573464
+	Dec 26.65495935
+	Radius 42.012
+	Distance 5064.814
+}
+
+OpenCluster "HSC 521"
+{
+	RA 19.96348736
+	Dec 28.13105815
+	Radius 73.047
+	Distance 2944.387
+}
+
+OpenCluster "UBC 1076"
+{
+	RA 19.9656654
+	Dec 30.5641734
+	Radius 47.543
+	Distance 8658.877
+}
+
+OpenCluster "HSC 539"
+{
+	RA 19.9668601
+	Dec 30.34829897
+	Radius 35.931
+	Distance 17499.092
+}
+
+OpenCluster "DSH J1958.1+3053:FSR 177:Kronberger 52:OC 0092"
+{
+	RA 19.96924996
+	Dec 30.87907326
+	Radius 129.5
+	Distance 20237.028
+}
+
+OpenCluster "FSR 0165:FSR 165"
+{
+	RA 19.96964736
+	Dec 26.75070135
+	Radius 36.138
+	Distance 7750.46
+}
+
+OpenCluster "HSC 487"
+{
+	RA 19.97222883
+	Dec 21.83196964
+	Radius 42.826
+	Distance 2309.001
+}
+
+OpenCluster "HSC 421"
+{
+	RA 19.97307666
+	Dec 11.93015602
+	Radius 34.76
+	Distance 6999.827
+}
+
+OpenCluster "Teutsch 292:UBC 1083"
+{
+	RA 19.97434912
+	Dec 33.15050339
+	Radius 54.975
+	Distance 3962.103
+}
+
+OpenCluster "DSH J1958.5+3048:Kronberger 53:OC 0091"
+{
+	RA 19.97630889
+	Dec 30.81073148
+	Radius 68.026
+	Distance 14808.782
+}
+
+OpenCluster "HSC 523"
+{
+	RA 19.97949567
+	Dec 28.08836518
+	Radius 99.857
+	Distance 17163.867
+}
+
+OpenCluster "OCL 121:Roslund 3:Theia 2301"
+{
+	RA 19.97995201
+	Dec 20.50493789
+	Radius 46.443
+	Distance 5390.023
+}
+
+OpenCluster "HSC 566"
+{
+	RA 19.9802646
+	Dec 35.5290567
+	Radius 93.877
+	Distance 14183.424
+}
+
+OpenCluster "UBC 134"
+{
+	RA 19.98121601
+	Dec 31.08627126
+	Radius 40.874
+	Distance 8183.467
+}
+
+OpenCluster "UPK 90"
+{
+	RA 19.98172934
+	Dec 28.43417747
+	Radius 24.407
+	Distance 2576.003
+}
+
+OpenCluster "HSC 516"
+{
+	RA 19.98298902
+	Dec 27.19578376
+	Radius 65.554
+	Distance 3021.381
+}
+
+OpenCluster "CWNU 2682"
+{
+	RA 19.98425597
+	Dec 26.21937196
+	Radius 66.379
+	Distance 13631.95
+}
+
+OpenCluster "Theia 3494"
+{
+	RA 19.9867834
+	Dec 40.6160311
+	Radius 74.706
+	Distance 6212.583
+}
+
+OpenCluster "UBC 143"
+{
+	RA 19.98718977
+	Dec 45.75096743
+	Radius 69.676
+	Distance 4243.422
+}
+
+OpenCluster "OC 0097:UBC 135"
+{
+	RA 19.98780652
+	Dec 33.72389103
+	Radius 121.669
+	Distance 12199.006
+}
+
+OpenCluster "HSC 531"
+{
+	RA 19.98878319
+	Dec 29.26253778
+	Radius 112.062
+	Distance 7878.632
+}
+
+OpenCluster "HSC 452"
+{
+	RA 19.988858
+	Dec 16.65448623
+	Radius 85.568
+	Distance 776.565
+}
+
+OpenCluster "UBC 1078"
+{
+	RA 19.98933073
+	Dec 31.17549146
+	Radius 60.491
+	Distance 9153.998
+}
+
+OpenCluster "HSC 538"
+{
+	RA 19.98947111
+	Dec 30.06269729
+	Radius 89.997
+	Distance 16451.289
+}
+
+OpenCluster "Theia 1876:UBC 582"
+{
+	RA 19.9907622
+	Dec 38.55893693
+	Radius 59.598
+	Distance 3588.237
+}
+
+OpenCluster "Theia 4892:Theia 5397:UBC 366"
+{
+	RA 19.99098939
+	Dec 37.20486478
+	Radius 28.965
+	Distance 5867.832
+}
+
+OpenCluster "Berkeley 49:FSR 191:OCL 144"
+{
+	RA 19.99124125
+	Dec 34.64270729
+	Radius 62.886
+	Distance 9663.586
+}
+
+OpenCluster "UBC 1074"
+{
+	RA 19.99180535
+	Dec 30.00560693
+	Radius 51.624
+	Distance 7736.408
+}
+
+OpenCluster "DC 6:DSH J1959.5+4918:Patchick 89"
+{
+	RA 19.99241798
+	Dec 49.31324123
+	Radius 70.866
+	Distance 24267.416
+}
+
+OpenCluster "FSR 0172"
+{
+	RA 20.00065049
+	Dec 29.21722012
+	Radius 70.624
+	Distance 9975.592
+}
+
+OpenCluster "HSC 530"
+{
+	RA 20.0046975
+	Dec 29.08170576
+	Radius 59.461
+	Distance 6036.656
+}
+
+OpenCluster "UBC 1086"
+{
+	RA 20.00511948
+	Dec 33.27425746
+	Radius 31.962
+	Distance 10202.1
+}
+
+OpenCluster "CWNU 1310"
+{
+	RA 20.0057637
+	Dec 32.79329807
+	Radius 42.547
+	Distance 12090.222
+}
+
+OpenCluster "HSC 582"
+{
+	RA 20.00709399
+	Dec 37.41085306
+	Radius 35.544
+	Distance 3761.677
+}
+
+OpenCluster "CWNU 1075"
+{
+	RA 20.01223873
+	Dec 38.72006863
+	Radius 40.605
+	Distance 1126.999
+}
+
+OpenCluster "HSC 554"
+{
+	RA 20.0159748
+	Dec 32.94515493
+	Radius 57.927
+	Distance 12237.79
+}
+
+OpenCluster "HSC 445"
+{
+	RA 20.01646063
+	Dec 15.0150541
+	Radius 24.716
+	Distance 7635.816
+}
+
+OpenCluster "CWNU 1255:Theia 247"
+{
+	RA 20.0182346
+	Dec 10.21412534
+	Radius 229.054
+	Distance 1497.546
+}
+
+OpenCluster "Theia 228"
+{
+	RA 20.0205618
+	Dec 19.64752721
+	Radius 149.327
+	Distance 1069.783
+}
+
+OpenCluster "Theia 1065:UPK 93"
+{
+	RA 20.02102677
+	Dec 29.94465206
+	Radius 63.04
+	Distance 2316.367
+}
+
+OpenCluster "OC 0098:OC 0099:Theia 6445:Toepler 1"
+{
+	RA 20.02151279
+	Dec 33.61301723
+	Radius 82.768
+	Distance 10671.95
+}
+
+OpenCluster "Berkeley 83:FSR 171:OCL 135"
+{
+	RA 20.02374508
+	Dec 28.6434224
+	Radius 91.383
+	Distance 15656.72
+}
+
+OpenCluster "DSH J2001.9+3126:FSR 181:Kronberger 69:SAI 133"
+{
+	RA 20.03391311
+	Dec 31.42030204
+	Radius 31.319
+	Distance 8377.146
+}
+
+OpenCluster "HSC 549"
+{
+	RA 20.0385475
+	Dec 31.5970271
+	Radius 45.869
+	Distance 12450.954
+}
+
+OpenCluster "Teutsch 8:Theia 3218"
+{
+	RA 20.04011736
+	Dec 35.30674343
+	Radius 59.031
+	Distance 6209.945
+}
+
+OpenCluster "HSC 515"
+{
+	RA 20.0414243
+	Dec 26.69190235
+	Radius 28.487
+	Distance 5510.443
+}
+
+OpenCluster "ASCC 110:MWSC 3234:Theia 3854"
+{
+	RA 20.04830806
+	Dec 33.52724535
+	Radius 83.14
+	Distance 6171.241
+}
+
+OpenCluster "CWNU 2645"
+{
+	RA 20.04860989
+	Dec 23.94083536
+	Radius 63.036
+	Distance 6161.496
+}
+
+OpenCluster "FSR 0241:FSR 241:MWSC 3236:Theia 5773"
+{
+	RA 20.05067907
+	Dec 46.19524814
+	Radius 48.641
+	Distance 6877.114
+}
+
+OpenCluster "ASCC 110:MWSC 3234:Theia 2673:Theia 3047:Theia 5676"
+{
+	RA 20.05201079
+	Dec 33.74410811
+	Radius 39.898
+	Distance 4436.047
+}
+
+OpenCluster "DSH J2003.1+3158:Kronberger 54"
+{
+	RA 20.05203878
+	Dec 31.96393277
+	Radius 75
+	Distance 13127.668
+}
+
+OpenCluster "CWNU 1870"
+{
+	RA 20.05360573
+	Dec 33.24722629
+	Radius 18.985
+	Distance 10048.109
+}
+
+OpenCluster "Gulliver 38"
+{
+	RA 20.05368126
+	Dec 34.43482282
+	Radius 69.883
+	Distance 7559.072
+}
+
+OpenCluster "HSC 543"
+{
+	RA 20.05557043
+	Dec 30.42328099
+	Radius 70.432
+	Distance 13173.56
+}
+
+OpenCluster "Casado 82"
+{
+	RA 20.05985157
+	Dec 36.0224399
+	Radius 63.646
+	Distance 6280.488
+}
+
+OpenCluster "CWNU 456:UBC 1084"
+{
+	RA 20.06074874
+	Dec 32.67499075
+	Radius 57.746
+	Distance 6689.947
+}
+
+OpenCluster "UPK 57"
+{
+	RA 20.06092649
+	Dec 12.64233741
+	Radius 32.67
+	Distance 2719.181
+}
+
+OpenCluster "CWNU 1032"
+{
+	RA 20.06129559
+	Dec 31.84783035
+	Radius 123.526
+	Distance 1206.702
+}
+
+OpenCluster "PHOC 37:Theia 3218"
+{
+	RA 20.06428399
+	Dec 34.62356487
+	Radius 34.998
+	Distance 3558.23
+}
+
+OpenCluster "NGC 6866:Theia 4895"
+{
+	RA 20.06547742
+	Dec 44.16597554
+	Radius 55.58
+	Distance 4572.803
+}
+
+OpenCluster "UBC 1077"
+{
+	RA 20.06767034
+	Dec 30.46443685
+	Radius 72.592
+	Distance 8897.496
+}
+
+OpenCluster "UBC 586"
+{
+	RA 20.07145684
+	Dec 46.71819232
+	Radius 123.711
+	Distance 8258.018
+}
+
+OpenCluster "DSH J2004.5+3514:Kronberger 36:SAI 136:UBC 137"
+{
+	RA 20.07594418
+	Dec 35.23565282
+	Radius 31.385
+	Distance 7935.267
+}
+
+OpenCluster "CWNU 2344"
+{
+	RA 20.07660213
+	Dec 34.59399467
+	Radius 39.716
+	Distance 7935.486
+}
+
+OpenCluster "HSC 382"
+{
+	RA 20.07872581
+	Dec 2.99601387
+	Radius 78.596
+	Distance 1872.823
+}
+
+OpenCluster "Berkeley 84:UBC 1089"
+{
+	RA 20.0800282
+	Dec 33.9857668
+	Radius 68.571
+	Distance 8291.901
+}
+
+OpenCluster "CWNU 1680"
+{
+	RA 20.08062583
+	Dec 29.44899553
+	Radius 53.938
+	Distance 10334.465
 }
 
 OpenCluster "Roslund 4"
 {
-	RA 20.081667
-	Dec 29.216667
-	Distance 6523
-	Radius 4.7
+	RA 20.08092824
+	Dec 29.19143741
+	Radius 71.327
+	Distance 6978.418
 }
 
-OpenCluster "NGC 6863"
+OpenCluster "Alessi 10:LeDrew 3:Theia 535"
 {
-	RA 20.085278
-	Dec -2.444444
-	Distance 3914
-	Radius 1.7
+	RA 20.08215286
+	Dec -10.52874723
+	Radius 97.474
+	Distance 1423.087
 }
 
-OpenCluster "Dolidze 38"
+OpenCluster "HSC 574"
 {
-	RA 20.095000
-	Dec 41.200000
-	Distance 3914
-	Radius 10.2
+	RA 20.08291348
+	Dec 36.0602038
+	Radius 27.177
+	Distance 7449.205
 }
 
-OpenCluster "NGC 6871"
+OpenCluster "FSR 0167:FSR 167:Theia 3810"
 {
-	RA 20.099722
-	Dec 35.776667
-	Distance 5133
-	Radius 21.7
+	RA 20.08328603
+	Dec 27.07968807
+	Radius 134.541
+	Distance 5753.278
 }
 
-OpenCluster "Basel 6"
+OpenCluster "UBC 1080"
 {
-	RA 20.113333
-	Dec 38.350000
-	Distance 5049
-	Radius 5.1
+	RA 20.08507706
+	Dec 31.63324916
+	Radius 72.012
+	Distance 8421.836
 }
 
-OpenCluster "Biurakan 1"
+OpenCluster "Theia 73"
 {
-	RA 20.125000
-	Dec 35.683333
-	Distance 5437
-	Radius 7.9
+	RA 20.08777521
+	Dec 31.52428971
+	Radius 102.027
+	Distance 2049.931
+}
+
+OpenCluster "HSC 557"
+{
+	RA 20.09110061
+	Dec 32.71123681
+	Radius 58.302
+	Distance 3461.653
+}
+
+OpenCluster "CWNU 47"
+{
+	RA 20.09143979
+	Dec 23.78660023
+	Radius 64.888
+	Distance 6023.233
+}
+
+OpenCluster "HSC 2643"
+{
+	RA 20.09890406
+	Dec -80.99652698
+	Radius 56.305
+	Distance 802.016
+}
+
+OpenCluster "NGC 6871:Collinder 413:OCL 148"
+{
+	RA 20.09932894
+	Dec 35.77555127
+	Radius 62.843
+	Distance 6012.169
+}
+
+OpenCluster "HSC 584"
+{
+	RA 20.10218473
+	Dec 36.90595162
+	Radius 25.292
+	Distance 9215.259
+}
+
+OpenCluster "UBC 1085"
+{
+	RA 20.10386604
+	Dec 32.44960254
+	Radius 79.49
+	Distance 12454.383
+}
+
+OpenCluster "OC 0103:Theia 2820:Theia 4725:UBC 1091"
+{
+	RA 20.10744778
+	Dec 36.43093108
+	Radius 81.37
+	Distance 9319.293
+}
+
+OpenCluster "UBC 1092"
+{
+	RA 20.10839063
+	Dec 36.36130399
+	Radius 66.585
+	Distance 10875.966
+}
+
+OpenCluster "DSH J2006.5+3534:Kronberger 28"
+{
+	RA 20.11060324
+	Dec 35.5503716
+	Radius 25.347
+	Distance 12142.783
+}
+
+OpenCluster "PHOC 33"
+{
+	RA 20.1107742
+	Dec 36.29328802
+	Radius 31.593
+	Distance 5967.008
+}
+
+OpenCluster "CWNU 1441"
+{
+	RA 20.11291057
+	Dec 34.11095305
+	Radius 32.024
+	Distance 5051.909
+}
+
+OpenCluster "HSC 170"
+{
+	RA 20.1149763
+	Dec -28.41949107
+	Radius 138.332
+	Distance 940.063
+}
+
+OpenCluster "HSC 704"
+{
+	RA 20.12498657
+	Dec 55.32558104
+	Radius 70.704
+	Distance 812.185
+}
+
+OpenCluster "Theia 470"
+{
+	RA 20.12525853
+	Dec 35.45778356
+	Radius 100.523
+	Distance 2172.384
+}
+
+OpenCluster "Gulliver 31"
+{
+	RA 20.1256713
+	Dec 38.24687229
+	Radius 43.799
+	Distance 7881
+}
+
+OpenCluster "HSC 501"
+{
+	RA 20.13065191
+	Dec 22.30931416
+	Radius 139.311
+	Distance 25774.653
+}
+
+OpenCluster "CWNU 67:UBC 1087"
+{
+	RA 20.13601884
+	Dec 32.36808537
+	Radius 30.324
+	Distance 5344.516
+}
+
+OpenCluster "CWNU 153"
+{
+	RA 20.13762928
+	Dec 23.16364242
+	Radius 29.1
+	Distance 4991.557
+}
+
+OpenCluster "Theia 213"
+{
+	RA 20.1386033
+	Dec 28.39212695
+	Radius 125.684
+	Distance 482.133
+}
+
+OpenCluster "CWNU 112"
+{
+	RA 20.13955546
+	Dec 33.95245148
+	Radius 34.551
+	Distance 7024.576
+}
+
+OpenCluster "HSC 593"
+{
+	RA 20.14186663
+	Dec 38.62421256
+	Radius 35.027
+	Distance 9068.718
+}
+
+OpenCluster "Theia 3010"
+{
+	RA 20.14192633
+	Dec 32.74628156
+	Radius 48.637
+	Distance 3626.954
+}
+
+OpenCluster "HSC 550"
+{
+	RA 20.14363915
+	Dec 30.75452559
+	Radius 51.449
+	Distance 14491.964
+}
+
+OpenCluster "HSC 546"
+{
+	RA 20.14729655
+	Dec 29.83755832
+	Radius 46.034
+	Distance 12835.424
+}
+
+OpenCluster "HSC 548"
+{
+	RA 20.14876371
+	Dec 30.6535523
+	Radius 43.779
+	Distance 17236.289
+}
+
+OpenCluster "HSC 525"
+{
+	RA 20.1504496
+	Dec 26.80376801
+	Radius 34.073
+	Distance 3620.506
+}
+
+OpenCluster "HSC 579"
+{
+	RA 20.15405585
+	Dec 36.06401403
+	Radius 40.093
+	Distance 6188.895
 }
 
 OpenCluster "Biurakan 2"
 {
-	RA 20.153333
-	Dec 35.483333
-	Distance 3607
-	Radius 10.5
+	RA 20.15480081
+	Dec 35.46390324
+	Radius 26.514
+	Distance 5641.44
+}
+
+OpenCluster "HSC 609"
+{
+	RA 20.15566913
+	Dec 41.10148815
+	Radius 59.87
+	Distance 16334.042
+}
+
+OpenCluster "Dolidze 1:Theia 3717:UBC 367"
+{
+	RA 20.15763096
+	Dec 36.49328763
+	Radius 41.291
+	Distance 8813.955
+}
+
+OpenCluster "HXWHB 14:UBC 372"
+{
+	RA 20.15801637
+	Dec 38.28872975
+	Radius 32.853
+	Distance 10794.278
+}
+
+OpenCluster "CWNU 2290"
+{
+	RA 20.16397365
+	Dec 37.20301398
+	Radius 33.813
+	Distance 4212.848
+}
+
+OpenCluster "CWNU 376:UBC 1090"
+{
+	RA 20.16646068
+	Dec 34.33701171
+	Radius 52.389
+	Distance 7589.152
+}
+
+OpenCluster "Berkeley 50:UBC 138"
+{
+	RA 20.16710181
+	Dec 34.9682249
+	Radius 84.748
+	Distance 12340.185
+}
+
+OpenCluster "CWNU 1084:Roslund 5:Theia 73"
+{
+	RA 20.16978622
+	Dec 33.4899507
+	Radius 152.214
+	Distance 1046.832
+}
+
+OpenCluster "HSC 614"
+{
+	RA 20.17396186
+	Dec 41.75202712
+	Radius 47.462
+	Distance 9723.753
 }
 
 OpenCluster "Roslund 5"
 {
-	RA 20.166667
-	Dec 33.766667
-	Distance 1268
-	Radius 9.2
+	RA 20.17449775
+	Dec 33.74065524
+	Radius 90.395
+	Distance 1757.656
 }
 
-OpenCluster "IC 1311"
+OpenCluster "NGC 6883:Gulliver 17:Teutsch 301:Theia 2815"
 {
-	RA 20.171667
-	Dec 41.216667
-	Distance 17394
-	Radius 12.6
+	RA 20.1769557
+	Dec 35.86693518
+	Radius 30.787
+	Distance 5642.033
 }
 
-OpenCluster "ASCC 111"
+OpenCluster "UPK 122"
 {
-	RA 20.186944
-	Dec 37.450000
-	Distance 5218
-	Radius 50.1
+	RA 20.17971799
+	Dec 47.75113125
+	Radius 45.34
+	Distance 2922.073
 }
 
-OpenCluster "NGC 6883"
+OpenCluster "IC 1311:Collinder 414:Dolidze 2:FSR 214:OCL 173:OCL 174:Trumpler 36"
 {
-	RA 20.188611
-	Dec 35.831667
-	Distance 4501
-	Radius 22.9
+	RA 20.1798957
+	Dec 41.18227471
+	Radius 136.37
+	Distance 21584.131
 }
 
-OpenCluster "Ruprecht 172"
+OpenCluster "CWNU 427"
 {
-	RA 20.193333
-	Dec 35.605000
-	Distance 3587
-	Radius 7.8
+	RA 20.1814898
+	Dec 30.63319602
+	Radius 81.765
+	Distance 3968.021
 }
 
-OpenCluster "NGC 6885"
+OpenCluster "HSC 588"
 {
-	RA 20.200278
-	Dec 26.478333
-	Distance 1947
-	Radius 5.7
+	RA 20.18192578
+	Dec 37.29254762
+	Radius 31.382
+	Distance 6153.141
 }
 
-OpenCluster "Berkeley 52"
+OpenCluster "NGC 6883:Theia 2100:UBC 139"
 {
-	RA 20.241667
-	Dec 28.946667
-	Distance 15982
-	Radius 7.0
+	RA 20.18206538
+	Dec 35.76654612
+	Radius 61.564
+	Distance 6782.518
 }
 
-OpenCluster "Dolidze 39"
+OpenCluster "HSC 591"
 {
-	RA 20.273333
-	Dec 37.866667
-	Distance 4660
-	Radius 8.1
+	RA 20.18299572
+	Dec 38.25166958
+	Radius 64.517
+	Distance 18886.837
+}
+
+OpenCluster "HSC 337"
+{
+	RA 20.18404968
+	Dec -6.94193448
+	Radius 59.127
+	Distance 15495.217
+}
+
+OpenCluster "HSC 583"
+{
+	RA 20.18504253
+	Dec 36.15291651
+	Radius 67.761
+	Distance 31810.158
+}
+
+OpenCluster "NGC 6883:Casado-Hendy 1"
+{
+	RA 20.18974647
+	Dec 35.83678673
+	Radius 48.783
+	Distance 6302.733
+}
+
+OpenCluster "UBC 368"
+{
+	RA 20.19103716
+	Dec 36.4936913
+	Radius 58.535
+	Distance 6770.74
+}
+
+OpenCluster "MWSC 3276:OCL 151:Ruprecht 172"
+{
+	RA 20.192497
+	Dec 35.6021527
+	Radius 64.196
+	Distance 11475.676
+}
+
+OpenCluster "NGC 6882:Collinder 416:FSR 168:MWSC 3277:MWSC 3278:OCL 133:OCSN 20:Theia 170"
+{
+	RA 20.19314742
+	Dec 26.75074414
+	Radius 130.991
+	Distance 1544.139
+}
+
+OpenCluster "20 Vul cluster:NGC 6882:NGC 6885:Collinder 416:Collinder 417:FSR 168:Gulliver 18:MWSC 3277:MWSC 3278:MWSC 3282:OCL 132:OCL 133:Theia 2530"
+{
+	RA 20.19356665
+	Dec 26.54097419
+	Radius 35.858
+	Distance 5039.781
+}
+
+OpenCluster "ASCC 111:MWSC 3274:Theia 196"
+{
+	RA 20.19737206
+	Dec 37.53095892
+	Radius 87.436
+	Distance 2752.677
+}
+
+OpenCluster "Berkeley 51:FSR 197:MWSC 3280:OCL 146"
+{
+	RA 20.19811765
+	Dec 34.4038843
+	Radius 59.614
+	Distance 16207.824
+}
+
+OpenCluster "FSR 0174:FSR 174:MWSC 3279"
+{
+	RA 20.20021211
+	Dec 28.28347527
+	Radius 34.249
+	Distance 4113.405
+}
+
+OpenCluster "MWSC 3276:OCL 151:Ruprecht 172:UBC 1093"
+{
+	RA 20.20053465
+	Dec 35.70911695
+	Radius 26.844
+	Distance 10653.682
+}
+
+OpenCluster "UBC 580"
+{
+	RA 20.21388418
+	Dec 35.90171306
+	Radius 66.1
+	Distance 11968.362
+}
+
+OpenCluster "HSC 589"
+{
+	RA 20.21832316
+	Dec 37.78808695
+	Radius 33.201
+	Distance 11043.428
+}
+
+OpenCluster "UBC 365"
+{
+	RA 20.22271264
+	Dec 34.38724215
+	Radius 69.972
+	Distance 9968.002
+}
+
+OpenCluster "HXHWL 40:PHOC 11"
+{
+	RA 20.22401628
+	Dec 32.12180632
+	Radius 46.796
+	Distance 6423.395
+}
+
+OpenCluster "CWNU 202:Theia 2007"
+{
+	RA 20.22492693
+	Dec 34.2470833
+	Radius 66.276
+	Distance 5027.769
+}
+
+OpenCluster "FSR 0166:FSR 166:MWSC 3286"
+{
+	RA 20.22709933
+	Dec 25.43037696
+	Radius 106.36
+	Distance 9155.685
+}
+
+OpenCluster "HSC 561"
+{
+	RA 20.22794548
+	Dec 32.48443302
+	Radius 187.449
+	Distance 15871.582
+}
+
+OpenCluster "DSH J2013.7+3644:FSR 203:Kronberger 73:MWSC 3287:UBC 1095"
+{
+	RA 20.2292934
+	Dec 36.74595103
+	Radius 35.232
+	Distance 18564.485
+}
+
+OpenCluster "Gulliver 60"
+{
+	RA 20.22969476
+	Dec 29.66024336
+	Radius 151.734
+	Distance 3474.11
+}
+
+OpenCluster "CWNU 1322"
+{
+	RA 20.23503038
+	Dec 37.61044937
+	Radius 106.723
+	Distance 11343.808
+}
+
+OpenCluster "CWNU 248:UBC 1097"
+{
+	RA 20.24022815
+	Dec 37.41609733
+	Radius 78.772
+	Distance 8085.779
+}
+
+OpenCluster "CWNU 2035"
+{
+	RA 20.24116021
+	Dec 35.40813072
+	Radius 75.453
+	Distance 11811.137
+}
+
+OpenCluster "Berkeley 52:FSR 179:MWSC 3288:OCL 140"
+{
+	RA 20.24142955
+	Dec 28.9469945
+	Radius 70.277
+	Distance 17203.076
+}
+
+OpenCluster "HSC 545"
+{
+	RA 20.24177631
+	Dec 28.94626471
+	Radius 22.798
+	Distance 6369.777
+}
+
+OpenCluster "HSC 573"
+{
+	RA 20.24213935
+	Dec 34.78893063
+	Radius 93.359
+	Distance 8142.672
+}
+
+OpenCluster "HSC 707"
+{
+	RA 20.24324768
+	Dec 54.83805955
+	Radius 31.649
+	Distance 2906.389
+}
+
+OpenCluster "Theia 3262:UBC 133"
+{
+	RA 20.24581543
+	Dec 28.3368016
+	Radius 50.246
+	Distance 5108.334
+}
+
+OpenCluster "HSC 440"
+{
+	RA 20.24736604
+	Dec 11.99760503
+	Radius 59.16
+	Distance 1313.973
+}
+
+OpenCluster "HSC 629"
+{
+	RA 20.2483314
+	Dec 43.39404399
+	Radius 60.829
+	Distance 569.241
+}
+
+OpenCluster "UBC 583"
+{
+	RA 20.24928647
+	Dec 36.638675
+	Radius 79.454
+	Distance 10303.088
+}
+
+OpenCluster "FSR 0219:OC 0118"
+{
+	RA 20.24947063
+	Dec 41.19046033
+	Radius 33.694
+	Distance 5583.849
+}
+
+OpenCluster "Theia 4069:Theia 73"
+{
+	RA 20.25112685
+	Dec 33.0874408
+	Radius 131.509
+	Distance 3542.549
+}
+
+OpenCluster "Dolidze 3"
+{
+	RA 20.25857776
+	Dec 36.83348703
+	Radius 19.815
+	Distance 6232.702
+}
+
+OpenCluster "LISC-III 3723:RSG 5"
+{
+	RA 20.26058017
+	Dec 45.73801653
+	Radius 40.95
+	Distance 1087.734
+}
+
+OpenCluster "Dolidze 39:Gulliver 42"
+{
+	RA 20.26171149
+	Dec 37.84452188
+	Radius 98.37
+	Distance 13287.682
+}
+
+OpenCluster "UPK 79"
+{
+	RA 20.26453326
+	Dec 21.57175681
+	Radius 39.66
+	Distance 2966.205
+}
+
+OpenCluster "CWNU 413"
+{
+	RA 20.2677459
+	Dec 30.33154879
+	Radius 88.76
+	Distance 3776.283
+}
+
+OpenCluster "Dolidze 39:UBC 1100"
+{
+	RA 20.27132924
+	Dec 37.91326416
+	Radius 41.554
+	Distance 11745.651
+}
+
+OpenCluster "ASCC 112:AT 11:Alessi-Teutsch 11:Alessi 46:Alessi J2016.5+5204:Alessi Teutsch 11:MWSC 3295:Theia 397"
+{
+	RA 20.27344595
+	Dec 52.07425148
+	Radius 69.538
+	Distance 2085.51
+}
+
+OpenCluster "CWNU 500:OC 0095"
+{
+	RA 20.27590173
+	Dec 29.77396024
+	Radius 27.426
+	Distance 5696.154
 }
 
 OpenCluster "IC 4996"
 {
-	RA 20.275278
-	Dec 37.655278
-	Distance 7821
-	Radius 2.5
+	RA 20.27601592
+	Dec 37.64845954
+	Radius 72.907
+	Distance 6372.518
 }
 
-OpenCluster "Alessi-Teutsch 11"
+OpenCluster "HSC 571"
 {
-	RA 20.275556
-	Dec 52.075000
-	Distance 1793
-	Radius 6.9
+	RA 20.27799786
+	Dec 34.43270842
+	Radius 34.646
+	Distance 12126.211
 }
 
-OpenCluster "Collinder 419"
+OpenCluster "UBC 584"
 {
-	RA 20.301944
-	Dec 40.731944
-	Distance 2508
-	Radius 1.5
+	RA 20.28067434
+	Dec 41.96859383
+	Radius 33.702
+	Distance 5479.922
 }
 
-OpenCluster "Berkeley 85"
+OpenCluster "FSR 0195"
 {
-	RA 20.315278
-	Dec 37.759167
-	Distance 5740
-	Radius 4.2
+	RA 20.28130377
+	Dec 33.61960677
+	Radius 47.798
+	Distance 10415.508
+}
+
+OpenCluster "Gulliver 23:OC 0112"
+{
+	RA 20.28419874
+	Dec 38.04956116
+	Radius 79.938
+	Distance 11808.985
+}
+
+OpenCluster "Dolidze 40:Feibelman 1"
+{
+	RA 20.2947366
+	Dec 38.03009011
+	Radius 34.896
+	Distance 11225.888
+}
+
+OpenCluster "CWNU 1757"
+{
+	RA 20.2950718
+	Dec 48.070718
+	Radius 46.15
+	Distance 7594.583
+}
+
+OpenCluster "OC 0127"
+{
+	RA 20.29535555
+	Dec 42.71354136
+	Radius 74.537
+	Distance 6164.729
+}
+
+OpenCluster "Theia 2232:UBC 136"
+{
+	RA 20.29729607
+	Dec 32.58219791
+	Radius 100.309
+	Distance 4499.423
+}
+
+OpenCluster "CWNU 106:OC 0126"
+{
+	RA 20.29773651
+	Dec 42.14667759
+	Radius 70.205
+	Distance 5226.688
+}
+
+OpenCluster "Theia 1920"
+{
+	RA 20.29780577
+	Dec 38.7247841
+	Radius 56.256
+	Distance 3634.092
+}
+
+OpenCluster "HSC 608"
+{
+	RA 20.30047767
+	Dec 39.72736764
+	Radius 70.937
+	Distance 10825.339
+}
+
+OpenCluster "vdBergh 130"
+{
+	RA 20.30116311
+	Dec 39.36664652
+	Radius 41.891
+	Distance 5471.791
+}
+
+OpenCluster "Collinder 419:Theia 286"
+{
+	RA 20.30180297
+	Dec 40.72565135
+	Radius 50.224
+	Distance 3270.081
+}
+
+OpenCluster "DSH J2018.3+3112:MWSC 3307:Teutsch 124"
+{
+	RA 20.30509765
+	Dec 31.2100609
+	Radius 155.874
+	Distance 26921.844
+}
+
+OpenCluster "HSC 611"
+{
+	RA 20.30840639
+	Dec 40.21607841
+	Radius 32.353
+	Distance 6150.016
+}
+
+OpenCluster "OC 0116:UBC 375"
+{
+	RA 20.31183719
+	Dec 40.04937085
+	Radius 38.481
+	Distance 5458.349
+}
+
+OpenCluster "Berkeley 85:Dolidze 41:FSR 208:MWSC 3309:MWSC 3311:OCL 160:OCL 163"
+{
+	RA 20.31323871
+	Dec 37.73113958
+	Radius 49.084
+	Distance 11929.874
+}
+
+OpenCluster "HSC 599"
+{
+	RA 20.31475299
+	Dec 38.18791398
+	Radius 27.688
+	Distance 5611.329
+}
+
+OpenCluster "Collinder 419:Theia 286"
+{
+	RA 20.3173439
+	Dec 40.6915039
+	Radius 49.02
+	Distance 5512.105
+}
+
+OpenCluster "HSC 517"
+{
+	RA 20.32021282
+	Dec 24.81887769
+	Radius 120.81
+	Distance 371.937
+}
+
+OpenCluster "UBC 1099"
+{
+	RA 20.32199691
+	Dec 37.36254699
+	Radius 12.766
+	Distance 6311.231
+}
+
+OpenCluster "CWNU 455"
+{
+	RA 20.32283463
+	Dec 41.39985863
+	Radius 54.787
+	Distance 4066.493
+}
+
+OpenCluster "UPK 94"
+{
+	RA 20.32338651
+	Dec 27.62774773
+	Radius 39.859
+	Distance 3061.511
+}
+
+OpenCluster "HSC 540"
+{
+	RA 20.32634299
+	Dec 27.71021798
+	Radius 62.333
+	Distance 6647.904
 }
 
 OpenCluster "Dolidze 42"
 {
-	RA 20.328333
-	Dec 38.133333
-	Distance 3170
-	Radius 3.2
+	RA 20.32696577
+	Dec 38.09927831
+	Radius 31.46
+	Distance 3642.584
 }
 
-OpenCluster "Berkeley 86"
+OpenCluster "UPK 85"
 {
-	RA 20.340000
-	Dec 38.700000
-	Distance 3626
-	Radius 3.2
+	RA 20.32885975
+	Dec 24.02960973
+	Radius 68.111
+	Distance 2900.835
+}
+
+OpenCluster "HSC 602"
+{
+	RA 20.33020128
+	Dec 38.69960458
+	Radius 37.849
+	Distance 12189.861
+}
+
+OpenCluster "CWNU 271:OC 0107"
+{
+	RA 20.33581077
+	Dec 36.20976529
+	Radius 29.143
+	Distance 5681.774
+}
+
+OpenCluster "Dolidze 5"
+{
+	RA 20.33588638
+	Dec 39.33492264
+	Radius 33.466
+	Distance 6891.146
+}
+
+OpenCluster "FSR 0222:FSR 0223"
+{
+	RA 20.33659742
+	Dec 40.80722127
+	Radius 50.174
+	Distance 8978.945
+}
+
+OpenCluster "HSC 601"
+{
+	RA 20.33828708
+	Dec 38.46070664
+	Radius 136.734
+	Distance 1935.853
+}
+
+OpenCluster "Berkeley 86:MWSC 3316:OCL 167"
+{
+	RA 20.3384779
+	Dec 38.67991353
+	Radius 25.395
+	Distance 5488.126
+}
+
+OpenCluster "OC 0106"
+{
+	RA 20.33929108
+	Dec 35.11442692
+	Radius 64.113
+	Distance 8180.767
+}
+
+OpenCluster "QC 1:Theia 1920:UBC 1104"
+{
+	RA 20.34029137
+	Dec 39.86927981
+	Radius 64.628
+	Distance 4057.119
+}
+
+OpenCluster "Theia 336:UPK 66"
+{
+	RA 20.3521803
+	Dec 13.34343907
+	Radius 117.507
+	Distance 2183.596
+}
+
+OpenCluster "OCSN 23:Theia 96"
+{
+	RA 20.35245431
+	Dec 48.92470289
+	Radius 45.232
+	Distance 1136.917
+}
+
+OpenCluster "HSC 586"
+{
+	RA 20.35684097
+	Dec 35.45102279
+	Radius 21.331
+	Distance 8958.545
+}
+
+OpenCluster "FoF 2179:UBC 140"
+{
+	RA 20.3573296
+	Dec 38.64443739
+	Radius 30.269
+	Distance 5551.636
+}
+
+OpenCluster "Theia 1975"
+{
+	RA 20.3591641
+	Dec 36.93166388
+	Radius 81.435
+	Distance 6243.412
 }
 
 OpenCluster "Berkeley 87"
 {
-	RA 20.361667
-	Dec 37.366667
-	Distance 2064
-	Radius 3.0
+	RA 20.36046008
+	Dec 37.41471584
+	Radius 18.529
+	Distance 5498.226
 }
 
-OpenCluster "Collinder 421"
+OpenCluster "CWNU 1336"
 {
-	RA 20.386111
-	Dec 41.693056
-	Distance 3424
-	Radius 1.8
+	RA 20.36102813
+	Dec 34.31022828
+	Radius 60.987
+	Distance 8809.029
 }
 
-OpenCluster "NGC 6910"
+OpenCluster "CWNU 2502"
 {
-	RA 20.386667
-	Dec 40.778333
-	Distance 3715
-	Radius 5.4
+	RA 20.36222982
+	Dec 35.80510652
+	Radius 68.916
+	Distance 6995.164
 }
 
-OpenCluster "NGC 6913"
+OpenCluster "HSC 580"
 {
-	RA 20.399167
-	Dec 38.508333
-	Distance 3744
-	Radius 5.4
+	RA 20.36826471
+	Dec 34.38180207
+	Radius 48.403
+	Distance 7363.201
+}
+
+OpenCluster "Theia 124:UPK 160"
+{
+	RA 20.37992566
+	Dec 64.26321864
+	Radius 107.275
+	Distance 1485.902
+}
+
+OpenCluster "UBC 374"
+{
+	RA 20.38309167
+	Dec 38.94749426
+	Radius 50.477
+	Distance 4963.59
+}
+
+OpenCluster "UPK 110"
+{
+	RA 20.38491571
+	Dec 38.00561737
+	Radius 54.765
+	Distance 2854.808
+}
+
+OpenCluster "NGC 6910:Theia 286"
+{
+	RA 20.38679265
+	Dec 40.77387725
+	Radius 77.001
+	Distance 5460.54
+}
+
+OpenCluster "Collinder 421:Theia 2340:UBC 142"
+{
+	RA 20.38779977
+	Dec 41.69492994
+	Radius 65.98
+	Distance 3837.795
+}
+
+OpenCluster "HSC 585"
+{
+	RA 20.38815924
+	Dec 34.58431323
+	Radius 90.613
+	Distance 9522.039
+}
+
+OpenCluster "CWNU 152"
+{
+	RA 20.38947294
+	Dec 32.73477191
+	Radius 27.78
+	Distance 3350.099
+}
+
+OpenCluster "CWNU 2254"
+{
+	RA 20.3897969
+	Dec 38.80267929
+	Radius 20.944
+	Distance 4682.94
+}
+
+OpenCluster "UBC 371"
+{
+	RA 20.39216153
+	Dec 36.08678682
+	Radius 41.269
+	Distance 5847.359
+}
+
+OpenCluster "CWNU 30:CWNU 64:Theia 3290:Theia 3325:Theia 4509:UBC 1088"
+{
+	RA 20.39382143
+	Dec 31.07496019
+	Radius 39.401
+	Distance 5684.158
+}
+
+OpenCluster "Cooling Tower:M 29:NGC 6913:Collinder 422:MWSC 3329:OCL 168"
+{
+	RA 20.3970212
+	Dec 38.49890096
+	Radius 33.752
+	Distance 5573.532
+}
+
+OpenCluster "DSH J2023.9+3636:FSR 206:Kronberger 57:MWSC 3330"
+{
+	RA 20.39917589
+	Dec 36.60341904
+	Radius 72.647
+	Distance 9588.776
+}
+
+OpenCluster "Berkeley 89:FSR 257:MWSC 3333:OCL 193"
+{
+	RA 20.40769588
+	Dec 46.0510988
+	Radius 51.124
+	Distance 10530.933
+}
+
+OpenCluster "Dolidze 8"
+{
+	RA 20.40841582
+	Dec 42.28999102
+	Radius 37.345
+	Distance 3130.862
+}
+
+OpenCluster "OC 0115"
+{
+	RA 20.40923318
+	Dec 39.01111842
+	Radius 39.19
+	Distance 3128.419
+}
+
+OpenCluster "FSR 0239:FSR 239:MWSC 3334"
+{
+	RA 20.41420562
+	Dec 42.80083008
+	Radius 61.258
+	Distance 12683.049
+}
+
+OpenCluster "HSC 607"
+{
+	RA 20.4177443
+	Dec 38.35815278
+	Radius 39.929
+	Distance 6380.357
+}
+
+OpenCluster "UPK 137"
+{
+	RA 20.41815323
+	Dec 54.39146685
+	Radius 37.828
+	Distance 2713.461
+}
+
+OpenCluster "UBC 364"
+{
+	RA 20.4184114
+	Dec 29.72811027
+	Radius 47.672
+	Distance 5585.156
+}
+
+OpenCluster "HSC 620"
+{
+	RA 20.42032121
+	Dec 40.40412685
+	Radius 34.943
+	Distance 3998.543
+}
+
+OpenCluster "FSR 0224:OC 0121"
+{
+	RA 20.42261425
+	Dec 40.21977672
+	Radius 20.542
+	Distance 5366.173
+}
+
+OpenCluster "OC 0123:OC 0124"
+{
+	RA 20.42374733
+	Dec 40.8951967
+	Radius 18.635
+	Distance 5647.211
+}
+
+OpenCluster "OC 0124"
+{
+	RA 20.42923152
+	Dec 40.92422178
+	Radius 33.49
+	Distance 6213.923
+}
+
+OpenCluster "CWNU 1694"
+{
+	RA 20.43346924
+	Dec 44.54796191
+	Radius 38.81
+	Distance 6529.473
+}
+
+OpenCluster "CWNU 411:OC 0130"
+{
+	RA 20.43855267
+	Dec 42.63766156
+	Radius 49.493
+	Distance 6046.458
+}
+
+OpenCluster "HSC 619"
+{
+	RA 20.43900164
+	Dec 40.23504713
+	Radius 84.188
+	Distance 8222.073
+}
+
+OpenCluster "HSC 595"
+{
+	RA 20.43950651
+	Dec 36.44907309
+	Radius 50.664
+	Distance 8345.409
+}
+
+OpenCluster "CWNU 468"
+{
+	RA 20.44088215
+	Dec 34.4523787
+	Radius 72.317
+	Distance 5715.06
+}
+
+OpenCluster "CWNU 349:UBC 1116"
+{
+	RA 20.44472603
+	Dec 49.10810222
+	Radius 71.997
+	Distance 5302.039
+}
+
+OpenCluster "HSC 632"
+{
+	RA 20.44536496
+	Dec 42.66121827
+	Radius 89.461
+	Distance 5972.33
+}
+
+OpenCluster "HSC 657"
+{
+	RA 20.44588121
+	Dec 46.82468733
+	Radius 53.618
+	Distance 8556.375
+}
+
+OpenCluster "HSC 626"
+{
+	RA 20.4460434
+	Dec 41.66886945
+	Radius 27.529
+	Distance 5705.257
+}
+
+OpenCluster "Dolidze 11"
+{
+	RA 20.44606163
+	Dec 41.37649343
+	Radius 45.301
+	Distance 6266.623
+}
+
+OpenCluster "Steine 20:UBC 1110"
+{
+	RA 20.44627253
+	Dec 44.07949741
+	Radius 106.299
+	Distance 7499.43
+}
+
+OpenCluster "HSC 618"
+{
+	RA 20.44965129
+	Dec 40.05275085
+	Radius 32.881
+	Distance 3113.867
+}
+
+OpenCluster "CWNU 439"
+{
+	RA 20.45151989
+	Dec 43.51798617
+	Radius 88.267
+	Distance 5525.218
+}
+
+OpenCluster "HSC 604"
+{
+	RA 20.45167632
+	Dec 37.79247633
+	Radius 32.641
+	Distance 4370.439
+}
+
+OpenCluster "HSC 562"
+{
+	RA 20.45550463
+	Dec 30.6259894
+	Radius 60.507
+	Distance 3560.134
+}
+
+OpenCluster "UBC 373"
+{
+	RA 20.4583775
+	Dec 37.64931649
+	Radius 41.723
+	Distance 4052.927
+}
+
+OpenCluster "UBC 1105"
+{
+	RA 20.46085736
+	Dec 39.34256193
+	Radius 63.365
+	Distance 5350.22
+}
+
+OpenCluster "OC 0117:UBC 1103"
+{
+	RA 20.46156551
+	Dec 38.86598798
+	Radius 45.405
+	Distance 5217.853
 }
 
 OpenCluster "Teutsch 30"
 {
-	RA 20.461944
-	Dec 36.075556
-	Distance 5218
-	Radius 2.4
+	RA 20.46201288
+	Dec 36.07057279
+	Radius 69.13
+	Distance 5591.981
 }
 
-OpenCluster "Roslund 6"
+OpenCluster "CWNU 51:UBC 1112"
 {
-	RA 20.480278
-	Dec 39.326667
-	Distance 1630
-	Radius 5.7
+	RA 20.46422415
+	Dec 45.42937968
+	Radius 86.346
+	Distance 9073.262
 }
 
-OpenCluster "NGC 6939"
+OpenCluster "UBC 585"
 {
-	RA 20.525000
-	Dec 60.661667
-	Distance 5871
-	Radius 8.5
+	RA 20.46429979
+	Dec 40.55470907
+	Radius 21.422
+	Distance 4632.103
 }
 
-OpenCluster "Bica 1"
+OpenCluster "DSH J2028.2+3506:MWSC 3347:Teutsch 28"
 {
-	RA 20.552778
-	Dec 41.218611
-	Distance 5871
-	Radius 2.6
+	RA 20.47113422
+	Dec 35.11253665
+	Radius 49.85
+	Distance 10640.588
+}
+
+OpenCluster "CWNU 388:Theia 4144:Theia 4846:Theia 5468:Theia 7866"
+{
+	RA 20.47365489
+	Dec 54.41209626
+	Radius 120.64
+	Distance 3442.857
+}
+
+OpenCluster "CWNU 2160"
+{
+	RA 20.47405023
+	Dec 48.90747271
+	Radius 110.886
+	Distance 18487.392
+}
+
+OpenCluster "HSC 645"
+{
+	RA 20.47567148
+	Dec 45.18770493
+	Radius 26.961
+	Distance 6808.835
+}
+
+OpenCluster "OC 0120"
+{
+	RA 20.48062572
+	Dec 39.59888892
+	Radius 40.205
+	Distance 5883.475
+}
+
+OpenCluster "CWNU 1761"
+{
+	RA 20.48219111
+	Dec 33.16413017
+	Radius 33.74
+	Distance 9634.253
+}
+
+OpenCluster "FSR 0227:FSR 227:MWSC 3349"
+{
+	RA 20.48331233
+	Dec 40.4855591
+	Radius 36.734
+	Distance 6192.215
+}
+
+OpenCluster "HSC 624"
+{
+	RA 20.48563085
+	Dec 41.2637349
+	Radius 35.245
+	Distance 5117.209
+}
+
+OpenCluster "HSC 672"
+{
+	RA 20.49164013
+	Dec 49.05223812
+	Radius 71.004
+	Distance 6904.071
+}
+
+OpenCluster "OC 0133"
+{
+	RA 20.49303329
+	Dec 44.63297608
+	Radius 126.74
+	Distance 6759.996
+}
+
+OpenCluster "UBC 376"
+{
+	RA 20.50043066
+	Dec 46.16519447
+	Radius 49.957
+	Distance 8149.337
+}
+
+OpenCluster "FoF 2253:Theia 3073:UBC 144"
+{
+	RA 20.50188973
+	Dec 45.92099463
+	Radius 45.216
+	Distance 4580.852
+}
+
+OpenCluster "CWNU 180"
+{
+	RA 20.50366257
+	Dec 38.17347136
+	Radius 53.822
+	Distance 3331.376
+}
+
+OpenCluster "Roslund 6:TRSG 6"
+{
+	RA 20.50622044
+	Dec 40.35590523
+	Radius 82.328
+	Distance 1141.735
+}
+
+OpenCluster "UPK 104"
+{
+	RA 20.51167934
+	Dec 31.92283628
+	Radius 93.236
+	Distance 2685.396
+}
+
+OpenCluster "HSC 663"
+{
+	RA 20.51172563
+	Dec 46.74278889
+	Radius 46.549
+	Distance 12008.143
+}
+
+OpenCluster "CWNU 167:OC 0113"
+{
+	RA 20.51368288
+	Dec 37.46682466
+	Radius 21.794
+	Distance 5469.549
+}
+
+OpenCluster "HSC 630"
+{
+	RA 20.514005
+	Dec 41.44863244
+	Radius 26.107
+	Distance 4220.612
+}
+
+OpenCluster "FSR 0278:FSR 278:MWSC 3355:Teutsch J2031.0+5102"
+{
+	RA 20.51745889
+	Dec 51.01706388
+	Radius 126.999
+	Distance 5474.115
+}
+
+OpenCluster "HSC 622"
+{
+	RA 20.52423294
+	Dec 40.73155298
+	Radius 95.65
+	Distance 4030.824
+}
+
+OpenCluster "NGC 6939:Melotte 231:Collinder 423:FSR 315:MWSC 3357:OCL 217:Theia 7410"
+{
+	RA 20.52676622
+	Dec 60.65130066
+	Radius 123.685
+	Distance 5935.275
+}
+
+OpenCluster "OC 0128"
+{
+	RA 20.52928369
+	Dec 40.74135223
+	Radius 46.437
+	Distance 5322.087
+}
+
+OpenCluster "CWNU 1243"
+{
+	RA 20.53031269
+	Dec 39.04261104
+	Radius 31.828
+	Distance 3023.694
+}
+
+OpenCluster "CWNU 1011:IRAS 20306+4005"
+{
+	RA 20.53728791
+	Dec 40.29188238
+	Radius 20.875
+	Distance 3052.76
+}
+
+OpenCluster "CWNU 2467"
+{
+	RA 20.53797624
+	Dec 48.22310586
+	Radius 99.727
+	Distance 8368.223
+}
+
+OpenCluster "HSC 808"
+{
+	RA 20.53868839
+	Dec 69.52556272
+	Radius 96.895
+	Distance 21323.763
+}
+
+OpenCluster "HSC 702"
+{
+	RA 20.54403432
+	Dec 52.65719881
+	Radius 43.379
+	Distance 10116.218
+}
+
+OpenCluster "CWNU 2253"
+{
+	RA 20.54420229
+	Dec 44.79038312
+	Radius 35.302
+	Distance 6985.989
+}
+
+OpenCluster "HSC 625"
+{
+	RA 20.54651463
+	Dec 40.83775174
+	Radius 17.167
+	Distance 5283.831
+}
+
+OpenCluster "CWNU 1836"
+{
+	RA 20.54906151
+	Dec 33.9430618
+	Radius 30.572
+	Distance 8846.404
+}
+
+OpenCluster "HSC 742"
+{
+	RA 20.55082364
+	Dec 59.70836362
+	Radius 65.331
+	Distance 3916.632
+}
+
+OpenCluster "HSC 435"
+{
+	RA 20.55121274
+	Dec 8.89393648
+	Radius 153.39
+	Distance 26208.206
+}
+
+OpenCluster "CWNU 2594"
+{
+	RA 20.55177085
+	Dec 45.5487029
+	Radius 35.004
+	Distance 7578.277
 }
 
 OpenCluster "Bica 2"
 {
-	RA 20.554167
-	Dec 41.312500
-	Distance 5871
-	Radius 4.3
+	RA 20.55460708
+	Dec 41.30050966
+	Radius 20.449
+	Distance 5292.72
 }
 
-OpenCluster "NGC 6940"
+OpenCluster "CWNU 336"
 {
-	RA 20.573889
-	Dec 28.283333
-	Distance 2511
-	Radius 9.1
+	RA 20.55491915
+	Dec 47.08856325
+	Radius 36.308
+	Distance 4652.73
 }
 
-OpenCluster "Alessi 12"
+OpenCluster "UBC 147"
 {
-	RA 20.730000
-	Dec 23.791667
-	Distance 1751
-	Radius 10.2
+	RA 20.55845573
+	Dec 47.04119421
+	Radius 46.291
+	Distance 6861.826
 }
 
-OpenCluster "Roslund 7"
+OpenCluster "CWNU 460"
 {
-	RA 20.868889
-	Dec 37.895556
-	Distance 1862
-	Radius 5.4
+	RA 20.56062921
+	Dec 43.74536292
+	Radius 54.346
+	Distance 3552.079
 }
 
-OpenCluster "Barkhatova 1"
+OpenCluster "Theia 876:UPK 119"
 {
-	RA 20.895000
-	Dec 46.033333
-	Distance 2716
-	Radius 7.9
+	RA 20.56415924
+	Dec 43.30038646
+	Radius 58.416
+	Distance 2513.968
 }
 
-OpenCluster "NGC 6991"
+OpenCluster "UPK 109"
 {
-	RA 20.915000
-	Dec 47.416667
-	Distance 2283
-	Radius 8.3
+	RA 20.56511726
+	Dec 35.24015079
+	Radius 18.962
+	Distance 2373.672
 }
 
-OpenCluster "NGC 6996"
+OpenCluster "Theia 180"
 {
-	RA 20.941667
-	Dec 44.633333
-	Distance 2478
-	Radius 5.0
+	RA 20.57248218
+	Dec 6.8873852
+	Radius 226.081
+	Distance 1994.526
 }
 
-OpenCluster "Berkeley 54"
+OpenCluster "NGC 6940:Melotte 232:Collinder 424:MWSC 3370:OCL 141:Theia 1272"
 {
-	RA 21.053333
-	Dec 40.466667
-	Distance 7501
-	Radius 4.4
+	RA 20.5727011
+	Dec 28.25839724
+	Radius 96.639
+	Distance 3296.318
+}
+
+OpenCluster "HSC 616"
+{
+	RA 20.57313368
+	Dec 38.9000367
+	Radius 76.765
+	Distance 3165.236
+}
+
+OpenCluster "FSR 0276:FSR 276:MWSC 3371"
+{
+	RA 20.5747259
+	Dec 49.94904082
+	Radius 98.406
+	Distance 13375.392
+}
+
+OpenCluster "CWNU 2844:FSR 0238:FSR 238:MWSC 3373"
+{
+	RA 20.58063747
+	Dec 41.47581609
+	Radius 89.851
+	Distance 4242.832
+}
+
+OpenCluster "HSC 656"
+{
+	RA 20.58102409
+	Dec 45.7906452
+	Radius 20.917
+	Distance 7300.869
+}
+
+OpenCluster "HSC 615"
+{
+	RA 20.58460514
+	Dec 38.47985594
+	Radius 30.46
+	Distance 4624.982
+}
+
+OpenCluster "Berkeley 90"
+{
+	RA 20.58745272
+	Dec 46.84413145
+	Radius 90.498
+	Distance 8917.963
+}
+
+OpenCluster "HSC 737"
+{
+	RA 20.59162188
+	Dec 58.3892506
+	Radius 31.838
+	Distance 6829.156
+}
+
+OpenCluster "CWNU 118:LISC 1351:UBC 1102"
+{
+	RA 20.59515705
+	Dec 36.56874272
+	Radius 55.461
+	Distance 9598.541
+}
+
+OpenCluster "QC 4:UBC 1115"
+{
+	RA 20.60755537
+	Dec 46.89379857
+	Radius 67.229
+	Distance 7373.273
+}
+
+OpenCluster "HSC 729"
+{
+	RA 20.61632334
+	Dec 55.32904142
+	Radius 32.439
+	Distance 3167.387
+}
+
+OpenCluster "Theia 137:UPK 88"
+{
+	RA 20.6211525
+	Dec 20.42955069
+	Radius 82.731
+	Distance 942.586
+}
+
+OpenCluster "QC 2:UBC 146"
+{
+	RA 20.62376896
+	Dec 46.47267728
+	Radius 49.651
+	Distance 7054.246
+}
+
+OpenCluster "CWNU 444:Theia 1292:Theia 199"
+{
+	RA 20.6254575
+	Dec 54.68755026
+	Radius 105.293
+	Distance 2624.577
+}
+
+OpenCluster "HSC 655"
+{
+	RA 20.62597689
+	Dec 45.19026625
+	Radius 162.998
+	Distance 12008.27
+}
+
+OpenCluster "HSC 628"
+{
+	RA 20.62649922
+	Dec 40.35115432
+	Radius 9.934
+	Distance 4376.801
+}
+
+OpenCluster "HSC 640"
+{
+	RA 20.65159106
+	Dec 42.12040166
+	Radius 90.882
+	Distance 4682.856
+}
+
+OpenCluster "UBC 148"
+{
+	RA 20.65173622
+	Dec 46.51506471
+	Radius 59.919
+	Distance 7121.822
+}
+
+OpenCluster "FSR 233:LK 10:Le Duigou-Knodlseder 10"
+{
+	RA 20.65566598
+	Dec 39.99567708
+	Radius 32.435
+	Distance 4627.7
+}
+
+OpenCluster "CWNU 478:Theia 3202"
+{
+	RA 20.65741606
+	Dec 38.48563217
+	Radius 128.41
+	Distance 4164.555
+}
+
+OpenCluster "HSC 669"
+{
+	RA 20.66042395
+	Dec 46.35212414
+	Radius 29.396
+	Distance 7286.244
+}
+
+OpenCluster "CWNU 1806"
+{
+	RA 20.66273016
+	Dec 36.72884307
+	Radius 28.661
+	Distance 7407.58
+}
+
+OpenCluster "FSR 0251:OC 0132"
+{
+	RA 20.66673476
+	Dec 42.96711285
+	Radius 30.774
+	Distance 4824.436
+}
+
+OpenCluster "Theia 844"
+{
+	RA 20.67395687
+	Dec 41.92191291
+	Radius 89.153
+	Distance 2121.81
+}
+
+OpenCluster "Theia 3462"
+{
+	RA 20.67687528
+	Dec 46.08190084
+	Radius 22.149
+	Distance 3071.462
+}
+
+OpenCluster "HSC 658"
+{
+	RA 20.68099532
+	Dec 45.15302694
+	Radius 24.236
+	Distance 3502.715
+}
+
+OpenCluster "Alessi 116:Theia 1177:UBC 131:UPK 84"
+{
+	RA 20.68295809
+	Dec 20.06965092
+	Radius 64.154
+	Distance 2942.003
+}
+
+OpenCluster "HSC 681"
+{
+	RA 20.68361634
+	Dec 48.20630967
+	Radius 33.207
+	Distance 7328.008
+}
+
+OpenCluster "HSC 638"
+{
+	RA 20.69043421
+	Dec 41.66463292
+	Radius 58.536
+	Distance 3248.967
+}
+
+OpenCluster "OC 0135:QC 3"
+{
+	RA 20.69282975
+	Dec 46.16089951
+	Radius 53.56
+	Distance 7479.397
+}
+
+OpenCluster "HSC 644"
+{
+	RA 20.69749407
+	Dec 43.39877298
+	Radius 60.793
+	Distance 10210.957
+}
+
+OpenCluster "HSC 627"
+{
+	RA 20.70013963
+	Dec 39.67037873
+	Radius 16.139
+	Distance 3061.699
+}
+
+OpenCluster "HSC 665"
+{
+	RA 20.70637266
+	Dec 45.49431275
+	Radius 30.843
+	Distance 9886.224
+}
+
+OpenCluster "CWNU 422:UBC 1128"
+{
+	RA 20.70890093
+	Dec 50.67780252
+	Radius 42.248
+	Distance 5978.131
+}
+
+OpenCluster "DB2001 22"
+{
+	RA 20.70970318
+	Dec 42.93911438
+	Radius 70.747
+	Distance 9937.557
+}
+
+OpenCluster "Theia 5468:Theia 6187:Theia 6823"
+{
+	RA 20.71453992
+	Dec 53.69299558
+	Radius 64.449
+	Distance 4628.695
+}
+
+OpenCluster "OC 0125"
+{
+	RA 20.71700326
+	Dec 38.42540461
+	Radius 45.045
+	Distance 8906.49
+}
+
+OpenCluster "C 2041+368:FSR 216:MWSC 3405:OCL 176:Ruprecht 174"
+{
+	RA 20.72406583
+	Dec 37.03127301
+	Radius 38.411
+	Distance 7725.601
+}
+
+OpenCluster "Alessi 12:LeDrew 2:MWSC 3404:Theia 254"
+{
+	RA 20.72472108
+	Dec 23.53846771
+	Radius 78.189
+	Distance 1757.495
+}
+
+OpenCluster "HSC 660"
+{
+	RA 20.72677072
+	Dec 44.91770371
+	Radius 98.37
+	Distance 9556.68
+}
+
+OpenCluster "FSR 0248:FSR 248:MWSC 3406"
+{
+	RA 20.73023486
+	Dec 41.70004184
+	Radius 47.1
+	Distance 5577.247
+}
+
+OpenCluster "CWNU 2494"
+{
+	RA 20.74224305
+	Dec 39.95670193
+	Radius 29.182
+	Distance 6985.013
+}
+
+OpenCluster "HSC 652"
+{
+	RA 20.74270022
+	Dec 44.01447561
+	Radius 32.968
+	Distance 10230.305
+}
+
+OpenCluster "HSC 612"
+{
+	RA 20.74643022
+	Dec 36.73965681
+	Radius 90.271
+	Distance 4692.719
+}
+
+OpenCluster "HSC 679"
+{
+	RA 20.7468827
+	Dec 47.59638314
+	Radius 27.411
+	Distance 8992.13
+}
+
+OpenCluster "FSR 0258:FSR 258:MWSC 3408:OC 0134"
+{
+	RA 20.74707549
+	Dec 43.89479232
+	Radius 34.231
+	Distance 7873.231
+}
+
+OpenCluster "CWNU 136:CWNU 521"
+{
+	RA 20.74793964
+	Dec 56.90036924
+	Radius 93.113
+	Distance 2911.669
+}
+
+OpenCluster "HSC 659"
+{
+	RA 20.74897638
+	Dec 44.62103229
+	Radius 42.067
+	Distance 7903.748
+}
+
+OpenCluster "Theia 3388:UPK 155"
+{
+	RA 20.74914243
+	Dec 60.74835309
+	Radius 52.541
+	Distance 2892.298
+}
+
+OpenCluster "HSC 576"
+{
+	RA 20.75197424
+	Dec 30.42512754
+	Radius 50.939
+	Distance 2276.877
+}
+
+OpenCluster "CWNU 421:UBC 1136"
+{
+	RA 20.75677012
+	Dec 52.31087397
+	Radius 109.613
+	Distance 5973.74
+}
+
+OpenCluster "Theia 48"
+{
+	RA 20.75896215
+	Dec 39.77653826
+	Radius 39.311
+	Distance 3015.697
+}
+
+OpenCluster "HSC 720"
+{
+	RA 20.75964356
+	Dec 52.98690394
+	Radius 29.718
+	Distance 7420.199
+}
+
+OpenCluster "UBC 1117"
+{
+	RA 20.76336807
+	Dec 46.76850031
+	Radius 31.732
+	Distance 8559.625
+}
+
+OpenCluster "HSC 680"
+{
+	RA 20.768172
+	Dec 47.49385099
+	Radius 98.732
+	Distance 1098.931
+}
+
+OpenCluster "HSC 653"
+{
+	RA 20.7691633
+	Dec 43.84128165
+	Radius 46.182
+	Distance 7734.587
+}
+
+OpenCluster "HSC 667"
+{
+	RA 20.76989858
+	Dec 45.26465839
+	Radius 37.785
+	Distance 4201.178
+}
+
+OpenCluster "UBC 588"
+{
+	RA 20.77037907
+	Dec 45.39830048
+	Radius 46.817
+	Distance 5296.742
+}
+
+OpenCluster "Theia 4351:UBC 378"
+{
+	RA 20.77093467
+	Dec 48.82201465
+	Radius 52.298
+	Distance 4750.198
+}
+
+OpenCluster "UBC 587"
+{
+	RA 20.77309601
+	Dec 43.7266414
+	Radius 53.496
+	Distance 9921.139
+}
+
+OpenCluster "HSC 654"
+{
+	RA 20.77379017
+	Dec 43.89964952
+	Radius 36.557
+	Distance 9768.437
+}
+
+OpenCluster "Teutsch 311:UBC 1113"
+{
+	RA 20.77774734
+	Dec 43.76909908
+	Radius 78.212
+	Distance 10776.978
+}
+
+OpenCluster "HSC 600"
+{
+	RA 20.78070479
+	Dec 34.37327007
+	Radius 26.169
+	Distance 3848.038
+}
+
+OpenCluster "HSC 648"
+{
+	RA 20.78178529
+	Dec 43.41877066
+	Radius 50.795
+	Distance 6142.088
+}
+
+OpenCluster "HSC 637"
+{
+	RA 20.78487505
+	Dec 40.58418347
+	Radius 47.271
+	Distance 3600.809
+}
+
+OpenCluster "Theia 7778"
+{
+	RA 20.78677032
+	Dec 35.63480885
+	Radius 53.443
+	Distance 6934.367
+}
+
+OpenCluster "LISC 3287:Theia 2203:Theia 4294:Theia 4906:UBC 151"
+{
+	RA 20.78686689
+	Dec 47.34069954
+	Radius 121.953
+	Distance 5479.622
+}
+
+OpenCluster "UPK 126"
+{
+	RA 20.7874129
+	Dec 43.817517
+	Radius 18.163
+	Distance 2640.058
+}
+
+OpenCluster "HSC 647"
+{
+	RA 20.80308147
+	Dec 42.9656801
+	Radius 206.92
+	Distance 12163.953
+}
+
+OpenCluster "HSC 636"
+{
+	RA 20.80869708
+	Dec 40.19343287
+	Radius 41.615
+	Distance 7063.117
+}
+
+OpenCluster "Theia 4027:Theia 4906:UBC 149"
+{
+	RA 20.81103945
+	Dec 46.49466141
+	Radius 75.806
+	Distance 8045.552
+}
+
+OpenCluster "Theia 168:UPK 116"
+{
+	RA 20.81857638
+	Dec 39.74573283
+	Radius 65.633
+	Distance 1387.046
+}
+
+OpenCluster "UBC 1124"
+{
+	RA 20.81975254
+	Dec 48.70176298
+	Radius 58.592
+	Distance 7486.575
+}
+
+OpenCluster "HSC 465"
+{
+	RA 20.82005407
+	Dec 10.56233369
+	Radius 42.866
+	Distance 1590.543
+}
+
+OpenCluster "HSC 613"
+{
+	RA 20.82249545
+	Dec 36.26069361
+	Radius 62.941
+	Distance 1468.143
+}
+
+OpenCluster "HSC 639"
+{
+	RA 20.8272808
+	Dec 40.46089935
+	Radius 225.077
+	Distance 12685.647
+}
+
+OpenCluster "HSC 673"
+{
+	RA 20.82832084
+	Dec 46.63638871
+	Radius 183.265
+	Distance 1434.55
+}
+
+OpenCluster "UPK 99"
+{
+	RA 20.83196077
+	Dec 25.56074389
+	Radius 33.156
+	Distance 2552.016
+}
+
+OpenCluster "CWNU 96"
+{
+	RA 20.83248974
+	Dec 38.31998859
+	Radius 61.839
+	Distance 2941.823
+}
+
+OpenCluster "HSC 617"
+{
+	RA 20.83307326
+	Dec 36.57065341
+	Radius 43.279
+	Distance 1320.525
+}
+
+OpenCluster "Theia 2937"
+{
+	RA 20.83892967
+	Dec 47.23428481
+	Radius 50.998
+	Distance 3758.256
+}
+
+OpenCluster "HSC 700"
+{
+	RA 20.84361481
+	Dec 50.07329065
+	Radius 31.319
+	Distance 5994.903
+}
+
+OpenCluster "HSC 643"
+{
+	RA 20.8471278
+	Dec 41.71977499
+	Radius 35.353
+	Distance 9508.532
+}
+
+OpenCluster "HSC 376"
+{
+	RA 20.85088267
+	Dec -4.03262783
+	Radius 55.835
+	Distance 853.41
+}
+
+OpenCluster "Theia 7478"
+{
+	RA 20.85099424
+	Dec 33.80637725
+	Radius 82.005
+	Distance 2825.128
+}
+
+OpenCluster "HSC 2721"
+{
+	RA 20.85657931
+	Dec -68.90341302
+	Radius 26.035
+	Distance 2466.716
+}
+
+OpenCluster "UBC 1122"
+{
+	RA 20.85801293
+	Dec 47.77081567
+	Radius 47.37
+	Distance 9604.989
+}
+
+OpenCluster "CWNU 2338"
+{
+	RA 20.86099133
+	Dec 49.32428978
+	Radius 67.734
+	Distance 8064.892
+}
+
+OpenCluster "HSC 682"
+{
+	RA 20.87434367
+	Dec 46.93033066
+	Radius 65.748
+	Distance 11400.36
+}
+
+OpenCluster "MWSC 3416:OCL 187:Roslund 7:Theia 2375"
+{
+	RA 20.88085657
+	Dec 37.92023721
+	Radius 134.871
+	Distance 4033.58
+}
+
+OpenCluster "UBC 379"
+{
+	RA 20.88341551
+	Dec 48.57077893
+	Radius 74.616
+	Distance 8069.023
+}
+
+OpenCluster "CWNU 1490"
+{
+	RA 20.89289015
+	Dec 47.34444542
+	Radius 72.264
+	Distance 9046.938
+}
+
+OpenCluster "Theia 3:UPK 127"
+{
+	RA 20.89338492
+	Dec 44.40550688
+	Radius 26.424
+	Distance 2595.666
+}
+
+OpenCluster "Barkhatova 1:Theia 3147"
+{
+	RA 20.89376547
+	Dec 46.02079841
+	Radius 26.051
+	Distance 6330.27
+}
+
+OpenCluster "CWNU 1302:FSR 0261"
+{
+	RA 20.89655312
+	Dec 43.10610605
+	Radius 34.696
+	Distance 9493.895
+}
+
+OpenCluster "UBC 1127"
+{
+	RA 20.89997711
+	Dec 49.09674218
+	Radius 23.536
+	Distance 6601.174
+}
+
+OpenCluster "CBJC 8:CWNU 2830"
+{
+	RA 20.9002745
+	Dec 44.87127566
+	Radius 66.511
+	Distance 7911.414
+}
+
+OpenCluster "Theia 6174:UBC 141"
+{
+	RA 20.90427387
+	Dec 35.68617576
+	Radius 45.731
+	Distance 4399.119
+}
+
+OpenCluster "Theia 20:UPK 121"
+{
+	RA 20.90549023
+	Dec 41.25330887
+	Radius 71.084
+	Distance 3139.226
+}
+
+OpenCluster "UBC 1121"
+{
+	RA 20.90856056
+	Dec 47.03415767
+	Radius 35.572
+	Distance 10274.7
+}
+
+OpenCluster "NGC 6991:Theia 1231"
+{
+	RA 20.90993895
+	Dec 47.37719743
+	Radius 155.593
+	Distance 1815.115
+}
+
+OpenCluster "CWNU 2366"
+{
+	RA 20.91168872
+	Dec 47.67274401
+	Radius 113.23
+	Distance 12964.252
+}
+
+OpenCluster "Gulliver 30"
+{
+	RA 20.91212802
+	Dec 45.99840909
+	Radius 37.479
+	Distance 6980.67
+}
+
+OpenCluster "UBC 590"
+{
+	RA 20.92279143
+	Dec 47.55955445
+	Radius 55.18
+	Distance 12168.41
+}
+
+OpenCluster "HSC 649"
+{
+	RA 20.92285977
+	Dec 42.14202751
+	Radius 41.046
+	Distance 8459.432
+}
+
+OpenCluster "UPK 120"
+{
+	RA 20.92646297
+	Dec 40.37909906
+	Radius 78.177
+	Distance 2150.627
+}
+
+OpenCluster "UBC 1598"
+{
+	RA 20.9273423
+	Dec 49.08854263
+	Radius 27.995
+	Distance 8308.768
+}
+
+OpenCluster "CWNU 519"
+{
+	RA 20.92878337
+	Dec 56.75453927
+	Radius 94.366
+	Distance 1048.228
+}
+
+OpenCluster "Berkeley 53:FSR 289:MWSC 3435:OCL 207"
+{
+	RA 20.93210166
+	Dec 51.0512391
+	Radius 86.455
+	Distance 11113.475
+}
+
+OpenCluster "HSC 662"
+{
+	RA 20.93747154
+	Dec 43.12674054
+	Radius 31.544
+	Distance 2557.786
+}
+
+OpenCluster "UPK 51"
+{
+	RA 20.93976849
+	Dec -6.71763033
+	Radius 124.501
+	Distance 1873.729
+}
+
+OpenCluster "Theia 3146:UPK 118"
+{
+	RA 20.94090811
+	Dec 39.57301281
+	Radius 51.936
+	Distance 2988.275
+}
+
+OpenCluster "NGC 6996:NGC 6997:Theia 899"
+{
+	RA 20.94193605
+	Dec 44.6222637
+	Radius 57.746
+	Distance 2812.787
+}
+
+OpenCluster "FSR 0284"
+{
+	RA 20.94244389
+	Dec 49.35806175
+	Radius 56.907
+	Distance 9610.969
+}
+
+OpenCluster "HSC 674"
+{
+	RA 20.94374668
+	Dec 45.6799651
+	Radius 98.853
+	Distance 962.307
+}
+
+OpenCluster "FSR 0275:FSR 275:MWSC 3434:OC 0138:SAI 138"
+{
+	RA 20.9442643
+	Dec 46.89698682
+	Radius 83.392
+	Distance 12259.591
+}
+
+OpenCluster "CWNU 1582"
+{
+	RA 20.95349204
+	Dec 44.82023543
+	Radius 81.52
+	Distance 16551.944
+}
+
+OpenCluster "HSC 706"
+{
+	RA 20.95463442
+	Dec 50.04115965
+	Radius 29.166
+	Distance 7482.665
+}
+
+OpenCluster "Theia 269"
+{
+	RA 20.95502914
+	Dec 16.60105575
+	Radius 48.672
+	Distance 2674.857
+}
+
+OpenCluster "Theia 5422:UBC 1571"
+{
+	RA 20.95570688
+	Dec 46.47997519
+	Radius 89.594
+	Distance 14984.844
+}
+
+OpenCluster "UBC 152"
+{
+	RA 20.95615541
+	Dec 47.41823752
+	Radius 76.556
+	Distance 4361.587
+}
+
+OpenCluster "HSC 692"
+{
+	RA 20.9574174
+	Dec 47.56917069
+	Radius 46.928
+	Distance 12010.722
+}
+
+OpenCluster "CWNU 1390"
+{
+	RA 20.96185492
+	Dec 46.25215913
+	Radius 64.829
+	Distance 11330.906
+}
+
+OpenCluster "HSC 715"
+{
+	RA 20.96607387
+	Dec 51.0269421
+	Radius 61.164
+	Distance 5254.622
+}
+
+OpenCluster "HSC 687"
+{
+	RA 20.97211545
+	Dec 46.81156653
+	Radius 58.633
+	Distance 2980.273
+}
+
+OpenCluster "UBC 1133"
+{
+	RA 20.97225597
+	Dec 49.9105259
+	Radius 50.637
+	Distance 7687.815
+}
+
+OpenCluster "OCSN 17:Theia 314"
+{
+	RA 20.97570188
+	Dec 16.41943829
+	Radius 92.615
+	Distance 1176.891
+}
+
+OpenCluster "HSC 693"
+{
+	RA 20.97888057
+	Dec 47.5384246
+	Radius 23.945
+	Distance 1237.393
+}
+
+OpenCluster "OCSN 24"
+{
+	RA 20.98481201
+	Dec 48.76105233
+	Radius 58.755
+	Distance 511.025
+}
+
+OpenCluster "CWNU 2619"
+{
+	RA 20.99340077
+	Dec 44.96950576
+	Radius 28.101
+	Distance 9467.974
+}
+
+OpenCluster "HXHWL 31:UBC 1119"
+{
+	RA 20.99920285
+	Dec 45.3351261
+	Radius 32.592
+	Distance 6216.06
+}
+
+OpenCluster "CWNU 1148:Theia 3916:Theia 5782"
+{
+	RA 21.00605452
+	Dec 39.00157017
+	Radius 100.212
+	Distance 3326.979
+}
+
+OpenCluster "UPK 144"
+{
+	RA 21.01145659
+	Dec 52.25938863
+	Radius 22.831
+	Distance 1823.388
+}
+
+OpenCluster "DSH J2101.7+4406:FSR 267:MWSC 3449:SAI 139:Teutsch 22:Teutsch J2101.7+4406"
+{
+	RA 21.02840688
+	Dec 44.1154441
+	Radius 42.187
+	Distance 13401.793
+}
+
+OpenCluster "OCSN 34:Theia 5"
+{
+	RA 21.02880352
+	Dec 68.15259758
+	Radius 177.817
+	Distance 1107.093
+}
+
+OpenCluster "Teutsch 312:Teutsch J2101.7+2938:Theia 276:UPK 108"
+{
+	RA 21.02912475
+	Dec 29.65145224
+	Radius 87.227
+	Distance 2741.54
+}
+
+OpenCluster "Theia 1178:UPK 131"
+{
+	RA 21.03178524
+	Dec 45.44809628
+	Radius 72.811
+	Distance 3101.201
+}
+
+OpenCluster "Theia 1450"
+{
+	RA 21.0329187
+	Dec 49.82411688
+	Radius 96.35
+	Distance 2478.373
+}
+
+OpenCluster "Theia 2850"
+{
+	RA 21.03335805
+	Dec 46.44363326
+	Radius 48.513
+	Distance 17930.352
+}
+
+OpenCluster "CWNU 462:OC 0204:Theia 8"
+{
+	RA 21.03831693
+	Dec 77.0165808
+	Radius 79.056
+	Distance 1209.397
+}
+
+OpenCluster "FSR 0282:FSR 282:MWSC 3453:SAI 140"
+{
+	RA 21.03873593
+	Dec 48.10474423
+	Radius 55.371
+	Distance 11546.964
+}
+
+OpenCluster "HSC 675"
+{
+	RA 21.04738828
+	Dec 44.76375668
+	Radius 88.257
+	Distance 25114.218
 }
 
 OpenCluster "Collinder 428"
 {
-	RA 21.053333
-	Dec 44.583333
-	Distance 3261
-	Radius 4.7
+	RA 21.04947321
+	Dec 44.49998764
+	Radius 67.883
+	Distance 23778.728
 }
 
-OpenCluster "NGC 7031"
+OpenCluster "Berkeley 54:FSR 256:MWSC 3456:OCL 194"
 {
-	RA 21.120000
-	Dec 50.875000
-	Distance 2935
-	Radius 6.0
+	RA 21.04949753
+	Dec 40.42927571
+	Radius 181.623
+	Distance 18209.818
 }
 
-OpenCluster "NGC 7036"
+OpenCluster "Theia 260"
 {
-	RA 21.167222
-	Dec 15.516667
-	Distance 3261
-	Radius 1.9
+	RA 21.0571689
+	Dec 17.43972036
+	Radius 155.939
+	Distance 1947.674
 }
 
-OpenCluster "Basel 12"
+OpenCluster "MWSC 3458:SAI 141:UBC 1126"
 {
-	RA 21.175000
-	Dec 46.233333
-	Distance 4781
-	Radius 2.8
+	RA 21.06070473
+	Dec 46.96773073
+	Radius 39.852
+	Distance 18039.798
 }
 
-OpenCluster "NGC 7039"
+OpenCluster "HSC 713"
 {
-	RA 21.180000
-	Dec 45.616667
-	Distance 3101
-	Radius 6.3
+	RA 21.0616647
+	Dec 49.86810298
+	Radius 171.264
+	Distance 22696.061
 }
 
-OpenCluster "ASCC 113"
+OpenCluster "DSH J2103.7+4713:FSR 280:MWSC 3459:SAI 142:Teutsch 156"
 {
-	RA 21.200000
-	Dec 38.600000
-	Distance 1467
-	Radius 12.0
+	RA 21.06257217
+	Dec 47.22320021
+	Radius 155.431
+	Distance 15614.029
 }
 
-OpenCluster "IC 1369"
+OpenCluster "UBC 1120"
 {
-	RA 21.201667
-	Dec 47.733333
-	Distance 6794
-	Radius 4.9
+	RA 21.06596674
+	Dec 45.380805
+	Radius 45.722
+	Distance 6460.226
 }
 
-OpenCluster "Basel 13"
+OpenCluster "LDN 988e:Theia 1"
 {
-	RA 21.205000
-	Dec 46.566667
-	Distance 4031
-	Radius 5.9
+	RA 21.06806051
+	Dec 50.24053402
+	Radius 54.54
+	Distance 2005.156
 }
 
-OpenCluster "NGC 7044"
+OpenCluster "UBC 1131"
 {
-	RA 21.219167
-	Dec 42.495000
-	Distance 10310
-	Radius 9.0
+	RA 21.06875763
+	Dec 48.42996259
+	Radius 83.364
+	Distance 10568.099
 }
 
-OpenCluster "Basel 15"
+OpenCluster "FoF 876:UBC 145"
 {
-	RA 21.265000
-	Dec 48.850000
-	Distance 4419
-	Radius 3.9
+	RA 21.07027018
+	Dec 42.06586547
+	Radius 48.093
+	Distance 6483.339
+}
+
+OpenCluster "CWNU 2871:LDN 988e"
+{
+	RA 21.0711529
+	Dec 50.22503138
+	Radius 42.39
+	Distance 8402.188
+}
+
+OpenCluster "FSR 0270:FSR 270:MWSC 3461:UBC 1118"
+{
+	RA 21.07141397
+	Dec 44.3421475
+	Radius 51.494
+	Distance 7645.622
+}
+
+OpenCluster "Theia 1970:Theia 3786:UBC 1123"
+{
+	RA 21.07220225
+	Dec 46.34197751
+	Radius 37.427
+	Distance 7659.75
+}
+
+OpenCluster "HSC 709"
+{
+	RA 21.07664866
+	Dec 49.48851493
+	Radius 68.435
+	Distance 19313.34
+}
+
+OpenCluster "CWNU 475"
+{
+	RA 21.07910012
+	Dec 59.85810394
+	Radius 22.75
+	Distance 3924.193
+}
+
+OpenCluster "Theia 3457"
+{
+	RA 21.08297579
+	Dec 47.27278593
+	Radius 131.878
+	Distance 5403.598
+}
+
+OpenCluster "UBC 381"
+{
+	RA 21.08332093
+	Dec 48.69992553
+	Radius 100.856
+	Distance 7038.297
+}
+
+OpenCluster "Theia 2988:UBC 153"
+{
+	RA 21.08340799
+	Dec 46.25189701
+	Radius 51.488
+	Distance 10454.551
+}
+
+OpenCluster "Theia 3384:Theia 3466:Theia 3786:UBC 1125"
+{
+	RA 21.08397363
+	Dec 46.40948412
+	Radius 39.494
+	Distance 10178.914
+}
+
+OpenCluster "CWNU 1818"
+{
+	RA 21.08455448
+	Dec 47.68734977
+	Radius 24.217
+	Distance 5435.081
+}
+
+OpenCluster "Gulliver 48"
+{
+	RA 21.08694378
+	Dec 50.74061951
+	Radius 102.381
+	Distance 2986.357
+}
+
+OpenCluster "CWNU 380:Theia 4708"
+{
+	RA 21.09387583
+	Dec 57.19004664
+	Radius 39.711
+	Distance 3802.074
+}
+
+OpenCluster "CWNU 2815"
+{
+	RA 21.09603504
+	Dec 51.32275019
+	Radius 39.822
+	Distance 5511.471
+}
+
+OpenCluster "HSC 741"
+{
+	RA 21.09730542
+	Dec 55.5378958
+	Radius 36.195
+	Distance 2743.956
+}
+
+OpenCluster "HSC 698"
+{
+	RA 21.10034086
+	Dec 47.45927415
+	Radius 48.727
+	Distance 1238.073
+}
+
+OpenCluster "NGC 7024:MWSC 3465:Theia 2793"
+{
+	RA 21.10174779
+	Dec 41.52751173
+	Radius 77.915
+	Distance 3789.179
+}
+
+OpenCluster "CWNU 1216"
+{
+	RA 21.10759718
+	Dec 47.18647099
+	Radius 96.212
+	Distance 947.731
+}
+
+OpenCluster "CWNU 40:Theia 3327"
+{
+	RA 21.10773185
+	Dec 46.69526916
+	Radius 60.293
+	Distance 4088.316
+}
+
+OpenCluster "CWNU 253:OC 0149"
+{
+	RA 21.11439256
+	Dec 53.02135966
+	Radius 49.542
+	Distance 5487.356
+}
+
+OpenCluster "HSC 723"
+{
+	RA 21.11639115
+	Dec 51.15991077
+	Radius 200.111
+	Distance 23093.957
+}
+
+OpenCluster "HSC 743"
+{
+	RA 21.11707375
+	Dec 56.14305401
+	Radius 84.065
+	Distance 1607.636
+}
+
+OpenCluster "HSC 710"
+{
+	RA 21.11930205
+	Dec 49.1194662
+	Radius 70.891
+	Distance 14119.368
+}
+
+OpenCluster "NGC 7031:Collinder 430:FSR 294:MWSC 3466:OCL 210:Theia 2164"
+{
+	RA 21.12021136
+	Dec 50.86559744
+	Radius 47.686
+	Distance 4338.266
+}
+
+OpenCluster "HSC 427"
+{
+	RA 21.12241645
+	Dec 1.94343695
+	Radius 55.427
+	Distance 742.827
+}
+
+OpenCluster "CWNU 2298"
+{
+	RA 21.12444526
+	Dec 50.12834508
+	Radius 34.426
+	Distance 5996.28
+}
+
+OpenCluster "UBC 589"
+{
+	RA 21.12727924
+	Dec 45.30457913
+	Radius 102.825
+	Distance 14581.813
+}
+
+OpenCluster "OC 0144"
+{
+	RA 21.13585378
+	Dec 50.97284111
+	Radius 56.598
+	Distance 6968.604
+}
+
+OpenCluster "CWNU 353:OC 0153"
+{
+	RA 21.13593784
+	Dec 56.4639019
+	Radius 44.022
+	Distance 5043.12
+}
+
+OpenCluster "HSC 738"
+{
+	RA 21.13788667
+	Dec 54.8215901
+	Radius 31.133
+	Distance 4125.677
+}
+
+OpenCluster "Theia 3651:Theia 4678:UBC 154"
+{
+	RA 21.14004995
+	Dec 46.33613127
+	Radius 57.885
+	Distance 10902.269
+}
+
+OpenCluster "FSR 0288:FSR 288:MWSC 3468:UBC 1134"
+{
+	RA 21.14092469
+	Dec 49.08997852
+	Radius 25.722
+	Distance 9269.429
+}
+
+OpenCluster "HSC 724"
+{
+	RA 21.14210609
+	Dec 51.05374147
+	Radius 42.769
+	Distance 6530.13
+}
+
+OpenCluster "UBC 1135"
+{
+	RA 21.14317474
+	Dec 49.10957122
+	Radius 99.225
+	Distance 11691.386
+}
+
+OpenCluster "HSC 390"
+{
+	RA 21.14350907
+	Dec -4.50643883
+	Radius 93.974
+	Distance 1254.264
+}
+
+OpenCluster "HSC 396"
+{
+	RA 21.14616087
+	Dec -3.6713698
+	Radius 218.752
+	Distance 323.337
+}
+
+OpenCluster "Theia 4432"
+{
+	RA 21.15034068
+	Dec 47.86464374
+	Radius 37.237
+	Distance 3614.05
+}
+
+OpenCluster "HSC 719"
+{
+	RA 21.1618417
+	Dec 49.62523853
+	Radius 65.351
+	Distance 323.232
+}
+
+OpenCluster "HSC 697"
+{
+	RA 21.16786906
+	Dec 46.45768954
+	Radius 65.895
+	Distance 16053.699
+}
+
+OpenCluster "CWNU 495:Theia 1465"
+{
+	RA 21.16797625
+	Dec 45.03889447
+	Radius 45.502
+	Distance 6416.038
+}
+
+OpenCluster "Theia 151:UPK 113"
+{
+	RA 21.1684392
+	Dec 34.27845257
+	Radius 101.953
+	Distance 2224.95
+}
+
+OpenCluster "CWNU 13:UBC 1130"
+{
+	RA 21.16998009
+	Dec 47.49865918
+	Radius 51.752
+	Distance 6301.314
+}
+
+OpenCluster "DSH J2110.2+4645:HXWHB 15:Teutsch 157"
+{
+	RA 21.17101012
+	Dec 46.75136546
+	Radius 188.422
+	Distance 17394.207
+}
+
+OpenCluster "HSC 661"
+{
+	RA 21.17295335
+	Dec 40.79021054
+	Radius 58.606
+	Distance 1921.567
+}
+
+OpenCluster "NGC 7039:Collinder 431:MWSC 3474:OCL 203:OC 0139"
+{
+	RA 21.17298761
+	Dec 45.5966987
+	Radius 114.832
+	Distance 18839.625
+}
+
+OpenCluster "CWNU 2173"
+{
+	RA 21.17394471
+	Dec 42.5636115
+	Radius 46.91
+	Distance 5471.894
+}
+
+OpenCluster "NGC 7039:Collinder 431:MWSC 3474:OCL 203:Theia 26"
+{
+	RA 21.1768467
+	Dec 45.58245926
+	Radius 45.769
+	Distance 2422.022
+}
+
+OpenCluster "OC 0146"
+{
+	RA 21.17733607
+	Dec 51.69479336
+	Radius 68.871
+	Distance 7532.557
+}
+
+OpenCluster "UBC 380:XDOCC 11"
+{
+	RA 21.18095456
+	Dec 47.68660556
+	Radius 104.784
+	Distance 6866.751
+}
+
+OpenCluster "Berkeley 91:FSR 287:MWSC 3476:OCL 206"
+{
+	RA 21.18136578
+	Dec 48.54150942
+	Radius 92.485
+	Distance 13616.221
+}
+
+OpenCluster "HSC 635"
+{
+	RA 21.18509679
+	Dec 36.27867943
+	Radius 54.577
+	Distance 3458.313
+}
+
+OpenCluster "HSC 721"
+{
+	RA 21.19329552
+	Dec 49.91119286
+	Radius 82.586
+	Distance 7523.987
+}
+
+OpenCluster "CWNU 1049:OC 0140"
+{
+	RA 21.19342653
+	Dec 46.86760447
+	Radius 18.86
+	Distance 2376.242
+}
+
+OpenCluster "DSH J2111.8+5222:FSR 300:Kronberger 80:MWSC 3479"
+{
+	RA 21.19699764
+	Dec 52.37595973
+	Radius 151.751
+	Distance 23496.309
+}
+
+OpenCluster "ASCC 113:MWSC 3480:Theia 461"
+{
+	RA 21.19750638
+	Dec 38.54530468
+	Radius 98.522
+	Distance 1818.057
+}
+
+OpenCluster "MWSC 3478:Riddle 6:UBC 385"
+{
+	RA 21.19788663
+	Dec 59.98264202
+	Radius 20.186
+	Distance 2718.43
+}
+
+OpenCluster "HSC 757"
+{
+	RA 21.20135598
+	Dec 58.00906444
+	Radius 74.775
+	Distance 7148.491
+}
+
+OpenCluster "IC 1369:Collinder 432:FSR 285:MWSC 3481:OCL 204:OC 0141"
+{
+	RA 21.20217496
+	Dec 47.77571808
+	Radius 127.394
+	Distance 11162.568
+}
+
+OpenCluster "HSC 730"
+{
+	RA 21.20340766
+	Dec 51.78265428
+	Radius 61.661
+	Distance 1943.281
+}
+
+OpenCluster "HSC 623"
+{
+	RA 21.20804512
+	Dec 34.24170785
+	Radius 51.675
+	Distance 9994.655
+}
+
+OpenCluster "HSC 726"
+{
+	RA 21.21193445
+	Dec 50.59614743
+	Radius 43.379
+	Distance 9988.909
+}
+
+OpenCluster "Gulliver 33:Theia 2926"
+{
+	RA 21.2155368
+	Dec 46.36568758
+	Radius 72.332
+	Distance 3633.59
+}
+
+OpenCluster "CWNU 2608"
+{
+	RA 21.21749358
+	Dec 49.33999671
+	Radius 34.563
+	Distance 5172.945
+}
+
+OpenCluster "CWNU 42"
+{
+	RA 21.21819224
+	Dec 46.08254111
+	Radius 141.38
+	Distance 7641.447
+}
+
+OpenCluster "NGC 7044:Collinder 433:FSR 268:MWSC 3485:OCL 198"
+{
+	RA 21.21903075
+	Dec 42.49437524
+	Radius 140.102
+	Distance 10745.762
+}
+
+OpenCluster "Basel 13:Bica 652"
+{
+	RA 21.22044694
+	Dec 46.55076462
+	Radius 54.191
+	Distance 11781.008
+}
+
+OpenCluster "HSC 712"
+{
+	RA 21.22409526
+	Dec 48.24414742
+	Radius 114.335
+	Distance 32287.846
+}
+
+OpenCluster "CWNU 2438"
+{
+	RA 21.22468755
+	Dec 49.0015123
+	Radius 74.977
+	Distance 8476.08
+}
+
+OpenCluster "UBC 155"
+{
+	RA 21.22762946
+	Dec 50.10232098
+	Radius 52.354
+	Distance 5211.5
+}
+
+OpenCluster "CWNU 1249:Theia 2561:UBC 1129"
+{
+	RA 21.23198268
+	Dec 46.40730621
+	Radius 29.903
+	Distance 3972.706
+}
+
+OpenCluster "Theia 1117"
+{
+	RA 21.23204813
+	Dec 45.41453902
+	Radius 73.322
+	Distance 1447.578
+}
+
+OpenCluster "OC 0137"
+{
+	RA 21.23284739
+	Dec 41.9190017
+	Radius 40.325
+	Distance 5932.836
+}
+
+OpenCluster "HSC 714"
+{
+	RA 21.23768271
+	Dec 48.64319044
+	Radius 93.776
+	Distance 19512.788
+}
+
+OpenCluster "HSC 752"
+{
+	RA 21.24048726
+	Dec 56.85135995
+	Radius 61.909
+	Distance 3411.227
+}
+
+OpenCluster "OC 0145"
+{
+	RA 21.24082073
+	Dec 50.43181709
+	Radius 33.896
+	Distance 8441.256
+}
+
+OpenCluster "Theia 3067"
+{
+	RA 21.24131533
+	Dec 57.19908473
+	Radius 73.468
+	Distance 3187.393
+}
+
+OpenCluster "CWNU 1192:OC 0158"
+{
+	RA 21.24946038
+	Dec 59.31892052
+	Radius 21.831
+	Distance 2757.595
+}
+
+OpenCluster "UBC 1132"
+{
+	RA 21.2502263
+	Dec 47.15100943
+	Radius 65.505
+	Distance 9280.395
+}
+
+OpenCluster "CWNU 1430"
+{
+	RA 21.2504675
+	Dec 50.79422706
+	Radius 59.376
+	Distance 7193.999
+}
+
+OpenCluster "UBC 1144"
+{
+	RA 21.25169202
+	Dec 56.19485977
+	Radius 100.514
+	Distance 14054.759
+}
+
+OpenCluster "Theia 420"
+{
+	RA 21.25756263
+	Dec 43.78165563
+	Radius 85.451
+	Distance 2864.007
+}
+
+OpenCluster "HSC 718"
+{
+	RA 21.26180825
+	Dec 48.54227106
+	Radius 79.468
+	Distance 3385.005
+}
+
+OpenCluster "HSC 677"
+{
+	RA 21.26300257
+	Dec 42.69201614
+	Radius 94.724
+	Distance 15736.741
+}
+
+OpenCluster "HSC 356"
+{
+	RA 21.26607152
+	Dec -11.01530887
+	Radius 97.619
+	Distance 1128.761
+}
+
+OpenCluster "CWNU 2404"
+{
+	RA 21.26652704
+	Dec 48.71668283
+	Radius 72.247
+	Distance 9136.786
+}
+
+OpenCluster "FSR 0291:FSR 291:MWSC 3489"
+{
+	RA 21.2719202
+	Dec 48.3540699
+	Radius 60.457
+	Distance 15048.082
+}
+
+OpenCluster "UPK 143"
+{
+	RA 21.27333706
+	Dec 49.90957687
+	Radius 103.163
+	Distance 2784.702
+}
+
+OpenCluster "FoF 2000:Theia 3067:Theia 6889:Theia 7711:UBC 161"
+{
+	RA 21.27528819
+	Dec 57.46419962
+	Radius 47.793
+	Distance 4423.212
+}
+
+OpenCluster "HXHWL 8"
+{
+	RA 21.28156684
+	Dec 44.08385852
+	Radius 100.4
+	Distance 3768.193
 }
 
 OpenCluster "Berkeley 55"
 {
-	RA 21.282778
-	Dec 51.758889
-	Distance 3946
-	Radius 2.4
+	RA 21.28231951
+	Dec 51.76087839
+	Radius 71.568
+	Distance 9271.012
 }
 
-OpenCluster "Berkeley 56"
+OpenCluster "UPK 150"
 {
-	RA 21.295000
-	Dec 41.826667
-	Distance 39466
-	Radius 11.5
+	RA 21.28819768
+	Dec 54.48546149
+	Radius 58.494
+	Distance 3202.097
 }
 
-OpenCluster "Basel 14"
+OpenCluster "UPK 152"
 {
-	RA 21.355000
-	Dec 44.816667
-	Distance 3144
-	Radius 2.3
+	RA 21.28938444
+	Dec 56.28666817
+	Radius 58.266
+	Distance 2384.313
 }
 
-OpenCluster "NGC 7058"
+OpenCluster "Berkeley 56:FSR 269:MWSC 3491:OCL 199"
 {
-	RA 21.364722
-	Dec 50.818333
-	Distance 1304
-	Radius 1.3
+	RA 21.29232252
+	Dec 41.82826884
+	Radius 234.192
+	Distance 28267.114
 }
 
-OpenCluster "NGC 7062"
+OpenCluster "CWNU 309:UBC 1150"
 {
-	RA 21.390833
-	Dec 46.378333
-	Distance 4827
-	Radius 3.5
+	RA 21.29995576
+	Dec 60.08146715
+	Radius 20.298
+	Distance 4957.271
 }
 
-OpenCluster "NGC 7063"
+OpenCluster "DSH J2118.3+5512:Kronberger 83"
 {
-	RA 21.405833
-	Dec 36.486667
-	Distance 2247
-	Radius 2.9
+	RA 21.30624292
+	Dec 55.20782841
+	Radius 220.41
+	Distance 20073.93
 }
 
-OpenCluster "NGC 7067"
+OpenCluster "HSC 651"
 {
-	RA 21.406389
-	Dec 48.010000
-	Distance 11742
-	Radius 10.2
+	RA 21.30812312
+	Dec 38.3995778
+	Radius 66.305
+	Distance 4933.298
 }
 
-OpenCluster "Kronberger 81"
+OpenCluster "OC 0143"
 {
-	RA 21.435833
-	Dec 53.532778
-	Distance 19243
-	Radius 9.8
+	RA 21.31410198
+	Dec 49.06723924
+	Radius 38.873
+	Distance 7893.12
 }
 
-OpenCluster "NGC 7082"
+OpenCluster "CWNU 213:Theia 7580"
 {
-	RA 21.488056
-	Dec 47.126667
-	Distance 4703
-	Radius 17.1
+	RA 21.32069193
+	Dec 56.96329522
+	Radius 61.586
+	Distance 4444.69
 }
 
-OpenCluster "Platais 1"
+OpenCluster "UBC 386"
 {
-	RA 21.500556
-	Dec 48.976667
-	Distance 4135
-	Radius 6.0
+	RA 21.32149548
+	Dec 62.0038085
+	Radius 37.899
+	Distance 3861.465
 }
 
-OpenCluster "NGC 7086"
+OpenCluster "CWNU 2892"
 {
-	RA 21.507500
-	Dec 51.600000
-	Distance 4233
-	Radius 7.4
+	RA 21.32688426
+	Dec 55.58242673
+	Radius 39.859
+	Distance 6852.288
 }
 
-OpenCluster "NGC 7092"
+OpenCluster "UBC 1601"
 {
-	RA 21.530000
-	Dec 48.433333
-	Distance 1063
-	Radius 4.5
+	RA 21.32842885
+	Dec 55.0803042
+	Radius 55.748
+	Distance 9461.191
 }
 
-OpenCluster "Trumpler 37"
+OpenCluster "HSC 694"
 {
-	RA 21.651667
-	Dec 57.500000
-	Distance 2723
-	Radius 35.3
+	RA 21.33718377
+	Dec 44.4273129
+	Radius 66.671
+	Distance 12482.385
 }
 
-OpenCluster "ASCC 114"
+OpenCluster "UBC 1138"
 {
-	RA 21.666944
-	Dec 53.970000
-	Distance 1793
-	Radius 5.0
+	RA 21.35582085
+	Dec 50.30262793
+	Radius 41.747
+	Distance 5218.513
 }
 
-OpenCluster "NGC 7128"
+OpenCluster "NGC 7058:MWSC 3501:Theia 1641"
 {
-	RA 21.732500
-	Dec 53.715000
-	Distance 7524
-	Radius 4.4
+	RA 21.36057285
+	Dec 50.83012287
+	Radius 136.405
+	Distance 1183.325
 }
 
-OpenCluster "NGC 7142"
+OpenCluster "DSH J2121.7+5036:MWSC 3500:Teutsch 144"
 {
-	RA 21.752500
-	Dec 65.775000
-	Distance 5499
-	Radius 9.6
+	RA 21.36234286
+	Dec 50.61420049
+	Radius 36.045
+	Distance 8583.08
 }
 
-OpenCluster "IC 5146"
+OpenCluster "HSC 684"
 {
-	RA 21.890000
-	Dec 47.266667
-	Distance 2778
-	Radius 8.1
+	RA 21.36963734
+	Dec 42.3500246
+	Radius 38.038
+	Distance 5354.302
 }
 
-OpenCluster "NGC 7160"
+OpenCluster "Theia 26"
 {
-	RA 21.894444
-	Dec 62.603333
-	Distance 2573
-	Radius 1.9
+	RA 21.3734053
+	Dec 46.86177668
+	Radius 80.401
+	Distance 2328.459
 }
 
-OpenCluster "Berkeley 93"
+OpenCluster "FSR 0295:FSR 295:MWSC 3503"
 {
-	RA 21.936667
-	Dec 63.933333
-	Distance 18265
-	Radius 5.3
+	RA 21.37642686
+	Dec 49.89817461
+	Radius 52.295
+	Distance 7630.864
 }
 
-OpenCluster "ASCC 115"
+OpenCluster "FSR 0379:FSR 379:MWSC 3504"
 {
-	RA 21.948056
-	Dec 51.480000
-	Distance 1957
-	Radius 5.5
+	RA 21.38042567
+	Dec 69.36114788
+	Radius 20.735
+	Distance 3237.697
 }
 
-OpenCluster "ASCC 116"
+OpenCluster "HSC 732"
 {
-	RA 21.976111
-	Dec 54.490000
-	Distance 16308
-	Radius 51.2
+	RA 21.38258777
+	Dec 50.26634697
+	Radius 76.316
+	Distance 12847.117
 }
 
-OpenCluster "ASCC 117"
+OpenCluster "HSC 708"
 {
-	RA 22.083056
-	Dec 62.270000
-	Distance 3914
-	Radius 23.9
+	RA 21.38353309
+	Dec 46.25974675
+	Radius 37.095
+	Distance 3994.117
 }
 
-OpenCluster "NGC 7209"
+OpenCluster "HSC 754"
 {
-	RA 22.085278
-	Dec 46.483333
-	Distance 3809
-	Radius 7.8
+	RA 21.38673424
+	Dec 56.04675929
+	Radius 53.087
+	Distance 3253.827
 }
 
-OpenCluster "Alessi-Teutsch 5"
+OpenCluster "HSC 606"
 {
-	RA 22.140833
-	Dec 61.028333
-	Distance 2935
-	Radius 10.8
+	RA 21.38913207
+	Dec 28.13582167
+	Radius 82.129
+	Distance 1265.857
 }
 
-OpenCluster "NGC 7226"
+OpenCluster "NGC 7062:Collinder 434:FSR 286:MWSC 3505:OCL 205"
 {
-	RA 22.173889
-	Dec 55.398333
-	Distance 8532
-	Radius 2.5
+	RA 21.39063102
+	Dec 46.38970896
+	Radius 40.558
+	Distance 7601.034
 }
 
-OpenCluster "NGC 7235"
+OpenCluster "FSR 0296:FSR 296:MWSC 3506:OC 0147"
 {
-	RA 22.206944
-	Dec 57.270000
-	Distance 10861
-	Radius 7.9
+	RA 21.39825714
+	Dec 49.92745532
+	Radius 74.698
+	Distance 10058.178
 }
 
-OpenCluster "NGC 7243"
+OpenCluster "NGC 7067:Collinder 436:MWSC 3508:OCL 208"
 {
-	RA 22.252222
-	Dec 49.898333
-	Distance 2635
-	Radius 11.1
+	RA 21.4033275
+	Dec 48.01075175
+	Radius 231.135
+	Distance 16796.407
 }
 
-OpenCluster "NGC 7245"
+OpenCluster "NGC 7063:Collinder 435:MWSC 3507:OCL 192"
 {
-	RA 22.253056
-	Dec 54.343333
-	Distance 12394
-	Radius 9.0
+	RA 21.40782463
+	Dec 36.48890403
+	Radius 99.332
+	Distance 2141.537
 }
 
-OpenCluster "King 9"
+OpenCluster "Berkeley 92:FSR 329:MWSC 3510:OCL 220"
 {
-	RA 22.258333
-	Dec 54.400000
-	Distance 25767
-	Radius 11.2
+	RA 21.41323792
+	Dec 57.52849832
+	Radius 116.745
+	Distance 22018.573
 }
 
-OpenCluster "IC 1442"
+OpenCluster "HSC 740"
 {
-	RA 22.275000
-	Dec 54.050000
-	Distance 7651
-	Radius 5.6
+	RA 21.41577179
+	Dec 52.81150132
+	Radius 111.345
+	Distance 28849.708
 }
 
-OpenCluster "Pismis-Moreno 1"
+OpenCluster "DSH J2126.1+5331:FSR 313:Kronberger 81:MWSC 3511"
 {
-	RA 22.313333
-	Dec 63.266667
-	Distance 2935
-	Radius 2.6
+	RA 21.43594112
+	Dec 53.5297852
+	Radius 76.846
+	Distance 15640.643
 }
 
-OpenCluster "ASCC 119"
+OpenCluster "HSC 473"
 {
-	RA 22.320000
-	Dec 46.900000
-	Distance 3261
-	Radius 12.0
+	RA 21.43609174
+	Dec 5.55401467
+	Radius 49.502
+	Distance 2154.542
 }
 
-OpenCluster "NGC 7261"
+OpenCluster "OC 0150"
 {
-	RA 22.336389
-	Dec 58.121667
-	Distance 5482
-	Radius 4.0
+	RA 21.43640664
+	Dec 52.72009955
+	Radius 63.506
+	Distance 6074.325
 }
 
-OpenCluster "Berkeley 94"
+OpenCluster "HSC 689"
 {
-	RA 22.378333
-	Dec 55.850000
-	Distance 8578
-	Radius 3.7
+	RA 21.43801652
+	Dec 42.48322066
+	Radius 56.696
+	Distance 2047.361
+}
+
+OpenCluster "OCSN 27"
+{
+	RA 21.44048048
+	Dec 47.63254455
+	Radius 125.875
+	Distance 1347.341
+}
+
+OpenCluster "HSC 784"
+{
+	RA 21.44420272
+	Dec 60.87629369
+	Radius 62.802
+	Distance 8529.832
+}
+
+OpenCluster "UBC 156"
+{
+	RA 21.44550233
+	Dec 49.12480925
+	Radius 49.207
+	Distance 7105.388
+}
+
+OpenCluster "OC 0148"
+{
+	RA 21.45851331
+	Dec 49.69018587
+	Radius 59.202
+	Distance 7892.788
+}
+
+OpenCluster "UBC 1139"
+{
+	RA 21.47256471
+	Dec 49.44635852
+	Radius 53.853
+	Distance 8351.429
+}
+
+OpenCluster "FSR 0306"
+{
+	RA 21.47461139
+	Dec 51.68954083
+	Radius 131.939
+	Distance 8418.136
+}
+
+OpenCluster "HSC 814"
+{
+	RA 21.47514705
+	Dec 66.44632688
+	Radius 17.699
+	Distance 2904.927
+}
+
+OpenCluster "Theia 822"
+{
+	RA 21.47605861
+	Dec 48.37343281
+	Radius 34.207
+	Distance 4493.281
+}
+
+OpenCluster "NGC 7082:MWSC 3517:OCL 209:Theia 2214"
+{
+	RA 21.47765656
+	Dec 47.1012803
+	Radius 46.303
+	Distance 4309.738
+}
+
+OpenCluster "CWNU 1205"
+{
+	RA 21.4803068
+	Dec 70.54418677
+	Radius 80.498
+	Distance 748.45
+}
+
+OpenCluster "HSC 876"
+{
+	RA 21.48315165
+	Dec 75.08814669
+	Radius 46.987
+	Distance 1962.276
+}
+
+OpenCluster "OC 0160"
+{
+	RA 21.48387417
+	Dec 58.73096111
+	Radius 47.859
+	Distance 2996.241
+}
+
+OpenCluster "Theia 178"
+{
+	RA 21.49478242
+	Dec 51.80205811
+	Radius 111.831
+	Distance 1759.984
+}
+
+OpenCluster "HSC 786"
+{
+	RA 21.49755096
+	Dec 61.57925471
+	Radius 41.308
+	Distance 3074.731
+}
+
+OpenCluster "HSC 771"
+{
+	RA 21.49811049
+	Dec 57.79231718
+	Radius 24.076
+	Distance 2879.074
+}
+
+OpenCluster "CWNU 333:OC 0142"
+{
+	RA 21.50297368
+	Dec 45.53258796
+	Radius 45.582
+	Distance 4953.456
+}
+
+OpenCluster "HSC 728"
+{
+	RA 21.50689588
+	Dec 47.84790111
+	Radius 52.788
+	Distance 15234.092
+}
+
+OpenCluster "UPK 136"
+{
+	RA 21.50729624
+	Dec 43.41697369
+	Radius 106.826
+	Distance 2092.721
+}
+
+OpenCluster "NGC 7086:Collinder 437:FSR 309:MWSC 3520:OCL 214:Theia 2737"
+{
+	RA 21.50851583
+	Dec 51.59531383
+	Radius 93.167
+	Distance 5209.987
+}
+
+OpenCluster "HSC 767"
+{
+	RA 21.51236338
+	Dec 57.39628117
+	Radius 30.753
+	Distance 3320.968
+}
+
+OpenCluster "OC 0152:Theia 5761"
+{
+	RA 21.5168472
+	Dec 52.83512812
+	Radius 152.742
+	Distance 9747.789
+}
+
+OpenCluster "HSC 696"
+{
+	RA 21.52153771
+	Dec 42.5447095
+	Radius 51.309
+	Distance 2697.211
+}
+
+OpenCluster "M 39:NGC 7092:Melotte 236:Collinder 438:MWSC 3521:OCL 211:Theia 517:Theia 822"
+{
+	RA 21.52203378
+	Dec 48.34913184
+	Radius 159.846
+	Distance 964.999
+}
+
+OpenCluster "HSC 703"
+{
+	RA 21.52420004
+	Dec 44.08695607
+	Radius 121.581
+	Distance 4438.838
+}
+
+OpenCluster "HSC 460"
+{
+	RA 21.52602061
+	Dec 2.62495963
+	Radius 50.067
+	Distance 623.147
+}
+
+OpenCluster "Theia 1297"
+{
+	RA 21.53593872
+	Dec 66.06975385
+	Radius 256.314
+	Distance 1709.025
+}
+
+OpenCluster "HSC 739"
+{
+	RA 21.55080471
+	Dec 51.30683498
+	Radius 69.641
+	Distance 14835.998
+}
+
+OpenCluster "CWNU 1756"
+{
+	RA 21.56472657
+	Dec 51.90779212
+	Radius 44.652
+	Distance 8310.501
+}
+
+OpenCluster "Theia 101"
+{
+	RA 21.57155045
+	Dec 53.07200755
+	Radius 102.783
+	Distance 1511.923
+}
+
+OpenCluster "HSC 774"
+{
+	RA 21.57355151
+	Dec 57.50739377
+	Radius 120.834
+	Distance 25394.129
+}
+
+OpenCluster "CWNU 1545:Theia 4007"
+{
+	RA 21.58405119
+	Dec 49.61527969
+	Radius 23.485
+	Distance 5725.281
+}
+
+OpenCluster "FSR 0320:UBC 158"
+{
+	RA 21.58933271
+	Dec 53.66205218
+	Radius 21.143
+	Distance 6758.276
+}
+
+OpenCluster "Theia 1528"
+{
+	RA 21.59023165
+	Dec 74.77706554
+	Radius 37.896
+	Distance 874.913
+}
+
+OpenCluster "CWNU 1987"
+{
+	RA 21.59153472
+	Dec 60.00825529
+	Radius 59.178
+	Distance 5212.025
+}
+
+OpenCluster "DSH J2135.5+5330:Kronberger 84:MWSC 3532"
+{
+	RA 21.59253423
+	Dec 53.51407799
+	Radius 102.607
+	Distance 15503.573
+}
+
+OpenCluster "HSC 763"
+{
+	RA 21.59887773
+	Dec 55.9256071
+	Radius 41.8
+	Distance 3179.874
+}
+
+OpenCluster "HSC 758"
+{
+	RA 21.59888095
+	Dec 55.1171061
+	Radius 27.888
+	Distance 468.204
+}
+
+OpenCluster "CWNU 227:Theia 3986:UBC 1141"
+{
+	RA 21.59937937
+	Dec 50.4918821
+	Radius 28.052
+	Distance 5809.861
+}
+
+OpenCluster "CWNU 2371"
+{
+	RA 21.59974258
+	Dec 51.36706458
+	Radius 39.585
+	Distance 6982.098
+}
+
+OpenCluster "UPK 164"
+{
+	RA 21.60138597
+	Dec 58.77185691
+	Radius 48.726
+	Distance 2964.048
+}
+
+OpenCluster "FSR 0324"
+{
+	RA 21.60351706
+	Dec 53.85596958
+	Radius 30.755
+	Distance 10683.353
+}
+
+OpenCluster "HSC 894"
+{
+	RA 21.60380187
+	Dec 76.35822113
+	Radius 55.34
+	Distance 745.188
+}
+
+OpenCluster "HSC 748"
+{
+	RA 21.60408605
+	Dec 52.99244578
+	Radius 62.149
+	Distance 13539.146
+}
+
+OpenCluster "IC 1396:Theia 990:Trumpler 37"
+{
+	RA 21.60735266
+	Dec 57.56737453
+	Radius 98.857
+	Distance 2675.122
+}
+
+OpenCluster "HXHWL 56"
+{
+	RA 21.62017376
+	Dec 47.65168771
+	Radius 32.222
+	Distance 4139.403
+}
+
+OpenCluster "CWNU 1012"
+{
+	RA 21.62194578
+	Dec -19.52708554
+	Radius 212.488
+	Distance 925.404
+}
+
+OpenCluster "UBC 1146"
+{
+	RA 21.62516872
+	Dec 55.58979347
+	Radius 64.424
+	Distance 10801.765
+}
+
+OpenCluster "HSC 691"
+{
+	RA 21.62711458
+	Dec 40.39469079
+	Radius 57.017
+	Distance 2286.441
+}
+
+OpenCluster "OCSN 28"
+{
+	RA 21.62793514
+	Dec 50.89109399
+	Radius 88.511
+	Distance 1427.019
+}
+
+OpenCluster "HSC 731"
+{
+	RA 21.63434041
+	Dec 47.57621157
+	Radius 61.281
+	Distance 3651.145
+}
+
+OpenCluster "CWNU 2739"
+{
+	RA 21.63537676
+	Dec 48.60538252
+	Radius 51.528
+	Distance 7509.506
+}
+
+OpenCluster "HSC 699"
+{
+	RA 21.63594434
+	Dec 41.83170753
+	Radius 60.683
+	Distance 2006.012
+}
+
+OpenCluster "IC 1396:Trumpler 37"
+{
+	RA 21.64318325
+	Dec 57.7676863
+	Radius 163.487
+	Distance 1960.1
+}
+
+OpenCluster "OCSN 30:Theia 248"
+{
+	RA 21.64638439
+	Dec 53.66893884
+	Radius 148.823
+	Distance 1555.781
+}
+
+OpenCluster "UBC 1143"
+{
+	RA 21.64695914
+	Dec 52.25578757
+	Radius 65.538
+	Distance 13693.113
+}
+
+OpenCluster "UBC 1140"
+{
+	RA 21.64748725
+	Dec 49.09753886
+	Radius 106.552
+	Distance 18037.95
+}
+
+OpenCluster "IC 1396:Trumpler 37"
+{
+	RA 21.65020125
+	Dec 57.493877
+	Radius 47.854
+	Distance 2953.954
+}
+
+OpenCluster "HSC 717"
+{
+	RA 21.6516715
+	Dec 44.34789613
+	Radius 45.088
+	Distance 2061.047
+}
+
+OpenCluster "Theia 901:UBC 10a:UBC 167:UPK 172"
+{
+	RA 21.65481473
+	Dec 62.32388856
+	Radius 71.465
+	Distance 2934.448
+}
+
+OpenCluster "UBC 382:UBC 591"
+{
+	RA 21.6672993
+	Dec 49.31300964
+	Radius 38.422
+	Distance 7167.946
+}
+
+OpenCluster "ASCC 114:MWSC 3542:Theia 296"
+{
+	RA 21.67085431
+	Dec 53.98983419
+	Radius 38.516
+	Distance 2992.825
+}
+
+OpenCluster "CWNU 1287"
+{
+	RA 21.67325663
+	Dec 50.52543146
+	Radius 78.495
+	Distance 12618.792
+}
+
+OpenCluster "FSR 0316:FSR 316:MWSC 3545"
+{
+	RA 21.68082554
+	Dec 52.30291804
+	Radius 29.765
+	Distance 13719.133
+}
+
+OpenCluster "HSC 770"
+{
+	RA 21.68382536
+	Dec 56.05423871
+	Radius 41.206
+	Distance 11494.14
+}
+
+OpenCluster "CWNU 2149"
+{
+	RA 21.68404983
+	Dec 55.08299895
+	Radius 90.348
+	Distance 7505.033
+}
+
+OpenCluster "Theia 901:UBC 10a"
+{
+	RA 21.68518598
+	Dec 61.96751167
+	Radius 89.603
+	Distance 2829.364
+}
+
+OpenCluster "Theia 487:UBC 150"
+{
+	RA 21.70446439
+	Dec 37.58100867
+	Radius 47.111
+	Distance 2710.077
+}
+
+OpenCluster "HSC 575"
+{
+	RA 21.70452523
+	Dec 19.09883335
+	Radius 63.364
+	Distance 819.63
+}
+
+OpenCluster "HSC 769"
+{
+	RA 21.7088654
+	Dec 55.73775343
+	Radius 57.837
+	Distance 7077.96
+}
+
+OpenCluster "NGC 7129"
+{
+	RA 21.71606296
+	Dec 66.12282299
+	Radius 40.022
+	Distance 2971.159
+}
+
+OpenCluster "HSC 956"
+{
+	RA 21.72096291
+	Dec 86.58321854
+	Radius 74.857
+	Distance 1582.752
+}
+
+OpenCluster "HSC 760"
+{
+	RA 21.7210489
+	Dec 54.02582627
+	Radius 36.333
+	Distance 3885.31
+}
+
+OpenCluster "CWNU 2034"
+{
+	RA 21.72533279
+	Dec 49.64218686
+	Radius 52.781
+	Distance 7008.299
+}
+
+OpenCluster "NGC 7128:Collinder 440:FSR 327:MWSC 3554:OCL 218:OC 0157"
+{
+	RA 21.73261121
+	Dec 53.71574777
+	Radius 55.269
+	Distance 11085.738
+}
+
+OpenCluster "HSC 705"
+{
+	RA 21.73270549
+	Dec 41.96761114
+	Radius 140.788
+	Distance 2248.776
+}
+
+OpenCluster "Theia 2883:Theia 7321:UBC 387"
+{
+	RA 21.73994418
+	Dec 58.76238467
+	Radius 140.271
+	Distance 5061.951
+}
+
+OpenCluster "NGC 7142:Collinder 442:FSR 373:MWSC 3557:OCL 241:Theia 6461"
+{
+	RA 21.75360919
+	Dec 65.778867
+	Radius 45.132
+	Distance 7526.935
+}
+
+OpenCluster "DSH J2145.6+5805:MWSC 3558:SAI 144:Teutsch 74"
+{
+	RA 21.76113
+	Dec 58.09479724
+	Radius 73.774
+	Distance 13677.523
+}
+
+OpenCluster "HSC 725"
+{
+	RA 21.7636857
+	Dec 44.62893256
+	Radius 45.248
+	Distance 739.539
+}
+
+OpenCluster "HSC 772"
+{
+	RA 21.76789813
+	Dec 55.59265553
+	Radius 70.661
+	Distance 15211.004
+}
+
+OpenCluster "UBC 1147"
+{
+	RA 21.77605462
+	Dec 54.4890258
+	Radius 53.061
+	Distance 8005.414
+}
+
+OpenCluster "Capricornus:ESO 600-11:GCL 123:MWSC 3561:Pal 12:Palomar 12"
+{
+	RA 21.77733699
+	Dec -21.254175
+	Radius 349.833
+	Distance 44902.281
+}
+
+OpenCluster "CWNU 2583"
+{
+	RA 21.77974593
+	Dec 56.88398367
+	Radius 65.267
+	Distance 6967.57
+}
+
+OpenCluster "Theia 131:UPK 169"
+{
+	RA 21.78276301
+	Dec 59.72225193
+	Radius 65.21
+	Distance 2731.203
+}
+
+OpenCluster "CWNU 1352"
+{
+	RA 21.78285103
+	Dec 54.18709457
+	Radius 53.346
+	Distance 5259.591
+}
+
+OpenCluster "HSC 746"
+{
+	RA 21.79205118
+	Dec 50.32441673
+	Radius 52.645
+	Distance 7589.182
+}
+
+OpenCluster "HSC 735"
+{
+	RA 21.79926637
+	Dec 47.86330513
+	Radius 17.95
+	Distance 2699.678
+}
+
+OpenCluster "Theia 4912"
+{
+	RA 21.80654186
+	Dec 52.54834096
+	Radius 72.89
+	Distance 2673.835
+}
+
+OpenCluster "CWNU 1790"
+{
+	RA 21.81320202
+	Dec 53.87523208
+	Radius 70.545
+	Distance 4928.267
+}
+
+OpenCluster "Theia 91:UBC 10b"
+{
+	RA 21.81488915
+	Dec 61.21420051
+	Radius 44.15
+	Distance 3057.878
+}
+
+OpenCluster "UBC 1149"
+{
+	RA 21.81497647
+	Dec 54.8244151
+	Radius 77.234
+	Distance 11516.419
+}
+
+OpenCluster "Theia 1922"
+{
+	RA 21.82406706
+	Dec 51.67767989
+	Radius 93.5
+	Distance 5705.453
+}
+
+OpenCluster "CWNU 1585"
+{
+	RA 21.82407796
+	Dec 52.62588229
+	Radius 136.123
+	Distance 9764.796
+}
+
+OpenCluster "CWNU 2390"
+{
+	RA 21.82760132
+	Dec 54.83056716
+	Radius 70.331
+	Distance 10493.304
+}
+
+OpenCluster "UBC 1151"
+{
+	RA 21.83340985
+	Dec 56.95500684
+	Radius 56.092
+	Distance 6417.567
+}
+
+OpenCluster "HSC 773"
+{
+	RA 21.83833739
+	Dec 54.87559949
+	Radius 87.717
+	Distance 12667.139
+}
+
+OpenCluster "FSR 0336:FSR 336:MWSC 3567:SAI 145"
+{
+	RA 21.84713602
+	Dec 55.23988774
+	Radius 74.286
+	Distance 8040.158
+}
+
+OpenCluster "FSR 0325:FSR 325:MWSC 3566:UBC 160"
+{
+	RA 21.84802019
+	Dec 51.37601117
+	Radius 32.461
+	Distance 6027.029
+}
+
+OpenCluster "HSC 734"
+{
+	RA 21.84874927
+	Dec 45.47907481
+	Radius 159.001
+	Distance 4040.311
+}
+
+OpenCluster "CWNU 286"
+{
+	RA 21.84879779
+	Dec 64.01389544
+	Radius 14.826
+	Distance 2824.731
+}
+
+OpenCluster "HSC 776"
+{
+	RA 21.84884255
+	Dec 55.24123159
+	Radius 13.126
+	Distance 5905.033
+}
+
+OpenCluster "LISC 3205:UBC 162"
+{
+	RA 21.85141952
+	Dec 52.97311313
+	Radius 50.733
+	Distance 6961.541
+}
+
+OpenCluster "CWNU 2613"
+{
+	RA 21.85275913
+	Dec 56.36718362
+	Radius 72.616
+	Distance 6724.046
+}
+
+OpenCluster "HSC 751"
+{
+	RA 21.8529296
+	Dec 50.9213246
+	Radius 80.75
+	Distance 1126.307
+}
+
+OpenCluster "CWNU 162"
+{
+	RA 21.8542263
+	Dec 58.11864452
+	Radius 79.567
+	Distance 4108.595
+}
+
+OpenCluster "Teutsch 324"
+{
+	RA 21.86282157
+	Dec 56.71083586
+	Radius 224.819
+	Distance 21515.869
+}
+
+OpenCluster "HSC 762"
+{
+	RA 21.86417893
+	Dec 52.7393901
+	Radius 52.095
+	Distance 14329.762
+}
+
+OpenCluster "CWNU 348"
+{
+	RA 21.87566375
+	Dec 64.94553439
+	Radius 26.757
+	Distance 3542.933
+}
+
+OpenCluster "UBC 1148"
+{
+	RA 21.8792702
+	Dec 53.92899623
+	Radius 37.799
+	Distance 12621.184
+}
+
+OpenCluster "UBC 1145"
+{
+	RA 21.88146226
+	Dec 51.58661022
+	Radius 87.214
+	Distance 9527.686
+}
+
+OpenCluster "IC 5146:Theia 88"
+{
+	RA 21.89207694
+	Dec 47.26153624
+	Radius 50.87
+	Distance 2443.916
+}
+
+OpenCluster "UPK 156"
+{
+	RA 21.89336552
+	Dec 51.95764045
+	Radius 36.16
+	Distance 2977.131
+}
+
+OpenCluster "HSC 811"
+{
+	RA 21.89426074
+	Dec 62.64878523
+	Radius 21.829
+	Distance 2492.9
+}
+
+OpenCluster "CWNU 2043:Theia 3659"
+{
+	RA 21.89659185
+	Dec 51.61100984
+	Radius 36.102
+	Distance 8232.991
+}
+
+OpenCluster "NGC 7160:Collinder 443:MWSC 3572:OCL 236:Theia 42"
+{
+	RA 21.89704221
+	Dec 62.57923036
+	Radius 45.636
+	Distance 2918.711
+}
+
+OpenCluster "HXHWL 1:Theia 4165"
+{
+	RA 21.90572793
+	Dec 46.96535084
+	Radius 116.071
+	Distance 4682.217
+}
+
+OpenCluster "HSC 448"
+{
+	RA 21.90847817
+	Dec -3.03937369
+	Radius 212.605
+	Distance 1122.618
+}
+
+OpenCluster "UBC 384"
+{
+	RA 21.91357478
+	Dec 52.81967285
+	Radius 52.239
+	Distance 7826.32
+}
+
+OpenCluster "Theia 3336:UBC 157"
+{
+	RA 21.91929831
+	Dec 49.68270143
+	Radius 88.408
+	Distance 3763.153
+}
+
+OpenCluster "CWNU 1055"
+{
+	RA 21.92209666
+	Dec 65.352464
+	Radius 66.71
+	Distance 1465.925
+}
+
+OpenCluster "Berkeley 93:MWSC 3574:OCL 239"
+{
+	RA 21.92479104
+	Dec 63.92713143
+	Radius 312.467
+	Distance 29672.128
+}
+
+OpenCluster "HSC 789"
+{
+	RA 21.94148997
+	Dec 58.91030116
+	Radius 36.805
+	Distance 2871.166
+}
+
+OpenCluster "ASCC 115:MWSC 3575"
+{
+	RA 21.94599326
+	Dec 51.54924563
+	Radius 38.562
+	Distance 2457.406
+}
+
+OpenCluster "HSC 766"
+{
+	RA 21.95084626
+	Dec 52.84840393
+	Radius 55.166
+	Distance 17204.802
+}
+
+OpenCluster "Theia 2503:Theia 3978:Theia 6166"
+{
+	RA 21.95229268
+	Dec 50.17871684
+	Radius 167.699
+	Distance 5569.636
+}
+
+OpenCluster "UBC 1152"
+{
+	RA 21.95281365
+	Dec 56.30943853
+	Radius 26.974
+	Distance 7983.137
+}
+
+OpenCluster "HSC 790"
+{
+	RA 21.95368742
+	Dec 59.08605153
+	Radius 50.071
+	Distance 13030.345
+}
+
+OpenCluster "HSC 765"
+{
+	RA 21.9574688
+	Dec 52.69845048
+	Radius 53.209
+	Distance 11416.28
+}
+
+OpenCluster "Theia 7701:UBC 1162"
+{
+	RA 21.9679458
+	Dec 60.18481939
+	Radius 84.153
+	Distance 12062.42
+}
+
+OpenCluster "UBC 1600"
+{
+	RA 21.97311845
+	Dec 46.04770561
+	Radius 160.036
+	Distance 7662.176
+}
+
+OpenCluster "OCSN 31"
+{
+	RA 21.97707861
+	Dec 50.78616573
+	Radius 85.33
+	Distance 864.363
+}
+
+OpenCluster "CWNU 1107"
+{
+	RA 21.98302275
+	Dec 63.98465654
+	Radius 36.231
+	Distance 3169.522
+}
+
+OpenCluster "CWNU 1524"
+{
+	RA 21.9889251
+	Dec 56.24106668
+	Radius 69.767
+	Distance 6063.495
+}
+
+OpenCluster "Theia 5356:Theia 8022"
+{
+	RA 22.00329369
+	Dec 64.18101552
+	Radius 67.808
+	Distance 3403.62
+}
+
+OpenCluster "CWNU 1965:Theia 3308"
+{
+	RA 22.01115338
+	Dec 53.0900935
+	Radius 24.499
+	Distance 7934.037
+}
+
+OpenCluster "CWNU 2096"
+{
+	RA 22.0155422
+	Dec 55.52710889
+	Radius 50.154
+	Distance 8148.152
+}
+
+OpenCluster "HSC 686"
+{
+	RA 22.02033722
+	Dec 34.3187976
+	Radius 54.468
+	Distance 9489.77
+}
+
+OpenCluster "CWNU 1636:Theia 6979"
+{
+	RA 22.0208781
+	Dec 61.19919319
+	Radius 33.039
+	Distance 5045.868
+}
+
+OpenCluster "Theia 619"
+{
+	RA 22.02299751
+	Dec 53.7988948
+	Radius 199.463
+	Distance 1631.398
+}
+
+OpenCluster "HSC 785"
+{
+	RA 22.02406666
+	Dec 55.70714836
+	Radius 46.081
+	Distance 13750.289
+}
+
+OpenCluster "FSR 0344:FSR 344:MWSC 3580"
+{
+	RA 22.02896564
+	Dec 54.80173179
+	Radius 39.535
+	Distance 13374.993
+}
+
+OpenCluster "HXHWL 28:UBC 1154"
+{
+	RA 22.03144433
+	Dec 56.02723219
+	Radius 56.278
+	Distance 4972.609
+}
+
+OpenCluster "UBC 1161"
+{
+	RA 22.03489688
+	Dec 59.45830112
+	Radius 144.708
+	Distance 17271.574
+}
+
+OpenCluster "Theia 3978:UBC 383"
+{
+	RA 22.0429347
+	Dec 49.11799806
+	Radius 66.706
+	Distance 5709.817
+}
+
+OpenCluster "Theia 2528:UBC 163"
+{
+	RA 22.05908738
+	Dec 55.64129947
+	Radius 79.319
+	Distance 4967.331
+}
+
+OpenCluster "CWNU 1276"
+{
+	RA 22.0596744
+	Dec 52.55186973
+	Radius 51.196
+	Distance 7391.935
+}
+
+OpenCluster "HSC 750"
+{
+	RA 22.06391466
+	Dec 48.19266606
+	Radius 51.681
+	Distance 7027.982
+}
+
+OpenCluster "OC 0168"
+{
+	RA 22.07693191
+	Dec 56.9660361
+	Radius 127.602
+	Distance 19619.106
+}
+
+OpenCluster "NGC 7209:Melotte 238:Collinder 444:MWSC 3585:OCL 215:Theia 4421"
+{
+	RA 22.08186228
+	Dec 46.53120675
+	Radius 137.38
+	Distance 3867.837
+}
+
+OpenCluster "HSC 787"
+{
+	RA 22.08497445
+	Dec 56.33330025
+	Radius 40.451
+	Distance 13367.365
+}
+
+OpenCluster "CWNU 2256"
+{
+	RA 22.08815389
+	Dec 54.23520829
+	Radius 16.889
+	Distance 6955.034
+}
+
+OpenCluster "CWNU 1376"
+{
+	RA 22.08818598
+	Dec 52.39445393
+	Radius 49.373
+	Distance 8278.06
+}
+
+OpenCluster "HSC 768"
+{
+	RA 22.09019747
+	Dec 51.40262772
+	Radius 108.525
+	Distance 14140.049
+}
+
+OpenCluster "HSC 788"
+{
+	RA 22.09029142
+	Dec 57.06827631
+	Radius 39.94
+	Distance 10473.395
+}
+
+OpenCluster "Theia 873"
+{
+	RA 22.10021859
+	Dec 59.52533094
+	Radius 83.694
+	Distance 2725.643
+}
+
+OpenCluster "CWNU 1639"
+{
+	RA 22.10317526
+	Dec 59.51753132
+	Radius 22.656
+	Distance 8365.963
+}
+
+OpenCluster "HSC 813"
+{
+	RA 22.10540749
+	Dec 61.17394713
+	Radius 67.255
+	Distance 3724.208
+}
+
+OpenCluster "CWNU 1156:Theia 3779"
+{
+	RA 22.10640382
+	Dec 63.00332851
+	Radius 58.356
+	Distance 3268.002
+}
+
+OpenCluster "CWNU 2001"
+{
+	RA 22.12344397
+	Dec 58.57145857
+	Radius 45.561
+	Distance 6754.462
+}
+
+OpenCluster "FSR 0342:FSR 342:MWSC 3588:SAI 146:Theia 5154:Theia 5985"
+{
+	RA 22.12836144
+	Dec 53.09411234
+	Radius 95.423
+	Distance 8809.997
+}
+
+OpenCluster "Theia 167"
+{
+	RA 22.13482588
+	Dec 49.19212984
+	Radius 140.945
+	Distance 1104.936
+}
+
+OpenCluster "ASCC 118:AT 5:Alessi-Teutsch 5:Alessi 27:Alessi Teutsch 5:MWSC 3589"
+{
+	RA 22.13621005
+	Dec 61.05242842
+	Radius 38.749
+	Distance 2855.564
+}
+
+OpenCluster "HSC 803"
+{
+	RA 22.14656421
+	Dec 58.58986186
+	Radius 87.147
+	Distance 1260.484
+}
+
+OpenCluster "UBC 592"
+{
+	RA 22.14821556
+	Dec 52.96708851
+	Radius 67.365
+	Distance 11672.196
+}
+
+OpenCluster "CWNU 144"
+{
+	RA 22.15294201
+	Dec 50.89679516
+	Radius 134.729
+	Distance 4065.874
+}
+
+OpenCluster "CWNU 1126"
+{
+	RA 22.15464192
+	Dec 64.0763187
+	Radius 37.37
+	Distance 2956.326
+}
+
+OpenCluster "UBC 1158"
+{
+	RA 22.15549865
+	Dec 56.58569829
+	Radius 50.702
+	Distance 8780.415
+}
+
+OpenCluster "Theia 893:UBC 168"
+{
+	RA 22.16011613
+	Dec 57.54641728
+	Radius 121.933
+	Distance 2950.803
+}
+
+OpenCluster "HSC 777"
+{
+	RA 22.16639782
+	Dec 51.93961799
+	Radius 140.91
+	Distance 15341.947
+}
+
+OpenCluster "CWNU 312"
+{
+	RA 22.17054908
+	Dec 56.46879353
+	Radius 91.228
+	Distance 4109.07
+}
+
+OpenCluster "Collinder 471:OCSN 38:Theia 10"
+{
+	RA 22.1708714
+	Dec 73.03231822
+	Radius 55.947
+	Distance 1106.974
+}
+
+OpenCluster "FSR 0358:FSR 358:Kirkpatrick 1:MWSC 3590"
+{
+	RA 22.1712077
+	Dec 58.78961612
+	Radius 172.463
+	Distance 22129.406
+}
+
+OpenCluster "HSC 796"
+{
+	RA 22.17280826
+	Dec 57.76507401
+	Radius 138.125
+	Distance 17920.388
+}
+
+OpenCluster "NGC 7226:Collinder 446:FSR 349:MWSC 3591:OCL 226:OC 0167"
+{
+	RA 22.1735989
+	Dec 55.39432347
+	Radius 45.974
+	Distance 16253.012
+}
+
+OpenCluster "IC 1434:Melotte 239:Collinder 445:FSR343:MWSC 3592:OCL 223:OC 0162:OC 0163:Theia 5154"
+{
+	RA 22.17501952
+	Dec 52.86169454
+	Radius 135.519
+	Distance 10895.22
+}
+
+OpenCluster "HSC 779"
+{
+	RA 22.17562799
+	Dec 52.59420395
+	Radius 44.741
+	Distance 7443.273
+}
+
+OpenCluster "HSC 792"
+{
+	RA 22.17761164
+	Dec 57.25339074
+	Radius 115.593
+	Distance 20508.768
+}
+
+OpenCluster "CWNU 1115:OC 0185"
+{
+	RA 22.18275723
+	Dec 63.39593762
+	Radius 136.585
+	Distance 2964.19
+}
+
+OpenCluster "UBC 1156"
+{
+	RA 22.19192355
+	Dec 55.65070475
+	Radius 60.099
+	Distance 10194.76
+}
+
+OpenCluster "UBC 1142"
+{
+	RA 22.19403908
+	Dec 45.15102984
+	Radius 68.522
+	Distance 9172.447
+}
+
+OpenCluster "UPK 189"
+{
+	RA 22.1963555
+	Dec 65.58760251
+	Radius 88.512
+	Distance 3209.056
+}
+
+OpenCluster "OC 0165:Teutsch 181:Theia 2293:Theia 3159:Theia 3245:Theia 3701:Theia 4516"
+{
+	RA 22.1998255
+	Dec 53.92790625
+	Radius 104.76
+	Distance 3480.165
+}
+
+OpenCluster "HSC 736"
+{
+	RA 22.20036479
+	Dec 42.66377735
+	Radius 18.182
+	Distance 2280.307
+}
+
+OpenCluster "HSC 761"
+{
+	RA 22.20329988
+	Dec 48.18995418
+	Radius 53.852
+	Distance 1578.515
+}
+
+OpenCluster "NGC 7235:OC 0171:OC 0172:OC 0173"
+{
+	RA 22.20576558
+	Dec 57.27330533
+	Radius 37.134
+	Distance 10986.114
+}
+
+OpenCluster "HSC 806"
+{
+	RA 22.20877551
+	Dec 58.31557512
+	Radius 67.271
+	Distance 13027.838
+}
+
+OpenCluster "HSC 794"
+{
+	RA 22.21095169
+	Dec 57.26200773
+	Radius 25.895
+	Distance 13581.27
+}
+
+OpenCluster "UBC 1153"
+{
+	RA 22.21345557
+	Dec 53.22159277
+	Radius 116.272
+	Distance 11603.745
+}
+
+OpenCluster "Teutsch 181"
+{
+	RA 22.2142058
+	Dec 54.00757815
+	Radius 96.177
+	Distance 1682.474
+}
+
+OpenCluster "DSH J2212.5+5851:MWSC 3597:Teutsch 125"
+{
+	RA 22.21991786
+	Dec 58.94084551
+	Radius 46.976
+	Distance 6581.317
+}
+
+OpenCluster "CWNU 2007"
+{
+	RA 22.22162004
+	Dec 56.4802831
+	Radius 27.245
+	Distance 9176.105
+}
+
+OpenCluster "OCSN 37:PTB 3:vdBergh 152"
+{
+	RA 22.22418849
+	Dec 70.17629104
+	Radius 15
+	Distance 1210.96
+}
+
+OpenCluster "CWNU 294:CWNU 311"
+{
+	RA 22.22890553
+	Dec 42.47926755
+	Radius 126.346
+	Distance 2075.177
+}
+
+OpenCluster "HSC 823"
+{
+	RA 22.22899277
+	Dec 61.40988459
+	Radius 27.312
+	Distance 3185.237
+}
+
+OpenCluster "DSH J2213.7+5543:MWSC 3599:Teutsch 126"
+{
+	RA 22.2318196
+	Dec 55.73141283
+	Radius 38.89
+	Distance 6980.529
+}
+
+OpenCluster "HSC 816"
+{
+	RA 22.233403
+	Dec 60.5757188
+	Radius 9.817
+	Distance 2848.376
+}
+
+OpenCluster "HSC 815"
+{
+	RA 22.23402374
+	Dec 60.39842537
+	Radius 39.929
+	Distance 2170.221
+}
+
+OpenCluster "BDSB30:BDSB 30:Kronberger 15:MWSC 3601"
+{
+	RA 22.2441951
+	Dec 61.44353163
+	Radius 28.857
+	Distance 2834.571
+}
+
+OpenCluster "NGC 7245:Melotte 241:Collinder 449:FSR 348:King 9:MWSC 3603:MWSC 3604:OCL 225:OCL 227:OC 0166:Theia 4757"
+{
+	RA 22.25395053
+	Dec 54.3387091
+	Radius 28.915
+	Distance 10873.573
+}
+
+OpenCluster "NGC 7243:Melotte 240:Collinder 448:MWSC 3602:OCL 221:Theia 356"
+{
+	RA 22.25448687
+	Dec 49.82474964
+	Radius 89.835
+	Distance 2818.476
+}
+
+OpenCluster "NGC 7245:Melotte 241:Collinder 449:FSR 348:King 9:MWSC 3603:MWSC 3604:OCL 225:OCL 227"
+{
+	RA 22.25860267
+	Dec 54.40801751
+	Radius 60.044
+	Distance 20481.619
+}
+
+OpenCluster "OC 0170"
+{
+	RA 22.25992168
+	Dec 56.20828183
+	Radius 81.049
+	Distance 7598.745
+}
+
+OpenCluster "HSC 824"
+{
+	RA 22.26224035
+	Dec 61.78915548
+	Radius 15.517
+	Distance 2973.569
+}
+
+OpenCluster "IC 1442:MWSC 3606:OCL 224:Theia 4265:UBC 164"
+{
+	RA 22.26547823
+	Dec 53.99161231
+	Radius 108.412
+	Distance 11101.451
+}
+
+OpenCluster "OC 0181"
+{
+	RA 22.26847736
+	Dec 60.91219694
+	Radius 14.4
+	Distance 2818.64
+}
+
+OpenCluster "CWNU 1882"
+{
+	RA 22.27022556
+	Dec 52.46281942
+	Radius 52.907
+	Distance 12023.019
+}
+
+OpenCluster "CWNU 2555"
+{
+	RA 22.27484108
+	Dec 55.51206353
+	Radius 41.375
+	Distance 14029.172
+}
+
+OpenCluster "FSR 0369:OC 0181"
+{
+	RA 22.27545924
+	Dec 60.79648629
+	Radius 12.732
+	Distance 2867.854
+}
+
+OpenCluster "UBC 166"
+{
+	RA 22.28309408
+	Dec 54.19384211
+	Radius 44.293
+	Distance 11104.575
+}
+
+OpenCluster "UBC 1163"
+{
+	RA 22.28373613
+	Dec 57.32163761
+	Radius 57.005
+	Distance 9231.461
+}
+
+OpenCluster "UPK 178"
+{
+	RA 22.29664034
+	Dec 60.08006241
+	Radius 41.051
+	Distance 3035.414
+}
+
+OpenCluster "CWNU 2541:Theia 4265"
+{
+	RA 22.30248598
+	Dec 53.72132324
+	Radius 109.64
+	Distance 10025.452
+}
+
+OpenCluster "FSR 0366:FSR 366:MWSC 3610"
+{
+	RA 22.30324487
+	Dec 59.11771994
+	Radius 63.089
+	Distance 11817.665
+}
+
+OpenCluster "Pismis-Moreno 1:Pismis Moreno 1"
+{
+	RA 22.30860688
+	Dec 63.23083947
+	Radius 56.434
+	Distance 2965.065
+}
+
+OpenCluster "CWNU 2746"
+{
+	RA 22.31110044
+	Dec 57.91991494
+	Radius 50.85
+	Distance 11833.984
+}
+
+OpenCluster "OC 0175"
+{
+	RA 22.31478712
+	Dec 57.43456174
+	Radius 58.01
+	Distance 9472.838
+}
+
+OpenCluster "SBB 2:Teutsch 127"
+{
+	RA 22.3162111
+	Dec 56.1228614
+	Radius 32.028
+	Distance 12505.723
+}
+
+OpenCluster "HSC 797"
+{
+	RA 22.3220477
+	Dec 55.98337883
+	Radius 49.561
+	Distance 12534.669
+}
+
+OpenCluster "HSC 793"
+{
+	RA 22.326652
+	Dec 55.76379941
+	Radius 95.739
+	Distance 14844.405
+}
+
+OpenCluster "NGC 7261:Collinder 450:FSR 363:MWSC 3617:OCL 237:OC 0177"
+{
+	RA 22.33660359
+	Dec 58.1262206
+	Radius 41.487
+	Distance 10582.317
+}
+
+OpenCluster "HSC 598"
+{
+	RA 22.34776576
+	Dec 13.20897655
+	Radius 107.863
+	Distance 601.147
+}
+
+OpenCluster "LISC 1369:UBC 1159"
+{
+	RA 22.35048283
+	Dec 54.9447712
+	Radius 70.927
+	Distance 11447.451
+}
+
+OpenCluster "CWNU 2458:Theia 2665"
+{
+	RA 22.36307068
+	Dec 55.93926396
+	Radius 35.419
+	Distance 4747.091
+}
+
+OpenCluster "HXHWL 23:Theia 4535"
+{
+	RA 22.36800174
+	Dec 54.56259806
+	Radius 116.007
+	Distance 4738.386
+}
+
+OpenCluster "LISC 1103:UBC 1157"
+{
+	RA 22.37991535
+	Dec 53.72367902
+	Radius 56.329
+	Distance 10164.933
+}
+
+OpenCluster "Berkeley 94:MWSC 3618:OCL 231"
+{
+	RA 22.38117717
+	Dec 55.86971203
+	Radius 81.491
+	Distance 13044.658
+}
+
+OpenCluster "HSC 841"
+{
+	RA 22.39693235
+	Dec 64.54805518
+	Radius 193.24
+	Distance 23898.009
+}
+
+OpenCluster "Theia 159:UBC 392:UPK 194"
+{
+	RA 22.40999142
+	Dec 64.90688265
+	Radius 44.841
+	Distance 2981.353
 }
 
 OpenCluster "NGC 7281"
 {
-	RA 22.421667
-	Dec 57.816667
-	Distance 2716
-	Radius 4.7
+	RA 22.41741324
+	Dec 57.83440525
+	Radius 101.915
+	Distance 7257.067
 }
 
-OpenCluster "Berkeley 96"
+OpenCluster "CWNU 505:OC 0189"
 {
-	RA 22.490000
-	Dec 55.400000
-	Distance 10068
-	Radius 2.9
+	RA 22.41938452
+	Dec 62.32734567
+	Radius 36.771
+	Distance 5474.405
 }
 
-OpenCluster "ASCC 120"
+OpenCluster "HSC 52"
 {
-	RA 22.510000
-	Dec 57.210000
-	Distance 8154
-	Radius 42.7
+	RA 22.42279016
+	Dec -38.01875663
+	Radius 54.582
+	Distance 800.126
 }
 
-OpenCluster "ASCC 121"
+OpenCluster "Delta Cephei Cluster:OCSN 33:Theia 161"
 {
-	RA 22.511944
-	Dec 54.900000
-	Distance 8154
-	Radius 32.7
+	RA 22.42825753
+	Dec 57.1572502
+	Radius 116.636
+	Distance 785.099
 }
 
-OpenCluster "ASCC 122"
+OpenCluster "HSC 2718"
 {
-	RA 22.553889
-	Dec 39.610000
-	Distance 2283
-	Radius 28.7
+	RA 22.42950342
+	Dec -64.24365516
+	Radius 264.685
+	Distance 707.53
 }
 
-OpenCluster "ASCC 123"
+OpenCluster "HSC 861"
 {
-	RA 22.710000
-	Dec 54.260000
-	Distance 815
-	Radius 18.2
+	RA 22.43014898
+	Dec 67.25871295
+	Radius 125.623
+	Distance 3738.963
 }
 
-OpenCluster "Berkeley 98"
+OpenCluster "Theia 5280"
 {
-	RA 22.710556
-	Dec 52.387778
-	Distance 12195
-	Radius 17.7
+	RA 22.43362207
+	Dec 52.18584691
+	Radius 87.818
+	Distance 4841.246
+}
+
+OpenCluster "UBC 1165"
+{
+	RA 22.4406195
+	Dec 56.43151111
+	Radius 157.541
+	Distance 13049.346
+}
+
+OpenCluster "CWNU 1230"
+{
+	RA 22.44123593
+	Dec 61.24979326
+	Radius 17.312
+	Distance 2464.273
+}
+
+OpenCluster "HSC 791"
+{
+	RA 22.44305197
+	Dec 53.50342757
+	Radius 37.579
+	Distance 5573.741
+}
+
+OpenCluster "Theia 7983:UPK 167"
+{
+	RA 22.44410708
+	Dec 49.51576869
+	Radius 93.348
+	Distance 1777.42
+}
+
+OpenCluster "Theia 1474:Theia 157"
+{
+	RA 22.44472836
+	Dec 60.14831355
+	Radius 69.076
+	Distance 3186.014
+}
+
+OpenCluster "HSC 745"
+{
+	RA 22.44509175
+	Dec 40.57954003
+	Radius 39.25
+	Distance 1316.472
+}
+
+OpenCluster "CWNU 1228"
+{
+	RA 22.4476794
+	Dec 63.7173432
+	Radius 24.737
+	Distance 2960.61
+}
+
+OpenCluster "HSC 807"
+{
+	RA 22.4487587
+	Dec 55.63961234
+	Radius 73.592
+	Distance 12737.411
+}
+
+OpenCluster "NGC 7296:Collinder 451:MWSC 3625:OCL 228"
+{
+	RA 22.46540784
+	Dec 52.31979569
+	Radius 40.14
+	Distance 7935.064
+}
+
+OpenCluster "CWNU 1141:OC 0194:Theia 2897"
+{
+	RA 22.46712481
+	Dec 64.93700063
+	Radius 48.363
+	Distance 3654.662
+}
+
+OpenCluster "HSC 818"
+{
+	RA 22.467946
+	Dec 58.16539821
+	Radius 51.62
+	Distance 11379.061
+}
+
+OpenCluster "Berkeley 95:FSR 375:MWSC 3626:OCL 242:OC 0182:OC 0183"
+{
+	RA 22.47141373
+	Dec 59.13436568
+	Radius 178.688
+	Distance 11126.393
+}
+
+OpenCluster "HSC 891"
+{
+	RA 22.47923259
+	Dec 71.28303641
+	Radius 24.467
+	Distance 2925.412
+}
+
+OpenCluster "UBC 396"
+{
+	RA 22.48351279
+	Dec 66.49821957
+	Radius 59.14
+	Distance 3307.555
+}
+
+OpenCluster "UPK 191"
+{
+	RA 22.48869248
+	Dec 63.19393471
+	Radius 38.227
+	Distance 2811.428
+}
+
+OpenCluster "HSC 853"
+{
+	RA 22.49147168
+	Dec 65.1871646
+	Radius 47.299
+	Distance 2950.175
+}
+
+OpenCluster "Berkeley 96:FSR 359:MWSC 3630:OCL 232"
+{
+	RA 22.49819885
+	Dec 55.41181909
+	Radius 132.372
+	Distance 12857.842
+}
+
+OpenCluster "UBC 388"
+{
+	RA 22.50429363
+	Dec 56.58608191
+	Radius 50.911
+	Distance 12670.577
+}
+
+OpenCluster "CWNU 209"
+{
+	RA 22.50543878
+	Dec 56.09865282
+	Radius 36.871
+	Distance 4388.078
+}
+
+OpenCluster "FSR 0357:FSR 357:MWSC 3633:OC 0174"
+{
+	RA 22.51476271
+	Dec 53.95137207
+	Radius 75.859
+	Distance 14363.141
+}
+
+OpenCluster "FoF 1800:UBC 170"
+{
+	RA 22.52162622
+	Dec 58.04503607
+	Radius 45.425
+	Distance 4451.855
+}
+
+OpenCluster "HSC 835"
+{
+	RA 22.52188335
+	Dec 62.00071793
+	Radius 43.308
+	Distance 2886.03
+}
+
+OpenCluster "HSC 800"
+{
+	RA 22.52601267
+	Dec 53.53184612
+	Radius 76.182
+	Distance 21821.305
+}
+
+OpenCluster "HSC 821"
+{
+	RA 22.54988775
+	Dec 57.31896874
+	Radius 22.227
+	Distance 3235.953
+}
+
+OpenCluster "HSC 804"
+{
+	RA 22.55218891
+	Dec 53.37749299
+	Radius 84.344
+	Distance 2006.558
+}
+
+OpenCluster "UBC 389"
+{
+	RA 22.55673905
+	Dec 58.40157804
+	Radius 116.133
+	Distance 7507.331
+}
+
+OpenCluster "HSC 809"
+{
+	RA 22.55829653
+	Dec 54.57795196
+	Radius 46.773
+	Distance 10014.15
+}
+
+OpenCluster "HSC 508"
+{
+	RA 22.56196746
+	Dec -3.31382361
+	Radius 114.529
+	Distance 466.863
+}
+
+OpenCluster "OC 0178:OC 0179"
+{
+	RA 22.56243313
+	Dec 56.53688783
+	Radius 81.844
+	Distance 12557.581
+}
+
+OpenCluster "Theia 776"
+{
+	RA 22.57210593
+	Dec 49.33378165
+	Radius 38.586
+	Distance 2693.591
+}
+
+OpenCluster "CWNU 508"
+{
+	RA 22.57246113
+	Dec 62.60189054
+	Radius 56.902
+	Distance 3265.434
+}
+
+OpenCluster "CWNU 1240"
+{
+	RA 22.5800733
+	Dec 69.17578609
+	Radius 35.798
+	Distance 3003.506
+}
+
+OpenCluster "OCSN 26:Theia 1188"
+{
+	RA 22.58282566
+	Dec 29.99126648
+	Radius 86.247
+	Distance 1060.623
+}
+
+OpenCluster "Delta Cephei Cluster:UPK 180"
+{
+	RA 22.58951597
+	Dec 56.5281479
+	Radius 148.411
+	Distance 2726.667
+}
+
+OpenCluster "CWNU 243:UBC 1164"
+{
+	RA 22.59258133
+	Dec 53.53248813
+	Radius 17.282
+	Distance 6611.845
+}
+
+OpenCluster "HSC 798"
+{
+	RA 22.59261827
+	Dec 52.20470082
+	Radius 30.024
+	Distance 2421.15
+}
+
+OpenCluster "Teutsch 330:UBC 1166"
+{
+	RA 22.59450338
+	Dec 56.2016674
+	Radius 60.293
+	Distance 12408.667
+}
+
+OpenCluster "HSC 832"
+{
+	RA 22.5964466
+	Dec 60.00674928
+	Radius 66.551
+	Distance 8780.588
+}
+
+OpenCluster "UBC 391"
+{
+	RA 22.5970578
+	Dec 59.05381877
+	Radius 30.528
+	Distance 7594.308
+}
+
+OpenCluster "ASCC 122:MWSC 3637:Theia 18:UBC 159"
+{
+	RA 22.59980772
+	Dec 39.63532814
+	Radius 40.591
+	Distance 1588.434
+}
+
+OpenCluster "HSC 805"
+{
+	RA 22.60045048
+	Dec 52.85557742
+	Radius 77.283
+	Distance 2588.741
+}
+
+OpenCluster "MWSC 3643:OCSN 29:Teutsch 39:Teutsch J2236.4+3747"
+{
+	RA 22.60825787
+	Dec 37.77103916
+	Radius 36.566
+	Distance 1601.502
+}
+
+OpenCluster "FSR 0398:FSR 398:MWSC 3644"
+{
+	RA 22.60844632
+	Dec 64.16053128
+	Radius 65.097
+	Distance 3015.592
+}
+
+OpenCluster "UPK 166"
+{
+	RA 22.61350284
+	Dec 47.00796724
+	Radius 122.632
+	Distance 2120.794
+}
+
+OpenCluster "Theia 710"
+{
+	RA 22.61396963
+	Dec 63.56790403
+	Radius 121.687
+	Distance 1292.029
+}
+
+OpenCluster "UBC 1168"
+{
+	RA 22.61430534
+	Dec 57.48396036
+	Radius 74.871
+	Distance 9301.947
+}
+
+OpenCluster "Berkeley 97:FSR 382:MWSC 3648:OCL 243"
+{
+	RA 22.65683125
+	Dec 59.00574772
+	Radius 64.021
+	Distance 9420.418
+}
+
+OpenCluster "Czernik 42:MWSC 3650:OCL 245"
+{
+	RA 22.65955854
+	Dec 59.90810033
+	Radius 48.368
+	Distance 13639.836
+}
+
+OpenCluster "HSC 831"
+{
+	RA 22.66105803
+	Dec 58.98580261
+	Radius 67.004
+	Distance 14583.845
+}
+
+OpenCluster "OC 0186"
+{
+	RA 22.66244683
+	Dec 58.70690817
+	Radius 31.624
+	Distance 9027.903
+}
+
+OpenCluster "UBC 1169"
+{
+	RA 22.67027832
+	Dec 57.07424361
+	Radius 83.414
+	Distance 14836.578
+}
+
+OpenCluster "CWNU 446"
+{
+	RA 22.67820249
+	Dec 65.28924433
+	Radius 26.87
+	Distance 3110.585
+}
+
+OpenCluster "HSC 857"
+{
+	RA 22.68229137
+	Dec 64.13658153
+	Radius 102.293
+	Distance 26176.041
+}
+
+OpenCluster "HSC 801"
+{
+	RA 22.6907947
+	Dec 50.90936157
+	Radius 79.888
+	Distance 3686.655
+}
+
+OpenCluster "OCSN 32:Theia 18:Theia 81"
+{
+	RA 22.69116717
+	Dec 40.21033521
+	Radius 46.773
+	Distance 1387.828
+}
+
+OpenCluster "CWNU 2159"
+{
+	RA 22.69576314
+	Dec 60.78829562
+	Radius 47.479
+	Distance 8331.221
+}
+
+OpenCluster "FSR 0381:FSR 381:MWSC 3649:MWSC 3652:UBC 1172"
+{
+	RA 22.70386516
+	Dec 58.34024545
+	Radius 30.83
+	Distance 10846.097
+}
+
+OpenCluster "FSR 0385:FSR 385:MWSC 3653"
+{
+	RA 22.70796505
+	Dec 58.93142756
+	Radius 130.624
+	Distance 6783.261
+}
+
+OpenCluster "Berkeley 98:FSR 361:MWSC 3655:OCL 234:OC 0176"
+{
+	RA 22.71132288
+	Dec 52.40534299
+	Radius 164.715
+	Distance 11883.051
+}
+
+OpenCluster "HSC 864"
+{
+	RA 22.71330054
+	Dec 64.82829088
+	Radius 76.067
+	Distance 3454.715
+}
+
+OpenCluster "CWNU 187:Theia 280"
+{
+	RA 22.71593852
+	Dec 49.34719197
+	Radius 170.486
+	Distance 2654.076
+}
+
+OpenCluster "CWNU 1546"
+{
+	RA 22.71639163
+	Dec 64.11995958
+	Radius 40.872
+	Distance 16269.792
+}
+
+OpenCluster "HSC 863"
+{
+	RA 22.72722122
+	Dec 64.19444661
+	Radius 100.938
+	Distance 18883.244
+}
+
+OpenCluster "Theia 3024:UBC 1170"
+{
+	RA 22.73347529
+	Dec 56.97531102
+	Radius 49.951
+	Distance 10239.058
+}
+
+OpenCluster "HSC 817"
+{
+	RA 22.73849206
+	Dec 53.91624205
+	Radius 105.431
+	Distance 2584.433
+}
+
+OpenCluster "CWNU 2367"
+{
+	RA 22.74100026
+	Dec 57.60702988
+	Radius 54.873
+	Distance 6394.106
+}
+
+OpenCluster "ASCC 123:MWSC 3654:Theia 117"
+{
+	RA 22.74103261
+	Dec 53.92483501
+	Radius 40.962
+	Distance 755.93
+}
+
+OpenCluster "CWNU 1860:Theia 3024"
+{
+	RA 22.74252118
+	Dec 57.05345794
+	Radius 38.86
+	Distance 8110.782
+}
+
+OpenCluster "CWNU 117:OC 0187:Theia 3024"
+{
+	RA 22.74322899
+	Dec 57.53000268
+	Radius 40.364
+	Distance 4880.974
+}
+
+OpenCluster "CWNU 2204"
+{
+	RA 22.7494048
+	Dec 60.64060928
+	Radius 33.136
+	Distance 5822.652
+}
+
+OpenCluster "ASCC 123:CWNU 161:MWSC 3654:Theia 2697"
+{
+	RA 22.74990518
+	Dec 54.69749036
+	Radius 122.293
+	Distance 3541.275
+}
+
+OpenCluster "OCSN 39:OC 0209:Theia 11"
+{
+	RA 22.75517111
+	Dec 75.15531408
+	Radius 33.804
+	Distance 1107.724
+}
+
+OpenCluster "Theia 3024:Theia 3364:UBC 174"
+{
+	RA 22.75596294
+	Dec 57.39089877
+	Radius 119.569
+	Distance 10628.83
+}
+
+OpenCluster "HSC 826"
+{
+	RA 22.76192198
+	Dec 56.32978452
+	Radius 54.979
+	Distance 6827.276
+}
+
+OpenCluster "HSC 836"
+{
+	RA 22.76193368
+	Dec 59.30436596
+	Radius 95.727
+	Distance 11012.171
+}
+
+OpenCluster "Theia 2632:UPK 198"
+{
+	RA 22.76759589
+	Dec 64.08754851
+	Radius 117.932
+	Distance 2739.677
+}
+
+OpenCluster "UBC 173"
+{
+	RA 22.78049137
+	Dec 56.40422286
+	Radius 89.231
+	Distance 10329.418
+}
+
+OpenCluster "CWNU 241:UBC 1171"
+{
+	RA 22.78911506
+	Dec 56.95887625
+	Radius 102.777
+	Distance 8485.098
+}
+
+OpenCluster "DSH J2247.4+5946:MWSC 3661:Teutsch 54"
+{
+	RA 22.79022009
+	Dec 59.7853312
+	Radius 75.143
+	Distance 12443.253
+}
+
+OpenCluster "Casado 21"
+{
+	RA 22.79386551
+	Dec 59.43921473
+	Radius 29.293
+	Distance 7979.517
 }
 
 OpenCluster "NGC 7380"
 {
-	RA 22.789167
-	Dec 58.131667
-	Distance 7247
-	Radius 21.1
+	RA 22.79476663
+	Dec 58.09950079
+	Radius 36.254
+	Distance 8664.95
 }
 
-OpenCluster "Alessi 37"
+OpenCluster "CWNU 2151"
 {
-	RA 22.802222
-	Dec 46.251667
-	Distance 1957
-	Radius 10.2
+	RA 22.79546552
+	Dec 55.55046801
+	Radius 89.905
+	Distance 12493.256
 }
 
-OpenCluster "NGC 7419"
+OpenCluster "CWNU 1625"
 {
-	RA 22.905556
-	Dec 60.815000
-	Distance 7501
-	Radius 5.5
+	RA 22.79685097
+	Dec 62.46284386
+	Radius 43.537
+	Distance 10825.564
 }
 
-OpenCluster "King 10"
+OpenCluster "ASCC 124:Alessi 37:MWSC 3663"
 {
-	RA 22.915000
-	Dec 59.166667
-	Distance 11021
-	Radius 6.4
+	RA 22.79804607
+	Dec 46.2901708
+	Radius 207.571
+	Distance 2327.818
 }
 
-OpenCluster "NGC 7423"
+OpenCluster "CWNU 58"
 {
-	RA 22.918889
-	Dec 57.096667
-	Distance 13535
-	Radius 9.8
+	RA 22.81062167
+	Dec 60.54127248
+	Radius 40.114
+	Distance 2806.368
 }
 
-OpenCluster "ASCC 125"
+OpenCluster "HSC 828"
 {
-	RA 22.938056
-	Dec 62.750000
-	Distance 4892
-	Radius 47.0
+	RA 22.82337319
+	Dec 55.65959631
+	Radius 43.653
+	Distance 7074.435
 }
 
-OpenCluster "NGC 7438"
+OpenCluster "HSC 838"
 {
-	RA 22.956111
-	Dec 54.338333
-	Distance 1957
-	Radius 2.3
+	RA 22.83443933
+	Dec 58.82683082
+	Radius 61.845
+	Distance 11992.423
 }
 
-OpenCluster "ASCC 126"
+OpenCluster "HSC 833"
 {
-	RA 23.105000
-	Dec 51.050000
-	Distance 2609
-	Radius 13.7
+	RA 22.8357064
+	Dec 57.17243332
+	Radius 73.634
+	Distance 10098.476
 }
 
-OpenCluster "King 19"
+OpenCluster "UBC 169"
 {
-	RA 23.138333
-	Dec 60.516667
-	Distance 6415
-	Radius 4.7
+	RA 22.84093207
+	Dec 49.49057861
+	Radius 35.167
+	Distance 4483.785
 }
 
-OpenCluster "ASCC 127"
+OpenCluster "CWNU 2564"
 {
-	RA 23.140000
-	Dec 64.850000
-	Distance 1141
-	Radius 14.3
+	RA 22.84153648
+	Dec 61.22285343
+	Radius 40.396
+	Distance 12531.845
+}
+
+OpenCluster "HSC 862"
+{
+	RA 22.85049356
+	Dec 62.5102489
+	Radius 26.746
+	Distance 2681.65
+}
+
+OpenCluster "FSR 0384:OC 0188"
+{
+	RA 22.86085399
+	Dec 56.1025267
+	Radius 48.3
+	Distance 6228.063
+}
+
+OpenCluster "Zanin 6"
+{
+	RA 22.86184322
+	Dec 41.30839697
+	Radius 66.052
+	Distance 1199.806
+}
+
+OpenCluster "CWNU 23"
+{
+	RA 22.86195182
+	Dec 61.64310186
+	Radius 114.094
+	Distance 10671.494
+}
+
+OpenCluster "HSC 852"
+{
+	RA 22.86320413
+	Dec 60.38977038
+	Radius 121.612
+	Distance 11155.387
+}
+
+OpenCluster "HSC 829"
+{
+	RA 22.86581528
+	Dec 55.23848652
+	Radius 59.952
+	Distance 2113.676
+}
+
+OpenCluster "FSR 392:King 18:MWSC 3669:OCL 247"
+{
+	RA 22.86999927
+	Dec 58.29196769
+	Radius 45.181
+	Distance 9425.087
+}
+
+OpenCluster "HSC 837"
+{
+	RA 22.87049369
+	Dec 58.03644063
+	Radius 59.598
+	Distance 10638.111
+}
+
+OpenCluster "OC 0190"
+{
+	RA 22.8784146
+	Dec 57.51709846
+	Radius 56.75
+	Distance 17886.757
+}
+
+OpenCluster "HSC 845"
+{
+	RA 22.87907044
+	Dec 59.15665181
+	Radius 45.806
+	Distance 9266.797
+}
+
+OpenCluster "CWNU 463"
+{
+	RA 22.88177534
+	Dec 60.27682167
+	Radius 76.069
+	Distance 4926.589
+}
+
+OpenCluster "UBC 1173"
+{
+	RA 22.88807884
+	Dec 57.017685
+	Radius 55.948
+	Distance 11507.692
+}
+
+OpenCluster "OC 0192"
+{
+	RA 22.89250486
+	Dec 57.52422364
+	Radius 28.834
+	Distance 2995.368
+}
+
+OpenCluster "HSC 887"
+{
+	RA 22.89374942
+	Dec 67.02577708
+	Radius 105.744
+	Distance 4880.386
+}
+
+OpenCluster "UBC 172"
+{
+	RA 22.89460603
+	Dec 54.33820991
+	Radius 125.891
+	Distance 7827.217
+}
+
+OpenCluster "HSC 868"
+{
+	RA 22.89739392
+	Dec 62.81902969
+	Radius 131.028
+	Distance 10793.851
+}
+
+OpenCluster "OC 0193"
+{
+	RA 22.90244612
+	Dec 58.96037999
+	Radius 27.241
+	Distance 5230.711
+}
+
+OpenCluster "NGC 7419:Collinder 453:FSR 400:MWSC 3672:OCL 250"
+{
+	RA 22.90499937
+	Dec 60.81420731
+	Radius 70.508
+	Distance 10368.693
+}
+
+OpenCluster "HSC 795"
+{
+	RA 22.91512145
+	Dec 46.09984043
+	Radius 71.192
+	Distance 11169.247
+}
+
+OpenCluster "FSR 396:King 10:MWSC 3673:OCL 248:Teutsch 182:Theia 1001:UBC 394:UBC 6"
+{
+	RA 22.91666345
+	Dec 59.2426145
+	Radius 62.52
+	Distance 2898.858
+}
+
+OpenCluster "FSR 396:King 10:MWSC 3673:OCL 248:Teutsch 182:UBC 6"
+{
+	RA 22.91668184
+	Dec 59.16839872
+	Radius 103.176
+	Distance 10771.417
+}
+
+OpenCluster "NGC 7423:Berkeley 57:FSR 391:MWSC 3674:OCL 246:OC 0191"
+{
+	RA 22.91920854
+	Dec 57.09865914
+	Radius 67.918
+	Distance 11681.131
+}
+
+OpenCluster "FSR 396:King 10:MWSC 3673:OCL 248:RSG 7:RSG 8:Teutsch 182:Theia 32:UBC 6"
+{
+	RA 22.91959417
+	Dec 59.22538184
+	Radius 56.314
+	Distance 1402.007
+}
+
+OpenCluster "CWNU 2183:FSR 0394:FSR 394:MWSC 3675:SAI 147"
+{
+	RA 22.92089958
+	Dec 58.71060833
+	Radius 81.65
+	Distance 12267.449
+}
+
+OpenCluster "HSC 870"
+{
+	RA 22.93557586
+	Dec 62.6179645
+	Radius 12.825
+	Distance 2352.645
+}
+
+OpenCluster "UBC 165:UPK 168"
+{
+	RA 22.93583973
+	Dec 43.24640785
+	Radius 159.337
+	Distance 1919.511
+}
+
+OpenCluster "CWNU 1270"
+{
+	RA 22.93644302
+	Dec 50.86939874
+	Radius 32.308
+	Distance 1538.608
+}
+
+OpenCluster "Theia 5006:UBC 6"
+{
+	RA 22.93812129
+	Dec 51.14488499
+	Radius 160.676
+	Distance 4491.125
+}
+
+OpenCluster "NGC 7429:MWSC 3676:OCL 249:RSG 7:RSG 8"
+{
+	RA 22.93932605
+	Dec 59.91164567
+	Radius 35.721
+	Distance 1361.488
+}
+
+OpenCluster "ASCC 125:FSR 409:MWSC 3677"
+{
+	RA 22.94011289
+	Dec 62.71052173
+	Radius 13.694
+	Distance 2701.154
+}
+
+OpenCluster "ASCC 125:FSR 409:MWSC 3677:Theia 4"
+{
+	RA 22.94193017
+	Dec 62.97720031
+	Radius 33.507
+	Distance 2759.789
+}
+
+OpenCluster "HSC 328"
+{
+	RA 22.94388425
+	Dec -23.78139608
+	Radius 82.37
+	Distance 7164.794
+}
+
+OpenCluster "Gulliver 19:Theia 2276"
+{
+	RA 22.9446907
+	Dec 61.10605344
+	Radius 104.449
+	Distance 4821.644
+}
+
+OpenCluster "HSC 849"
+{
+	RA 22.94767415
+	Dec 58.78022315
+	Radius 89.699
+	Distance 10742.953
+}
+
+OpenCluster "HSC 855"
+{
+	RA 22.94809442
+	Dec 60.03519596
+	Radius 30.093
+	Distance 3215.767
+}
+
+OpenCluster "HSC 839"
+{
+	RA 22.95897726
+	Dec 56.82018292
+	Radius 78.003
+	Distance 9714.582
+}
+
+OpenCluster "OC 0196:Teutsch 182:UBC 6"
+{
+	RA 22.96319547
+	Dec 59.03375217
+	Radius 67.912
+	Distance 3951.975
+}
+
+OpenCluster "HSC 889"
+{
+	RA 22.96387854
+	Dec 66.26814197
+	Radius 70.522
+	Distance 2390.23
+}
+
+OpenCluster "NGC 7438:MWSC 3682:Theia 4429:Theia 866:UBC 175"
+{
+	RA 22.96590399
+	Dec 54.43408005
+	Radius 110.605
+	Distance 4232.056
+}
+
+OpenCluster "HSC 858"
+{
+	RA 22.96946368
+	Dec 60.20841129
+	Radius 117.06
+	Distance 10698.877
+}
+
+OpenCluster "NGC 7438:MWSC 3682"
+{
+	RA 22.97807636
+	Dec 54.25125688
+	Radius 104.362
+	Distance 2590.838
+}
+
+OpenCluster "Theia 52:UPK 201"
+{
+	RA 22.98040186
+	Dec 61.67234214
+	Radius 27.069
+	Distance 2925.794
+}
+
+OpenCluster "CWNU 498"
+{
+	RA 22.98924958
+	Dec 61.08572255
+	Radius 89.833
+	Distance 7113.538
+}
+
+OpenCluster "HSC 873"
+{
+	RA 23.00417514
+	Dec 61.99739399
+	Radius 28.224
+	Distance 1179.664
+}
+
+OpenCluster "HSC 869"
+{
+	RA 23.01165465
+	Dec 61.3128542
+	Radius 23.873
+	Distance 3611.982
+}
+
+OpenCluster "HSC 844"
+{
+	RA 23.01477487
+	Dec 56.68395687
+	Radius 55.254
+	Distance 3651.586
+}
+
+OpenCluster "HSC 872"
+{
+	RA 23.01516559
+	Dec 61.60675883
+	Radius 52.578
+	Distance 17111.732
+}
+
+OpenCluster "FSR 0401:FSR 401:MWSC 3686"
+{
+	RA 23.01614506
+	Dec 59.6969721
+	Radius 34.847
+	Distance 10911.835
+}
+
+OpenCluster "CWNU 2169"
+{
+	RA 23.01637468
+	Dec 58.38482568
+	Radius 37.118
+	Distance 6529.488
+}
+
+OpenCluster "HSC 860"
+{
+	RA 23.02270569
+	Dec 59.75869105
+	Radius 48.607
+	Distance 9444.022
+}
+
+OpenCluster "RSG 8"
+{
+	RA 23.03019736
+	Dec 59.50879452
+	Radius 70.823
+	Distance 1570.195
+}
+
+OpenCluster "FSR 0414:FSR 0416:Theia 27"
+{
+	RA 23.03186167
+	Dec 63.00458384
+	Radius 14.329
+	Distance 2702.473
+}
+
+OpenCluster "OC 0195:UBC 176"
+{
+	RA 23.03473169
+	Dec 57.06169984
+	Radius 71.13
+	Distance 10759.888
+}
+
+OpenCluster "HSC 830"
+{
+	RA 23.03774712
+	Dec 52.62738906
+	Radius 44.852
+	Distance 5887.365
+}
+
+OpenCluster "CWNU 1774"
+{
+	RA 23.03811583
+	Dec 60.3569987
+	Radius 44.436
+	Distance 10156.841
+}
+
+OpenCluster "CWNU 56"
+{
+	RA 23.03840377
+	Dec 69.28686867
+	Radius 70.76
+	Distance 3971.504
+}
+
+OpenCluster "UBC 395"
+{
+	RA 23.03968614
+	Dec 57.20642842
+	Radius 25.384
+	Distance 7433.486
+}
+
+OpenCluster "CWNU 2273"
+{
+	RA 23.04158035
+	Dec 58.14536491
+	Radius 35.353
+	Distance 5342.83
+}
+
+OpenCluster "UBC 393"
+{
+	RA 23.04292495
+	Dec 56.92602121
+	Radius 83.588
+	Distance 10403.184
+}
+
+OpenCluster "HSC 812"
+{
+	RA 23.04356405
+	Dec 46.61713253
+	Radius 39.647
+	Distance 3699.312
+}
+
+OpenCluster "HSC 866"
+{
+	RA 23.04457923
+	Dec 60.29832195
+	Radius 45.947
+	Distance 2991.253
+}
+
+OpenCluster "HSC 747"
+{
+	RA 23.05314084
+	Dec 28.69399934
+	Radius 32.726
+	Distance 811.751
+}
+
+OpenCluster "Casado 19:UBC 1175"
+{
+	RA 23.0544365
+	Dec 57.87232763
+	Radius 104.017
+	Distance 10845.067
+}
+
+OpenCluster "CWNU 1566"
+{
+	RA 23.0577762
+	Dec 60.0641008
+	Radius 27.617
+	Distance 9567.713
+}
+
+OpenCluster "UBC 178"
+{
+	RA 23.07650452
+	Dec 63.35511905
+	Radius 18.007
+	Distance 2723.613
+}
+
+OpenCluster "CWNU 1537"
+{
+	RA 23.08456384
+	Dec 59.06540275
+	Radius 39.512
+	Distance 10420.93
+}
+
+OpenCluster "HSC 856"
+{
+	RA 23.0902017
+	Dec 57.82377955
+	Radius 150.737
+	Distance 16118.458
+}
+
+OpenCluster "UBC 593"
+{
+	RA 23.0903539
+	Dec 55.13230418
+	Radius 71.958
+	Distance 6094.394
+}
+
+OpenCluster "FoF 2275:UBC 171:UPK 185"
+{
+	RA 23.09386817
+	Dec 49.36749842
+	Radius 76.304
+	Distance 1786.716
+}
+
+OpenCluster "Theia 46"
+{
+	RA 23.11081875
+	Dec 63.38749349
+	Radius 38.135
+	Distance 2250.187
+}
+
+OpenCluster "CWNU 1844"
+{
+	RA 23.11279678
+	Dec 59.09930882
+	Radius 34.404
+	Distance 11552.044
+}
+
+OpenCluster "HSC 854"
+{
+	RA 23.12207586
+	Dec 56.82684681
+	Radius 38.975
+	Distance 3563.374
+}
+
+OpenCluster "CWNU 502:UBC 1176"
+{
+	RA 23.12259507
+	Dec 59.93399722
+	Radius 47.447
+	Distance 8823.737
+}
+
+OpenCluster "OCSN 35:Theia 100"
+{
+	RA 23.12584029
+	Dec 46.06794338
+	Radius 90.164
+	Distance 1552.695
+}
+
+OpenCluster "CWNU 419:Theia 2902:UBC 1574"
+{
+	RA 23.12615955
+	Dec 58.88550196
+	Radius 64.088
+	Distance 4779.727
+}
+
+OpenCluster "Theia 4401"
+{
+	RA 23.12755915
+	Dec 56.77037934
+	Radius 153.038
+	Distance 4583.786
+}
+
+OpenCluster "FSR 412:MWSC 3702:PWM 3:Pfleiderer 3"
+{
+	RA 23.1361018
+	Dec 60.8723995
+	Radius 78.263
+	Distance 19889.283
+}
+
+OpenCluster "King 19:OC 0201"
+{
+	RA 23.13648502
+	Dec 60.52371914
+	Radius 61.916
+	Distance 8481.134
+}
+
+OpenCluster "CWNU 2651"
+{
+	RA 23.14795233
+	Dec 59.40369055
+	Radius 51.949
+	Distance 9227.029
+}
+
+OpenCluster "ASCC 127:MWSC 3704"
+{
+	RA 23.15347543
+	Dec 65.18290876
+	Radius 90.68
+	Distance 1220.456
+}
+
+OpenCluster "CWNU 1997"
+{
+	RA 23.15747746
+	Dec 58.99900947
+	Radius 26.899
+	Distance 10852.53
+}
+
+OpenCluster "HSC 877"
+{
+	RA 23.17630222
+	Dec 61.13927854
+	Radius 62.694
+	Distance 3381.302
+}
+
+OpenCluster "HSC 846"
+{
+	RA 23.17718165
+	Dec 54.4066804
+	Radius 28.314
+	Distance 5166.477
+}
+
+OpenCluster "UBC 397"
+{
+	RA 23.18136496
+	Dec 58.6336762
+	Radius 62.374
+	Distance 10833.813
 }
 
 OpenCluster "NGC 7510"
 {
-	RA 23.184167
-	Dec 60.570000
-	Distance 11350
-	Radius 9.9
+	RA 23.18439454
+	Dec 60.57245015
+	Radius 123.071
+	Distance 9657.48
+}
+
+OpenCluster "HSC 898"
+{
+	RA 23.18510652
+	Dec 65.14463344
+	Radius 61.224
+	Distance 9494.56
+}
+
+OpenCluster "CWNU 2203"
+{
+	RA 23.1855608
+	Dec 61.08914004
+	Radius 18.749
+	Distance 9328.612
+}
+
+OpenCluster "HSC 892"
+{
+	RA 23.18877534
+	Dec 63.27874524
+	Radius 27.227
+	Distance 2814.963
+}
+
+OpenCluster "HSC 879"
+{
+	RA 23.19530691
+	Dec 60.85754296
+	Radius 47.124
+	Distance 14950
+}
+
+OpenCluster "HSC 881"
+{
+	RA 23.19970307
+	Dec 61.08112647
+	Radius 42.66
+	Distance 2393.703
+}
+
+OpenCluster "CWNU 459"
+{
+	RA 23.20362391
+	Dec 60.97048646
+	Radius 96.133
+	Distance 9065.536
+}
+
+OpenCluster "Casado 20:OC 0199"
+{
+	RA 23.20400536
+	Dec 56.81781885
+	Radius 62.9
+	Distance 6083.518
+}
+
+OpenCluster "UBC 1181"
+{
+	RA 23.20446112
+	Dec 64.79713189
+	Radius 94.611
+	Distance 17275.857
+}
+
+OpenCluster "CWNU 394:CWNU 415:LISC 3420:Theia 2526:Theia 904"
+{
+	RA 23.2071671
+	Dec 57.48462151
+	Radius 83.434
+	Distance 3473.426
+}
+
+OpenCluster "HSC 884"
+{
+	RA 23.21864752
+	Dec 61.71191539
+	Radius 33.586
+	Distance 2491.355
+}
+
+OpenCluster "HSC 878"
+{
+	RA 23.22089927
+	Dec 60.35965666
+	Radius 115.627
+	Distance 1047.528
+}
+
+OpenCluster "HSC 875"
+{
+	RA 23.22404726
+	Dec 59.34879344
+	Radius 71.884
+	Distance 2323.239
+}
+
+OpenCluster "CWNU 1299"
+{
+	RA 23.22481204
+	Dec 61.11726428
+	Radius 83.052
+	Distance 8834.333
+}
+
+OpenCluster "FSR 0417:OC 0202"
+{
+	RA 23.23291877
+	Dec 59.81248974
+	Radius 74.471
+	Distance 10885.669
+}
+
+OpenCluster "HSC 901"
+{
+	RA 23.23599252
+	Dec 65.66437749
+	Radius 115.573
+	Distance 22723.73
+}
+
+OpenCluster "CWNU 1624"
+{
+	RA 23.23774843
+	Dec 59.42442071
+	Radius 32.01
+	Distance 10568.873
+}
+
+OpenCluster "HSC 825"
+{
+	RA 23.23928149
+	Dec 46.104935
+	Radius 124.904
+	Distance 1492.859
+}
+
+OpenCluster "CWNU 428"
+{
+	RA 23.2449293
+	Dec 58.19706554
+	Radius 64.831
+	Distance 6271.55
+}
+
+OpenCluster "HSC 880"
+{
+	RA 23.25024003
+	Dec 59.99886976
+	Radius 58.945
+	Distance 9253.174
 }
 
 OpenCluster "Markarian 50"
 {
-	RA 23.255000
-	Dec 60.466667
-	Distance 6895
-	Radius 2.0
+	RA 23.25390708
+	Dec 60.44024051
+	Radius 87.843
+	Distance 9264.056
 }
 
-OpenCluster "ASCC 128"
+OpenCluster "OC 0203"
 {
-	RA 23.343056
-	Dec 54.600000
-	Distance 2935
-	Radius 17.9
+	RA 23.25461874
+	Dec 59.98695944
+	Radius 22.689
+	Distance 4510.154
 }
 
-OpenCluster "Berkeley 99"
+OpenCluster "FSR 0430:FSR 430:MWSC 3713:OC 0205:SAI 148:Theia 2907"
 {
-	RA 23.360000
-	Dec 71.750000
-	Distance 15982
-	Radius 11.6
+	RA 23.25796005
+	Dec 64.1651351
+	Radius 46.111
+	Distance 8839.443
 }
 
-OpenCluster "NGC 7654"
+OpenCluster "HSC 915"
 {
-	RA 23.413333
-	Dec 61.593333
-	Distance 4566
-	Radius 10.0
+	RA 23.26076544
+	Dec 69.8461133
+	Radius 12.87
+	Distance 3390.141
 }
 
-OpenCluster "Czernik 43"
+OpenCluster "CWNU 225:OC 0198:Theia 4245"
 {
-	RA 23.430000
-	Dec 61.316667
-	Distance 8186
-	Radius 6.0
+	RA 23.26390523
+	Dec 55.20043037
+	Radius 37.801
+	Distance 2755.85
 }
 
-OpenCluster "Alessi J2327+55"
+OpenCluster "HSC 842"
 {
-	RA 23.461389
-	Dec 55.591667
-	Distance 3261
-	Radius 12.0
+	RA 23.26986218
+	Dec 50.88593286
+	Radius 40.68
+	Distance 2389.503
 }
 
-OpenCluster "King 20"
+OpenCluster "HSC 810"
 {
-	RA 23.554167
-	Dec 58.466667
-	Distance 6197
-	Radius 5.4
+	RA 23.27214469
+	Dec 40.32197095
+	Radius 79.787
+	Distance 11045.603
 }
 
-OpenCluster "Stock 12"
+OpenCluster "UBC 1177"
 {
-	RA 23.605556
-	Dec 52.543333
-	Distance 1552
-	Radius 7.9
+	RA 23.27304452
+	Dec 60.46440378
+	Radius 74.571
+	Distance 9036.824
 }
 
-OpenCluster "Aveni-Hunter 1"
+OpenCluster "CWNU 124"
 {
-	RA 23.629722
-	Dec 48.560000
-	Distance 1630
-	Radius 11.1
+	RA 23.28068236
+	Dec 64.69409548
+	Radius 64.896
+	Distance 3368.418
+}
+
+OpenCluster "HSC 882"
+{
+	RA 23.28440538
+	Dec 59.79596965
+	Radius 175.678
+	Distance 7488.96
+}
+
+OpenCluster "HSC 282"
+{
+	RA 23.28443031
+	Dec -26.87716508
+	Radius 68.329
+	Distance 1545.847
+}
+
+OpenCluster "HSC 916"
+{
+	RA 23.28838741
+	Dec 69.50737501
+	Radius 36.272
+	Distance 4036.018
+}
+
+OpenCluster "CWNU 2262"
+{
+	RA 23.28884051
+	Dec 61.60579581
+	Radius 134.524
+	Distance 8825.325
+}
+
+OpenCluster "HSC 778"
+{
+	RA 23.29317857
+	Dec 29.79495259
+	Radius 146.651
+	Distance 475.528
+}
+
+OpenCluster "HSC 888"
+{
+	RA 23.30759397
+	Dec 60.69589018
+	Radius 160.234
+	Distance 3228.718
+}
+
+OpenCluster "HSC 912"
+{
+	RA 23.31435286
+	Dec 66.64630525
+	Radius 47.995
+	Distance 3915.581
+}
+
+OpenCluster "UBC 1179"
+{
+	RA 23.31449792
+	Dec 60.66264991
+	Radius 34.466
+	Distance 9614.745
+}
+
+OpenCluster "CWNU 297:UBC 1174"
+{
+	RA 23.33644555
+	Dec 51.50450862
+	Radius 32.678
+	Distance 6688.71
+}
+
+OpenCluster "CWNU 2441"
+{
+	RA 23.33692893
+	Dec 56.65380052
+	Radius 52.856
+	Distance 13559.151
+}
+
+OpenCluster "UBC 1178"
+{
+	RA 23.34079493
+	Dec 59.49628071
+	Radius 114.203
+	Distance 9893.011
+}
+
+OpenCluster "ASCC 128:MWSC 3720"
+{
+	RA 23.34409488
+	Dec 54.57336087
+	Radius 199.459
+	Distance 2142.991
+}
+
+OpenCluster "Berkeley 99:FSR 455:MWSC 3722:OCL 271"
+{
+	RA 23.35016592
+	Dec 71.77482633
+	Radius 82.189
+	Distance 17721.566
+}
+
+OpenCluster "OCSN 36"
+{
+	RA 23.35107706
+	Dec 43.72628736
+	Radius 86.458
+	Distance 1540.545
+}
+
+OpenCluster "HXHWL 45"
+{
+	RA 23.35777779
+	Dec 58.36683078
+	Radius 25.16
+	Distance 3179.731
+}
+
+OpenCluster "Theia 1232"
+{
+	RA 23.36217174
+	Dec 60.56101753
+	Radius 47.304
+	Distance 1176.837
+}
+
+OpenCluster "CWNU 354"
+{
+	RA 23.37808746
+	Dec 68.75583219
+	Radius 22.669
+	Distance 3886.651
+}
+
+OpenCluster "Gulliver 49:Theia 2376"
+{
+	RA 23.37889819
+	Dec 61.96406971
+	Radius 81.717
+	Distance 5242.519
+}
+
+OpenCluster "HSC 885"
+{
+	RA 23.39004459
+	Dec 58.69061868
+	Radius 47.032
+	Distance 4867.685
+}
+
+OpenCluster "CWNU 1502"
+{
+	RA 23.39279105
+	Dec 60.6254685
+	Radius 32.679
+	Distance 12365.956
+}
+
+OpenCluster "Theia 1084:Theia 367:UBC 402:UPK 220"
+{
+	RA 23.39693041
+	Dec 66.4616163
+	Radius 101.375
+	Distance 3078.301
+}
+
+OpenCluster "Theia 3528:UBC 179"
+{
+	RA 23.39754333
+	Dec 59.47243559
+	Radius 116.483
+	Distance 3846.044
+}
+
+OpenCluster "Scorpion Cluster:M 52:NGC 7654:Melotte 243:Collinder 455:MWSC 3725:OCL 260:Theia 2376:Theia 3500"
+{
+	RA 23.41069127
+	Dec 61.46187355
+	Radius 91.067
+	Distance 9517.426
+}
+
+OpenCluster "NGC 7654:Melotte 243:Collinder 455:MWSC 3725:OCL 260:Theia 2085:Theia 2376"
+{
+	RA 23.41266344
+	Dec 61.59925754
+	Radius 49.938
+	Distance 5123.314
+}
+
+OpenCluster "CWNU 1416"
+{
+	RA 23.41408739
+	Dec 62.37108381
+	Radius 162.996
+	Distance 9684.756
+}
+
+OpenCluster "NGC 7654:Melotte 243:Collinder 455:Czernik 43:MWSC 3725:OCL 260:Theia 2376:UBC 399"
+{
+	RA 23.42791999
+	Dec 61.35905467
+	Radius 66.065
+	Distance 8216.613
+}
+
+OpenCluster "Berkeley 100:MWSC 3727:OCL 264"
+{
+	RA 23.43257899
+	Dec 63.77997815
+	Radius 126.097
+	Distance 15699.781
+}
+
+OpenCluster "CWNU 1885"
+{
+	RA 23.43427736
+	Dec 61.9835536
+	Radius 20.515
+	Distance 5996.525
+}
+
+OpenCluster "CWNU 2614"
+{
+	RA 23.43872229
+	Dec 64.12888782
+	Radius 56.196
+	Distance 14054.579
+}
+
+OpenCluster "HSC 903"
+{
+	RA 23.44921173
+	Dec 62.07016289
+	Radius 43.125
+	Distance 9292.431
+}
+
+OpenCluster "UBC 398"
+{
+	RA 23.46204092
+	Dec 60.42742973
+	Radius 70.63
+	Distance 8938.807
+}
+
+OpenCluster "CWNU 2508"
+{
+	RA 23.46332853
+	Dec 66.54407477
+	Radius 120.069
+	Distance 7283.361
+}
+
+OpenCluster "HSC 890"
+{
+	RA 23.46432901
+	Dec 57.66290275
+	Radius 43.205
+	Distance 3444.983
+}
+
+OpenCluster "UPK 219"
+{
+	RA 23.46749768
+	Dec 65.37721602
+	Radius 38.145
+	Distance 2607.988
+}
+
+OpenCluster "HSC 893"
+{
+	RA 23.46907501
+	Dec 57.71716335
+	Radius 31.319
+	Distance 7672.842
+}
+
+OpenCluster "ASCC 129:Alessi 70:Alessi J2327+55:Alessi J2327.0+55:Alessi J2327.6+5535:MWSC 3730"
+{
+	RA 23.47006115
+	Dec 55.61456581
+	Radius 35.158
+	Distance 5917.584
+}
+
+OpenCluster "HSC 913"
+{
+	RA 23.48210812
+	Dec 64.46816495
+	Radius 69.991
+	Distance 1253.132
+}
+
+OpenCluster "UBC 1187:UPK 224"
+{
+	RA 23.4865128
+	Dec 66.95398585
+	Radius 27.882
+	Distance 2500.559
+}
+
+OpenCluster "HSC 896"
+{
+	RA 23.48805475
+	Dec 58.2019328
+	Radius 45.659
+	Distance 6441.939
+}
+
+OpenCluster "Theia 997:UPK 226"
+{
+	RA 23.4915481
+	Dec 68.69199376
+	Radius 56.062
+	Distance 2729.578
+}
+
+OpenCluster "CWNU 92"
+{
+	RA 23.49349869
+	Dec 62.22891586
+	Radius 46.423
+	Distance 3556.293
+}
+
+OpenCluster "HSC 899"
+{
+	RA 23.49483166
+	Dec 59.65566546
+	Radius 29.73
+	Distance 1507.927
+}
+
+OpenCluster "HSC 907"
+{
+	RA 23.49730018
+	Dec 62.56738689
+	Radius 48.366
+	Distance 9263.198
+}
+
+OpenCluster "Theia 667"
+{
+	RA 23.49905068
+	Dec 63.99262274
+	Radius 119.54
+	Distance 2525.365
+}
+
+OpenCluster "FSR 0442:FSR 442:MWSC 442:Theia 2084"
+{
+	RA 23.49958097
+	Dec 63.44725128
+	Radius 130.789
+	Distance 4517.07
+}
+
+OpenCluster "CWNU 109:UBC 1184"
+{
+	RA 23.50280457
+	Dec 62.32251662
+	Radius 56.296
+	Distance 5346.176
+}
+
+OpenCluster "FSR 0436:FSR 436:MWSC 3733:MWSC 3735:Skiff J2330+60.2"
+{
+	RA 23.50422659
+	Dec 60.26000608
+	Radius 81.822
+	Distance 9037.907
+}
+
+OpenCluster "ADS 16795:AR Cas"
+{
+	RA 23.50614433
+	Dec 58.55341329
+	Radius 100.516
+	Distance 673.376
+}
+
+OpenCluster "CWNU 69:UBC 1183"
+{
+	RA 23.51023434
+	Dec 62.05460856
+	Radius 55.925
+	Distance 8429.545
+}
+
+OpenCluster "CWNU 1819"
+{
+	RA 23.51611225
+	Dec 67.35687927
+	Radius 37.744
+	Distance 6321.486
+}
+
+OpenCluster "UBC 1182"
+{
+	RA 23.52462538
+	Dec 61.39121619
+	Radius 190.431
+	Distance 12320.25
+}
+
+OpenCluster "FSR 0435:FSR 435"
+{
+	RA 23.52544968
+	Dec 59.78019362
+	Radius 36.201
+	Distance 3152.23
+}
+
+OpenCluster "OC 0206"
+{
+	RA 23.52957552
+	Dec 59.93519585
+	Radius 34.437
+	Distance 9107.635
+}
+
+OpenCluster "UBC 1185"
+{
+	RA 23.53896285
+	Dec 62.11020216
+	Radius 84.45
+	Distance 9225.817
+}
+
+OpenCluster "Berkeley 101:FSR 444:MWSC 3737:OCL 267"
+{
+	RA 23.54710484
+	Dec 64.20633438
+	Radius 51.521
+	Distance 14450.154
+}
+
+OpenCluster "FSR 434:King 20:MWSC 3739:OCL 262:Theia 2513"
+{
+	RA 23.55365082
+	Dec 58.46654681
+	Radius 42.218
+	Distance 6026.626
+}
+
+OpenCluster "UBC 400"
+{
+	RA 23.55571812
+	Dec 61.05388421
+	Radius 87.81
+	Distance 9280.914
+}
+
+OpenCluster "Czernik 44:MWSC 3740:OCL 265"
+{
+	RA 23.56219999
+	Dec 61.95534803
+	Radius 161.857
+	Distance 15304.238
+}
+
+OpenCluster "HSC 905"
+{
+	RA 23.56254889
+	Dec 60.04007286
+	Radius 74.711
+	Distance 12754.383
+}
+
+OpenCluster "HSC 914"
+{
+	RA 23.58170048
+	Dec 63.37182831
+	Radius 169.594
+	Distance 12151.707
+}
+
+OpenCluster "HSC 900"
+{
+	RA 23.58538698
+	Dec 58.60792934
+	Radius 117.714
+	Distance 2638.599
+}
+
+OpenCluster "HSC 865"
+{
+	RA 23.58595916
+	Dec 47.48166863
+	Radius 94.93
+	Distance 674.633
+}
+
+OpenCluster "CWNU 2556"
+{
+	RA 23.58596148
+	Dec 56.70798577
+	Radius 142.371
+	Distance 16380.156
+}
+
+OpenCluster "HSC 927"
+{
+	RA 23.58854881
+	Dec 70.08998518
+	Radius 144.356
+	Distance 1935.844
+}
+
+OpenCluster "MWSC 3743:OCL 258:Stock 12:Theia 451"
+{
+	RA 23.59133762
+	Dec 52.62348853
+	Radius 117.523
+	Distance 1406.194
+}
+
+OpenCluster "Aveni-Hunter 1:Aveni Hunter 1:Theia 33"
+{
+	RA 23.61750543
+	Dec 48.49009576
+	Radius 123.604
+	Distance 1355.65
+}
+
+OpenCluster "CWNU 457"
+{
+	RA 23.61761561
+	Dec 67.00381024
+	Radius 59.461
+	Distance 6267.108
+}
+
+OpenCluster "CWNU 2018"
+{
+	RA 23.62005972
+	Dec 58.37216191
+	Radius 45.635
+	Distance 7966.552
+}
+
+OpenCluster "Theia 840:UPK 230"
+{
+	RA 23.63237008
+	Dec 71.8962815
+	Radius 272.879
+	Distance 1758.403
+}
+
+OpenCluster "MWSC 3748:SAI 149"
+{
+	RA 23.63411681
+	Dec 60.54057128
+	Radius 38.06
+	Distance 10684.951
+}
+
+OpenCluster "CWNU 108:OC 0207"
+{
+	RA 23.63905889
+	Dec 57.78981663
+	Radius 45.298
+	Distance 4418.83
+}
+
+OpenCluster "Patchick 41:Ramakers 3:TPK 1:Teutsch-Patchick-Kronberger 1:Theia 1635"
+{
+	RA 23.64086621
+	Dec 47.42241979
+	Radius 90.137
+	Distance 1670.594
+}
+
+OpenCluster "HSC 917"
+{
+	RA 23.64250857
+	Dec 63.49142372
+	Radius 81.231
+	Distance 11612.24
+}
+
+OpenCluster "Berkeley 102:MWSC 3750:OCL 263"
+{
+	RA 23.64473532
+	Dec 56.64042528
+	Radius 148.352
+	Distance 25394.993
+}
+
+OpenCluster "HSC 925"
+{
+	RA 23.65131054
+	Dec 68.71780531
+	Radius 79.627
+	Distance 3363.043
+}
+
+OpenCluster "Majaess 225"
+{
+	RA 23.65238686
+	Dec 61.91991153
+	Radius 53.553
+	Distance 9385.828
+}
+
+OpenCluster "CWNU 1767:Majaess 225"
+{
+	RA 23.6552501
+	Dec 61.99927967
+	Radius 40.148
+	Distance 6163.194
+}
+
+OpenCluster "UBC 1602"
+{
+	RA 23.65747224
+	Dec 61.32629367
+	Radius 41.12
+	Distance 7918.299
+}
+
+OpenCluster "HSC 859"
+{
+	RA 23.65769916
+	Dec 43.82702548
+	Radius 64.015
+	Distance 1363.004
+}
+
+OpenCluster "OC 0208"
+{
+	RA 23.67469297
+	Dec 60.1975504
+	Radius 110.075
+	Distance 9346.33
+}
+
+OpenCluster "CWNU 1454"
+{
+	RA 23.6846584
+	Dec 60.6447233
+	Radius 89.259
+	Distance 6891.956
+}
+
+OpenCluster "FSR 0441:FSR 441:MWSC 3752:SAI 150:UBC 401"
+{
+	RA 23.70052641
+	Dec 58.54252614
+	Radius 66.657
+	Distance 11066.08
+}
+
+OpenCluster "Theia 3453:Theia 888"
+{
+	RA 23.70541182
+	Dec 55.94382732
+	Radius 88.842
+	Distance 2991.167
+}
+
+OpenCluster "CWNU 1155"
+{
+	RA 23.72375521
+	Dec 66.94084718
+	Radius 32.351
+	Distance 3184.9
+}
+
+OpenCluster "CWNU 1683:FSR 0443:FSR 443:MWSC 3753"
+{
+	RA 23.72563189
+	Dec 59.07770208
+	Radius 73.828
+	Distance 9074.144
+}
+
+OpenCluster "Theia 153"
+{
+	RA 23.72949399
+	Dec 60.13305793
+	Radius 114.77
+	Distance 2691.666
 }
 
 OpenCluster "Stock 17"
 {
-	RA 23.729722
-	Dec 62.160278
-	Distance 6993
-	Radius 1.0
+	RA 23.73027448
+	Dec 62.16014183
+	Radius 64.535
+	Distance 9566.108
 }
 
-OpenCluster "Negueruela 1"
+OpenCluster "CWNU 219:UBC 1189"
 {
-	RA 23.788889
-	Dec 63.220000
-	Distance 8190
-	Radius 2.4
+	RA 23.73728841
+	Dec 62.67244821
+	Radius 64.846
+	Distance 8092.187
 }
 
-OpenCluster "King 11"
+OpenCluster "CWNU 1506"
 {
-	RA 23.796667
-	Dec 68.633333
-	Distance 9432
-	Radius 6.9
+	RA 23.74241071
+	Dec 59.67287544
+	Radius 55.197
+	Distance 8933.593
 }
 
-OpenCluster "King 21"
+OpenCluster "CWNU 533:Theia 391"
 {
-	RA 23.831667
-	Dec 62.716667
-	Distance 6859
-	Radius 4.0
+	RA 23.74795985
+	Dec 55.16953161
+	Radius 111.138
+	Distance 1457.594
 }
 
-OpenCluster "Pfleiderer 4"
+OpenCluster "Berkeley 103:MWSC 3755:OCL 266"
 {
-	RA 23.848611
-	Dec 62.320833
-	Distance 25767
-	Radius 15.0
+	RA 23.75355132
+	Dec 59.29941378
+	Radius 231.088
+	Distance 19069.505
 }
 
-OpenCluster "NGC 7772"
+OpenCluster "HSC 920"
 {
-	RA 23.862778
-	Dec 16.246667
-	Distance 4892
-	Radius 2.1
+	RA 23.75598758
+	Dec 62.79345519
+	Radius 39.937
+	Distance 6045.861
 }
 
-OpenCluster "ASCC 130"
+OpenCluster "HSC 919"
 {
-	RA 23.880000
-	Dec 62.440000
-	Distance 11089
-	Radius 29.0
+	RA 23.76775127
+	Dec 62.27646979
+	Radius 76.036
+	Distance 13407.905
 }
 
-OpenCluster "King 12"
+OpenCluster "HSC 883"
 {
-	RA 23.883333
-	Dec 61.966667
-	Distance 7756
-	Radius 3.4
+	RA 23.77451014
+	Dec 46.38517753
+	Radius 75.514
+	Distance 1313.572
 }
 
-OpenCluster "NGC 7788"
+OpenCluster "HSC 848"
 {
-	RA 23.945833
-	Dec 61.398333
-	Distance 7743
-	Radius 4.5
+	RA 23.78112822
+	Dec 35.94293671
+	Radius 59.658
+	Distance 2308.002
 }
 
-OpenCluster "NGC 7789"
+OpenCluster "FSR 0448:FSR 448:MWSC 3756"
 {
-	RA 23.956667
-	Dec 56.708333
-	Distance 5854
-	Radius 21.3
+	RA 23.78709207
+	Dec 60.89695952
+	Radius 38.946
+	Distance 9177.69
 }
 
-OpenCluster "Frolov 1"
+OpenCluster "HSC 936"
 {
-	RA 23.956667
-	Dec 61.633333
-	Distance 8349
-	Radius 4.9
+	RA 23.78871027
+	Dec 68.25153318
+	Radius 77.241
+	Distance 13170.137
 }
 
-OpenCluster "NGC 7790"
+OpenCluster "FSR 0453:Negueruela 1"
 {
-	RA 23.973333
-	Dec 61.208333
-	Distance 9602
-	Radius 7.0
+	RA 23.79005798
+	Dec 63.22154341
+	Radius 13.13
+	Distance 9620.708
 }
 
-OpenCluster "NGC 7762"
+OpenCluster "Majaess 227:UBC 1188"
 {
-	RA 23.998889
-	Dec 68.034167
-	Distance 2544
-	Radius 1.6
+	RA 23.79076701
+	Dec 60.51038315
+	Radius 58.179
+	Distance 6524.856
 }
 
+OpenCluster "Theia 775"
+{
+	RA 23.79114001
+	Dec 62.81736215
+	Radius 113.096
+	Distance 2648.157
+}
+
+OpenCluster "FSR 467:King 11:MWSC 3759:OCL 279"
+{
+	RA 23.79398298
+	Dec 68.63627933
+	Radius 104.81
+	Distance 9528.571
+}
+
+OpenCluster "HSC 886"
+{
+	RA 23.7955257
+	Dec 46.77054179
+	Radius 50.68
+	Distance 1384.201
+}
+
+OpenCluster "DSH J2347.9+6259:FSR 454:MWSC 3760:Teutsch 23"
+{
+	RA 23.79787931
+	Dec 62.9925274
+	Radius 16.359
+	Distance 9415.158
+}
+
+OpenCluster "Alessi 22:CWNU 1254:Theia 1106"
+{
+	RA 23.81148761
+	Dec 36.2292495
+	Radius 78.302
+	Distance 1154.325
+}
+
+OpenCluster "UPK 214"
+{
+	RA 23.81170072
+	Dec 53.51128869
+	Radius 136.76
+	Distance 2594.094
+}
+
+OpenCluster "HSC 923"
+{
+	RA 23.81772126
+	Dec 63.3967119
+	Radius 47.985
+	Distance 15841.273
+}
+
+OpenCluster "OC 0210:UBC 180"
+{
+	RA 23.82416742
+	Dec 58.9781813
+	Radius 46.618
+	Distance 6521.497
+}
+
+OpenCluster "King 21:MWSC 3762:OCL 270:OC 0212"
+{
+	RA 23.8317698
+	Dec 62.70045141
+	Radius 45.406
+	Distance 9403.228
+}
+
+OpenCluster "NGC 7762:Melotte 244:Collinder 457:FSR 468:MWSC 3784:OCL 280:PTB 9:Theia 1344"
+{
+	RA 23.83299324
+	Dec 68.03075564
+	Radius 79.097
+	Distance 3073.571
+}
+
+OpenCluster "UPK 233"
+{
+	RA 23.84340642
+	Dec 71.57473978
+	Radius 64.107
+	Distance 1564.126
+}
+
+OpenCluster "MWSC 3764:PWM 4:Pfleiderer 4"
+{
+	RA 23.84893342
+	Dec 62.31812123
+	Radius 129.002
+	Distance 41862.245
+}
+
+OpenCluster "FSR 0465:FSR 465:MWSC 3765:SAI 151"
+{
+	RA 23.85009922
+	Dec 66.18378803
+	Radius 104.804
+	Distance 13257.996
+}
+
+OpenCluster "FSR 0451:FSR 451:MWSC 3766:Theia 1767:UBC 404"
+{
+	RA 23.85267655
+	Dec 60.85099319
+	Radius 97.39
+	Distance 9136.675
+}
+
+OpenCluster "CWNU 174"
+{
+	RA 23.85536036
+	Dec 54.01508419
+	Radius 196.281
+	Distance 3632.551
+}
+
+OpenCluster "CWNU 1066"
+{
+	RA 23.86394281
+	Dec -18.7854153
+	Radius 95.33
+	Distance 324.102
+}
+
+OpenCluster "FSR 457:King 12:MWSC 3771:OCL 272"
+{
+	RA 23.88431623
+	Dec 61.9574806
+	Radius 29.193
+	Distance 9150.203
+}
+
+OpenCluster "CWNU 148"
+{
+	RA 23.88791654
+	Dec 57.76520478
+	Radius 50.447
+	Distance 5188.792
+}
+
+OpenCluster "CWNU 2667"
+{
+	RA 23.89351137
+	Dec 63.07096664
+	Radius 52.469
+	Distance 11689.377
+}
+
+OpenCluster "HSC 749"
+{
+	RA 23.89801806
+	Dec 3.45550369
+	Radius 239.064
+	Distance 395.144
+}
+
+OpenCluster "CWNU 2585"
+{
+	RA 23.9055625
+	Dec 68.22157279
+	Radius 86.707
+	Distance 8630.542
+}
+
+OpenCluster "UBC 405"
+{
+	RA 23.90567092
+	Dec 62.54350309
+	Radius 54.686
+	Distance 13966.203
+}
+
+OpenCluster "CWNU 530:UBC 1186"
+{
+	RA 23.90595292
+	Dec 51.42695941
+	Radius 64.428
+	Distance 5262.164
+}
+
+OpenCluster "CWNU 1504:FoF 888"
+{
+	RA 23.91316494
+	Dec 60.8523418
+	Radius 33.555
+	Distance 7740.238
+}
+
+OpenCluster "HSC 940"
+{
+	RA 23.91427028
+	Dec 69.2832548
+	Radius 69.184
+	Distance 1127.865
+}
+
+OpenCluster "HSC 922"
+{
+	RA 23.91813375
+	Dec 59.71261511
+	Radius 23.068
+	Distance 2782.379
+}
+
+OpenCluster "White Rose Cluster:Caroline's Rose:NGC 7789:Melotte 245:Collinder 460:FSR 450:MWSC 3779:OCL 269:OCSN 40:Theia 920"
+{
+	RA 23.92385578
+	Dec 56.48449254
+	Radius 79.614
+	Distance 1311.744
+}
+
+OpenCluster "FoF 888:HXHWL 4:UBC 1190"
+{
+	RA 23.92627785
+	Dec 60.87111084
+	Radius 32.528
+	Distance 8459.074
+}
+
+OpenCluster "CWNU 1271"
+{
+	RA 23.93923303
+	Dec 55.94184919
+	Radius 46.36
+	Distance 6917.415
+}
+
+OpenCluster "NGC 7788:Collinder 459:FSR 458:MWSC 3777:OCL 275"
+{
+	RA 23.94574341
+	Dec 61.39641155
+	Radius 24.83
+	Distance 8822.642
+}
+
+OpenCluster "NGC 7789:Melotte 245:Collinder 460:FSR 450:MWSC 3779:OCL 269:Theia 3615:Theia 6475"
+{
+	RA 23.95524115
+	Dec 56.72375025
+	Radius 92.528
+	Distance 6420.458
+}
+
+OpenCluster "UBC 594"
+{
+	RA 23.96408777
+	Dec 61.44470454
+	Radius 116.444
+	Distance 13947.749
+}
+
+OpenCluster "HSC 937"
+{
+	RA 23.96611726
+	Dec 63.79172391
+	Radius 135.987
+	Distance 15731.877
+}
+
+OpenCluster "HSC 929"
+{
+	RA 23.96624088
+	Dec 61.3430772
+	Radius 72.926
+	Distance 7481.294
+}
+
+OpenCluster "NGC 7790:Collinder 461:FSR 461:MWSC 3781:OCL 276:OC 0213"
+{
+	RA 23.97466064
+	Dec 61.20784602
+	Radius 41.34
+	Distance 10198.935
+}
+
+OpenCluster "HSC 945"
+{
+	RA 23.97582701
+	Dec 69.97334629
+	Radius 73.649
+	Distance 17414.98
+}
+
+OpenCluster "HSC 935"
+{
+	RA 23.97712093
+	Dec 63.20733241
+	Radius 78.583
+	Distance 14207.884
+}
+
+OpenCluster "HSC 931"
+{
+	RA 23.98407695
+	Dec 61.36984939
+	Radius 192.444
+	Distance 1780.715
+}
+
+OpenCluster "FSR 0460:FSR 460:MWSC 3783:SAI 153"
+{
+	RA 23.98413966
+	Dec 60.69059589
+	Radius 69.331
+	Distance 16733.314
+}
+
+OpenCluster "HSC 930"
+{
+	RA 23.98989053
+	Dec 60.79592935
+	Radius 79.79
+	Distance 4185.025
+}
+
+OpenCluster "HSC 934"
+{
+	RA 23.99314842
+	Dec 62.44023191
+	Radius 111.322
+	Distance 12068.025
+}
+
+OpenCluster "HSC 938"
+{
+	RA 23.99855229
+	Dec 63.86418661
+	Radius 31.532
+	Distance 9901.386
+}
+
+OpenCluster "HSC 926"
+{
+	RA 23.99949005
+	Dec 59.75364684
+	Radius 114.619
+	Distance 967.303
+}


### PR DESCRIPTION
My first content PR, it completely rewrites the star cluster dsc files to remove dependency on ancient, undocumented Fridger scripts.
I've also adopted a newer, much more complete source for open star clusters and replaced mu25 isophote globular cluster radii to tidal radii ("Radius" in GCs are purely visual and only say the markers where to put thenselves). Sources are noted in the headers.

galaxies.dsc is left for a separate PR due to its making having a complexity on its own.

Any updates after this can be done by hand, without usage of scripts, due to the lack of dependence on the aformentioned scripts by Fridger.

Cheers!