### PR TITLE
Add licenses to apollo, shroxclassic, skylab add-ons

### DIFF
--- a/extras-standard/apollo/apollo.ssc
+++ b/extras-standard/apollo/apollo.ssc
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2002 Shrox
+# SPDX-License-Identifier: CC-BY-4.0
+
 "Apollo 10" "Sol/Earth/Moon"
 {
 	Class "spacecraft"
@@ -172,4 +175,3 @@
 	Albedo	 0.10
 	InfoURL	"https://en.wikipedia.org/wiki/Apollo_17"
 }
-

--- a/extras-standard/apollo/models/apollo.3ds.license
+++ b/extras-standard/apollo/models/apollo.3ds.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2002 Shrox
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/extras-standard/shroxclassic/models/gemini.3ds.license
+++ b/extras-standard/shroxclassic/models/gemini.3ds.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2002 Shrox
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/extras-standard/shroxclassic/models/mercury7.3ds.license
+++ b/extras-standard/shroxclassic/models/mercury7.3ds.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2002 Shrox
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/extras-standard/shroxclassic/shroxclassic.ssc
+++ b/extras-standard/shroxclassic/shroxclassic.ssc
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2002 Shrox
+# SPDX-License-Identifier: CC-BY-4.0
+
 # Gemini and Mercury models created by Shrox -- http://www.shrox.com/
 
 "Friendship 7:Mercury-Atlas 6:MA-6" "Sol/Earth"

--- a/extras-standard/shroxmars/shroxmars.ssc
+++ b/extras-standard/shroxmars/shroxmars.ssc
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2002 Shrox
+# SPDX-License-Identifier: CC-BY-4.0
+
 # 2001 Mars Odyssey
 
 "Mars Odyssey:2001-013A" "Sol/Mars"
@@ -9,7 +12,7 @@
 	#Ending	"2025 12 31 12:00:00"	# Estimated end-of-life
 	EllipticalOrbit
 	{
-		Epoch    2452623.5	#  2002-Dec-15 00:00:00  
+		Epoch    2452623.5	#  2002-Dec-15 00:00:00
 		Period        0.08232123167015755
 		SemiMajorAxis 3800.228229494881
 		Eccentricity  0.007407825218454815

--- a/extras-standard/skylab/models/skylab.3ds.license
+++ b/extras-standard/skylab/models/skylab.3ds.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2002 Shrox
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/extras-standard/skylab/skylab.ssc
+++ b/extras-standard/skylab/skylab.ssc
@@ -1,7 +1,10 @@
+# SPDX-FileCopyrightText: 2002 Shrox
+# SPDX-License-Identifier: CC-BY-4.0
+
 # Skylab model created by Shrox -- http://www.shrox.com/
 
 "Skylab" "Sol/Earth" {
-	
+
 	Class "spacecraft"
 	Mesh "skylab.3ds"
 	Radius 0.015
@@ -20,8 +23,8 @@
 		ArgOfPericenter	 321.3613
 		MeanAnomaly	  38.6556
 	}
-	
-	Orientation		[ 90 0 0 1 ]		
+
+	Orientation		[ 90 0 0 1 ]
 	Albedo 	      0.10
 
 	FixedRotation {}


### PR DESCRIPTION
Unlike shroxmars which was discussed as being under CC-BY-4.0, the other Shrox add-ons do not have a clear licensing situation.

Related issue: #144