### PR TITLE
Standardize 'moon' vs 'minormoon' classification

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -82,7 +82,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 
 "Charon:134340 Pluto I:Pluto I:S 1978 P 1:S 1978 (134340) 1" "Sol/Pluto"
 {
-	Class	"dwarfplanet"
+	Class	"moon"
 	Texture	"charon.*"
 	NormalMap	"charon-normal.*"
 	Color	[ 0.994 1.0 0.972 ]

--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -82,7 +82,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 
 "Charon:134340 Pluto I:Pluto I:S 1978 P 1:S 1978 (134340) 1" "Sol/Pluto"
 {
-	Class	"moon"
+	Class	"dwarfplanet"
 	Texture	"charon.*"
 	NormalMap	"charon-normal.*"
 	Color	[ 0.994 1.0 0.972 ]
@@ -381,7 +381,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 
 "Hi'iaka:136108 Haumea I:Haumea I:S 2005 (2003 EL61) 1" "Sol/Haumea"
 {
-	Class	"moon"
+	Class	"minormoon"
 	Mesh	"roughsphere.cms"
 	Texture	"icymoon.*"
 	Radius	160

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -16,6 +16,9 @@
 # mass ratios (and thus relative semi-major axes) have been computed from the cube of
 # the component sizes, under the assumption of equal densities for both of them.
 
+# Satellites smaller than 200 km are classified as 'minormoon', otherwise they are moon.
+# Satellites with mass ratio of over 1:25 relative to their parent are given their physical class instead.
+
 # Likely dwarf planets
 
 # Braga-Ribas et al. (2013), ApJ 773 (1), 26
@@ -195,7 +198,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 
 "Vanth:90482 Orcus I:Orcus I:S 2005 (90482) 1" "Sol/Orcus"
 {
-	Class	"moon"
+	Class	"asteroid"
 	Texture	"asteroid.*"
 	Color	[ 0.438 0.423 0.404 ]
 	BlendTexture	true
@@ -546,7 +549,7 @@ ReferencePoint "Huya System" "Sol"
 
 "S 2012 (38628) 1" "Sol/Huya"
 {
-	Class	"moon"
+	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.445 0.418 0.377 ]  # assume same color as primary
@@ -666,7 +669,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 
 "Paha:47171 Lempo I:Lempo I:S 2001 (47171) 1:1999 TC36 B" "Sol/Lempo"
 {
-	Class	"minormoon"
+	Class	"asteroid"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.454 0.416 0.365 ]  # assume equal albedo
@@ -854,7 +857,7 @@ ReferencePoint "Varda-Ilmare" "Sol"
 
 "Ilmare:174567 Varda I:Varda I:S 2009 (174567) 1" "Sol/Varda"
 {
-	Class	"moon"
+	Class	"asteroid"
 	Mesh	"roughsphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.468 0.433 0.404 ]

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -17,7 +17,7 @@
 # the component sizes, under the assumption of equal densities for both of them.
 
 # Satellites smaller than 200 km are classified as 'minormoon', otherwise they are moon.
-# Satellites with mass ratio of over 1:25 relative to their parent are given their physical class instead.
+# Small satellites with mass ratio of over 1:25 relative to their parent are given their physical class instead.
 
 # Likely dwarf planets
 

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -198,7 +198,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 
 "Vanth:90482 Orcus I:Orcus I:S 2005 (90482) 1" "Sol/Orcus"
 {
-	Class	"asteroid"
+	Class	"moon"
 	Texture	"asteroid.*"
 	Color	[ 0.438 0.423 0.404 ]
 	BlendTexture	true


### PR DESCRIPTION
See Issue #129, going with making relatively large satellites use their physical classes (so Charon is a dwarfplanet and Vanth is an asteroid).