### PR TITLE
Use pipx to install reuse

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -16,15 +16,10 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
-    - name: Install reuse
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y reuse
-
     - name: Checkout source code
       uses: actions/checkout@v4
 
     - name: Validate licenses
       working-directory: ${{github.workspace}}
       run: |
-        reuse lint
+        python3 -m pipx run reuse lint


### PR DESCRIPTION
The version of reuse in the Ubuntu-22.04 repositories lists JPL-image as a bad license. This would likely cause problems here. Install it via pipx instead.