### PR TITLE
Refine Launch/Reentry Dates for Mir

### DIFF
--- a/extras-standard/mir/mir.ssc
+++ b/extras-standard/mir/mir.ssc
@@ -1,10 +1,10 @@
-"Mir:1986-017A" "Sol/Earth"
+"Mir:DOS-7:1986-017A" "Sol/Earth"
 {
 	Class	"spacecraft"
 	Mesh	"mir.3ds"
 	Radius	0.0165
-	Beginning	"1986 02 20"
-	Ending	"2001 03 23 05:52"
+	Beginning	"1986 02 19 21:28:23"
+	Ending	"2001 03 23 05:59:24"
 	EllipticalOrbit
 	{
 		Period	0.06415338
@@ -32,7 +32,7 @@
 			}
 			Secondary
 			{
-				Axis	"-y"
+				Axis	"-x"
 				RelativeVelocity
 				{
 					Observer	"Sol/Earth/Mir"


### PR DESCRIPTION
`Beginning` date now reflects its actual launch date/time as well as `Ending` matching its exact reentry date/time.

Also added its prelaunch designation (DOS-7) and reoriented Mir so that its forward docking port always faces prograde instead of sideways