### PR TITLE
Add licenses for asteroid models from Vernazza et al. (2021)

### DIFF
--- a/models/elektra.cmod.license
+++ b/models/elektra.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/eugenia.cmod.license
+++ b/models/eugenia.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/hygiea.cmod.license
+++ b/models/hygiea.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/interamnia.cmod.license
+++ b/models/interamnia.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/iris.cmod.license
+++ b/models/iris.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/juno.cmod.license
+++ b/models/juno.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/kleopatra.cmod.license
+++ b/models/kleopatra.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/pallas.cmod.license
+++ b/models/pallas.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/models/sylvia.cmod.license
+++ b/models/sylvia.cmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Vernazza et al. (2021), A&A 654, A56
+
+SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
More progress towards #162

From discussion there, source for these was [Vernazza et al. (2021)](https://www.aanda.org/articles/aa/full_html/2021/10/aa41781-21/aa41781-21.html), so CC-BY-4.0.