### PR TITLE
outersys.ssc color update

### DIFF
--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -64,7 +64,7 @@
 		Texture	"quaoar-rings.*"
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.109
+	GeomAlbedo	0.124
 	BondAlbedo	0.057
 	InfoURL	"https://en.wikipedia.org/wiki/50000_Quaoar"
 }
@@ -185,7 +185,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		AscendingNode	83.3
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.23
+	GeomAlbedo	0.231
 	InfoURL	"https://en.wikipedia.org/wiki/90482_Orcus"
 }
 
@@ -316,14 +316,14 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		Inclination	66
 		AscendingNode	234
 	}
-	LunarLambert	0.5
-	GeomAlbedo	0.076  # main body
 	Rings  # derived from ring radius, component widths and average gap size
 	{
 		Inner	313
 		Outer	335
 		Texture	"chariklo-rings.*"
 	}
+	LunarLambert	0.5
+	GeomAlbedo	0.076  # main body
 	InfoURL	"https://en.wikipedia.org/wiki/2060_Chiron"
 }
 
@@ -357,14 +357,14 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		Inclination	48.52
 		AscendingNode	241.3
 	}
-	LunarLambert	0.5
-	GeomAlbedo	0.038  # main body
 	Rings  # derived from ring radii and average widths by Braga-Ribas et al. (2014)
 	{
 		Inner	387.3
 		Outer	406.5
 		Texture	"chariklo-rings.*"
 	}
+	LunarLambert	0.5
+	GeomAlbedo	0.038  # main body
 	InfoURL	"https://en.wikipedia.org/wiki/10199_Chariklo"
 }
 
@@ -484,7 +484,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		Period	12.4
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.141
+	GeomAlbedo	0.108
 	BondAlbedo	0.037
 	InfoURL	"https://en.wikipedia.org/wiki/28978_Ixion"
 }
@@ -532,7 +532,7 @@ ReferencePoint "Huya System" "Sol"
 		Period	5.28
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.083
+	GeomAlbedo	0.079
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya"
 }
 
@@ -554,7 +554,7 @@ ReferencePoint "Huya System" "Sol"
 		SemiMajorAxis	1520
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.083
+	GeomAlbedo	0.079	# assume same albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya#Satellite"
 }
 
@@ -614,7 +614,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	330.0
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079
+	GeomAlbedo	0.079	# assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo"
 }
 
@@ -652,7 +652,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	330.0
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079
+	GeomAlbedo	0.079	# assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Hiisi"
 }
 
@@ -689,7 +689,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	325.2
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079
+	GeomAlbedo	0.079	# assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Paha"
 }
 
@@ -754,7 +754,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	110.4
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.044
+	GeomAlbedo	0.042
 	InfoURL	"https://en.wikipedia.org/wiki/120347_Salacia"
 }
 
@@ -782,7 +782,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		MeanAnomaly	214.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.044
+	GeomAlbedo	0.042	// assume same albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/Actaea_(moon)"
 }
 
@@ -840,7 +840,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		AscendingNode	5.1
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.097
+	GeomAlbedo	0.099
 	InfoURL	"https://en.wikipedia.org/wiki/174567_Varda"
 }
 
@@ -933,7 +933,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		AscendingNode	128.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.142
+	GeomAlbedo	0.142	// assume equal albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/229762_G%C7%83k%C3%BAn%C7%81%CA%BCh%C3%B2md%C3%ADm%C3%A0#Satellite"
 }
 

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -1,12 +1,11 @@
 # Colors are mainly derived from B-V and V-R indices, most of which
 # come from the MBOSS compilation: http://www.eso.org/~ohainaut/MBOSS/
-# and converted using Askaniy's TrueColorTools:
+# Centaur colors are derived from SMASS spectra: http://smass.mit.edu/smass.html
+# They are converted to RGB values using Askaniy's TrueColorTools:
 # https://github.com/Askaniy/TrueColorTools
 # or FarGetaNik's color calculator:
-# https://docs.google.com/spreadsheets/d/1_mMXYzeYE4JcXJFrn4j5XWJvf2ik13r8v1BZ7G9I4EY/
-# Centaur colors are derived from SMASS spectra and converted
-# to RGB values using Matt Wronkiewicz's spectrum2rgb utility
-# that is distributed with the Celestia source package.
+# https://docs.google.com/spreadsheets/d/1NvPGGiql5EdOUVTynE8CyoB9P4rSjblmzppyNGjR6bI/edit
+# or Matt Wronkiewicz's spectrum2rgb utility that is distributed with the Celestia source package.
 # These are then scaled for albedo = 0.5 textures by dividing 0.735357 with them.
 # https://docs.google.com/spreadsheets/d/1POAssGnBsFBGyoevCkom8sHODIgdsn_s/edit
 

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -1,6 +1,8 @@
 # Colors are mainly derived from B-V and V-R indices, most of which
 # come from the MBOSS compilation: http://www.eso.org/~ohainaut/MBOSS/
-# and converted using FarGetaNik's color calculator:
+# and converted using Askaniy's TrueColorTools:
+# https://github.com/Askaniy/TrueColorTools
+# or FarGetaNik's color calculator:
 # https://docs.google.com/spreadsheets/d/1_mMXYzeYE4JcXJFrn4j5XWJvf2ik13r8v1BZ7G9I4EY/
 # Centaur colors are derived from SMASS spectra and converted
 # to RGB values using Matt Wronkiewicz's spectrum2rgb utility
@@ -22,7 +24,7 @@
 # Mass, radii, and rotation period from Morgado et al. (2023), Nature 614, 239–243
 # "A dense ring of the trans-Neptunian object Quaoar outside its Roche limit"
 # https://ui.adsabs.harvard.edu/abs/2023Natur.614..239M/abstract
-# Ring rotation axis from Pereira et al. (2023), A&A 673, 14
+# Ring rotation axis and geometric albedo from Pereira et al. (2023), A&A 673, 14
 # "The two rings of (50000) Quaoar"
 # https://ui.adsabs.harvard.edu/abs/2023A%26A...673L...4P/abstract
 # Bond albedo from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
@@ -30,10 +32,9 @@
 # https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "50000 Quaoar:Quaoar:2002 LM60" "Sol"
 {
-	Class	"asteroid"
-	# Class	"dwarfplanet"
+	Class	"dwarfplanet"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.893 0.787 ]
+	Color	[ 0.557 0.519 0.469 ]
 	BlendTexture	true
 	Radius	579.5  # equatorial
 	Oblateness	0.12	# projected
@@ -103,10 +104,9 @@
 
 "90377 Sedna:Sedna:2003 VB12" "Sol"
 {
-	Class	"asteroid"
-	# Class	"dwarfplanet"
+	Class	"dwarfplanet"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.860 0.692 ]
+	Color	[ 0.978 0.886 0.746 ]
 	BlendTexture	true
 	Radius	497.5
 	EllipticalOrbit
@@ -158,10 +158,9 @@ ReferencePoint "Orcus-Vanth" "Sol"
 
 "90482 Orcus:Orcus:2004 DW" "Sol"
 {
-	Class	"asteroid"
-	# Class	"dwarfplanet"
+	Class	"dwarfplanet"
 	Texture	"asteroid.*"
-	Color	[ 0.998 1.000 0.995 ]
+	Color	[ 0.698 0.706 0.709 ]
 	BlendTexture	true
 	Radius	455
 	Mass	0.00009125921
@@ -194,7 +193,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 {
 	Class	"moon"
 	Texture	"asteroid.*"
-	Color	[ 0.69 0.60 0.51 ]  # reddish; adjusted for albedo
+	Color	[ 0.438 0.423 0.404 ]
 	BlendTexture	true
 	Radius	221.25
 	Mass	0.0000145680
@@ -225,10 +224,9 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # "Photometry of Transneptunian Objects for the Herschel Key Program 'TNOs are Cool'"
 "225088 Gonggong:Gonggong:2007 OR10" "Sol"
 {
-	Class	"asteroid"
-	# Class	"dwarfplanet"
+	Class	"dwarfplanet"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.818 0.604 ]
+	Color	[ 0.622 0.542 0.42 ]
 	BlendTexture	true
 	Radius	615
 	Oblateness	0.03
@@ -260,6 +258,8 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
+	Color	[ 1.0 0.946 0.873 ]
+	BlendTexture	true
 	Radius	50  # dynamical upper limit
 	OrbitFrame
 	{
@@ -286,13 +286,17 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # Ortiz et al. (2015), A&A 576, A18
 # "Possible ring material around centaur (2060) Chiron"
 # https://www.aanda.org/articles/aa/abs/2015/04/aa24461-14/aa24461-14.html
+# Geometric albedo from Braga-Ribas et al. (2023), A&A 676, A72
+# "Constraints on (2060) Chiron's size, shape, and surrounding material from
+# the November 2018 and September 2019 stellar occultations"
+# https://ui.adsabs.harvard.edu/abs/2023A%26A...676A..72B/abstract
 "2060 Chiron:Chiron:1977 UB:95P Chiron" "Sol"
 {
 	Class	"asteroid"
 	# Class	"comet"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.960 0.919 ]
+	Color	[ 0.416 0.415 0.415 ]
 	BlendTexture	true
 	SemiAxes	[ 100 84 70 ]
 	EllipticalOrbit
@@ -313,7 +317,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		AscendingNode	234
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.08  # main body
+	GeomAlbedo	0.076  # main body
 	Rings  # derived from ring radius, component widths and average gap size
 	{
 		Inner	313
@@ -331,7 +335,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.903 0.786 ]
+	Color	[ 0.298 0.286 0.26 ]
 	BlendTexture	true
 	Radius	143  # equatorial
 	Oblateness	0.329
@@ -371,7 +375,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Class	"asteroid"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.872 0.798 ]
+	Color	[ 1.0 0.932 0.872 ]
 	BlendTexture	true
 	Radius	54
 	EllipticalOrbit
@@ -398,7 +402,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.909 0.810 ]
+	Color	[ 1.0 0.947 0.87 ]
 	BlendTexture	true
 	Radius	300
 	EllipticalOrbit
@@ -428,7 +432,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.902 0.813 ]
+	Color	[ 0.644 0.607 0.56 ]
 	BlendTexture	true
 	Radius	502  # long-axis from occultation
 	SemiAxes	[ 1 0.6 0.432 ]  # hydrostatic equilibrium assumed
@@ -454,14 +458,14 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/20000_Varuna"
 }
 
-# Bond albedo from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
+# Bond and geom albedo from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
 # "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
 # https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "28978 Ixion:Ixion:2001 KX76" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.910 0.782 ]
+	Color	[ 0.519 0.486 0.431 ]
 	BlendTexture	true
 	Radius	308.5
 	EllipticalOrbit
@@ -503,11 +507,14 @@ ReferencePoint "Huya System" "Sol"
 	Clickable true
 }
 
+# Geometric albedo from Santos-Sanz et al. (2022), A&A 664, A130
+# "Physical properties of the trans-Neptunian object (38628) Huya from a multi-chord stellar occultation"
+# https://ui.adsabs.harvard.edu/abs/2022A%26A...664A.130S/abstract
 "38628 Huya:Huya:2000 EB173" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.909 0.799 ]
+	Color	[ 0.445 0.418 0.377 ]
 	BlendTexture	true
 	Radius	203
 	OrbitFrame
@@ -534,7 +541,7 @@ ReferencePoint "Huya System" "Sol"
 	Class	"moon"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.909 0.799 ]  # assume same color as primary
+	Color	[ 0.445 0.418 0.377 ]  # assume same color as primary
 	BlendTexture	true
 	Radius	106.5
 	OrbitFrame
@@ -551,6 +558,10 @@ ReferencePoint "Huya System" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya#Satellite"
 }
 
+# System geometric albedo from Mommert et al. (2012), A&A 541, A93
+# "TNOs are cool: A survey of the trans-Neptunian region. V.
+# Physical characterization of 18 Plutinos using Herschel-PACS observations"
+# https://ui.adsabs.harvard.edu/abs/2012A%26A...541A..93M/abstract
 ReferencePoint "Lempo-Hiisi" "Sol"
 {
 	EllipticalOrbit
@@ -574,7 +585,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.0 0.82 0.64 ]
+	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
 	BlendTexture	true
 	Radius	136
 	OrbitFrame
@@ -612,7 +623,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.0 0.82 0.64 ]
+	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
 	BlendTexture	true
 	Radius	125.5
 	OrbitFrame
@@ -650,7 +661,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.0 0.82 0.64 ]
+	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
 	BlendTexture	true
 	Radius	66
 	OrbitFrame
@@ -682,11 +693,15 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Paha"
 }
 
+# Geometric albedo from Vilenius et al. (2014), A&A 564, A35
+# ""TNOs are Cool": A survey of the trans-Neptunian region. X.
+# Analysis of classical Kuiper belt objects from Herschel and Spitzer observations"
+# https://ui.adsabs.harvard.edu/abs/2014A%26A...564A..35V/abstract
 "(55565) 2002 AW197:2002 AW197" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.916 0.822 ]
+	Color	[ 0.523 0.496 0.456 ]
 	BlendTexture	true
 	Radius	384
 	EllipticalOrbit
@@ -711,11 +726,14 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 
 # Sizes from Grundy et al. (2019), Icarus 334, 62
 # "Mutual orbit orientations of transneptunian binaries"
+# Geometric albedo from Brown and Butler (2017), AJ 154, no. 1, 19
+# "The Density of Mid-sized Kuiper Belt Objects from ALMA Thermal Observations"
+# https://ui.adsabs.harvard.edu/abs/2017AJ....154...19B/abstract
 "120347 Salacia:Salacia:2004 SB60" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.990 0.988 ]
+	Color	[ 0.306 0.309 0.311 ]
 	BlendTexture	true
 	Radius	423
 	EllipticalOrbit
@@ -745,7 +763,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"moon"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.990 0.988 ]  # assume same color as primary
+	Color	[ 0.306 0.309 0.311 ]  # assume same color as primary
 	BlendTexture	true
 	Radius	142
 	OrbitFrame
@@ -768,9 +786,12 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/Actaea_(moon)"
 }
 
-# Souami et al. (2020), eprint arXiv:2008.04818
+# Souami et al. (2020), A&A 643, A125
 # "A multi-chord stellar occultation by the large trans-Neptunian object (174567) Varda"
-# https://arxiv.org/abs/2008.04818
+# https://ui.adsabs.harvard.edu/abs/2020A%26A...643A.125S/abstract
+# Colors from Grundy et al. (2015), Icarus 257, p. 130-138
+# "The mutual orbit, mass, and density of the large transneptunian binary system Varda and Ilmarë"
+# https://ui.adsabs.harvard.edu/abs/2015Icar..257..130G/abstract
 ReferencePoint "Varda-Ilmare" "Sol"
 {
 	EllipticalOrbit
@@ -793,7 +814,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.929 0.842 ]
+	Color	[ 0.498 0.467 0.432 ]
 	BlendTexture	true
 	Radius	381  # equatorial
 	Oblateness	0.043
@@ -828,7 +849,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	Class	"moon"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 0.941 0.875 0.793 ]  # assume same color as primary; adjusted for albedo
+	Color	[ 0.468 0.433 0.404 ]
 	BlendTexture	true
 	Radius	178
 	OrbitFrame
@@ -860,6 +881,8 @@ ReferencePoint "Varda-Ilmare" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
+	Color	[ 0.583 0.556 0.521 ]
+	BlendTexture	true
 	SemiAxes	[ 339 339 305.7 ]
 	EllipticalOrbit
 	{
@@ -886,7 +909,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.00 0.88 0.75 ]  # reddish
+	Color	[ 1.0 0.857 0.644 ]  # reddish
 	BlendTexture	true
 	Radius	72
 	OrbitFrame
@@ -928,7 +951,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 0.993 1.000 0.999 ]
+	Color	[ 0.472 0.475 0.475 ]
 	BlendTexture	true
 	SemiAxes	[ 412 412 385 ] # projected
 	EllipticalOrbit

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -1049,7 +1049,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	Texture	"asteroid.*"
 	Color	[ 1.0 0.988 0.956 ]
 	BlendTexture	true
-	Radius	280	 # minimum radius
+	Radius	280  # minimum radius
 	EllipticalOrbit
 	{
 		Epoch	2457000.5  # 2014 Dec 09

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -39,7 +39,7 @@
 	Color	[ 0.557 0.519 0.469 ]
 	BlendTexture	true
 	Radius	579.5  # equatorial
-	Oblateness	0.12	# projected
+	Oblateness	0.12  # projected
 	Mass	0.0002009377
 	EllipticalOrbit
 	{
@@ -71,14 +71,17 @@
 	InfoURL	"https://en.wikipedia.org/wiki/50000_Quaoar"
 }
 
+# Radius and geometric albedo from Fernandez-Valenzuela et al., 55th Annual DPS Meeting Joint with EPSC
+# "Weywot: the darkest known satellite in the trans-Neptunian region"
+# https://submissions.mirasmart.com/DPS55/Itinerary/PresentationDetail.aspx?evdid=75
 "Weywot:50000 Quaoar I:Quaoar I:S 2006 (50000) 1" "Sol/Quaoar"
 {
 	Class	"minormoon"
-	Mesh	"asteroid.cms"
+	Mesh	"asteroid.cms"  # almost 200 km effective diameter
 	Texture	"asteroid.*"
-	Color	[ 0.5 0.5 0.5 ]  # adjust texture brightness for albedo
+	Color	[ 0.319 0.296 0.265 ]  # assume same photometric color as primary
 	BlendTexture	true
-	Radius	85  # JOA 10 (1), 24
+	Radius	100
 	OrbitFrame
 	{
 		EquatorJ2000	{ Center "Sol/Quaoar" }
@@ -100,7 +103,7 @@
 		AscendingNode	352.3
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.03  # recalculated for size
+	GeomAlbedo	0.04
 	InfoURL	"https://en.wikipedia.org/wiki/Weywot_(moon)"
 }
 
@@ -560,7 +563,7 @@ ReferencePoint "Huya System" "Sol"
 		SemiMajorAxis	1520
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079	# assume same albedo as primary
+	GeomAlbedo	0.079  # assume same albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya#Satellite"
 }
 
@@ -591,7 +594,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
+	Color	[ 0.454 0.416 0.365 ]  # assume equal albedo
 	BlendTexture	true
 	Radius	136
 	OrbitFrame
@@ -620,7 +623,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	330.0
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079	# assume equal albedo
+	GeomAlbedo	0.079  # assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo"
 }
 
@@ -629,7 +632,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
-	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
+	Color	[ 0.454 0.416 0.365 ]  # assume equal albedo
 	BlendTexture	true
 	Radius	125.5
 	OrbitFrame
@@ -658,7 +661,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	330.0
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079	# assume equal albedo
+	GeomAlbedo	0.079  # assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Hiisi"
 }
 
@@ -667,7 +670,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
-	Color	[ 0.454 0.416 0.365 ]	# assume equal albedo
+	Color	[ 0.454 0.416 0.365 ]  # assume equal albedo
 	BlendTexture	true
 	Radius	66
 	OrbitFrame
@@ -695,7 +698,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		AscendingNode	325.2
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.079	# assume equal albedo
+	GeomAlbedo	0.079  # assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Paha"
 }
 
@@ -788,7 +791,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		MeanAnomaly	214.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.042	# assume same albedo as primary
+	GeomAlbedo	0.042  # assume same albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/Actaea_(moon)"
 }
 
@@ -939,7 +942,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		AscendingNode	128.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.142	# assume equal albedo as primary
+	GeomAlbedo	0.142  # assume equal albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/229762_G%C7%83k%C3%BAn%C7%81%CA%BCh%C3%B2md%C3%ADm%C3%A0#Satellite"
 }
 
@@ -959,7 +962,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	Texture	"asteroid.*"
 	Color	[ 0.472 0.475 0.475 ]
 	BlendTexture	true
-	SemiAxes	[ 412 412 385 ] # projected
+	SemiAxes	[ 412 412 385 ]  # projected
 	EllipticalOrbit
 	{
 		Epoch	2460200.5  # 2023-Sep-13.0
@@ -1044,9 +1047,9 @@ ReferencePoint "Varda-Ilmare" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.0 0.988 0.956 ]	# self-calculated albedo
+	Color	[ 1.0 0.988 0.956 ]
 	BlendTexture	true
-	Radius	280	# minimum radius
+	Radius	280	 # minimum radius
 	EllipticalOrbit
 	{
 		Epoch	2457000.5  # 2014 Dec 09
@@ -1063,6 +1066,6 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		Period	6  # guess
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.099	# assume minimum radius
+	GeomAlbedo	0.099  # assume minimum radius
 	InfoURL	"https://en.wikipedia.org/wiki/(612911)_2004_XR190"
 }

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -987,10 +987,14 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/(307261)_2002_MS4"
 }
 
+# Color derived from observations made by La Silla and PAN-STARRS 1 on 2010-04-06
+# https://www.minorplanetcenter.net/db_search/show_object?object_id=471143
 "471143 Dziewanna:Dziewanna:2010 EK139" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
+	Color	[ 1.0 0.92 0.818 ]
+	BlendTexture	true
 	Radius	235
 	EllipticalOrbit
 	{

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -458,7 +458,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/20000_Varuna"
 }
 
-# Bond and geom albedo from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
+# Bond and geometric albedo from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
 # "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
 # https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "28978 Ixion:Ixion:2001 KX76" "Sol"
@@ -782,7 +782,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 		MeanAnomaly	214.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.042	// assume same albedo as primary
+	GeomAlbedo	0.042	# assume same albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/Actaea_(moon)"
 }
 
@@ -933,7 +933,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		AscendingNode	128.5
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.142	// assume equal albedo as primary
+	GeomAlbedo	0.142	# assume equal albedo as primary
 	InfoURL	"https://en.wikipedia.org/wiki/229762_G%C7%83k%C3%BAn%C7%81%CA%BCh%C3%B2md%C3%ADm%C3%A0#Satellite"
 }
 

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -7,6 +7,8 @@
 # Centaur colors are derived from SMASS spectra and converted
 # to RGB values using Matt Wronkiewicz's spectrum2rgb utility
 # that is distributed with the Celestia source package.
+# These are then scaled for albedo = 0.5 textures by dividing 0.735357 with them.
+# https://docs.google.com/spreadsheets/d/1POAssGnBsFBGyoevCkom8sHODIgdsn_s/edit
 
 # Orbits for satellites have been taken from Emelyanov & Drozdov (2020), MNRAS 494 (2), 2410
 # "Determination of the orbits of 62 moons of asteroids based on astrometric observations."

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -255,14 +255,18 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/225088_Gonggong"
 }
 
+# Radius from Arakawa et al. (2021), AJ 162, no. 6, 226
+# "Tidal Evolution of the Eccentric Moon around Dwarf Planet (225088) Gonggong"
+# https://ui.adsabs.harvard.edu/abs/2021AJ....162..226A/abstract
+# Geometric albedo is calculated using this radius.
 "Xiangliu:225088 Gonggong I:Gonggong I:S 2010 (225088) 1" "Sol/Gonggong"
 {
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
-	Color	[ 1.0 0.946 0.873 ]
+	Color	[ 0.448 0.421 0.385 ]
 	BlendTexture	true
-	Radius	50  # dynamical upper limit
+	Radius	100
 	OrbitFrame
 	{
 		EquatorJ2000	{ Center "Sol/Gonggong" }
@@ -279,7 +283,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		MeanAnomaly	96.52
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.2
+	GeomAlbedo	0.08
 	InfoURL	"https://en.wikipedia.org/wiki/Xiangliu_(moon)"
 }
 
@@ -1035,13 +1039,14 @@ ReferencePoint "Varda-Ilmare" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/486958_Arrokoth"
 }
 
+# Minimum radius from http://www.euraster.net/results/2021/index.html#0122--
 "(612911) 2004 XR190:2004 XR190" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 1.000 0.971 0.919 ]
+	Color	[ 1.0 0.988 0.956 ]	# self-calculated albedo
 	BlendTexture	true
-	Radius	290
+	Radius	280	# minimum radius
 	EllipticalOrbit
 	{
 		Epoch	2457000.5  # 2014 Dec 09
@@ -1058,6 +1063,6 @@ ReferencePoint "Varda-Ilmare" "Sol"
 		Period	6  # guess
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.09  # assumed
+	GeomAlbedo	0.099	# assume minimum radius
 	InfoURL	"https://en.wikipedia.org/wiki/(612911)_2004_XR190"
 }


### PR DESCRIPTION
Updated colors of most objects in outersys.ssc to reflect their actual albedo, following the addition of color-calibrated asteroid texture. The four consensus dwarf planets are also now given the dwarfplanet class, but remains in outersys.ssc for the moment.