### PR TITLE
Add COSPAR ID to Skylab

### DIFF
--- a/extras-standard/skylab/skylab.ssc
+++ b/extras-standard/skylab/skylab.ssc
@@ -3,7 +3,7 @@
 
 # Skylab model created by Shrox -- http://www.shrox.com/
 
-"Skylab" "Sol/Earth" {
+"Skylab:1973-027A" "Sol/Earth" {
 
 	Class "spacecraft"
 	Mesh "skylab.3ds"


### PR DESCRIPTION
COSPAR ID added as an alternate name for Skylab