### PR TITLE
Recategorization of minormoons around planetary bodies

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -464,7 +464,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 
 "Namaka:Haumea II:136108 Haumea II:S 2005 (2003 EL61) 2" "Sol/Haumea"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"asteroid.cms"
 	Texture	"icymoon.*"
 	Radius	80
@@ -504,7 +504,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # https://ui.adsabs.harvard.edu/abs/2022EPSC...16..406F
 "Hi'iaka:Haumea I:136108 Haumea I:S 2005 (2003 EL61) 1" "Sol/Haumea"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"roughsphere.cms"
 	Texture	"icymoon.*"
 	Radius	175	 # "...a larger effective diameter than what has been published so far."
@@ -596,7 +596,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # https://submissions.mirasmart.com/DPS55/Itinerary/PresentationDetail.aspx?evdid=75
 "Weywot:Quaoar I:50000 Quaoar I:S 2006 (50000) 1" "Sol/Quaoar"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"asteroid.cms"  # almost 200 km effective diameter
 	Texture	"asteroid.*"
 	Color	[ 0.319 0.296 0.265 ]  # assume same photometric color as primary
@@ -665,7 +665,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 
 "S 2015 (136472) 1:MK 2" "Sol/Makemake"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
 	Radius	87.5
@@ -725,7 +725,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # Geometric albedo is calculated using this radius.
 "Xiangliu:Gonggong I:225088 Gonggong I:S 2010 (225088) 1" "Sol/Gonggong"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.448 0.421 0.385 ]

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -345,7 +345,7 @@
 # https://ui.adsabs.harvard.edu/abs/2014Icar..229...92P/abstract
 "Phobos:Mars I" "Sol/Mars"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"phobos.cmod"
 	MeshCenter	[ -0.233 -0.156 -0.168 ]
 	Texture	"phobos.*"
@@ -387,7 +387,7 @@
 
 "Deimos:Mars II" "Sol/Mars"
 {
-	Class	"minormoon"
+	Class	"moon"
 	Mesh	"deimos.cmod"
 	Texture	"deimos.*"
 	Color	[ 1.0 0.97168 0.93149 ]


### PR DESCRIPTION
As a result of https://celestiaproject.space/forum/viewtopic.php?f=4&t=24482, I have changed the classifications of small moons around planetary bodies: Mars, Haumea, Makemake, Gonggong, and Quaoar, from minormoon to moon, providing that the system does not also contain much larger moons (as is the case for Pluto-Charon system). Considering this old discussion https://celestiaproject.space/forum/viewtopic.php?f=2&t=12329&start=20, this does not apply to asteroids.