### PR TITLE
Add licensing information to source code files and translations

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,6 +3,18 @@ Upstream-Name: Celestia Content
 Upstream-Contact: Celestia Development Team
 Source: https://github.com/CelestiaProject/CelestiaContent
 
+Files: .github/*
+Copyright: Celestia Development Team
+License: GPL-2.0-or-later
+
+Files: debian/*
+Copyright: 2001-2002 Marcelo E. Magallon <mmagallo@debian.org>
+           2003 Mika Fischer <mf@debian.org>
+           2005 Mathias Weyland <mathias@weyland.ch>
+           2007-2013 Guus Sliepen <guus@debian.org>
+           2019 Celestia Development Team
+License: GPL-2.0-or-later
+
 # Sample paragraph, commented out:
 #
 # Files: src/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 cmake_minimum_required(VERSION 3.8)
 
 project(celestia VERSION "1.7.0" LANGUAGES NONE)

--- a/cmake/FixGettext.cmake
+++ b/cmake/FixGettext.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 macro(GETTEXT_CREATE_TRANSLATIONS2 _potFile _firstPoFileArg)
    # make it a real variable, so we can modify it here
    set(_firstPoFile "${_firstPoFileArg}")

--- a/cmake/install_to_extras_subdir.cmake
+++ b/cmake/install_to_extras_subdir.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 macro(install_to_extras_subdir)
   if(${ARGC} LESS 3)
     message(FATAL_ERROR "install_to_extras_subdir requires at least 3 arguments")

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 if(ENABLE_HIPPARCOS)
   add_custom_command(OUTPUT stars.dat COMMAND buildstardb -q DEPENDS buildstardb)
   add_custom_target(hipparcos_data ALL DEPENDS stars.dat)

--- a/debian/copyright
+++ b/debian/copyright
@@ -6,10 +6,6 @@ Files: *
 Copyright: 2001-2020 Celestia Development Team
 License: GPL-2+
 
-Files: data/openclusters.dsc
-Copyright: 2008 Andrew Tribick <ajtribick@googlemail.com>
-License: CC-BY-SA-4.0
-
 Files: debian/*
 Copyright: 2001-2002 Marcelo E. Magallon <mmagallo@debian.org>
            2003 Mika Fischer <mf@debian.org>

--- a/extras-standard/CMakeLists.txt
+++ b/extras-standard/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 add_subdirectory(apollo)
 add_subdirectory(cassini)
 add_subdirectory(galileo)

--- a/extras-standard/apollo/CMakeLists.txt
+++ b/extras-standard/apollo/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(APOLLO_SOURCES
   apollo.ssc
   models/apollo.3ds

--- a/extras-standard/cassini/CMakeLists.txt
+++ b/extras-standard/cassini/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(CASSINI_SOURCES
   data/cassini-cruise.xyzv
   data/cassini-saturn_01y.xyzv

--- a/extras-standard/galileo/CMakeLists.txt
+++ b/extras-standard/galileo/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(GALILEO_SOURCES
   galileo.ssc
   data/galileo-cruise.xyzv

--- a/extras-standard/hubble/CMakeLists.txt
+++ b/extras-standard/hubble/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(HUBBLE_SOURCES
   hubble.ssc
   models/hubble.cmod

--- a/extras-standard/interstellar-objects/CMakeLists.txt
+++ b/extras-standard/interstellar-objects/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(INTERSTELLAR_SOURCES
   data/borisov.xyzv
   data/oumuamua.xyzv

--- a/extras-standard/iss/CMakeLists.txt
+++ b/extras-standard/iss/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(ISS_SOURCES
   iss.ssc
   textures/medres/issmod.jpg

--- a/extras-standard/mir/CMakeLists.txt
+++ b/extras-standard/mir/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(MIR_SOURCES
   models/mir.3ds
   mir.ssc

--- a/extras-standard/shroxclassic/CMakeLists.txt
+++ b/extras-standard/shroxclassic/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(CLASSIC_SOURCES
   models/gemini.3ds
   models/mercury7.3ds

--- a/extras-standard/shroxmars/CMakeLists.txt
+++ b/extras-standard/shroxmars/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(MARS_SOURCES
   models/marsglobalsurvr.3ds
   models/marsodyssey.3ds

--- a/extras-standard/skylab/CMakeLists.txt
+++ b/extras-standard/skylab/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(SKYLAB_SOURCES
   models/skylab.3ds
   skylab.ssc

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(EXTRA_SOURCES
 )
 

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(MODELS_SOURCES
   amalthea.cmod
   arrokoth.cmod

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 if((NOT ENABLE_NLS) OR (NOT GETTEXT_FOUND))
   return()
 endif()

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 po_files := $(wildcard *.po)
 domain   := celestia-data
 pot_file := $(domain).pot

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,8 +1,11 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Arabic Translation.
 # Copyright (C) 2006 Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.
 # 1.Ali Ibrahim Al-Khudair, 2006.
-# 2.Hussain Al-Ghamdi, 2006 
+# 2.Hussain Al-Ghamdi, 2006
 # 3.Abdullah Al-Ghamdi,2006
 msgid ""
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Hleb Valoshka <375gnu@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,12 +1,15 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2023
 # Georgi Georgiev (Жоро) <g.georgiev.shumen@gmail.com>, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""

--- a/po/celestia-data.pot
+++ b/po/celestia-data.pot
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.

--- a/po/de.po
+++ b/po/de.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of de.po to deutsch
 # translation of celestia-kde.po to deutsch
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/el.po
+++ b/po/el.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of en_US.po to Français
 # This file is distributed under the same license as the PACKAGE package.
 # Copyright (C) YEAR Chris Laurel.

--- a/po/en.po
+++ b/po/en.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of en_US.po to Français
 # This file is distributed under the same license as the PACKAGE package.
 # Copyright (C) YEAR Chris Laurel.

--- a/po/es.po
+++ b/po/es.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of es.po to Français
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/gl.po
+++ b/po/gl.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of en.po to Galician
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 msgid ""
 msgstr ""
 "Project-Id-Version: Konstellációk\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Translation of celestia_constellations.pot to Italian.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Japanese translations for PACKAGE package.
 # Copyright (C) 2006 Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/ka.po
+++ b/po/ka.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of celestia-kde.po to Korean
 # This file is distributed under the same license as the PACKAGE package.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.

--- a/po/lt.po
+++ b/po/lt.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Russian translations for celestia package
 # Copyright (C) 2006 The SIMOfOR, Inc.
 # This file is distributed under the same license as the celestia package.

--- a/po/lv.po
+++ b/po/lv.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Norwegian translation of Celestia.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the Celestia package.

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Nederlandstalige vertaling van sterrenbeelden voor Celestia.
 # Copyright (C) 2006 Myckel Habets
 # This file is distributed under the same license as the Celestia package.

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # This file is distributed under the same license as the celestia package.
 # Michał Trzebiatowski <hippie_1968@hotmail.com>, 2008

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 msgid ""
 msgstr ""
 "Project-Id-Version: Celestia Constellations-pt\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 msgid ""
 msgstr ""
 "Project-Id-Version: Celestia Constellations-pt\n"

--- a/po/remove-potcdate.sin
+++ b/po/remove-potcdate.sin
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Sed script that remove the POT-Creation-Date line in the header entry
 # from a POT file.
 #

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Russian translations for celestia package
 # Copyright (C) 2006 The SIMOfOR, Inc.
 # This file is distributed under the same license as the celestia package.

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Swedish translation of celestia.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the celestia package.

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # , 2011.
 msgid ""
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # translation of uk.po to Ukrainian
 # Ukrainian translations for celestia package
 # Copyright (C) 2006, 2008 Free Software Foundation, Inc.

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Simplied Chinese translations for CELESTIA package.
 # Copyright (C) 2006 Chris Laurel
 # This file is distributed under the same license as the CELESTIA package.

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team, Translators
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Chris Laurel
 # This file is distributed under the same license as the PACKAGE package.

--- a/textures/CMakeLists.txt
+++ b/textures/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 file(GLOB TEXTURES_SOURCES "*.jpg" "*.png")
 
 install(FILES ${TEXTURES_SOURCES} DESTINATION "${DATADIR}/textures" COMPONENT core)

--- a/textures/hires/CMakeLists.txt
+++ b/textures/hires/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 file(GLOB HIRES_SOURCES "*.jpg" "*.png" "*.dds")
 
 install(FILES ${HIRES_SOURCES} DESTINATION "${DATADIR}/textures/hires" COMPONENT core)

--- a/textures/lores/CMakeLists.txt
+++ b/textures/lores/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 file(GLOB LORES_SOURCES "*.jpg" "*.png" "*.dds")
 
 install(FILES ${LORES_SOURCES} DESTINATION "${DATADIR}/textures/lores" COMPONENT core)

--- a/textures/medres/CMakeLists.txt
+++ b/textures/medres/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 file(GLOB MEDRES_SOURCES "*.jpg" "*.png" "*.dds")
 
 install(FILES ${MEDRES_SOURCES} DESTINATION "${DATADIR}/textures/medres" COMPONENT core)

--- a/warp/CMakeLists.txt
+++ b/warp/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Celestia Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 set(WARP_SOURCES
   warp.map
 )


### PR DESCRIPTION
Most source code files appear to be under GPL-2.0-or-later, so use that as the identifier.
Translation copyright information is derived from Git history and may have errors.
Copyright information for the debian directory taken from debian/copyright