### PR TITLE
Eris system tinkering

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -503,7 +503,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 	UniformRotation
 	{
 		Epoch	2453979.0  # 2006 Aug 31 12:00
-		# Period	378.504
+		# Period	378.504  # measured
 		Period	378.861576
 		Inclination	45.49
 		AscendingNode	126.17

--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -499,11 +499,12 @@ ReferencePoint "Pluto-Charon" "Sol"
 		ArgOfPericenter	150.8438151283544
 		MeanAnomaly	194.2922017610525
 	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 		Period	378.504
-		Inclination	61.59
-		AscendingNode	139.12
+		Inclination	45.49
+		AscendingNode	126.17
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.96
@@ -515,9 +516,9 @@ ReferencePoint "Pluto-Charon" "Sol"
 {
 	Class	"moon"
 	Texture	"asteroid.*"
-	Color	[ 0.5 0.5 0.5 ]  # adjust texture brightness for albedo
+	Color	[ 0.337 0.337 0.337 ]
 	BlendTexture	true
-	Radius	350
+	Radius	307.5
 	Mass	0.000013717
 	OrbitFrame	{ EquatorJ2000 {} }
 	EllipticalOrbit
@@ -531,15 +532,15 @@ ReferencePoint "Pluto-Charon" "Sol"
 		ArgOfPericenter	180.83
 		MeanAnomaly	178.78
 	}
-	BodyFrame	{ EclipticJ2000 {} }
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 		Period	378.861576
-		Inclination	61.59
-		AscendingNode	139.12
+		Inclination	45.49
+		AscendingNode	126.17
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.04
+	GeomAlbedo	0.05
 	InfoURL	"https://en.wikipedia.org/wiki/Dysnomia_(moon)"
 }
 

--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -502,9 +502,12 @@ ReferencePoint "Pluto-Charon" "Sol"
 	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
-		Period	378.504
+		Epoch	2453979.0  # 2006 Aug 31 12:00
+		# Period	378.504
+		Period	378.861576
 		Inclination	45.49
 		AscendingNode	126.17
+		MeridianAngle	359.61
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.96
@@ -535,9 +538,10 @@ ReferencePoint "Pluto-Charon" "Sol"
 	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
-		Period	378.861576
+		Epoch	2453979.0  # 2006 Aug 31 12:00
 		Inclination	45.49
 		AscendingNode	126.17
+		MeridianAngle	179.61
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.05


### PR DESCRIPTION
- Added albedo-adjusted color for the moon of Eris as well as updating its albedo and radius.
- Rotation of the system now uses Equatorial coordinates consistent with how the orbit of the moon is defined.