### PR TITLE
Use apt-get instead of apt in translations workflow

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - name: 'Install dependencies'
       run: |
-        sudo apt update
-        sudo apt install -y gettext
+        sudo apt-get update
+        sudo apt-get install -y gettext
 
     - name: 'Checkout source code'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: 'Validate translations'
       working-directory: ${{github.workspace}}/po


### PR DESCRIPTION
- Fixes warning in workflow output
- Also update checkout to v4