### PR TITLE
Put asterism translations into separate msgctxt

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -11,6 +11,7 @@ $(pot_file): $(pot_file)-update
 
 $(pot_file)-update: data.cpp
 	xgettext --keyword=_ --keyword=i18n \
+	         --keyword=C_:1c,2 --keyword=i18nc:1c,2 \
 	         --sort-by-file --qt --add-comments \
 	         --default-domain=$(domain) --package-name=celestia --package-version=1.7.0 \
 	         --msgid-bugs-address=team@celestiaproject.space \
@@ -20,7 +21,7 @@ $(pot_file)-update: data.cpp
 	         data.cpp
 
 data.cpp: ../data/asterisms.dat ../data/solarsys.ssc ../data/earth_locs.ssc ../data/world-capitals.ssc ../data/dwarfplanets.ssc ../data/minormoons.ssc ../data/well-known-starnames.txt ../data/well-known-dsonames.txt
-	egrep '^\"' ../data/asterisms.dat | awk -F'\"' '{ print "_(\"" $$2 "\");" }' > data.cpp
+	egrep '^\"' ../data/asterisms.dat | awk -F'\"' '{ print "C_(\"asterism\", \"" $$2 "\");" }' > data.cpp
 	egrep '^(\"|ReferencePoint)' ../data/solarsys.ssc | awk -F'\"|:' '{ print "_(\"" $$2 "\");" }' >> data.cpp
 	egrep '^(\"|ReferencePoint)' ../data/dwarfplanets.ssc | awk -F'\"|:' '{ print "_(\"" $$2 "\");" }' >> data.cpp
 	egrep '^(\"|ReferencePoint)' ../data/minormoons.ssc | awk -F'\"|:' '{ print "_(\"" $$2 "\");" }' >> data.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ar \n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:10+0100\n"
 "PO-Revision-Date: 2006-06-05 22:00+0100\n"
 "Last-Translator: Ali Al-Khudair <saudilink@lycos.com>\n"
 "Language-Team: Arabic <ar@li.org>\n"
@@ -21,358 +21,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "أندروميدا"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "أنتليا"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "أبس"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "برج الدلو"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "أكويلا"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "ايرا"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "برج الحمل"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "أورجا"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "بيوتس"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "كيوم"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "كاملوبارداليس"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "سرطان"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "كانز فيناتيشي"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "كانيس كبير"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "كانيس صغير"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "كابريكورنس"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "كاراينا"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "كاسيوبيا"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "سنتوراس"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "سيفيوس"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "سيتس"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "شاميليون"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "سيريسنس"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "كولومبا"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "كوما برانيسيز"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "كورونا أوسترالس"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "كورونا بوريلس"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "كورفس"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "فوهة بركان"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "جوهره"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "سيقنس"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "ديلفينس"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "دورادو"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "دريكو"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "اكيولياس"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "اريدنس"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "فورناكس"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "الجوزاء"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "قرس"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "هركليز"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "هورولوجم"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr ""
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "هايدرس"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "اندس"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "لاسيرتا"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "برج الأسد"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "برج الأسد الصغير"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "ليبس"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "برج الميزان"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "داء الذئبة"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "الوشق"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "لايرا"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "منسا"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "ميكروسكوبيوم"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "مونوسيروس"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "موكا"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "نورما"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "أوكتنز"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "أوفيتشيس"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "أوراين"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "بافو"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "بيقاسوس"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "برسيوس"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "العنقاء"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "بكتور"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "برج الحوت"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "بيسس أوسترينوس"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "بوبيس"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "بايكسوس"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "ريتيكيولم"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "ساجيتا"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "برج القوس"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "برج العقرب"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "النحات"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "سكيوتم"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "سيربنس كابوت"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "سيربنس كودا"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "سيكستانس"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "برج الثور"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "تيليسكوبيام"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "ترايانقيولم"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "ترايانقيولم أوستريل"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "توكانا"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "الدب الأكبر"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "الدب الأصغر"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "فيلا"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "برج العذراء"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "فولانز"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "فيباكيولا"
 
@@ -529,3960 +618,4013 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "هايدرس"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
-msgid "Haumea"
+msgid "Orcus-Vanth"
 msgstr ""
 
 #: data.cpp:131
-msgid "Namaka"
+msgid "Orcus"
 msgstr ""
 
 #: data.cpp:132
-msgid "Hi'iaka"
+msgid "Vanth"
 msgstr ""
 
 #: data.cpp:133
-msgid "Makemake"
+msgid "Haumea"
 msgstr ""
 
 #: data.cpp:134
-msgid "S 2015 (136472) 1"
+msgid "Namaka"
 msgstr ""
 
 #: data.cpp:135
-msgid "Eris"
+msgid "Hi'iaka"
 msgstr ""
 
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
+msgid "S 2015 (136472) 1"
 msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "ترايانقيولم"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "باندورا"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
+msgid "Amalthea"
 msgstr ""
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "‎‎الضفدع الثاني ‎‎‎"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "المشتري"
+msgid "Pandia"
+msgstr "باندورا"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "‎‎الضفدع الثاني ‎‎‎"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "المشتري"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "المشتري"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "المشتري"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "المشتري"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "المشتري"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "المشتري"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "‎‎السيون ‎‎‎"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "المشتري"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "المشتري"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "كاليستو"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "المشتري"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "المشتري"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "المشتري"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "المشتري"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "المشتري"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "المشتري"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "المشتري"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "المشتري"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "المشتري"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "المشتري"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "كاليستو"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "مصقول"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "المشتري"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "المشتري"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "المشتري"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "جينوس"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "بروميثياس"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "باندورا"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "ايبيماثيوس"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "جينوس"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "‎‎الساق - ساق ساقي الماء ‎‎‎"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "‎‎الساق - ساق ساقي الماء ‎‎‎"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "‎‎منقار الدجاجة ‎‎‎"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "زحل"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "زحل"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr ""
 
-#: data.cpp:285
+#: data.cpp:293
 #, fuzzy
 msgid "Fornjot"
 msgstr "فورناكس"
 
-#: data.cpp:286
+#: data.cpp:294
 #, fuzzy
 msgid "Saturn LVIII"
 msgstr "زحل"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr ""
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr ""
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr ""
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr ""
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr ""
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr ""
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr ""
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr ""
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr ""
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr ""
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr ""
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr ""
 
-#: data.cpp:299
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "المريخ"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "المجرّات"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "لاريسّا"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "جنايميد"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "‎الشمس‎"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "أمريكا الشمالية"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "أمريكا الجنوبية"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "أوراسيا"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "أفريقيا"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "أستراليا"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "أنتارتيكا"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "المحيط الأطلسي الشمالي"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "المحيط الأطلسي الجنوبي"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "المحيط الهاديء الشمالي"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "المحيط الهاديء الجنوبي"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "المحيط الهندي"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "المحيط القطب الشمالي"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr ""
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr ""
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr ""
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr ""
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr ""
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr ""
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr ""
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr ""
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr ""
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr ""
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr ""
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr ""
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr ""
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr ""
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr ""
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr ""
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr ""
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr ""
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr ""
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr ""
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr ""
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr ""
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr ""
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr ""
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr ""
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr ""
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr ""
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr ""
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr ""
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr ""
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr ""
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr ""
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr ""
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr ""
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr ""
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr ""
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr ""
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr ""
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr ""
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr ""
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr ""
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr ""
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr ""
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr ""
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr ""
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr ""
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr ""
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr ""
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr ""
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr ""
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr ""
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr ""
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr ""
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr ""
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr ""
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr ""
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr ""
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr ""
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr ""
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr ""
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr ""
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr ""
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr ""
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr ""
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr ""
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr ""
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr ""
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr ""
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr ""
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr ""
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr ""
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr ""
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr ""
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr ""
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr ""
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr ""
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr ""
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr ""
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr ""
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr ""
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr ""
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr ""
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr ""
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr ""
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr ""
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr ""
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr ""
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr ""
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr ""
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr ""
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr ""
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr ""
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr ""
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr ""
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr ""
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr ""
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr ""
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr ""
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr ""
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr ""
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr ""
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr ""
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr ""
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr ""
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr ""
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr ""
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr ""
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr ""
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr ""
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr ""
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr ""
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr ""
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr ""
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr ""
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr ""
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr ""
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr ""
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr ""
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr ""
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr ""
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr ""
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr ""
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr ""
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr ""
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr ""
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr ""
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr ""
 
-#: data.cpp:462
+#: data.cpp:470
 #, fuzzy
 msgid "Mexico City"
 msgstr "إظهار مواقع المدن"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr ""
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr ""
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr ""
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr ""
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr ""
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr ""
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr ""
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr ""
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr ""
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr ""
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr ""
 
-#: data.cpp:474
+#: data.cpp:482
 #, fuzzy
 msgid "New Delhi"
 msgstr "اسم جديد"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr ""
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr ""
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr ""
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr ""
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr ""
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr ""
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr ""
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr ""
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr ""
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr ""
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr ""
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr ""
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr ""
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr ""
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr ""
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr ""
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr ""
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr ""
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr ""
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr ""
 
-#: data.cpp:495
+#: data.cpp:503
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr "وحدة قياس فضائية"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr ""
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr ""
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr ""
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr ""
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr ""
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr ""
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr ""
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr ""
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr ""
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr ""
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr ""
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr ""
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr ""
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr ""
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr ""
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr ""
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr ""
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr ""
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr ""
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr ""
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr ""
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr ""
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr ""
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr ""
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr ""
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr ""
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr ""
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr ""
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr ""
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr ""
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr ""
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr ""
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr ""
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr ""
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr ""
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr ""
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr ""
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr ""
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr ""
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr ""
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr ""
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr ""
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr ""
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr ""
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr ""
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr ""
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr ""
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr ""
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr ""
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr ""
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr ""
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr ""
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr ""
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr ""
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr ""
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr ""
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr ""
 
-#: data.cpp:555
-msgid "The Valley"
-msgstr ""
-
-#: data.cpp:556
-#, fuzzy
-msgid "Vatican City"
-msgstr "إظهار مواقع المدن"
-
-#: data.cpp:557
-msgid "Victoria"
-msgstr ""
-
-#: data.cpp:558
-msgid "Vienna"
-msgstr ""
-
-#: data.cpp:559
-msgid "Vientiane"
-msgstr ""
-
-#: data.cpp:560
-msgid "Vilnius"
-msgstr ""
-
-#: data.cpp:561
-msgid "Warsaw"
-msgstr ""
-
-#: data.cpp:562
-msgid "Washington D.C."
-msgstr ""
-
 #: data.cpp:563
-msgid "Wellington"
+msgid "The Valley"
 msgstr ""
 
 #: data.cpp:564
 #, fuzzy
-msgid "West Island"
-msgstr "الغرب"
+msgid "Vatican City"
+msgstr "إظهار مواقع المدن"
 
 #: data.cpp:565
-msgid "Willemstad"
+msgid "Victoria"
 msgstr ""
 
 #: data.cpp:566
-msgid "Windhoek"
+msgid "Vienna"
 msgstr ""
 
 #: data.cpp:567
-msgid "Yamoussoukro"
+msgid "Vientiane"
 msgstr ""
 
 #: data.cpp:568
-msgid "Yaounde"
+msgid "Vilnius"
 msgstr ""
 
 #: data.cpp:569
-msgid "Yaren District"
+msgid "Warsaw"
 msgstr ""
 
 #: data.cpp:570
-msgid "Yerevan"
+msgid "Washington D.C."
 msgstr ""
 
 #: data.cpp:571
-msgid "Zagreb"
+msgid "Wellington"
 msgstr ""
 
 #: data.cpp:572
+#, fuzzy
+msgid "West Island"
+msgstr "الغرب"
+
+#: data.cpp:573
+msgid "Willemstad"
+msgstr ""
+
+#: data.cpp:574
+msgid "Windhoek"
+msgstr ""
+
+#: data.cpp:575
+msgid "Yamoussoukro"
+msgstr ""
+
+#: data.cpp:576
+msgid "Yaounde"
+msgstr ""
+
+#: data.cpp:577
+msgid "Yaren District"
+msgstr ""
+
+#: data.cpp:578
+msgid "Yerevan"
+msgstr ""
+
+#: data.cpp:579
+msgid "Zagreb"
+msgstr ""
+
+#: data.cpp:580
 msgid "Sol"
 msgstr "‎الشمس‎"
 
-#: data.cpp:573
+#: data.cpp:581
 #, fuzzy
 msgid "Solar System Barycenter"
 msgstr "نقطة منتصف نظام النجوم\n"
 
-#: data.cpp:574
+#: data.cpp:582
 #, fuzzy
 msgid "Sun"
 msgstr "زحل"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "‎‎الفرس‎‎"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "‎‎سرة الفرس‎‎"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "‎‎الكف الخضيب ‎‎‎"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "‎‎الجنب‎‎"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "‎‎ذنب قيطس الشمالي‎‎"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "‎‎العنقاء ‎‎‎"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "‎صدر‎"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "‎‎الصدر‎‎"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "‎‎الضفدع الثاني ‎‎‎"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "‎‎ذنب قيطس‎‎"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "‎‎‎منطقة ذات الكرسي‎‎‎"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "‎‎فان مانن 2 ‏‎‎"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "‎‎رأس التوأم المقدم ‎‎‎"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "‎‎نافي‎‎"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "إاضافة مفضلة قريبة نسبيا للمستند الحالي"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "‎‎الرشا‎‎"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "‎‎الذيل - ذيل ثوب المسلسلة ‎‎‎"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "‎‎ركبة ذات الكرسي‎‎"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "‎‎الفرس‎‎"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "تيتان"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "‎‎آخر النهر _ المحلف ‎‎‎"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "‎‎بطن قيطس ‎‎‎"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "‎‎كابوت تراينجولي‎‎"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "‎‎الشرطان 2 ‏‎‎‎"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "‎‎سيجين‎‎"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "‎‎الشرطان 1 ‎‎‎"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "‎‎الرشا‎‎"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "‎‎الرشا‎‎"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "‎‎عناق الأرض‎‎"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "‎‎‎عناق الأرض‎‎"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "العناق"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "‎‎الأشراط 1 ‎‎‎"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "‎‎ميرا ‎‎‎"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "‎‎الجدي ‎‎‎"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "‎‎تشارا ‎‎‎"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "‎‎ميرا ‎‎‎"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "‎‎رجعة النهر‎‎"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "‎‎أدحي النعام‎‎"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "‎‎آخر النهر م ‎‎‎"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "‎‎المنخر - منخر قيطس ‎‎‎"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "‎‎منقار قيطس 2‎‎"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "‎‎الغول ‎‎‎"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "‎‎البطين ‎‎‎"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "‎‎مرفق الثريا‎‎"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "‎‎المرفق ‎‎‎"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "‎‎مرفق الثريا‎‎"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "‎‎رنا‎‎"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "‎‎رنا‎‎"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "‎‎العاتق ‎‎‎"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "‎‎سيلاينو ‎‎‎"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "‎‎إلكترا ‎‎‎"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "‎‎تيجيتا ‎‎‎"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "‎‎مايا ‎‎‎"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "‎‎أستيروب ‎‎‎"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "‎‎ميروب  ‎‎‎"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "‎‎السيون ‎‎‎"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "‎‎بليون ‎‎‎"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "‎‎الزورق  ‎‎‎"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "‎‎المنكب  ‎‎‎"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "‎‎البيض ‎‎‎"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "‎‎القيض ‎‎‎"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "‎‎العين - عين الثور ‎‎‎"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "‎‎الدبران ‎‎‎"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "‎‎الثابت‎‎"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "‎‎نجم هند كريمزون‎‎"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "‎‎‎عناق الأرض‎‎"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "المجرّات"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "‎ساداتوني‎"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "‎‎كرسي الجوزاء المقدم‎‎"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "‎‎نجمة كابتين ‎‎‎"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "‎‎رجل الجوزاء ‎‎‎"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "‎‎العيوق ‎‎‎"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "‎‎الناجذ ‎‎‎"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "‎‎النطح‎‎"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "‎‎الناطح ‎‎‎"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "‎‎النهال ‎‎‎"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "‎‎الثابت‎‎"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "‎‎نظم الجوزاء 1‎‎"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "‎‎الأرنب ‎‎‎"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "‎‎الهقعة‎‎"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "‎‎الهقعة‎‎"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "‎‎نظم الجوزاء 2‎‎"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "مثلث"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "‎‎حضار‎‎"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "‎‎نظم الجوزاء 3‎‎"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "‎‎السيف - سيف الجبار ‎‎‎"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "‎‎الوزن ‏‎‎‎"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "‎‎منكب الجوزاء ‎‎‎"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "‎‎منكب ذي العنان ‎‎‎"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "‎‎الفرود ‎‎‎"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "‎‎سهيل ‎‎‎"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "‎‎المربع الأحمر ‎‎‎"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "‎‎الفرود ‎‎‎"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "‎‎مرزم الشعرى اليمانية‎‎"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "‎مرزم‎"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "‎‎التحائي ‎‎‎"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "‎‎سهيل ‎‎‎"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "‎‎سهيل اليماني‎‎"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "إظهار النجوم"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "‎‎الهنعة ‎‎‎"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "‎‎الميسان‎‎"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "‎‎الأظفار 1 ‎‎‎"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "‎‎الشعرى اليمانية‎‎"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "‎‎العذارى 1 ‎‎‎"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "العذارى"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "‎‎المحلفان أ‎‎"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "‎‎الأظفار 2 ‎‎‎"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "‎‎العذارى 2‎‎"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "‎‎بيرنز 135 ‏‎‎‎"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "‎‎الأظفار 3‎‎"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "‎‎العذرة ‎‎‎"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "‎‎مرزم الغميصاء ‎‎‎"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "‎‎نجمة لويتين ‎‎‎"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "‎‎رأس التوأم المقدم ‎‎‎"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "‎‎الشعرى الشامية‎‎"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "‎الغميصاء‎"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "‎‎رأس التوأم المؤخر ‎‎‎"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "‎‎التريس‎‎"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "‎‎التريس‎‎"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "‎‎سهيل حضار ‎‎‎"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "‎‎سهيل الوزن ‎‎‎"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "‎‎صدفة السرطان ‎‎‎"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "‎‎الطرف 1‎‎"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "‎‎الطرف 1‎‎"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "‎‎آفيور ‎‎‎"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "‎‎الظباء ‎‎‎"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "‎‎‎منطقة ذات الكرسي‎‎‎"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "‎‎الحمار الشمالي ‎‎‎"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "‎‎الحمار الجنوبي ‎‎‎"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "‎‎مخلب سرطان البحر‎‎"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "noces‎"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "‎‎سهيل رقاس‎‎"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "‎‎المياه الهادئة ‎‎‎"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "‎‎التريس ‎‎‎"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "‎‎المركب‎‎"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "‎‎الفرد ‎‎‎"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "‎قلب الشجاع‎"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "‎‎الطرف ‎‎‎"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "‎العقدة‎"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "‎‎الزبرة خ‎‎"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "‎رأس الأسد الجنوبي‎"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "‎‎رأس الأسد الشمالي ‎‎‎"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "‎رأس الأسد الشمالي‎"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "‎‎قلب الأسد ‎‎‎"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "‎قلب الأسد‎"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "‎قلب الأسد‎"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "‎‎الجبهة 1‎‎‎"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "‎الضفيرة‎"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "‎‎القفزة الثانية الشمالية ‎‎‎"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "‎‎الجبهة 2 ‎‎‎"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "‎‎القفزة الثانية الجنوبية ‎‎‎"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr ""
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "‎‎الكأس ‎‎‎"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "‎‎المراق‎‎"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "‎‎الدب‎‎"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "‎الدب‎"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "‎‎الزبرة ، الخراتان 1 ‎‎‎"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "‎‎ظهر الأسد‎‎"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "‎‎الزبرة ، الخراتان 2‎‎"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "‎‎كوكسا‎‎"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "‎الخرت‎"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "‎‎القفزة الأولى الجنوبية‎‎"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "‎‎القفزة الأولى الشمالية‎‎"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "‎‎السهم ‎‎‎"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "‎‎جوزهر ‎‎‎"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "إظهار الوقت المحلي"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr ""
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "‎‎الصرفة ‎‎‎"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "‎‎العوا 1‎‎"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "الأعراف"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr ""
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "‎‎جروم بردج 1830‎‎"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "‎‎فخذ الدب‎‎"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "‎‎فخذ الدب‎‎"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "‎‎الخباء ‎‎‎"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "‎‎المغرز‎‎"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "‎‎الجناح‎ ‎‎‎"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "‎‎العوا 2‎‎"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "‎‎ألفا الصليب ‎‎‎"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "‎‎الغراب ‎‎‎"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "‎‎جاما الصليب ‎‎‎"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "‎‎تشارا ‎‎‎"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "‎‎عرش السماك الأعزل‎‎"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "‎‎المحلفان ب‎‎"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "‎‎العوا 3 ‎‎‎"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "‎‎ميموسا ‎‎‎"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "‎‎الجون ‎‎‎"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "‎‎العوا 4‎‎"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "‎‎العوا 4‎‎"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "‎‎كبد الأسد ‎‎‎"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "‎‎العوا 5 ‎‎‎"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "‎‎المريدون‎‎"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "‎‎العناق ‎‎‎"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "‎‎السماك الأعزل ‎‎‎"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "‎‎السماك الأعزل‎‎"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "‎‎السها ‎‎‎"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "‎‎هيزي‎‎"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "‎‎القائد ‎‎‎"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "‎‎بنات نعش‎‎"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "‎‎مفرد الرامح ‎‎‎"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "‎‎حضار ‎‎‎"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "‎‎أجينا‎‎"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "‎‎الثعبان ‎‎‎"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "‎‎منكب قنطورس ‎‎‎"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "‎‎السماك الرامح ‎‎‎"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "‎‎الغفر 1 ‎‎‎"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "‎‎بروكسيما ‎‎‎"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "‎‎الراعي م ‎‎‎"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "‎‎الراعي‎‎"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "‎‎الإزار - إزار الراعي ‎‎‎"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "‎المراق‎"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "‎‎بولتشيريما‎‎"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "‎‎أنور الفرقدين‎‎"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "‎‎أنور الفرقدين‎‎"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "‎‎الزبانا الجنوبي‎‎"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "‎‎زبانا العقرب 3‎‎"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "‎‎البقار ‎‎‎"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "‎‎الزبانا الشمالي‎‎"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "‎‎أخفى الفرقدين‎‎"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "‎‎أخفى الفرقدين‎‎"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "‎‎عصا الراعي ‎‎‎"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "‎‎الذيخ ‎‎‎"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "‎‎قصعة المساكين‎‎"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "‎‎نيّر الفكة‎‎"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "‎‎جيما‎‎"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "‎‎زبانا العقرب 4‎‎"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "‎‎زبانا العقرب 4‎‎"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "‎‎عنق الحية ‎‎‎"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "‎‎الإكليل 2‎‎"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "‎‎زبانا العقرب‎‎"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "العقرب"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "المريخ"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "‎‎جبهة العقرب‎‎"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "‎‎النياط 2 ‎‎‎"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "‎‎النياط 2 ‎‎‎"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr ""
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "‎‎الهراوة ‎‎‎"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "‎‎قلب العقرب ‎‎‎"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "‎‎حامل الهراوة ‎‎‎"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "‎‎مرفق الحواء ‎‎‎"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "‎‎ألفا المثلث الجنوبي ‎‎‎"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr ""
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "‎‎العوا 3 ‎‎‎"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "أيابوتس"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "‎‎الراقص‎‎"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "‎‎الراقص‎‎"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "‎‎الخباء ‎‎‎"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "‎‎السابق الثاني ‎‎‎"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "‎‎رأس الجاثي ‎‎‎"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "‎‎رأس الجاثي‎‎"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "‎‎سارن‎‎"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "‎‎العوائذ 1 ‎‎‎"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "‎‎معصم الجاثي ‎‎‎"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "‎‎الشولة 2‎‎"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "‎اللسعة‎"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "‎‎العوائذ 4‎‎"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "‎‎فأس الرحا‎‎‎"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "‎‎الشولة 1 ‎‎‎"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "‎‎رأس الحواء ‎‎‎"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "‎‎سارجاس‎‎"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "‎‎الذئبان‎‎"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "‎‎كلب الراعي ‎‎‎"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "مراصد"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "‎‎العوائذ 3‎‎"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "‎‎التنين‎‎"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "‎‎العوائذ 2 ‎‎‎"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "‎‎نجمة بارنارد ‎‎‎"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "‎‎النعائم الواردة 1‎‎"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "‎‎القوس المتوسط‎‎"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "‎‎القوس الجنوبي‎‎"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "‎‎الأظفار‎‎"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "‎‎القوس الشمالي‎‎"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "‎‎النسر الواقع ‎‎‎"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "‎‎الشلياق ‎‎‎"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "‎‎كوكبا الفرق 1‎‎"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "‎‎ننكي‎‎"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "‎‎-‎‎"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "‎‎السلحفاة ‎‎‎"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "‎‎إبط الرامي‎‎"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "‎‎ذنب العقاب‎‎"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "‎سعد بلع 1‎‎"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "‎‎التنين ‎‎‎"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "‎‎التيس‎‎"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "‎‎العقدة الثانية‎‎"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "‎‎الأظفار م‎‎"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr ""
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "‎‎العرقوب - عرقوب الرامي ‎‎‎"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "‎‎العرقوب - عرقوب الرامي ‎‎‎"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "‎‎ركبة الرامي ‎‎‎"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "‎‎منقار الدجاجة ‎‎‎"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "‎‎الأثافي‎‎"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "‎‎نجمة كامبل ‎‎‎"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "‎‎السهم ‎‎‎"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr ""
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "‎‎الميزان ‎‎‎"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "‎‎التنين م‎‎"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "‎‎النسر الطائر ‎‎‎"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "‎‎عمود الميزان ‎‎‎"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "‎‎سعد الذابح 1 ‏‎‎‎"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "‎‎عمود الميزان ‎‎‎"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "‎‎سعد الذابح 2 ‏‎‎‎"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "‎‎صدر الدجاجة ‎‎‎"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "‎‎الطاووس ‎‎‎"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "‎‎روتانيف‎‎"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "‎‎سوالوكين‎‎"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "‎‎ذنب الدجاجة‎‎"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr ""
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "‎سعد بلع 1‎‎"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "‎‎القوس الجنوبي‎‎"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "‎‎الجدي ‎‎‎"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "‎‎قطعة الفرس ‎‎‎"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "‎Lacaille 8760‎"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "‎‎كوكبا الفرق 1‎‎"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "‎‎كوكبا الفرق 2‎‎"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "‎‎سعد السعود 1‎ ‎‎‎"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "إظهار الحدود الفاصلة"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "‎‎سعد ناشرة 1 ‏‎‎‎"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "‎‎ذيل الدجاجة‎‎"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "‎نجم جارنت هرشل‎"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "‎‎الراقص‎‎"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "‎‎جحفلة الفرس ‎‎‎"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "‎‎سعد ناشرة 2 ‏‎‎‎"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "‎‎ذنب السمكة‎‎"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "‎‎ذنب السمكة‎‎"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "‎‎القرحة ‎‎‎"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "‎‎سعد الملك 1‎‎‎‎"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "‎‎اليمامتان 1‎‎"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "‎‎سعد البهام ‎‎‎"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "‎‎الورك - ورك ساقي الماء ‎‎‎"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "‎‎سعد الأخبية 1‎ ‎‎‎"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "‎‎سعد الأخبية 4‎‎"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "‎‎كروجر 60 ‏‎‎‎"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "‎‎الجرة‎‎"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "‎‎سعد الهمام‎‎"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "‎‎سعد مطر ‎‎‎"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "‎‎نجمة بابكوك ‎‎‎"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "‎‎سعد البارع ‎‎‎"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "‎‎الساق - ساق ساقي الماء ‎‎‎"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "‎‎فم الحوت - الضفدع الأول ‎‎‎"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "‎‎ساعد الفرس‎‎"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "‎‎فم السمكة‎‎"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "‎‎فم السمكة‎‎"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "‎‎المركب‎‎"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "منكب الفرس"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "‎‎القائد ‎‎‎"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "‎‎الراعي ‎‎‎"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr ""
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr ""
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr ""
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "‎‎الثريا‎‎"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "‎‎القلاص‎‎"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "‎‎النثرة‎‎"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "‎‎حشد النثرة‎‎"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "‎‎مافي_1‎‎"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "‎‎مافي_2‎‎"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "‎‎الأسد أ‎‎"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "‎‎السدس ب‎‎"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "‎‎الأسد 1‎‎"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "‎‎السدس أ‎‎"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "سيريسنس"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "‎‎هولمبرج 6‎‎"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "‎‎فاذ 703‎‎"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "‎‎47 الطوقان‎‎"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "اريدنس"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "بايكسوس"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "‎تونانتزينتلا 2‎"
 

--- a/po/be.po
+++ b/po/be.po
@@ -14,369 +14,461 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:10+0100\n"
 "PO-Revision-Date: 2023-11-03 11:00+0000\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>, 2024\n"
-"Language-Team: Belarusian (https://app.transifex.com/celestia/teams/93131/be/)\n"
+"Language-Team: Belarusian (https://app.transifex.com/celestia/teams/93131/"
+"be/)\n"
+"Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: be\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Андрамэда"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Помпа"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Райская птушка"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Вадаліў"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Арол"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Ахвярнік"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Авен"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Возьнік"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Валапас"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Разец"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Жыраф"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Рак"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Ганчакі"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Вялікі пёс"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Малы пёс"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Казарог"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Кіль"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Касіяпэя"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Кентаўр"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Цэфэй"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Кіт"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Хамэлеон"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Цыркуль"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Голуб"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Валасы Веранікі"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Паўднёвая карона"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Паўночная карона"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Крумкач"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Кратэр"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Крыж"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Лебедзь"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Дэльфін"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Залатая рыба"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Дракон"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Малы конь"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Эрыдан"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Печ"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Блізьняты"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Журавель"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Геркулес"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Гадзіньнік"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Гідра"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Паўднёвая гідра"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Індзеец"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Яшчарка"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Леў"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Малы леў"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Заяц"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Лібра"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Воўк"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Рысь"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Ліра"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Сталовая гара"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Мікраскоп"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Аднарог"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Муха"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Норма"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Актант"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Зьмяяносец"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Арыён"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Пава"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Пэгас"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Пэрсэй"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Фэнікс"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Мастак"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Рыбы"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Паўднёвая рыба"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Карма"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Компас"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Сетка"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Страла"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Стралец"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Скарпіён"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Скульптар"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Шчыт"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Галава зьмяі"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Хвост зьмяі"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Сэкстанс"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Цялец"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Тэлескоп"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Трохкутнік"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Паўднёвы трохкутнік"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Тукан"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Вялікая мядзьведзіца"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Малая мядзьведзіца"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Ветразі"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Дзева"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Лятучая рыба"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Лісічка"
 
@@ -532,3878 +624,3932 @@ msgstr "Нікс"
 msgid "Kerberos"
 msgstr "Цэрбэр"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Гідра"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr "Цэрэра"
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+#, fuzzy
+msgid "Vanth"
+msgstr "Эвантэ"
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "Гаўмэя"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "Намака"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "Гіяка"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "Макемаке"
 
-#: data.cpp:134
+#: data.cpp:139
 msgid "S 2015 (136472) 1"
 msgstr "S 2015 (136472) 1"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Трохкутнік"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "Эрыда"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "Дысномія"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "Мэтыс"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "Адрастэя"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "Амальтэя"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "Тэба"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "Тэміста"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "Леда"
 
-#: data.cpp:143
+#: data.cpp:151
 msgid "Ersa"
 msgstr "Эрса"
 
-#: data.cpp:144
+#: data.cpp:152
 msgid "Pandia"
 msgstr "Пандыя"
 
-#: data.cpp:145
+#: data.cpp:153
 msgid "Himalia"
 msgstr "Гімалія"
 
-#: data.cpp:146
+#: data.cpp:154
 msgid "Lysithea"
 msgstr "Лісітэя"
 
-#: data.cpp:147
+#: data.cpp:155
 msgid "Elara"
 msgstr "Элара"
 
-#: data.cpp:148
+#: data.cpp:156
 msgid "Dia"
 msgstr "Дыя"
 
-#: data.cpp:149
+#: data.cpp:157
 msgid "Carpo"
 msgstr "Карпа"
 
-#: data.cpp:150
+#: data.cpp:158
 msgid "Valetudo"
 msgstr "Валетуда"
 
-#: data.cpp:151
+#: data.cpp:159
 msgid "Euporie"
 msgstr "Эўпарые"
 
-#: data.cpp:152
+#: data.cpp:160
 msgid "Jupiter LV"
 msgstr "Юпітэр LV"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr "Эўфэмэ"
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr "S 2003 J 16"
 
-#: data.cpp:155
+#: data.cpp:163
 msgid "Jupiter LXVIII"
 msgstr "Юпітэр LXVIII"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "Ананка"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "Гарпаліка"
 
-#: data.cpp:158
+#: data.cpp:166
 msgid "S 2003 J 12"
 msgstr "S 2003 J 12"
 
-#: data.cpp:159
+#: data.cpp:167
 msgid "Jupiter LII"
 msgstr "Юпітэр LII"
 
-#: data.cpp:160
+#: data.cpp:168
 msgid "Praxidike"
 msgstr "Праксыдыка"
 
-#: data.cpp:161
+#: data.cpp:169
 msgid "S 2003 J 2"
 msgstr "S 2003 J 2"
 
-#: data.cpp:162
+#: data.cpp:170
 msgid "Euanthe"
 msgstr "Эвантэ"
 
-#: data.cpp:163
+#: data.cpp:171
 msgid "Orthosie"
 msgstr "Артазіе"
 
-#: data.cpp:164
+#: data.cpp:172
 msgid "Jupiter LXIV"
 msgstr "Юпітэр LXIV"
 
-#: data.cpp:165
+#: data.cpp:173
 msgid "Iocaste"
 msgstr "Якастэ"
 
-#: data.cpp:166
+#: data.cpp:174
 msgid "Mneme"
 msgstr "Мнэмэ"
 
-#: data.cpp:167
+#: data.cpp:175
 msgid "Thyone"
 msgstr "Тыёна"
 
-#: data.cpp:168
+#: data.cpp:176
 msgid "Jupiter LIV"
 msgstr "Юпітэр LIV"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr "Тэльксыноэ"
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr "Геліке"
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr "Герміпэ"
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr "Філафрасінэ"
 
-#: data.cpp:173
+#: data.cpp:181
 msgid "Jupiter LVI"
 msgstr "Юпітэр LVI"
 
-#: data.cpp:174
+#: data.cpp:182
 msgid "Kallichore"
 msgstr "Каліхорэ"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "Хальдэна"
 
-#: data.cpp:176
+#: data.cpp:184
 msgid "Arche"
 msgstr "Архэ"
 
-#: data.cpp:177
+#: data.cpp:185
 msgid "Jupiter LXIX"
 msgstr "Юпітэр LXIX"
 
-#: data.cpp:178
+#: data.cpp:186
 msgid "Kale"
 msgstr "Кале"
 
-#: data.cpp:179
+#: data.cpp:187
 msgid "Jupiter LXXII"
 msgstr "Юпітэр LXXII"
 
-#: data.cpp:180
+#: data.cpp:188
 msgid "Jupiter LXI"
 msgstr "Юпітэр LXI"
 
-#: data.cpp:181
+#: data.cpp:189
 msgid "Cyllene"
 msgstr "Кілена"
 
-#: data.cpp:182
+#: data.cpp:190
 msgid "Taygete"
 msgstr "Тайґета"
 
-#: data.cpp:183
+#: data.cpp:191
 msgid "Jupiter LXX"
 msgstr "Юпітэр LXX"
 
-#: data.cpp:184
+#: data.cpp:192
 msgid "Eurydome"
 msgstr "Эўрыдомэ"
 
-#: data.cpp:185
+#: data.cpp:193
 msgid "Jupiter LI"
 msgstr "Юпітэр LI"
 
-#: data.cpp:186
+#: data.cpp:194
 msgid "S 2003 J 9"
 msgstr "S 2003 J 9"
 
-#: data.cpp:187
+#: data.cpp:195
 msgid "Jupiter LXVII"
 msgstr "Юпітэр LXVII"
 
-#: data.cpp:188
+#: data.cpp:196
 msgid "Aitne"
 msgstr "Айтнэ"
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "Карма"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "Каліроэ"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "Эрынома"
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr "Пасытэя"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr "Эйрэнэ"
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr "S 2003 J 24"
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "Сынопа"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr "Эўкеладэ"
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "Ісаноа"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr "S 2003 J 4"
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr "Аўтаноэ"
 
-#: data.cpp:200
+#: data.cpp:208
 msgid "Herse"
 msgstr "Герсэ"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "Пасыфая"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr "S 2003 J 10"
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr "Корэ"
 
-#: data.cpp:204
+#: data.cpp:212
 msgid "Jupiter LXIII"
 msgstr "Юпітэр LXIII"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr "Гегемон"
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr "Спондэ"
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "Каліка"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr "Аойдэ"
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "Мэґаклітэ"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr "S 2003 J 23"
 
-#: data.cpp:211
+#: data.cpp:219
 msgid "Jupiter LXVI"
 msgstr "Юпітэр LXVI"
 
-#: data.cpp:212
+#: data.cpp:220
 msgid "Jupiter LIX"
 msgstr "Юпітэр LIX"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr "S 2009 S 1"
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "Пан"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr "Дафніс"
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "Атляс"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Прамэтэй"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Пандора"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Эпімэтэй"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Янус"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr "Эгеон"
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr "Мэтонэ"
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr "Антэ"
 
-#: data.cpp:224
+#: data.cpp:232
 msgid "Pallene"
 msgstr "Палена"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "Тэлеста"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "Каліпса"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr "Палідэўк"
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "Гелена"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr "S 2019 S 1"
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr "Ківіёк"
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr "Іджырак"
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr "Паліяк"
 
-#: data.cpp:233
+#: data.cpp:241
 msgid "Skathi"
 msgstr "Скаці"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr "S 2004 S 37"
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr "S 2007 S 2"
 
-#: data.cpp:236
+#: data.cpp:244
 msgid "Albiorix"
 msgstr "Альбіёрыкс"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr "Бевінь"
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr "S 2004 S 31"
 
-#: data.cpp:239
+#: data.cpp:247
 msgid "Saturn LX"
 msgstr "Сатурн LX"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr "Скол"
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr "Таркек"
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr "Тарвас"
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr "Эрыяпус"
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr "Сіярнак"
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr "Ґрэйп"
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr "Гіракін"
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr "Мундыльфары"
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr "S 2006 S 1"
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr "S 2004 S 13"
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr "S 2007 S 3"
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr "Сутунґ"
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr "Ґрыдр"
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr "Нарві"
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr "Ярнсакса"
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr "S 2004 S 12"
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr "Бэльгемір"
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr "Эґтэр"
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr "S 2004 S 17"
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr "Гаці"
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr "Фарбаўці"
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr "Трым"
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr "S 2004 S 7"
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr "Бэлі"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr "Бэстла"
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr "Ґерд"
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr "Анґрбода"
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr "Ґунлод"
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr "Эґір"
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr "S 2006 S 3"
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr "Алвальдзі"
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr "Кары"
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr "Скрымі"
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr "S 2004 S 28"
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr "Фэнрыр"
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr "Лоґе"
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr "S 2004 S 21"
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr "Ґейрод"
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr "S 2004 S 24"
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr "S 2004 S 36"
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr "Імір"
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr "Суртур"
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr "S 2004 S 39"
 
-#: data.cpp:283
+#: data.cpp:291
 msgid "Saturn LXIV"
 msgstr "Сатурн LXIV"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr "Т’яцэ"
 
-#: data.cpp:285
+#: data.cpp:293
 msgid "Fornjot"
 msgstr "Форн’ёт"
 
-#: data.cpp:286
+#: data.cpp:294
 msgid "Saturn LVIII"
 msgstr "Сатурн LVIII"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "Кардэлія"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "Афэлія"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "Б'янка"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "Крэсыда"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "Дэздэмона"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "Джульета"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "Портыя"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "Разалін"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr "Купідон"
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "Бэлінда"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr "Пэрдыта"
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "Пук"
 
-#: data.cpp:299
+#: data.cpp:307
 msgid "Mab"
 msgstr "Маб"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr "Францыска"
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "Калібан"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "Стэфана"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr "Трынкула"
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "Сыкоракс"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr "Марґарэт"
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "Праспэра"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "Сэтэбас"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr "Фэрдынанд"
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "Наяд"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "Таляса"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "Дэспіна"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "Галятэя"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Лярыса"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr "Гіпакамп"
 
-#: data.cpp:315
+#: data.cpp:323
 msgid "Halimede"
 msgstr "Галімэд"
 
-#: data.cpp:316
+#: data.cpp:324
 msgid "Sao"
 msgstr "Сао"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr "Лаамэдэя"
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr "Псамафа"
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr "Нэса"
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ПАЎНОЧНАЯ АМЭРЫКА"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ПАЎДНЁВАЯ АМЭРЫКА"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ЭЎРАЗІЯ"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "АФРЫКА"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "АЎСТРАЛІЯ"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "АНТАРКТЫКА"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ПАЎНОЧНЫ АТЛЯНТЫЧНЫ АКІЯН"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ПАЎДНЁВЫ АТЛЯНТЫЧНЫ АКІЯН"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ПАЎНОЧНЫ ЦІХІ АКІЯН"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ПАЎДНЁВЫ ЦІХІ АКІЯН"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ІНДЫЙСКІ АКІЯН"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ПАЎНОЧНА-ЛЕДАВІТЫ АКІЯН"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Абу Дабі"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Акра"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Адамстаўн"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Адыс Абэба"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Альжыр"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Алофі"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Аман"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Амстэрдам"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Андора-ля-Вэлья"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Анкара"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Антанарыва"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Апія"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ашгабад"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Асмара"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Астана"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Асунсьён"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Афіны"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Баку"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Бамака"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Бандар Сэры Бэґаван"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Банґкок"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Банґі"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Банжул"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Бас-Тэр"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Бастэр"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Пэкін"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Бэйрут"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Бялград"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Бэльмапан"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Бэрлін"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Бэрн"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Бішкек"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Бісаў"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Блюмфантэйн"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Баґота"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Бразылія"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Братыслава"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Бразавіль"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Брыджтаўн"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Брусэль"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Бухарэст"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Будапэшт"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Буэнас Айрэс"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Каір"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Канбэра"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Кэйптаўн"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Каракас"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Кастрыз"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Каена"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Шарлёт Амалія"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Кішынёў"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Калёмба"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Конакры"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Капэнгаґен"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Катону"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Дакар"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Дар-эс-Салям"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Дака"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Дылі"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Джыбуці"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Дога"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Дуґлас"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Дублін"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Душанбэ"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Фанґафале"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Форт-дэ-Франс"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Фрытаўн"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Ґабаронэ"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Джордж Таўн"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Джорджтаўн"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Ґібралтар"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Ґранд Турк"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Ґватэмала"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Гаґатна"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Гааґа"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Ґамільтан"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Харарэ"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Гавана"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Гельсынкі"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr "Ганконґ"
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Ганіяра"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Ісламабад"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Джэймстаўн"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Ерусалім"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Кабул"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Кампала"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Кіеў"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Кіґалі"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Кінґстан"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Кінґстаўн"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Кіншаса"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Корар"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Куара Люмпур"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Кувэйт"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Эль-Аюн"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "Ля Пас"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Лібрэвіль"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Лілонґвэ"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Ліма"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Лісабон"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Лабамба"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Ломэ"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Лёндан"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Лонґ'ір"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Луанда"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Люксэмбурґ"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Мадрыд"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Маджура"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Малаба"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Малі"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Манаґуа"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Манама"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Маніла"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Мапута"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Масэру"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Мбабанэ"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Мэхіка"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Менск"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Маґадышу"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Манака"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Манровія"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Монтэвідэа"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Мароні"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Масква"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Маскат"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Найробі"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Насаў"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Нджамэна"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Нью Дэлі"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Ньямэ"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Нікасія"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Нумэа"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Нуук"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Араньестад"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Осла"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Атава"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Уаґудуґу"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Паґа Паґа"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Палікір"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Панама"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Папээтэ"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Парамарыба"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Парыж"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Пнам Пень"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Плімут"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Порт Луі"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Порт Морсбі"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Порт-о-Прэнс"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спэйн"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Порта-Нова"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Порт-Віла"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Прага"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Прая"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Прэторыя"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Кіта"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Рабат"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Ранґун"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Рэйк'явік"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Рыга"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Рыяд"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Роўд Таўн"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Рым"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Разо"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Сэнт Джорджэс"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Сэнт Гэльер"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Сэнт Джонс"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Сэнт-Пітэр-Порт"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Сэн Дэні"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Сэн П'ер"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "Сан Хасэ"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "Сан Хуан"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Сан Марына"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Сан Сальвадор"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Сана"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Сант'яґа"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Санта Дамінґа"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Сан Тамэ"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Сараева"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Сэул"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Сэтльмэнт"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Сынґапур"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Скоп'е"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Сафія"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шры-Джаявардэнэпура-Катэ"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Стэнлі"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Стакгольм"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Сукрэ"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Сува"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Тайпэй"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Талін"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Тбілісі"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Тэґусыґальпа"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Тэгеран"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Тэль Авіў"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Тымбу"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Тырана"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Токіё"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Торсгаўн"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Трыпалі"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Туніс"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Уланбатар"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Валета"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Вэлі"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Ватыкан"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Вікторыя"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Вена"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Віенцьян"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Вільня"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Вашынґтон"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Вэлінґтан"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Вэст Айлэнд"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Вілемстад"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Віндгук"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Ямусукра"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Яундэ"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Ярэн"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Ерыван"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Заграб"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Сонца"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Барыцэнтар сонечнай сыстэмы"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Сонца"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Альфэрац"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Сіра"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Каф"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Альджэніб"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr "Цытадэль"
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Схемалі"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Анкаа"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr "Фэліксварэла"
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr "Фулу"
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Шэдыр"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Дыфда"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Дэнэб Каітас"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr "Какіболка"
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Ачырд"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Ван Маанэн 2"
 
-#: data.cpp:591
+#: data.cpp:599
 msgid "Castula"
 msgstr "Кастула"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Наві"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr "Нэнке"
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr "Уурэн"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Мірах"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr "Эміў"
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr "Рэваці"
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Азіль"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr "Бэленас"
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Рухба"
 
-#: data.cpp:601
+#: data.cpp:609
 msgid "Alpherg"
 msgstr "Альфэрґ"
 
-#: data.cpp:602
+#: data.cpp:610
 msgid "Titawin"
 msgstr "Тытавін"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ахернар"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr "Нэмбус"
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr "Таркулар"
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr "Таркулярыс сэптэнтрыяналіс"
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Батэн Каітас"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr "Масалаг"
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Капут Трыанґулі"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Мэзарсым"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Сэґін"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Шэратан"
 
-#: data.cpp:613
+#: data.cpp:621
 msgid "Alrescha"
 msgstr "Альрэсха"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Аль Рэсха"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Альмак"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Альмаак"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Гамаль"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Міра"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Палярная"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr "Буна"
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr "Кафальджыдма"
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr "Каэя"
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr "Ліліі Барэа"
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr "Нушаґак"
 
-#: data.cpp:626
+#: data.cpp:634
 msgid "Bharani"
 msgstr "Бхарані"
 
-#: data.cpp:627
+#: data.cpp:635
 msgid "Miram"
 msgstr "Мірам"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Анджэтэнар"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Азга"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Акамар"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr "Іравадзі"
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Мэнкар"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Мэнкаб"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Альголь"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr "Місам"
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Батэін"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr "Далім"
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr "Зібаль"
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr "Інтан"
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Мірфак"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Мірфак"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Марфак"
 
-#: data.cpp:643
+#: data.cpp:651
 msgid "Ran"
 msgstr "Ран"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr "Тупі"
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Рана"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Ацік"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Келена"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Электра"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Тайгета"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Мая"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Астэропа"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Мэропа"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Алькіёна"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Плеёна"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Заўрак"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Мэнкіб"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Бэід"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Кэід"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr "Прыма Гіядум"
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr "Сэкунда Гіядум"
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr "Бээмім"
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Аін"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr "Чамукуй"
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr "Гоґар"
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr "Тээмін"
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Альдэбаран"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr "Сцэптрум"
 
-#: data.cpp:668
+#: data.cpp:676
 msgid "Tabit"
 msgstr "Табіт"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr "Муун"
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr "Гасале"
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Пурпуровая зорка Гайнда"
 
-#: data.cpp:672
+#: data.cpp:680
 msgid "Almaaz"
 msgstr "Альмааз"
 
-#: data.cpp:673
+#: data.cpp:681
 msgid "Saclateni"
 msgstr "Сацлятэні"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Садатоні"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr "Гэдус"
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Курса"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr "Маґа"
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Зорка Каптэйна"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Рыґель"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Капэла"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Бэлятрыкс"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Эльнат"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Альнас"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Нігаль"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Табіт"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Мінтака"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Арнэб"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Мэіса"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Гека"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr "Гатыса"
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Альнілям"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr "Бубуп"
 
-#: data.cpp:693
+#: data.cpp:701
 msgid "Tianguan"
 msgstr "Тыянґвэн"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Факт"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Альнітак"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Саіф"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Вазн"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Бэтэльґейзэ"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Мэнкалінан"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr "Магазім"
 
-#: data.cpp:702
+#: data.cpp:710
 msgid "Elkurud"
 msgstr "Элькуруб"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr "Амадыёга"
 
-#: data.cpp:704
+#: data.cpp:712
 msgid "Propus"
 msgstr "Пропус"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Чырвоны прастакутнік"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Фуруд"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Мірзам"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Мурзым"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Тэят"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Канопус"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Сугель"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr "Луцылінбурук"
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr "Люзытанія"
 
-#: data.cpp:714
+#: data.cpp:722
 msgid "Plaskett's Star"
 msgstr "Зорка Пласкета"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Альгена"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Альмэісан"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr "Насаха"
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Мэбсута"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Сырыюс"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr "Альзыр"
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr "Нэрвія"
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Азара"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr "Сытала"
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr "Унурґунітэ"
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Муліфэйн"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Мэкбуда"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Вэзэн"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Бэрнэс 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Уасат"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Алюдра"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Ґамэіса"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Зорка Лейтэна"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Кастор"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr "Джыш'ю"
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Працыён"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Эльґамаіса"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr "Сэйба"
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Палукс"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr "Тапэк"
 
-#: data.cpp:741
+#: data.cpp:749
 msgid "Azmidi"
 msgstr "Азмідзі"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Асмідыске"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Наас"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr "Турэйс"
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Рэґар"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Тэґмэн"
 
-#: data.cpp:747
+#: data.cpp:755
 msgid "Tarf"
 msgstr "Тарф"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Аль Тарф"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr "Насьці"
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr "Піаўтас"
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Авіёр"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr "Альшаўкат"
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Мусцыда"
 
-#: data.cpp:754
+#: data.cpp:762
 msgid "Minchir"
 msgstr "Мінхір"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr "Ґакіід"
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr "Мэлеф"
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Асэлюс Барэаліс"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Асэлюс Аўстраліс"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr "Альсэфіна"
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr "Ашлеша"
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr "Капэрнік"
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr "Стрыбор"
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Акубэнс"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr "Таліса"
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Дноцэс"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr "Алькафра"
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Сугаіл"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr "Нан"
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Міяпляцыдус"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Асьпідыска"
 
-#: data.cpp:772
+#: data.cpp:780
 msgid "Markeb"
 msgstr "Маркеб"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Альфард"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Кор Гідра"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr "Інтэркрус"
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Альтэрф"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr "Ілірыян"
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr "Калаўсі"
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Укда"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Субра"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Рас Элясэд Аўстраліс"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr "Наташа"
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr "Жанґ"
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Расалас"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Рас Элясэд Барэаліс"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr "Фэліс"
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr "Біда"
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Рэґул"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Кабэлецэд"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Кор Леоніс"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Азафэра"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Альдафэра"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Танія Барэаліс"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Альґеба"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Танія Аўстраліс"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr "Маконда"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr "Прэцыпуа"
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr "Чалаван"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Алькес"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Мэрак"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Лаландэ 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Дубге"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Дуб"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr "Дынґалэй"
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Зосма"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Дур"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Хорт"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Кокса"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Хорт"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr "Зорка Іннэсы"
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr "Гунапу"
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Алюля Аўстраліс"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Алюля Аўстраліс"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 msgid "Shama"
 msgstr "Шама"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Джаўсар"
 
-#: data.cpp:817
+#: data.cpp:825
 msgid "Formosa"
 msgstr "Фармоза"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr "Саґармата"
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr "Зорка Пшыбыльскага"
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr "Уклун"
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr "Флеґетонтэ"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr "Таянґшу"
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Дэнэбала"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Завіява"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr "Аніяра"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Ґрумбрыдж 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Фэкда"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Фад"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr "Танатыю"
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Альхіба"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr "Імай"
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Мэґрэз"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Джэнаг"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Занія"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr "Ґінан"
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr "Тупа"
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Акрукс"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Алґораб"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Ґакрукс"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr "Фуні"
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Хара"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Краз"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Муліфаін"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Парыма"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr "Ля Супэрба"
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr "Цяньі"
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Мімоза"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Аліёт"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr "Тайі"
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Мінэлаува"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Аува"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Кор Каролі"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Віндэміятрыкс"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Альмурэдын"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr "Дыядэм"
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Міцар"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Сьпіка"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Азымэх"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Алькор"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr "Дафіна"
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr "Лесма"
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Гезэ"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Алькайд"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Бэнэтнасх"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Муфрыд"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Гадар"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Аґена"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Субан"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Мэнкент"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr "Канґ"
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Арктур"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Сырма"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr "Ксанж"
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr "Эльґафар"
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Проксіма"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Сэґінус"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Цэґінус"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr "Толіман"
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr "Рыґіль Кентаўрус"
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Ізар"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Мірак"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Пульгерыма"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr "Мёнх"
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr "Мэрґа"
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Кахаб"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Кохаб"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Зубэн-аль-джэнубі"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr "Аркаліс"
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr "Бэкду"
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Зубэн Элакрыбі"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Нэкар"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr "Брахіюм"
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Зубэн-аш-шамалі"
 
-#: data.cpp:895
+#: data.cpp:903
 msgid "Pherkad Minor"
 msgstr "Фэркад Мінор"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr "Нікаві"
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Фэркад"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Алькалюропс"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Эдасіх"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Нусакан"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Альфэка"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Нырка"
 
-#: data.cpp:903
+#: data.cpp:911
 msgid "Zubenelhakrabi"
 msgstr "Зубэнэльгакрабі"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Зубэн Эльфкраб"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr "Карака"
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Унукальгаі"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr "Ґудзія"
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr "Ікліл"
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr "Фанґ"
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Джуба"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr "Акраб"
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Ґрафіяс"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Акраб"
 
-#: data.cpp:915
+#: data.cpp:923
 msgid "Marsic"
 msgstr "Марсык"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Джаба"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr "Шар’я"
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr "Ед Прыёр"
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr "Ед Пастэрыёр"
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr "Гунор"
 
-#: data.cpp:921
+#: data.cpp:929
 msgid "Alniyat"
 msgstr "Альніят"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Аль Ніят"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr "Атэбынэ"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Каям"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr "Тымір"
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Антарэс"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Карнэфарос"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr "Оґма"
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Марфік"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr "Разаліядэкастра"
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr "Паўкайгале"
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Атрыя"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr "Лараваґ"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr "Ксамідымура"
 
-#: data.cpp:935
+#: data.cpp:943
 msgid "Pipirima"
 msgstr "Піпірыма"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr "Масаці"
 
-#: data.cpp:937
+#: data.cpp:945
 msgid "Rapeto"
 msgstr "Рапэта"
 
-#: data.cpp:938
+#: data.cpp:946
 msgid "Alrakis"
 msgstr "Альракіс"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Аракіс"
 
-#: data.cpp:940
+#: data.cpp:948
 msgid "Aldhibah"
 msgstr "Альдыба"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Сабік"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Расальґесі"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Рас Альґэці"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Сарын"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr "Ґунібу"
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr "Інкуйль"
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Растабан"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Маасым"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Лесас"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Лесут"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Кума"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Ільдун"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Шаўла"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Рас Альгаґ"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Сарґас"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Дзібан"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr "Ґіртаб"
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Кебальраі"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr "Альруба"
 
-#: data.cpp:961
+#: data.cpp:969
 msgid "Cervantes"
 msgstr "Сэрвантэс"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr "Фаю"
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Ґруміюм"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Эльтанін"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Этамін"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Зорка Барнарда"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr "Пінкоя"
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Альнасл"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr "Поліс"
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Каўс Мэдыя"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr "Аласія"
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Каўс Аўстраліс"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Аль Атфар"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr "Фафнір"
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Каўс Барэаліс"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Вэга"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr "Сіхэ"
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Шэліяк"
 
-#: data.cpp:979
+#: data.cpp:987
 msgid "Ainalrami"
 msgstr "Айнальрамі"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Нункі"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr "Кавэ"
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Алья"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Суляфат"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Асцэла"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr "Акаб"
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Дэнэб эль Акаб"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr "Мэрыдыяна"
 
-#: data.cpp:988
+#: data.cpp:996
 msgid "Albaldah"
 msgstr "Альбада"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Альтаіс"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Аль Таіс"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Нодус сэкундус"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Аладфар"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr "Ґумала"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr "Бэлел"
 
-#: data.cpp:995
+#: data.cpp:1003
 msgid "Arkab Prior"
 msgstr "Аркаб Прыёр"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Аркаб"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr "Сыка"
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr "Аркаб Пастэрыёр"
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Рукбат"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr "Ансэр"
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Альбірэо"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr "Урук"
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Альсафі"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Зорка Кэмпбэла"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Шам"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr "Фаварыс"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Таразэд"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Тыль"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Альтаір"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr "Лібэртас"
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Альшаін"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr "Тэрэбэлюм"
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr "Фаэніцыя"
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr "Шэшыя"
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Альджэдзі"
 
-#: data.cpp:1017
+#: data.cpp:1025
 msgid "Alshat"
 msgstr "Альшат"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Дабіг"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Садр"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Пікак"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr "Альдульфін"
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Рутанеў"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Суаляцын"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Дэнэб"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr "Альджана"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Альбалі"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr "Музыка"
 
-#: data.cpp:1028
+#: data.cpp:1036
 msgid "Polaris Australis"
 msgstr "Палярыс Аўстраліс (Паўднёвая палярная)"
 
-#: data.cpp:1029
+#: data.cpp:1037
 msgid "Solaris"
 msgstr "Салярыс"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Кітальфа"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Альдэрамін"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Альфірк"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Садальсуд"
 
-#: data.cpp:1035
+#: data.cpp:1043
 msgid "Bunda"
 msgstr "Бунда"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr "Самая"
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Нашыра"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Азэльфафаґе"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr "Басона"
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Гранатавая зорка Гершэля"
 
-#: data.cpp:1041
+#: data.cpp:1049
 msgid "Erakis"
 msgstr "Эракіс"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Эніф"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Дэнэб Альджэдзі"
 
-#: data.cpp:1044
+#: data.cpp:1052
 msgid "Aldhanab"
 msgstr "Альдханаб"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Аль Дханаб"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr "Ітонда"
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Кургаг"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Садальмэлік"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Альнаір"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Бігам"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Анха"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Садахбія"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Сэат"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr "Лайнрок"
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Круґер 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Сітула"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Гомам"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr "Тыякі"
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Матар"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Зорка Бэбкапа"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Садальбары"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr "Гідор"
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Скат"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr "Гельвэтыяс"
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Фамальгаўт"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Шэат"
 
-#: data.cpp:1068
+#: data.cpp:1076
 msgid "Fumalsamakah"
 msgstr "Фумальсамака"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Фум аль Самака"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Маркаб"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Мархаб"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr "Эбла"
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Брэдлі 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr "Сальм"
 
-#: data.cpp:1075
+#: data.cpp:1083
 msgid "Alkarab"
 msgstr "Алькараб"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr "Вэрытатэ"
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr "Паэрава"
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Эраі"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr "Аксалётль"
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Млечны шлях"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "ВМВ"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "ММВ"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Плеяды"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Гіяды"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Жолаб"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Скопішча «Вулей»"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Мафэй 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Мафэй 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Леў A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Сэкстанс B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Леў I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Сэкстанс A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Цыркуль"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr "Галяктыка «Андрамэда»"
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr "Галяктыка «Трохкутнік»"
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Гольмбэрг VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Фатх 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Тукана"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Эрыдан"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Компас"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"

--- a/po/bg.po
+++ b/po/bg.po
@@ -15,369 +15,459 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:10+0100\n"
 "PO-Revision-Date: 2023-11-03 11:00+0000\n"
 "Last-Translator: Georgi Georgiev (Жоро) <g.georgiev.shumen@gmail.com>, 2024\n"
-"Language-Team: Bulgarian (https://app.transifex.com/celestia/teams/93131/bg/)\n"
+"Language-Team: Bulgarian (https://app.transifex.com/celestia/teams/93131/"
+"bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Андромеда"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Помпа"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Райска птица"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Водолей"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Орел"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Жертвеник"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Овен"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Колар"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Воловар"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Длето"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Жираф"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Рак"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Ловджийски кучета"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Голямо куче"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Малко куче"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Козирог"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Кил"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Касиопея"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Кентавър"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Цефей"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Кит"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Хамелеон"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Пергел"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Гълъб"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Косите на Вероника"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Южна корона"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Северна корона"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Врана"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Чаша"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Южен кръст"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Лебед"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Делфин"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Златна рибка"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Дракон"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Жребче"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Еридан"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Пещ"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Близнаци"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Жерав"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Херкулес"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Часовник"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Хидра"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Водна змия"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Индианец"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Гущер"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Лъв"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Малък лъв"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Заек"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Везни"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Вълк"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Рис"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Лира"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Маса"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Микроскоп"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Еднорог"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Муха"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Ъгломер"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Октант"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Змиеносец"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Орион"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Паун"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Пегас"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Персей"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Феникс"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Живописец"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Риби"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Южна риба"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Кърма"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Компас"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Мрежичка"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Стрела"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Стрелец"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Скорпион"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Скулптор"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Щит"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Змийска глава"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Змийска опашка"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Секстант"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Бик"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Телескоп"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Триъгълник"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Южен триъгълник"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Тукан"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Голяма мечка"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Малка мечка"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Корабни платна"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Дева"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Летяща риба"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Малка лисица"
 
@@ -533,3878 +623,3932 @@ msgstr "Никта"
 msgid "Kerberos"
 msgstr "Цербер"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Хидра"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr "Церера"
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+#, fuzzy
+msgid "Vanth"
+msgstr "Еванта"
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "Хаумея"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "Намака"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "Хияка"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "Макемаке"
 
-#: data.cpp:134
+#: data.cpp:139
 msgid "S 2015 (136472) 1"
 msgstr "S 2015 (136472) 1"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Триъгълник"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "Ерида"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "Дисномия"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "Метис"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "Адрастея"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "Амалтея"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "Тива"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "Темисто"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "Леда"
 
-#: data.cpp:143
+#: data.cpp:151
 msgid "Ersa"
 msgstr "Ерса"
 
-#: data.cpp:144
+#: data.cpp:152
 msgid "Pandia"
 msgstr "Пандия"
 
-#: data.cpp:145
+#: data.cpp:153
 msgid "Himalia"
 msgstr "Хималия"
 
-#: data.cpp:146
+#: data.cpp:154
 msgid "Lysithea"
 msgstr "Лизитея"
 
-#: data.cpp:147
+#: data.cpp:155
 msgid "Elara"
 msgstr "Елара"
 
-#: data.cpp:148
+#: data.cpp:156
 msgid "Dia"
 msgstr "Дия"
 
-#: data.cpp:149
+#: data.cpp:157
 msgid "Carpo"
 msgstr "Карпо"
 
-#: data.cpp:150
+#: data.cpp:158
 msgid "Valetudo"
 msgstr "Валетудо"
 
-#: data.cpp:151
+#: data.cpp:159
 msgid "Euporie"
 msgstr "Евпория"
 
-#: data.cpp:152
+#: data.cpp:160
 msgid "Jupiter LV"
 msgstr "Юпитер LV"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr "Евфема"
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr "S 2003 J 16"
 
-#: data.cpp:155
+#: data.cpp:163
 msgid "Jupiter LXVIII"
 msgstr "Юпитер LXVIII"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "Ананке"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "Харпалика"
 
-#: data.cpp:158
+#: data.cpp:166
 msgid "S 2003 J 12"
 msgstr "S 2003 J 12"
 
-#: data.cpp:159
+#: data.cpp:167
 msgid "Jupiter LII"
 msgstr "Юпитер LII"
 
-#: data.cpp:160
+#: data.cpp:168
 msgid "Praxidike"
 msgstr "Праксидика"
 
-#: data.cpp:161
+#: data.cpp:169
 msgid "S 2003 J 2"
 msgstr "S 2003 J 2"
 
-#: data.cpp:162
+#: data.cpp:170
 msgid "Euanthe"
 msgstr "Еванта"
 
-#: data.cpp:163
+#: data.cpp:171
 msgid "Orthosie"
 msgstr "Ортосия"
 
-#: data.cpp:164
+#: data.cpp:172
 msgid "Jupiter LXIV"
 msgstr "Юпитер LXIV"
 
-#: data.cpp:165
+#: data.cpp:173
 msgid "Iocaste"
 msgstr "Йокаста"
 
-#: data.cpp:166
+#: data.cpp:174
 msgid "Mneme"
 msgstr "Мнема"
 
-#: data.cpp:167
+#: data.cpp:175
 msgid "Thyone"
 msgstr "Тиона"
 
-#: data.cpp:168
+#: data.cpp:176
 msgid "Jupiter LIV"
 msgstr "Юпитер LIV"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr "Телксиноя"
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr "Хелика"
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr "Хермипа"
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr "Филофросина"
 
-#: data.cpp:173
+#: data.cpp:181
 msgid "Jupiter LVI"
 msgstr "Юпитер LVI"
 
-#: data.cpp:174
+#: data.cpp:182
 msgid "Kallichore"
 msgstr "Калихора"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "Калдена"
 
-#: data.cpp:176
+#: data.cpp:184
 msgid "Arche"
 msgstr "Архи"
 
-#: data.cpp:177
+#: data.cpp:185
 msgid "Jupiter LXIX"
 msgstr "Юпитер LXIX"
 
-#: data.cpp:178
+#: data.cpp:186
 msgid "Kale"
 msgstr "Кайла"
 
-#: data.cpp:179
+#: data.cpp:187
 msgid "Jupiter LXXII"
 msgstr "Юпитер LXXII"
 
-#: data.cpp:180
+#: data.cpp:188
 msgid "Jupiter LXI"
 msgstr "Юпитер LXI"
 
-#: data.cpp:181
+#: data.cpp:189
 msgid "Cyllene"
 msgstr "Силена"
 
-#: data.cpp:182
+#: data.cpp:190
 msgid "Taygete"
 msgstr "Тайгета"
 
-#: data.cpp:183
+#: data.cpp:191
 msgid "Jupiter LXX"
 msgstr "Юпитер LXX"
 
-#: data.cpp:184
+#: data.cpp:192
 msgid "Eurydome"
 msgstr "Евридома"
 
-#: data.cpp:185
+#: data.cpp:193
 msgid "Jupiter LI"
 msgstr "Юпитер LI"
 
-#: data.cpp:186
+#: data.cpp:194
 msgid "S 2003 J 9"
 msgstr "S 2003 J 9"
 
-#: data.cpp:187
+#: data.cpp:195
 msgid "Jupiter LXVII"
 msgstr "Юпитер LXVII"
 
-#: data.cpp:188
+#: data.cpp:196
 msgid "Aitne"
 msgstr "Етна"
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "Карме"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "Калироя"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "Еринома"
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr "Паситея"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr "Ирена"
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr "S 2003 J 24"
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "Синопа"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr "Евкелада"
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "Исоноя"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr "S 2003 J 4"
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr "Автоноя"
 
-#: data.cpp:200
+#: data.cpp:208
 msgid "Herse"
 msgstr "Херса"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "Пасифая"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr "S 2003 J 10"
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr "Коре"
 
-#: data.cpp:204
+#: data.cpp:212
 msgid "Jupiter LXIII"
 msgstr "Юпитер LXIII"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr "Хегемона"
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr "Спонда"
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "Калика"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr "Аойда"
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "Мегаклита"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr "S 2003 J 23"
 
-#: data.cpp:211
+#: data.cpp:219
 msgid "Jupiter LXVI"
 msgstr "Юпитер LXVI"
 
-#: data.cpp:212
+#: data.cpp:220
 msgid "Jupiter LIX"
 msgstr "Юпитер LIX"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr "S 2009 S 1"
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "Пан"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr "Дафнис"
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "Атлас"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Прометей"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Пандора"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Епиметей"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Янус"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr "Егеон"
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr "Метония"
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr "Анфа"
 
-#: data.cpp:224
+#: data.cpp:232
 msgid "Pallene"
 msgstr "Палена"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "Телесто"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "Калипсо"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr "Полидевк"
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "Елена"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr "S 2019 S 1"
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr "Кивиок"
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr "Ижирак"
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr "Палиак"
 
-#: data.cpp:233
+#: data.cpp:241
 msgid "Skathi"
 msgstr "Скади"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr "S 2004 S 37"
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr "S 2007 S 2"
 
-#: data.cpp:236
+#: data.cpp:244
 msgid "Albiorix"
 msgstr "Албиорикс"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr "Бебхион"
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr "S 2004 S 31"
 
-#: data.cpp:239
+#: data.cpp:247
 msgid "Saturn LX"
 msgstr "Сатурн LX"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr "Скол"
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr "Таркек"
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr "Тарвос"
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr "Ериапо"
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr "Шиарнак"
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr "Грейп"
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr "Хирокин"
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr "Мундилфари"
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr "S 2006 S 1"
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr "S 2004 S 13"
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr "S 2007 S 3"
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr "Сутунг"
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr "Грид"
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr "Нарви"
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr "Ярнсакса"
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr "S 2004 S 12"
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr "Бергелмир"
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr "Егтер"
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr "S 2004 S 17"
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr "Хати"
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr "Форбоути"
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr "Тримър"
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr "S 2004 S 7"
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr "Бели"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr "Бестла"
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr "Герд"
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr "Ангрбода"
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr "Гунльод"
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr "Егир"
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr "S 2006 S 3"
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr "Алвалди"
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr "Кари"
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr "Скрюмир"
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr "S 2004 S 28"
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr "Фенрир"
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr "Логе"
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr "S 2004 S 21"
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr "Гейрод"
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr "S 2004 S 24"
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr "S 2004 S 36"
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr "Имир"
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr "Суртур"
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr "S 2004 S 39"
 
-#: data.cpp:283
+#: data.cpp:291
 msgid "Saturn LXIV"
 msgstr "Сатурн LXIV"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr "Тияци"
 
-#: data.cpp:285
+#: data.cpp:293
 msgid "Fornjot"
 msgstr "Форнджот"
 
-#: data.cpp:286
+#: data.cpp:294
 msgid "Saturn LVIII"
 msgstr "Сатурн LVIII"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "Корделия"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "Офелия"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "Бианка"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "Кресида"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "Дездемона"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "Жулиета"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "Порция"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "Розалинда"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr "Купидон"
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "Белинда"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr "Пердита"
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "Пък"
 
-#: data.cpp:299
+#: data.cpp:307
 msgid "Mab"
 msgstr "Маб"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr "Франциско"
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "Калибан"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "Стефано"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr "Тринкуло"
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "Сикоракс"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr "Маргарет"
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "Просперо"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "Сетебос"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr "Фердинанд"
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "Наяда"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "Таласа"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "Деспина"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "Галатея"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Лариса"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr "Хипокамп"
 
-#: data.cpp:315
+#: data.cpp:323
 msgid "Halimede"
 msgstr "Халимеда"
 
-#: data.cpp:316
+#: data.cpp:324
 msgid "Sao"
 msgstr "Сао"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr "Лаомедея"
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr "Самате"
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr "Несо"
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "СЕВЕРНА АМЕРИКА"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ЮЖНА АМЕРИКА"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ЕВРАЗИЯ"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "АФРИКА"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "АВСТРАЛИЯ"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "АНТАРКТИКА"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "СЕВЕРЕН АТЛАНТИЧЕСКИ ОКЕАН"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ЮЖЕН АТЛАНТИЧЕСКИ ОКЕАН"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "СЕВЕРЕН ТИХ ОКЕАН"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ЮЖЕН ТИХ ОКЕАН"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ИНДИЙСКИ ОКЕАН"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "СЕВЕРЕН ЛЕДОВИТ ОКЕАН"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Абу Даби"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Акра"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Адамстаун"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Адис Абеба"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Алжир"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Алофи"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Аман"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Амстердам"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Андора ла Вела"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Анкара"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Антананариво"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Апия"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ашхабад"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Асмара"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Астана"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Асунсион"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Атина"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Баку"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Бамако"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Бандар Сери Бегаван"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Банкок"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Бангуи"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Банджул"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Бас Тер"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Басетере"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Пекин"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Бейрут"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Белград"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Белмопан"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Берлин"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Берн"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Бишкек"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Бисау"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Блумфонтейн"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Богота"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Бразилия"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Братислава"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Бразавил"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Бриджтаун"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Брюксел"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Букурещ"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Будапеща"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Буенос Айрес"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Кайро"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Канбера"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Кейптаун"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Каракас"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Кастрис"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Кайен"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Шарлот Амали"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Кишинев"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Коломбо"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Конакри"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Копенхаген"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Котону"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Дакар"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Дар ес Салаам"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Дака"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Дили"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Джибути"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Доха"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Дъглас"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Дъблин"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Душанбе"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Фонгафале"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Фор дьо Франс"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Фрийтаун"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Габороне"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Джордж Таун"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Джорджтаун"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Гибралтар"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Гранд Търк"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Гватемала"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Хагатна"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Хага"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Хамилтън"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Хараре"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Хавана"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Хелзинки"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr "Хонконг"
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Хониара"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Исламабад"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Джеймстаун"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Ерусалим"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Кабул"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Кампала"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Киев"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Кигали"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Кингстън"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Кингстаун"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Киншаса"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Корор"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Куала Лумпур"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Кувейт"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Ал-Аюн"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "Ла Пас"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Либревил"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Лилонгве"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Лима"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Лисабон"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Лобамба"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Ломе"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Лондон"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Лонгирбюен"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Луанда"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Люксембург"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Мадрид"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Маджуро"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Малабо"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Мале"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Манагуа"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Манама"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Манила"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Мапуто"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Масеру"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Мбабане"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Мексико"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Минск"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Могадишу"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Монако"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Монровия"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Монтевидео"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Морони"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Москва"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Маскат"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Найроби"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Насау"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Нджамена"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Ню Делхи"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Ниамей"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Никозия"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Нумеа"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Нуук"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Оранестад"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Осло"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Отава"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Уагадугу"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Паго Паго"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Паликир"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Панама"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Папеете"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Парамарибо"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Париж"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Пном Пен"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Плимут"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Порт Луи"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Порт Морсби"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Порт о Пренс"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Порт ъф Спейн"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Порто Ново"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Порт Вила"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Прага"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Прая"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Претория"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Пхенян"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Кито"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Рабат"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Янгон"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Рейкявик"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Рига"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Рияд"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Роуд Таун"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Рим"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Розо"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Сейнт Джордж"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Сейнт Хелиър"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Сейнт Джонс"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Сейнт Питър Порт"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Сен Дени"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Сен Пиер"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "Сан Хосе"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "Сан Хуан"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Сан Марино"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Сан Салвадор"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Сана"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Сантяго"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Санто Доминго"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Сао Томе"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Сараево"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Сеул"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Селището"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Сингапур"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Скопие"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "София"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шри Джаяварданапура Коте"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Стенли"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Стокхолм"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Сукре"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Сува"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Тайпе"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Талин"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Тарауа"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Тбилиси"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Тегусигалпа"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Техеран"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Тел Авив"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Тхимпху"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Тирана"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Токио"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Торсхавн"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Триполи"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Тунис"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Улан Батор"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Валета"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Вали"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Ватикан"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Виктория"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Виена"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Виентян"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Вилнюс"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Вашингтон"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Уелингтън"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Уест Айлънд"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Вилемстад"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Виндхук"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Ямусукро"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Яунде"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Ярен"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Ереван"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Загреб"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Слънце"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Център на масата на Слънчевата система"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Слънце"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Алферац"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Сира"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Каф"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Алгениб"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr "Ситадел"
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Шемали"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Анкаа"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr "Феликсварела"
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr "Фулу"
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Шедар"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Шедир"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Дифда"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Денеб Кайтос"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr "Косиболка"
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Ахирд"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Ван Манен 2"
 
-#: data.cpp:591
+#: data.cpp:599
 msgid "Castula"
 msgstr "Кастула"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Нави"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr "Ненке"
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr "Вурен"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Мирах"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr "Емиу"
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr "Ревати"
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Адил"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr "Беленос"
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Рухба"
 
-#: data.cpp:601
+#: data.cpp:609
 msgid "Alpherg"
 msgstr "Алферг"
 
-#: data.cpp:602
+#: data.cpp:610
 msgid "Titawin"
 msgstr "Титауин"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ахернар"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr "Нембус"
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr "Торкулар"
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr "Торкуларис Септентрионалис"
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Батен Кайтос"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr "Моталах"
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Капут Триангули"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Месартим"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Сегин"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Шератан"
 
-#: data.cpp:613
+#: data.cpp:621
 msgid "Alrescha"
 msgstr "Алреша"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Ал Реша"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Алмах"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Алмак"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Аламак"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Хамал"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Мира"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Полярна звезда"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr "Буна"
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr "Кафалджидма"
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr "Коея"
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr "Лили Борея"
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr "Нушагак"
 
-#: data.cpp:626
+#: data.cpp:634
 msgid "Bharani"
 msgstr "Барани"
 
-#: data.cpp:627
+#: data.cpp:635
 msgid "Miram"
 msgstr "Мирам"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Ангетенар"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Ажа"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Акамар"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr "Айеярди"
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Менкар"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Менкаб"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Алгол"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr "Мизам"
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Ботейн"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr "Далим"
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr "Зибал"
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr "Интан"
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Мѝрфак"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Мирфак"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Марфак"
 
-#: data.cpp:643
+#: data.cpp:651
 msgid "Ran"
 msgstr "Ран"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr "Тупи"
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Рана"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Атик"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Келаино"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Електра"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Тайгета"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Мая"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Астеропа"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Меропа"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Алциона"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Плейона"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Заурак"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Менкиб"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Беид"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Кеид"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr "Прима Хядум"
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr "Секунда Хядум"
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr "Бимим"
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Аин"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr "Чамукуй"
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr "Ахагар"
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr "Тимин"
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Алдебаран"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr "Скиптър"
 
-#: data.cpp:668
+#: data.cpp:676
 msgid "Tabit"
 msgstr "Табит"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr "Мухун"
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr "Хасалех"
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Пурпурна звезда на Хинд"
 
-#: data.cpp:672
+#: data.cpp:680
 msgid "Almaaz"
 msgstr "Алмаз"
 
-#: data.cpp:673
+#: data.cpp:681
 msgid "Saclateni"
 msgstr "Саклатени"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Садатони"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr "Хедус"
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Курса"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr "Маго"
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Звезда на Каптейн"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Ригел"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Капела"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Белатрикс"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Елнат"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Алнат"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Нихал"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Табит"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Минтака"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Арнеб"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Мейса"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Хека"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr "Хатиса"
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Алнилам"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr "Бубуп"
 
-#: data.cpp:693
+#: data.cpp:701
 msgid "Tianguan"
 msgstr "Тиенгуан"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Факт"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Алнитак"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Саиф"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Уазн"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Бетелгейзе"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Приджипати"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Менкалинан"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr "Махасим"
 
-#: data.cpp:702
+#: data.cpp:710
 msgid "Elkurud"
 msgstr "Елкуруд"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr "Амадиоха"
 
-#: data.cpp:704
+#: data.cpp:712
 msgid "Propus"
 msgstr "Пропус"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Червен правоъгълник"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Фуруд"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Мирзам"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Мурзим"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Тейжат"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Канопус"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Сухел"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr "Лусилинбурхук"
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr "Лузитания"
 
-#: data.cpp:714
+#: data.cpp:722
 msgid "Plaskett's Star"
 msgstr "Звезда на Пласкет"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Алхена"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Алмейсан"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr "Носакса"
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Мебсута"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Сириус"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr "Алзир"
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr "Нервия"
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Адхара"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Адара"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr "Ситала"
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr "Унургунит"
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Мулфейн"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Мекбуда"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Уезен"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Берн 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Уасат"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Алудра"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Гомейса"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Звезда на Лютън"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Кастор"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr "Дзишуей"
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Процион"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Елгомейса"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr "Сейбо"
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Полукс"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr "Тапеке"
 
-#: data.cpp:741
+#: data.cpp:749
 msgid "Azmidi"
 msgstr "Азмиди"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Асмидиске"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Наос"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr "Турайс"
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Регор"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Тегмина"
 
-#: data.cpp:747
+#: data.cpp:755
 msgid "Tarf"
 msgstr "Тарф"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Алтарф"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr "Насти"
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr "Пиаутос"
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Авиор"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr "Алсиаукат"
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Мусцида"
 
-#: data.cpp:754
+#: data.cpp:762
 msgid "Minchir"
 msgstr "Минхир"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr "Гакид"
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr "Мелеф"
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Аселус Бореалис"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Аселус Аустралис"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr "Алсефина"
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr "Ашлеша"
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr "Коперник"
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr "Стрибор"
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Акубенс"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr "Талита"
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Дносес"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr "Алкафра"
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Талита Аустралис"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Сухаил"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr "Нан"
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Мияпласидус"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Аспидиске"
 
-#: data.cpp:772
+#: data.cpp:780
 msgid "Markeb"
 msgstr "Маркеб"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Алфард"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Кор Хидре"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr "Интеркрус"
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Алтерф"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr "Илириец"
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr "Калауси"
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Укда"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Субра"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Разеласед Аустралис"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr "Наташа"
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr "Джан"
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Расалас"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Разеласед Бореалис"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr "Фелис"
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr "Бибха"
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Регул"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Кабелесед"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Кор Леони"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Адафера"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Алдафера"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Таня Бореалис"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Алгиеба"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Таня Аустралис"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr "Макондо"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr "Преципуа"
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr "Чалаван"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Алкес"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Мерак"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Лаланд 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Дубхе"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Дуб"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr "Динголай"
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Зосма"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Дур"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Шертан"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Коха"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Корт"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr "Звезда на Инес"
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr "Хунахпу"
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Алула Аустралис"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Алула Бореалис"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Цзе Чян"
 
-#: data.cpp:815
+#: data.cpp:823
 msgid "Shama"
 msgstr "Шама"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Гиаузар"
 
-#: data.cpp:817
+#: data.cpp:825
 msgid "Formosa"
 msgstr "Формоса"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr "Сагарматха"
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr "Звезда на Пшибилски"
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr "Уклун"
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr "Флегетон"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr "Тайяншоу"
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Денебола"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Завиджава"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Алараф"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr "Аниора"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Грумбридж 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Фекда"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Фад"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr "Тонатиу"
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Алхиба"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr "Имай"
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Мегрец"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Гиена"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Зания"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr "Гинан"
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr "Тупъ"
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Акрукс"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Алгораб"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Гакрукс"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr "Фуни"
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Чара"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Краз"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Мулфаин"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Порима"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr "Ла Суперба"
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr "Тиени"
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Мимоза"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Алиот"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr "Тайи"
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Минелаува"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Аува"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Кор Кароли"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Виндемиатрикс"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Алмуредин"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr "Диадема"
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Мицар"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Спика"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Азимех"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Алкор"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr "Дофида"
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr "Лиесма"
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Хезе"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Алкаид"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Бенетнаш"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Муфрид"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Хадар"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Агена"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Тубан"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Менкент"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr "Кан"
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Арктур"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Сирма"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr "Сюенгъ"
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr "Елгафар"
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Проксима"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Сегѝнус"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Сегинус"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr "Толиман"
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr "Ригил Кентавър"
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Ицар"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Мирак"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Пулчерима"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr "Мьонх"
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr "Мерга"
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Кохаб"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Кокаб"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Зубенелгенуби"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr "Аркалис"
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr "Пекту"
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Зубенелакриби"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Некар"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr "Брахиум"
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Зубенесхамали"
 
-#: data.cpp:895
+#: data.cpp:903
 msgid "Pherkad Minor"
 msgstr "Феркад Минор"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr "Никауи"
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Феркад"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Алкалуропс"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Едазих"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Нусакан"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Алфека"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Хема"
 
-#: data.cpp:903
+#: data.cpp:911
 msgid "Zubenelhakrabi"
 msgstr "Зубенелакраби"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Зубенелакраб"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr "Карака"
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Унукалхай"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Джоу"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr "Гуджа"
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr "Иклил"
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr "Фан"
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Дшуба"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr "Елакраб"
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Графиас"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Акраб"
 
-#: data.cpp:915
+#: data.cpp:923
 msgid "Marsic"
 msgstr "Марсик"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Джабах"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr "Шарджа"
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr "Йед Приор"
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr "Йед Постериор"
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr "Хунор"
 
-#: data.cpp:921
+#: data.cpp:929
 msgid "Alniyat"
 msgstr "Алният"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Ал Ният"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr "Атебин"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Куджам"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr "Тимир"
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Антарес"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Корнефорос"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr "Огма"
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Марфик"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr "Розалиядекастро"
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr "Пайкохале"
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Атрия"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr "Ларауаг"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr "Камидимура"
 
-#: data.cpp:935
+#: data.cpp:943
 msgid "Pipirima"
 msgstr "Пипирима"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr "Масати"
 
-#: data.cpp:937
+#: data.cpp:945
 msgid "Rapeto"
 msgstr "Рапето"
 
-#: data.cpp:938
+#: data.cpp:946
 msgid "Alrakis"
 msgstr "Алракис"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Аракис"
 
-#: data.cpp:940
+#: data.cpp:948
 msgid "Aldhibah"
 msgstr "Алдиба"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Сабик"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Расалгеди"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Рас Алгеди"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Сарин"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr "Гунибу"
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr "Инкил"
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Растабан"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Маазим"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Лесат"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Лесут"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Кума"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Йилдун"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Шаула"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Расалхаге"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Рас Алхаге"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Саргас"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Дзибан"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr "Гиртаб"
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Себалрай"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr "Алруба"
 
-#: data.cpp:961
+#: data.cpp:969
 msgid "Cervantes"
 msgstr "Сервантес"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr "Фуюе"
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Грумиум"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Елтанин"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Етамин"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Звезда на Барнард"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr "Пинкоя"
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Алнасл"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr "Полис"
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Каус Медия"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr "Аласия"
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Каус Аустралис"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Аладфар"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr "Фафнир"
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Каус Бореалис"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Вега"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr "Сихъ"
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Шелиак"
 
-#: data.cpp:979
+#: data.cpp:987
 msgid "Ainalrami"
 msgstr "Аиналрами"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Нунки"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr "Кавех"
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Алия"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Сулафат"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Аскела"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr "Окаб"
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Денеб Елокаб"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr "Меридиана"
 
-#: data.cpp:988
+#: data.cpp:996
 msgid "Albaldah"
 msgstr "Албалда"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Алтаис"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Ал Таис"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Нодус Секундус"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Аладфар"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr "Гумала"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr "Белел"
 
-#: data.cpp:995
+#: data.cpp:1003
 msgid "Arkab Prior"
 msgstr "Аркаб Приор"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Аркаб"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr "Сика"
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr "Аркаб Постериор"
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Рукбат"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr "Ансер"
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Албирео"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr "Урук"
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Алсафи"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Звезда на Кембъл"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Шам"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr "Фаварис"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Таразед"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Тил"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Алтаир"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Атаир"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr "Либертас"
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Алшаин"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr "Теребелум"
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr "Финикия"
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr "Чечия"
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Алгеди"
 
-#: data.cpp:1017
+#: data.cpp:1025
 msgid "Alshat"
 msgstr "Алшат"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Дабих"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Садр"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Паун"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr "Алдулфин"
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Ротанев"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Суалосин"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Денеб"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr "Алджана"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Албали"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr "Музика"
 
-#: data.cpp:1028
+#: data.cpp:1036
 msgid "Polaris Australis"
 msgstr "Южна полярна звезда"
 
-#: data.cpp:1029
+#: data.cpp:1037
 msgid "Solaris"
 msgstr "Соларис"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Киталфа"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Лакай 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Алдерамин"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Алфирк"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Садалсууд"
 
-#: data.cpp:1035
+#: data.cpp:1043
 msgid "Bunda"
 msgstr "Бунда"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr "Самая"
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Нашира"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Азелфафаг"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr "Босона"
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Гранатова звезда на Хершел"
 
-#: data.cpp:1041
+#: data.cpp:1049
 msgid "Erakis"
 msgstr "Еракис"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Ениф"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Денеб Алгеди"
 
-#: data.cpp:1044
+#: data.cpp:1052
 msgid "Aldhanab"
 msgstr "Алданаб"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Ал Данаб"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr "Итонда"
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Курах"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Садалмелик"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Алнаир"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Ал Наир"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Бихам"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Анка"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Садакбия"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Сеат"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr "Лионрок"
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Крюгер 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Ситула"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Хомам"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr "Тиаки"
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Матар"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Звезда на Бабкок"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Садалбари"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr "Хидор"
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Скат"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr "Хелвеций"
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Фомалхаут"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Шеат"
 
-#: data.cpp:1068
+#: data.cpp:1076
 msgid "Fumalsamakah"
 msgstr "Фумалсамак"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Фум Алсамак"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Маркаб"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Мархаб"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr "Ебла"
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Брадли 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr "Салм"
 
-#: data.cpp:1075
+#: data.cpp:1083
 msgid "Alkarab"
 msgstr "Алкараб"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr "Веритате"
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr "Поерава"
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Ерай"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr "Аксолотъл"
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Млечен път"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "ГМО"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "ММО"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Плеяди"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Хияди"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Ясли"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Звезден куп Ясли"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Мафей 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Мафей 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Лъв А"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Секстант В"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Лъв I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Секстант А"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Пергел"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr "Галактика Андромеда"
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr "Галактика Триъгълник"
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Холмбърг VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Фат 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 от Тукан"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Еридан"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Компас"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Тонантзинтла 2"

--- a/po/celestia-data.pot
+++ b/po/celestia-data.pot
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Celestia Development Team, Translators
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
@@ -11,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr ""
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr ""
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr ""
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr ""
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr ""
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr ""
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr ""
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr ""
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr ""
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr ""
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr ""
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr ""
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr ""
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr ""
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr ""
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr ""
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr ""
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr ""
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr ""
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr ""
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr ""
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr ""
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr ""
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr ""
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr ""
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr ""
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr ""
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr ""
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr ""
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr ""
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr ""
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr ""
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr ""
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr ""
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr ""
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr ""
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr ""
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr ""
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr ""
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr ""
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr ""
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr ""
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr ""
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr ""
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr ""
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr ""
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr ""
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr ""
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr ""
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr ""
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr ""
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr ""
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr ""
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr ""
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr ""
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr ""
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr ""
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr ""
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr ""
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr ""
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr ""
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr ""
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr ""
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr ""
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr ""
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr ""
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr ""
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr ""
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr ""
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr ""
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr ""
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr ""
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr ""
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr ""
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr ""
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr ""
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr ""
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr ""
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr ""
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr ""
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr ""
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr ""
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr ""
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr ""
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr ""
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr ""
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr ""
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr ""
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr ""
 
@@ -528,3878 +616,3926 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+msgid "Hydra"
+msgstr ""
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
-msgid "Haumea"
+msgid "Orcus-Vanth"
 msgstr ""
 
 #: data.cpp:131
-msgid "Namaka"
+msgid "Orcus"
 msgstr ""
 
 #: data.cpp:132
-msgid "Hi'iaka"
+msgid "Vanth"
 msgstr ""
 
 #: data.cpp:133
-msgid "Makemake"
+msgid "Haumea"
 msgstr ""
 
 #: data.cpp:134
-msgid "S 2015 (136472) 1"
+msgid "Namaka"
 msgstr ""
 
 #: data.cpp:135
-msgid "Eris"
+msgid "Hi'iaka"
 msgstr ""
 
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
+msgid "S 2015 (136472) 1"
 msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
+msgid "Xiangliu"
 msgstr ""
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-msgid "Pandia"
+msgid "Sedna"
 msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
+msgid "Amalthea"
 msgstr ""
 
 #: data.cpp:148
-msgid "Dia"
+msgid "Thebe"
 msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
-msgid "Jupiter LV"
+msgid "Pandia"
 msgstr ""
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
-msgid "Jupiter LXVIII"
+msgid "Elara"
 msgstr ""
 
 #: data.cpp:156
-msgid "Ananke"
+msgid "Dia"
 msgstr ""
 
 #: data.cpp:157
-msgid "Harpalyke"
+msgid "Carpo"
 msgstr ""
 
 #: data.cpp:158
-msgid "S 2003 J 12"
+msgid "Valetudo"
 msgstr ""
 
 #: data.cpp:159
-msgid "Jupiter LII"
+msgid "Euporie"
 msgstr ""
 
 #: data.cpp:160
-msgid "Praxidike"
+msgid "Jupiter LV"
 msgstr ""
 
 #: data.cpp:161
-msgid "S 2003 J 2"
+msgid "Eupheme"
 msgstr ""
 
 #: data.cpp:162
-msgid "Euanthe"
+msgid "S 2003 J 16"
 msgstr ""
 
 #: data.cpp:163
-msgid "Orthosie"
+msgid "Jupiter LXVIII"
 msgstr ""
 
 #: data.cpp:164
-msgid "Jupiter LXIV"
+msgid "Ananke"
 msgstr ""
 
 #: data.cpp:165
-msgid "Iocaste"
+msgid "Harpalyke"
 msgstr ""
 
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
-msgid "Thyone"
+msgid "Jupiter LII"
 msgstr ""
 
 #: data.cpp:168
-msgid "Jupiter LIV"
+msgid "Praxidike"
 msgstr ""
 
 #: data.cpp:169
-msgid "Thelxinoe"
+msgid "S 2003 J 2"
 msgstr ""
 
 #: data.cpp:170
-msgid "Helike"
+msgid "Euanthe"
 msgstr ""
 
 #: data.cpp:171
-msgid "Hermippe"
+msgid "Orthosie"
 msgstr ""
 
 #: data.cpp:172
-msgid "Philophrosyne"
+msgid "Jupiter LXIV"
 msgstr ""
 
 #: data.cpp:173
-msgid "Jupiter LVI"
+msgid "Iocaste"
 msgstr ""
 
 #: data.cpp:174
-msgid "Kallichore"
+msgid "Mneme"
 msgstr ""
 
 #: data.cpp:175
-msgid "Chaldene"
+msgid "Thyone"
 msgstr ""
 
 #: data.cpp:176
-msgid "Arche"
+msgid "Jupiter LIV"
 msgstr ""
 
 #: data.cpp:177
-msgid "Jupiter LXIX"
+msgid "Thelxinoe"
 msgstr ""
 
 #: data.cpp:178
-msgid "Kale"
+msgid "Helike"
 msgstr ""
 
 #: data.cpp:179
-msgid "Jupiter LXXII"
+msgid "Hermippe"
 msgstr ""
 
 #: data.cpp:180
-msgid "Jupiter LXI"
+msgid "Philophrosyne"
 msgstr ""
 
 #: data.cpp:181
-msgid "Cyllene"
+msgid "Jupiter LVI"
 msgstr ""
 
 #: data.cpp:182
-msgid "Taygete"
+msgid "Kallichore"
 msgstr ""
 
 #: data.cpp:183
-msgid "Jupiter LXX"
+msgid "Chaldene"
 msgstr ""
 
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr ""
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr ""
 
 #: data.cpp:188
-msgid "Aitne"
+msgid "Jupiter LXI"
 msgstr ""
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
-msgid "Callirrhoe"
+msgid "Taygete"
 msgstr ""
 
 #: data.cpp:191
-msgid "Erinome"
+msgid "Jupiter LXX"
 msgstr ""
 
 #: data.cpp:192
-msgid "Pasithee"
+msgid "Eurydome"
 msgstr ""
 
 #: data.cpp:193
-msgid "Eirene"
+msgid "Jupiter LI"
 msgstr ""
 
 #: data.cpp:194
-msgid "S 2003 J 24"
+msgid "S 2003 J 9"
 msgstr ""
 
 #: data.cpp:195
-msgid "Sinope"
+msgid "Jupiter LXVII"
 msgstr ""
 
 #: data.cpp:196
-msgid "Eukelade"
+msgid "Aitne"
 msgstr ""
 
 #: data.cpp:197
-msgid "Isonoe"
+msgid "Carme"
 msgstr ""
 
 #: data.cpp:198
-msgid "S 2003 J 4"
+msgid "Callirrhoe"
 msgstr ""
 
 #: data.cpp:199
-msgid "Autonoe"
+msgid "Erinome"
 msgstr ""
 
 #: data.cpp:200
-msgid "Herse"
+msgid "Pasithee"
 msgstr ""
 
 #: data.cpp:201
-msgid "Pasiphae"
+msgid "Eirene"
 msgstr ""
 
 #: data.cpp:202
-msgid "S 2003 J 10"
+msgid "S 2003 J 24"
 msgstr ""
 
 #: data.cpp:203
-msgid "Kore"
+msgid "Sinope"
 msgstr ""
 
 #: data.cpp:204
-msgid "Jupiter LXIII"
+msgid "Eukelade"
 msgstr ""
 
 #: data.cpp:205
-msgid "Hegemone"
+msgid "Isonoe"
 msgstr ""
 
 #: data.cpp:206
-msgid "Sponde"
+msgid "S 2003 J 4"
 msgstr ""
 
 #: data.cpp:207
-msgid "Kalyke"
+msgid "Autonoe"
 msgstr ""
 
 #: data.cpp:208
-msgid "Aoede"
+msgid "Herse"
 msgstr ""
 
 #: data.cpp:209
-msgid "Megaclite"
+msgid "Pasiphae"
 msgstr ""
 
 #: data.cpp:210
-msgid "S 2003 J 23"
+msgid "S 2003 J 10"
 msgstr ""
 
 #: data.cpp:211
-msgid "Jupiter LXVI"
+msgid "Kore"
 msgstr ""
 
 #: data.cpp:212
-msgid "Jupiter LIX"
+msgid "Jupiter LXIII"
 msgstr ""
 
 #: data.cpp:213
-msgid "S 2009 S 1"
+msgid "Hegemone"
 msgstr ""
 
 #: data.cpp:214
-msgid "Pan"
+msgid "Sponde"
 msgstr ""
 
 #: data.cpp:215
-msgid "Daphnis"
+msgid "Kalyke"
 msgstr ""
 
 #: data.cpp:216
-msgid "Atlas"
+msgid "Aoede"
 msgstr ""
 
 #: data.cpp:217
-msgid "Prometheus"
+msgid "Megaclite"
 msgstr ""
 
 #: data.cpp:218
-msgid "Pandora"
+msgid "S 2003 J 23"
 msgstr ""
 
 #: data.cpp:219
-msgid "Epimetheus"
+msgid "Jupiter LXVI"
 msgstr ""
 
 #: data.cpp:220
-msgid "Janus"
+msgid "Jupiter LIX"
 msgstr ""
 
 #: data.cpp:221
-msgid "Aegaeon"
+msgid "S 2009 S 1"
 msgstr ""
 
 #: data.cpp:222
-msgid "Methone"
+msgid "Pan"
 msgstr ""
 
 #: data.cpp:223
-msgid "Anthe"
+msgid "Daphnis"
 msgstr ""
 
 #: data.cpp:224
-msgid "Pallene"
+msgid "Atlas"
 msgstr ""
 
 #: data.cpp:225
-msgid "Telesto"
+msgid "Prometheus"
 msgstr ""
 
 #: data.cpp:226
-msgid "Calypso"
+msgid "Pandora"
 msgstr ""
 
 #: data.cpp:227
-msgid "Polydeuces"
+msgid "Epimetheus"
 msgstr ""
 
 #: data.cpp:228
-msgid "Helene"
+msgid "Janus"
 msgstr ""
 
 #: data.cpp:229
-msgid "S 2019 S 1"
+msgid "Aegaeon"
 msgstr ""
 
 #: data.cpp:230
-msgid "Kiviuq"
+msgid "Methone"
 msgstr ""
 
 #: data.cpp:231
-msgid "Ijiraq"
+msgid "Anthe"
 msgstr ""
 
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
-msgid "Skathi"
+msgid "Telesto"
 msgstr ""
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
-msgid "Albiorix"
+msgid "Helene"
 msgstr ""
 
 #: data.cpp:237
-msgid "Bebhionn"
+msgid "S 2019 S 1"
 msgstr ""
 
 #: data.cpp:238
-msgid "S 2004 S 31"
+msgid "Kiviuq"
 msgstr ""
 
 #: data.cpp:239
-msgid "Saturn LX"
+msgid "Ijiraq"
 msgstr ""
 
 #: data.cpp:240
-msgid "Skoll"
+msgid "Paaliaq"
 msgstr ""
 
 #: data.cpp:241
-msgid "Tarqeq"
+msgid "Skathi"
 msgstr ""
 
 #: data.cpp:242
-msgid "Tarvos"
+msgid "S 2004 S 37"
 msgstr ""
 
 #: data.cpp:243
-msgid "Erriapus"
+msgid "S 2007 S 2"
 msgstr ""
 
 #: data.cpp:244
-msgid "Siarnaq"
+msgid "Albiorix"
 msgstr ""
 
 #: data.cpp:245
-msgid "Greip"
+msgid "Bebhionn"
 msgstr ""
 
 #: data.cpp:246
-msgid "Hyrrokkin"
+msgid "S 2004 S 31"
 msgstr ""
 
 #: data.cpp:247
-msgid "Mundilfari"
+msgid "Saturn LX"
 msgstr ""
 
 #: data.cpp:248
-msgid "S 2006 S 1"
+msgid "Skoll"
 msgstr ""
 
 #: data.cpp:249
-msgid "S 2004 S 13"
+msgid "Tarqeq"
 msgstr ""
 
 #: data.cpp:250
-msgid "S 2007 S 3"
+msgid "Tarvos"
 msgstr ""
 
 #: data.cpp:251
-msgid "Suttungr"
+msgid "Erriapus"
 msgstr ""
 
 #: data.cpp:252
-msgid "Gridr"
+msgid "Siarnaq"
 msgstr ""
 
 #: data.cpp:253
-msgid "Narvi"
+msgid "Greip"
 msgstr ""
 
 #: data.cpp:254
-msgid "Jarnsaxa"
+msgid "Hyrrokkin"
 msgstr ""
 
 #: data.cpp:255
-msgid "S 2004 S 12"
+msgid "Mundilfari"
 msgstr ""
 
 #: data.cpp:256
-msgid "Bergelmir"
+msgid "S 2006 S 1"
 msgstr ""
 
 #: data.cpp:257
-msgid "Eggther"
+msgid "S 2004 S 13"
 msgstr ""
 
 #: data.cpp:258
-msgid "S 2004 S 17"
+msgid "S 2007 S 3"
 msgstr ""
 
 #: data.cpp:259
-msgid "Hati"
+msgid "Suttungr"
 msgstr ""
 
 #: data.cpp:260
-msgid "Farbauti"
+msgid "Gridr"
 msgstr ""
 
 #: data.cpp:261
-msgid "Thrymr"
+msgid "Narvi"
 msgstr ""
 
 #: data.cpp:262
-msgid "S 2004 S 7"
+msgid "Jarnsaxa"
 msgstr ""
 
 #: data.cpp:263
-msgid "Beli"
+msgid "S 2004 S 12"
 msgstr ""
 
 #: data.cpp:264
-msgid "Bestla"
+msgid "Bergelmir"
 msgstr ""
 
 #: data.cpp:265
-msgid "Gerd"
+msgid "Eggther"
 msgstr ""
 
 #: data.cpp:266
-msgid "Angrboda"
+msgid "S 2004 S 17"
 msgstr ""
 
 #: data.cpp:267
-msgid "Gunnlod"
+msgid "Hati"
 msgstr ""
 
 #: data.cpp:268
-msgid "Aegir"
+msgid "Farbauti"
 msgstr ""
 
 #: data.cpp:269
-msgid "S 2006 S 3"
+msgid "Thrymr"
 msgstr ""
 
 #: data.cpp:270
-msgid "Alvaldi"
+msgid "S 2004 S 7"
 msgstr ""
 
 #: data.cpp:271
-msgid "Kari"
+msgid "Beli"
 msgstr ""
 
 #: data.cpp:272
-msgid "Skrymir"
+msgid "Bestla"
 msgstr ""
 
 #: data.cpp:273
-msgid "S 2004 S 28"
+msgid "Gerd"
 msgstr ""
 
 #: data.cpp:274
-msgid "Fenrir"
+msgid "Angrboda"
 msgstr ""
 
 #: data.cpp:275
-msgid "Loge"
+msgid "Gunnlod"
 msgstr ""
 
 #: data.cpp:276
-msgid "S 2004 S 21"
+msgid "Aegir"
 msgstr ""
 
 #: data.cpp:277
-msgid "Geirrod"
+msgid "S 2006 S 3"
 msgstr ""
 
 #: data.cpp:278
-msgid "S 2004 S 24"
+msgid "Alvaldi"
 msgstr ""
 
 #: data.cpp:279
-msgid "S 2004 S 36"
+msgid "Kari"
 msgstr ""
 
 #: data.cpp:280
-msgid "Ymir"
+msgid "Skrymir"
 msgstr ""
 
 #: data.cpp:281
-msgid "Surtur"
+msgid "S 2004 S 28"
 msgstr ""
 
 #: data.cpp:282
-msgid "S 2004 S 39"
+msgid "Fenrir"
 msgstr ""
 
 #: data.cpp:283
-msgid "Saturn LXIV"
+msgid "Loge"
 msgstr ""
 
 #: data.cpp:284
-msgid "Thiazzi"
+msgid "S 2004 S 21"
 msgstr ""
 
 #: data.cpp:285
-msgid "Fornjot"
+msgid "Geirrod"
 msgstr ""
 
 #: data.cpp:286
-msgid "Saturn LVIII"
+msgid "S 2004 S 24"
 msgstr ""
 
 #: data.cpp:287
-msgid "Cordelia"
+msgid "S 2004 S 36"
 msgstr ""
 
 #: data.cpp:288
-msgid "Ophelia"
+msgid "Ymir"
 msgstr ""
 
 #: data.cpp:289
-msgid "Bianca"
+msgid "Surtur"
 msgstr ""
 
 #: data.cpp:290
-msgid "Cressida"
+msgid "S 2004 S 39"
 msgstr ""
 
 #: data.cpp:291
-msgid "Desdemona"
+msgid "Saturn LXIV"
 msgstr ""
 
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
-msgid "Portia"
+msgid "Fornjot"
 msgstr ""
 
 #: data.cpp:294
-msgid "Rosalind"
+msgid "Saturn LVIII"
 msgstr ""
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
-msgid "Mab"
+msgid "Desdemona"
 msgstr ""
 
 #: data.cpp:300
-msgid "Francisco"
+msgid "Juliet"
 msgstr ""
 
 #: data.cpp:301
-msgid "Caliban"
+msgid "Portia"
 msgstr ""
 
 #: data.cpp:302
-msgid "Stephano"
+msgid "Rosalind"
 msgstr ""
 
 #: data.cpp:303
-msgid "Trinculo"
+msgid "Cupid"
 msgstr ""
 
 #: data.cpp:304
-msgid "Sycorax"
+msgid "Belinda"
 msgstr ""
 
 #: data.cpp:305
-msgid "Margaret"
+msgid "Perdita"
 msgstr ""
 
 #: data.cpp:306
-msgid "Prospero"
+msgid "Puck"
 msgstr ""
 
 #: data.cpp:307
-msgid "Setebos"
+msgid "Mab"
 msgstr ""
 
 #: data.cpp:308
-msgid "Ferdinand"
+msgid "Francisco"
 msgstr ""
 
 #: data.cpp:309
-msgid "Naiad"
+msgid "Caliban"
 msgstr ""
 
 #: data.cpp:310
-msgid "Thalassa"
+msgid "Stephano"
 msgstr ""
 
 #: data.cpp:311
-msgid "Despina"
+msgid "Trinculo"
 msgstr ""
 
 #: data.cpp:312
-msgid "Galatea"
+msgid "Sycorax"
 msgstr ""
 
 #: data.cpp:313
-msgid "Larissa"
+msgid "Margaret"
 msgstr ""
 
 #: data.cpp:314
-msgid "Hippocamp"
+msgid "Prospero"
 msgstr ""
 
 #: data.cpp:315
-msgid "Halimede"
+msgid "Setebos"
 msgstr ""
 
 #: data.cpp:316
-msgid "Sao"
+msgid "Ferdinand"
 msgstr ""
 
 #: data.cpp:317
-msgid "Laomedeia"
+msgid "Naiad"
 msgstr ""
 
 #: data.cpp:318
-msgid "Psamathe"
+msgid "Thalassa"
 msgstr ""
 
 #: data.cpp:319
-msgid "Neso"
+msgid "Despina"
 msgstr ""
 
 #: data.cpp:320
-msgid "NORTH AMERICA"
+msgid "Galatea"
 msgstr ""
 
 #: data.cpp:321
-msgid "SOUTH AMERICA"
+msgid "Larissa"
 msgstr ""
 
 #: data.cpp:322
-msgid "EURASIA"
+msgid "Hippocamp"
 msgstr ""
 
 #: data.cpp:323
-msgid "AFRICA"
+msgid "Halimede"
 msgstr ""
 
 #: data.cpp:324
-msgid "AUSTRALIA"
+msgid "Sao"
 msgstr ""
 
 #: data.cpp:325
-msgid "ANTARCTICA"
+msgid "Laomedeia"
 msgstr ""
 
 #: data.cpp:326
-msgid "NORTH ATLANTIC OCEAN"
+msgid "Psamathe"
 msgstr ""
 
 #: data.cpp:327
-msgid "SOUTH ATLANTIC OCEAN"
+msgid "Neso"
 msgstr ""
 
 #: data.cpp:328
-msgid "NORTH PACIFIC OCEAN"
+msgid "NORTH AMERICA"
 msgstr ""
 
 #: data.cpp:329
-msgid "SOUTH PACIFIC OCEAN"
+msgid "SOUTH AMERICA"
 msgstr ""
 
 #: data.cpp:330
-msgid "INDIAN OCEAN"
+msgid "EURASIA"
 msgstr ""
 
 #: data.cpp:331
-msgid "ARCTIC OCEAN"
+msgid "AFRICA"
 msgstr ""
 
 #: data.cpp:332
-msgid "Abu Dhabi"
+msgid "AUSTRALIA"
 msgstr ""
 
 #: data.cpp:333
-msgid "Abuja"
+msgid "ANTARCTICA"
 msgstr ""
 
 #: data.cpp:334
-msgid "Accra"
+msgid "NORTH ATLANTIC OCEAN"
 msgstr ""
 
 #: data.cpp:335
-msgid "Adamstown"
+msgid "SOUTH ATLANTIC OCEAN"
 msgstr ""
 
 #: data.cpp:336
-msgid "Addis Ababa"
+msgid "NORTH PACIFIC OCEAN"
 msgstr ""
 
 #: data.cpp:337
-msgid "Algiers"
+msgid "SOUTH PACIFIC OCEAN"
 msgstr ""
 
 #: data.cpp:338
-msgid "Alofi"
+msgid "INDIAN OCEAN"
 msgstr ""
 
 #: data.cpp:339
-msgid "Amman"
+msgid "ARCTIC OCEAN"
 msgstr ""
 
 #: data.cpp:340
-msgid "Amsterdam"
+msgid "Abu Dhabi"
 msgstr ""
 
 #: data.cpp:341
-msgid "Andorra la Vella"
+msgid "Abuja"
 msgstr ""
 
 #: data.cpp:342
-msgid "Ankara"
+msgid "Accra"
 msgstr ""
 
 #: data.cpp:343
-msgid "Antananarivo"
+msgid "Adamstown"
 msgstr ""
 
 #: data.cpp:344
-msgid "Apia"
+msgid "Addis Ababa"
 msgstr ""
 
 #: data.cpp:345
-msgid "Ashgabat"
+msgid "Algiers"
 msgstr ""
 
 #: data.cpp:346
-msgid "Asmara"
+msgid "Alofi"
 msgstr ""
 
 #: data.cpp:347
-msgid "Astana"
+msgid "Amman"
 msgstr ""
 
 #: data.cpp:348
-msgid "Asuncion"
+msgid "Amsterdam"
 msgstr ""
 
 #: data.cpp:349
-msgid "Athens"
+msgid "Andorra la Vella"
 msgstr ""
 
 #: data.cpp:350
-msgid "Avarua"
+msgid "Ankara"
 msgstr ""
 
 #: data.cpp:351
-msgid "Baghdad"
+msgid "Antananarivo"
 msgstr ""
 
 #: data.cpp:352
-msgid "Baku"
+msgid "Apia"
 msgstr ""
 
 #: data.cpp:353
-msgid "Bamako"
+msgid "Ashgabat"
 msgstr ""
 
 #: data.cpp:354
-msgid "Bandar Seri Begawan"
+msgid "Asmara"
 msgstr ""
 
 #: data.cpp:355
-msgid "Bangkok"
+msgid "Astana"
 msgstr ""
 
 #: data.cpp:356
-msgid "Bangui"
+msgid "Asuncion"
 msgstr ""
 
 #: data.cpp:357
-msgid "Banjul"
+msgid "Athens"
 msgstr ""
 
 #: data.cpp:358
-msgid "Basse-Terre"
+msgid "Avarua"
 msgstr ""
 
 #: data.cpp:359
-msgid "Basseterre"
+msgid "Baghdad"
 msgstr ""
 
 #: data.cpp:360
-msgid "Beijing"
+msgid "Baku"
 msgstr ""
 
 #: data.cpp:361
-msgid "Beirut"
+msgid "Bamako"
 msgstr ""
 
 #: data.cpp:362
-msgid "Belgrade"
+msgid "Bandar Seri Begawan"
 msgstr ""
 
 #: data.cpp:363
-msgid "Belmopan"
+msgid "Bangkok"
 msgstr ""
 
 #: data.cpp:364
-msgid "Berlin"
+msgid "Bangui"
 msgstr ""
 
 #: data.cpp:365
-msgid "Bern"
+msgid "Banjul"
 msgstr ""
 
 #: data.cpp:366
-msgid "Bishkek"
+msgid "Basse-Terre"
 msgstr ""
 
 #: data.cpp:367
-msgid "Bissau"
+msgid "Basseterre"
 msgstr ""
 
 #: data.cpp:368
-msgid "Bloemfontein"
+msgid "Beijing"
 msgstr ""
 
 #: data.cpp:369
-msgid "Bogota"
+msgid "Beirut"
 msgstr ""
 
 #: data.cpp:370
-msgid "Brasilia"
+msgid "Belgrade"
 msgstr ""
 
 #: data.cpp:371
-msgid "Bratislava"
+msgid "Belmopan"
 msgstr ""
 
 #: data.cpp:372
-msgid "Brazzaville"
+msgid "Berlin"
 msgstr ""
 
 #: data.cpp:373
-msgid "Bridgetown"
+msgid "Bern"
 msgstr ""
 
 #: data.cpp:374
-msgid "Brussels"
+msgid "Bishkek"
 msgstr ""
 
 #: data.cpp:375
-msgid "Bucharest"
+msgid "Bissau"
 msgstr ""
 
 #: data.cpp:376
-msgid "Budapest"
+msgid "Bloemfontein"
 msgstr ""
 
 #: data.cpp:377
-msgid "Buenos Aires"
+msgid "Bogota"
 msgstr ""
 
 #: data.cpp:378
-msgid "Bujumbura"
+msgid "Brasilia"
 msgstr ""
 
 #: data.cpp:379
-msgid "Cairo"
+msgid "Bratislava"
 msgstr ""
 
 #: data.cpp:380
-msgid "Canberra"
+msgid "Brazzaville"
 msgstr ""
 
 #: data.cpp:381
-msgid "Cape Town"
+msgid "Bridgetown"
 msgstr ""
 
 #: data.cpp:382
-msgid "Caracas"
+msgid "Brussels"
 msgstr ""
 
 #: data.cpp:383
-msgid "Castries"
+msgid "Bucharest"
 msgstr ""
 
 #: data.cpp:384
-msgid "Cayenne"
+msgid "Budapest"
 msgstr ""
 
 #: data.cpp:385
-msgid "Charlotte Amalie"
+msgid "Buenos Aires"
 msgstr ""
 
 #: data.cpp:386
-msgid "Chisinau"
+msgid "Bujumbura"
 msgstr ""
 
 #: data.cpp:387
-msgid "Colombo"
+msgid "Cairo"
 msgstr ""
 
 #: data.cpp:388
-msgid "Conakry"
+msgid "Canberra"
 msgstr ""
 
 #: data.cpp:389
-msgid "Copenhagen"
+msgid "Cape Town"
 msgstr ""
 
 #: data.cpp:390
-msgid "Cotonou"
+msgid "Caracas"
 msgstr ""
 
 #: data.cpp:391
-msgid "Dakar"
+msgid "Castries"
 msgstr ""
 
 #: data.cpp:392
-msgid "Damascus"
+msgid "Cayenne"
 msgstr ""
 
 #: data.cpp:393
-msgid "Dar es Salaam"
+msgid "Charlotte Amalie"
 msgstr ""
 
 #: data.cpp:394
-msgid "Dhaka"
+msgid "Chisinau"
 msgstr ""
 
 #: data.cpp:395
-msgid "Dili"
+msgid "Colombo"
 msgstr ""
 
 #: data.cpp:396
-msgid "Djibouti"
+msgid "Conakry"
 msgstr ""
 
 #: data.cpp:397
-msgid "Doha"
+msgid "Copenhagen"
 msgstr ""
 
 #: data.cpp:398
-msgid "Douglas"
+msgid "Cotonou"
 msgstr ""
 
 #: data.cpp:399
-msgid "Dublin"
+msgid "Dakar"
 msgstr ""
 
 #: data.cpp:400
-msgid "Dushanbe"
+msgid "Damascus"
 msgstr ""
 
 #: data.cpp:401
-msgid "Fongafale"
+msgid "Dar es Salaam"
 msgstr ""
 
 #: data.cpp:402
-msgid "Fort-de-France"
+msgid "Dhaka"
 msgstr ""
 
 #: data.cpp:403
-msgid "Freetown"
+msgid "Dili"
 msgstr ""
 
 #: data.cpp:404
-msgid "Gaborone"
+msgid "Djibouti"
 msgstr ""
 
 #: data.cpp:405
-msgid "George Town"
+msgid "Doha"
 msgstr ""
 
 #: data.cpp:406
-msgid "Georgetown"
+msgid "Douglas"
 msgstr ""
 
 #: data.cpp:407
-msgid "Gibraltar"
+msgid "Dublin"
 msgstr ""
 
 #: data.cpp:408
-msgid "Grand Turk"
+msgid "Dushanbe"
 msgstr ""
 
 #: data.cpp:409
-msgid "Guatemala"
+msgid "Fongafale"
 msgstr ""
 
 #: data.cpp:410
-msgid "Hagatna"
+msgid "Fort-de-France"
 msgstr ""
 
 #: data.cpp:411
-msgid "The Hague"
+msgid "Freetown"
 msgstr ""
 
 #: data.cpp:412
-msgid "Hamilton"
+msgid "Gaborone"
 msgstr ""
 
 #: data.cpp:413
-msgid "Hanoi"
+msgid "George Town"
 msgstr ""
 
 #: data.cpp:414
-msgid "Harare"
+msgid "Georgetown"
 msgstr ""
 
 #: data.cpp:415
-msgid "Havana"
+msgid "Gibraltar"
 msgstr ""
 
 #: data.cpp:416
-msgid "Helsinki"
+msgid "Grand Turk"
 msgstr ""
 
 #: data.cpp:417
-msgid "Hong Kong"
+msgid "Guatemala"
 msgstr ""
 
 #: data.cpp:418
-msgid "Honiara"
+msgid "Hagatna"
 msgstr ""
 
 #: data.cpp:419
-msgid "Islamabad"
+msgid "The Hague"
 msgstr ""
 
 #: data.cpp:420
-msgid "Jakarta"
+msgid "Hamilton"
 msgstr ""
 
 #: data.cpp:421
-msgid "Jamestown"
+msgid "Hanoi"
 msgstr ""
 
 #: data.cpp:422
-msgid "Jerusalem"
+msgid "Harare"
 msgstr ""
 
 #: data.cpp:423
-msgid "Kabul"
+msgid "Havana"
 msgstr ""
 
 #: data.cpp:424
-msgid "Kampala"
+msgid "Helsinki"
 msgstr ""
 
 #: data.cpp:425
-msgid "Kathmandu"
+msgid "Hong Kong"
 msgstr ""
 
 #: data.cpp:426
-msgid "Khartoum"
+msgid "Honiara"
 msgstr ""
 
 #: data.cpp:427
-msgid "Kiev"
+msgid "Islamabad"
 msgstr ""
 
 #: data.cpp:428
-msgid "Kigali"
+msgid "Jakarta"
 msgstr ""
 
-#: data.cpp:429 data.cpp:430
-msgid "Kingston"
+#: data.cpp:429
+msgid "Jamestown"
+msgstr ""
+
+#: data.cpp:430
+msgid "Jerusalem"
 msgstr ""
 
 #: data.cpp:431
-msgid "Kingstown"
+msgid "Kabul"
 msgstr ""
 
 #: data.cpp:432
-msgid "Kinshasa"
+msgid "Kampala"
 msgstr ""
 
 #: data.cpp:433
-msgid "Koror"
+msgid "Kathmandu"
 msgstr ""
 
 #: data.cpp:434
-msgid "Kuala Lumpur"
+msgid "Khartoum"
 msgstr ""
 
 #: data.cpp:435
-msgid "Kuwait"
+msgid "Kiev"
 msgstr ""
 
 #: data.cpp:436
-msgid "La'youn"
+msgid "Kigali"
 msgstr ""
 
-#: data.cpp:437
-msgid "La Paz"
-msgstr ""
-
-#: data.cpp:438
-msgid "Libreville"
+#: data.cpp:437 data.cpp:438
+msgid "Kingston"
 msgstr ""
 
 #: data.cpp:439
-msgid "Lilongwe"
+msgid "Kingstown"
 msgstr ""
 
 #: data.cpp:440
-msgid "Lima"
+msgid "Kinshasa"
 msgstr ""
 
 #: data.cpp:441
-msgid "Lisbon"
+msgid "Koror"
 msgstr ""
 
 #: data.cpp:442
-msgid "Ljubljana"
+msgid "Kuala Lumpur"
 msgstr ""
 
 #: data.cpp:443
-msgid "Lobamba"
+msgid "Kuwait"
 msgstr ""
 
 #: data.cpp:444
-msgid "Lome"
+msgid "La'youn"
 msgstr ""
 
 #: data.cpp:445
-msgid "London"
+msgid "La Paz"
 msgstr ""
 
 #: data.cpp:446
-msgid "Longyearbyen"
+msgid "Libreville"
 msgstr ""
 
 #: data.cpp:447
-msgid "Luanda"
+msgid "Lilongwe"
 msgstr ""
 
 #: data.cpp:448
-msgid "Lusaka"
+msgid "Lima"
 msgstr ""
 
 #: data.cpp:449
-msgid "Luxembourg"
+msgid "Lisbon"
 msgstr ""
 
 #: data.cpp:450
-msgid "Madrid"
+msgid "Ljubljana"
 msgstr ""
 
 #: data.cpp:451
-msgid "Majuro"
+msgid "Lobamba"
 msgstr ""
 
 #: data.cpp:452
-msgid "Malabo"
+msgid "Lome"
 msgstr ""
 
 #: data.cpp:453
-msgid "Male"
+msgid "London"
 msgstr ""
 
 #: data.cpp:454
-msgid "Mamoutzou"
+msgid "Longyearbyen"
 msgstr ""
 
 #: data.cpp:455
-msgid "Managua"
+msgid "Luanda"
 msgstr ""
 
 #: data.cpp:456
-msgid "Manama"
+msgid "Lusaka"
 msgstr ""
 
 #: data.cpp:457
-msgid "Manila"
+msgid "Luxembourg"
 msgstr ""
 
 #: data.cpp:458
-msgid "Maputo"
+msgid "Madrid"
 msgstr ""
 
 #: data.cpp:459
-msgid "Maseru"
+msgid "Majuro"
 msgstr ""
 
 #: data.cpp:460
-msgid "Mata-Utu"
+msgid "Malabo"
 msgstr ""
 
 #: data.cpp:461
-msgid "Mbabane"
+msgid "Male"
 msgstr ""
 
 #: data.cpp:462
-msgid "Mexico City"
+msgid "Mamoutzou"
 msgstr ""
 
 #: data.cpp:463
-msgid "Minsk"
+msgid "Managua"
 msgstr ""
 
 #: data.cpp:464
-msgid "Mogadishu"
+msgid "Manama"
 msgstr ""
 
 #: data.cpp:465
-msgid "Monaco"
+msgid "Manila"
 msgstr ""
 
 #: data.cpp:466
-msgid "Monrovia"
+msgid "Maputo"
 msgstr ""
 
 #: data.cpp:467
-msgid "Montevideo"
+msgid "Maseru"
 msgstr ""
 
 #: data.cpp:468
-msgid "Moroni"
+msgid "Mata-Utu"
 msgstr ""
 
 #: data.cpp:469
-msgid "Moscow"
+msgid "Mbabane"
 msgstr ""
 
 #: data.cpp:470
-msgid "Muscat"
+msgid "Mexico City"
 msgstr ""
 
 #: data.cpp:471
-msgid "Nairobi"
+msgid "Minsk"
 msgstr ""
 
 #: data.cpp:472
-msgid "Nassau"
+msgid "Mogadishu"
 msgstr ""
 
 #: data.cpp:473
-msgid "N'Djamena"
+msgid "Monaco"
 msgstr ""
 
 #: data.cpp:474
-msgid "New Delhi"
+msgid "Monrovia"
 msgstr ""
 
 #: data.cpp:475
-msgid "Niamey"
+msgid "Montevideo"
 msgstr ""
 
 #: data.cpp:476
-msgid "Nicosia"
+msgid "Moroni"
 msgstr ""
 
 #: data.cpp:477
-msgid "Nouakchott"
+msgid "Moscow"
 msgstr ""
 
 #: data.cpp:478
-msgid "Noumea"
+msgid "Muscat"
 msgstr ""
 
 #: data.cpp:479
-msgid "Nuku'alofa"
+msgid "Nairobi"
 msgstr ""
 
 #: data.cpp:480
-msgid "Nuuk"
+msgid "Nassau"
 msgstr ""
 
 #: data.cpp:481
-msgid "Oranjestad"
+msgid "N'Djamena"
 msgstr ""
 
 #: data.cpp:482
-msgid "Oslo"
+msgid "New Delhi"
 msgstr ""
 
 #: data.cpp:483
-msgid "Ottawa"
+msgid "Niamey"
 msgstr ""
 
 #: data.cpp:484
-msgid "Ouagadougou"
+msgid "Nicosia"
 msgstr ""
 
 #: data.cpp:485
-msgid "Pago Pago"
+msgid "Nouakchott"
 msgstr ""
 
 #: data.cpp:486
-msgid "Palikir"
+msgid "Noumea"
 msgstr ""
 
 #: data.cpp:487
-msgid "Panama"
+msgid "Nuku'alofa"
 msgstr ""
 
 #: data.cpp:488
-msgid "Papeete"
+msgid "Nuuk"
 msgstr ""
 
 #: data.cpp:489
-msgid "Paramaribo"
+msgid "Oranjestad"
 msgstr ""
 
 #: data.cpp:490
-msgid "Paris"
+msgid "Oslo"
 msgstr ""
 
 #: data.cpp:491
-msgid "Phnom Penh"
+msgid "Ottawa"
 msgstr ""
 
 #: data.cpp:492
-msgid "Plymouth"
+msgid "Ouagadougou"
 msgstr ""
 
 #: data.cpp:493
-msgid "Port Louis"
+msgid "Pago Pago"
 msgstr ""
 
 #: data.cpp:494
-msgid "Port Moresby"
+msgid "Palikir"
 msgstr ""
 
 #: data.cpp:495
-msgid "Port-au-Prince"
+msgid "Panama"
 msgstr ""
 
 #: data.cpp:496
-msgid "Port-of-Spain"
+msgid "Papeete"
 msgstr ""
 
 #: data.cpp:497
-msgid "Porto-Novo"
+msgid "Paramaribo"
 msgstr ""
 
 #: data.cpp:498
-msgid "Port-Vila"
+msgid "Paris"
 msgstr ""
 
 #: data.cpp:499
-msgid "Prague"
+msgid "Phnom Penh"
 msgstr ""
 
 #: data.cpp:500
-msgid "Praia"
+msgid "Plymouth"
 msgstr ""
 
 #: data.cpp:501
-msgid "Pretoria"
+msgid "Port Louis"
 msgstr ""
 
 #: data.cpp:502
-msgid "P'yongyang"
+msgid "Port Moresby"
 msgstr ""
 
 #: data.cpp:503
-msgid "Quito"
+msgid "Port-au-Prince"
 msgstr ""
 
 #: data.cpp:504
-msgid "Rabat"
+msgid "Port-of-Spain"
 msgstr ""
 
 #: data.cpp:505
-msgid "Rangoon"
+msgid "Porto-Novo"
 msgstr ""
 
 #: data.cpp:506
-msgid "Reykjavik"
+msgid "Port-Vila"
 msgstr ""
 
 #: data.cpp:507
-msgid "Riga"
+msgid "Prague"
 msgstr ""
 
 #: data.cpp:508
-msgid "Riyadh"
+msgid "Praia"
 msgstr ""
 
 #: data.cpp:509
-msgid "Road Town"
+msgid "Pretoria"
 msgstr ""
 
 #: data.cpp:510
-msgid "Rome"
+msgid "P'yongyang"
 msgstr ""
 
 #: data.cpp:511
-msgid "Roseau"
+msgid "Quito"
 msgstr ""
 
 #: data.cpp:512
-msgid "Saint George's"
+msgid "Rabat"
 msgstr ""
 
 #: data.cpp:513
-msgid "Saint Helier"
+msgid "Rangoon"
 msgstr ""
 
 #: data.cpp:514
-msgid "Saint John's"
+msgid "Reykjavik"
 msgstr ""
 
 #: data.cpp:515
-msgid "Saint Peter Port"
+msgid "Riga"
 msgstr ""
 
 #: data.cpp:516
-msgid "Saint-Denis"
+msgid "Riyadh"
 msgstr ""
 
 #: data.cpp:517
-msgid "Saint-Pierre"
+msgid "Road Town"
 msgstr ""
 
 #: data.cpp:518
-msgid "Saipan"
+msgid "Rome"
 msgstr ""
 
 #: data.cpp:519
-msgid "San Jose"
+msgid "Roseau"
 msgstr ""
 
 #: data.cpp:520
-msgid "San Juan"
+msgid "Saint George's"
 msgstr ""
 
 #: data.cpp:521
-msgid "San Marino"
+msgid "Saint Helier"
 msgstr ""
 
 #: data.cpp:522
-msgid "San Salvador"
+msgid "Saint John's"
 msgstr ""
 
 #: data.cpp:523
-msgid "Sanaa"
+msgid "Saint Peter Port"
 msgstr ""
 
 #: data.cpp:524
-msgid "Santiago"
+msgid "Saint-Denis"
 msgstr ""
 
 #: data.cpp:525
-msgid "Santo Domingo"
+msgid "Saint-Pierre"
 msgstr ""
 
 #: data.cpp:526
-msgid "Sao Tome"
+msgid "Saipan"
 msgstr ""
 
 #: data.cpp:527
-msgid "Sarajevo"
+msgid "San Jose"
 msgstr ""
 
 #: data.cpp:528
-msgid "Seoul"
+msgid "San Juan"
 msgstr ""
 
 #: data.cpp:529
-msgid "The Settlement"
+msgid "San Marino"
 msgstr ""
 
 #: data.cpp:530
-msgid "Singapore"
+msgid "San Salvador"
 msgstr ""
 
 #: data.cpp:531
-msgid "Skopje"
+msgid "Sanaa"
 msgstr ""
 
 #: data.cpp:532
-msgid "Sofia"
+msgid "Santiago"
 msgstr ""
 
 #: data.cpp:533
-msgid "Sri Jayewardenepura Kotte"
+msgid "Santo Domingo"
 msgstr ""
 
 #: data.cpp:534
-msgid "Stanley"
+msgid "Sao Tome"
 msgstr ""
 
 #: data.cpp:535
-msgid "Stockholm"
+msgid "Sarajevo"
 msgstr ""
 
 #: data.cpp:536
-msgid "Sucre"
+msgid "Seoul"
 msgstr ""
 
 #: data.cpp:537
-msgid "Suva"
+msgid "The Settlement"
 msgstr ""
 
 #: data.cpp:538
-msgid "Taipei"
+msgid "Singapore"
 msgstr ""
 
 #: data.cpp:539
-msgid "Tallinn"
+msgid "Skopje"
 msgstr ""
 
 #: data.cpp:540
-msgid "Tarawa"
+msgid "Sofia"
 msgstr ""
 
 #: data.cpp:541
-msgid "Tashkent"
+msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
 #: data.cpp:542
-msgid "T'bilisi"
+msgid "Stanley"
 msgstr ""
 
 #: data.cpp:543
-msgid "Tegucigalpa"
+msgid "Stockholm"
 msgstr ""
 
 #: data.cpp:544
-msgid "Tehran"
+msgid "Sucre"
 msgstr ""
 
 #: data.cpp:545
-msgid "Tel Aviv"
+msgid "Suva"
 msgstr ""
 
 #: data.cpp:546
-msgid "Thimphu"
+msgid "Taipei"
 msgstr ""
 
 #: data.cpp:547
-msgid "Tirana"
+msgid "Tallinn"
 msgstr ""
 
 #: data.cpp:548
-msgid "Tokyo"
+msgid "Tarawa"
 msgstr ""
 
 #: data.cpp:549
-msgid "Torshavn"
+msgid "Tashkent"
 msgstr ""
 
 #: data.cpp:550
-msgid "Tripoli"
+msgid "T'bilisi"
 msgstr ""
 
 #: data.cpp:551
-msgid "Tunis"
+msgid "Tegucigalpa"
 msgstr ""
 
 #: data.cpp:552
-msgid "Ulaanbaatar"
+msgid "Tehran"
 msgstr ""
 
 #: data.cpp:553
-msgid "Vaduz"
+msgid "Tel Aviv"
 msgstr ""
 
 #: data.cpp:554
-msgid "Valletta"
+msgid "Thimphu"
 msgstr ""
 
 #: data.cpp:555
-msgid "The Valley"
+msgid "Tirana"
 msgstr ""
 
 #: data.cpp:556
-msgid "Vatican City"
+msgid "Tokyo"
 msgstr ""
 
 #: data.cpp:557
-msgid "Victoria"
+msgid "Torshavn"
 msgstr ""
 
 #: data.cpp:558
-msgid "Vienna"
+msgid "Tripoli"
 msgstr ""
 
 #: data.cpp:559
-msgid "Vientiane"
+msgid "Tunis"
 msgstr ""
 
 #: data.cpp:560
-msgid "Vilnius"
+msgid "Ulaanbaatar"
 msgstr ""
 
 #: data.cpp:561
-msgid "Warsaw"
+msgid "Vaduz"
 msgstr ""
 
 #: data.cpp:562
-msgid "Washington D.C."
+msgid "Valletta"
 msgstr ""
 
 #: data.cpp:563
-msgid "Wellington"
+msgid "The Valley"
 msgstr ""
 
 #: data.cpp:564
-msgid "West Island"
+msgid "Vatican City"
 msgstr ""
 
 #: data.cpp:565
-msgid "Willemstad"
+msgid "Victoria"
 msgstr ""
 
 #: data.cpp:566
-msgid "Windhoek"
+msgid "Vienna"
 msgstr ""
 
 #: data.cpp:567
-msgid "Yamoussoukro"
+msgid "Vientiane"
 msgstr ""
 
 #: data.cpp:568
-msgid "Yaounde"
+msgid "Vilnius"
 msgstr ""
 
 #: data.cpp:569
-msgid "Yaren District"
+msgid "Warsaw"
 msgstr ""
 
 #: data.cpp:570
-msgid "Yerevan"
+msgid "Washington D.C."
 msgstr ""
 
 #: data.cpp:571
-msgid "Zagreb"
+msgid "Wellington"
 msgstr ""
 
 #: data.cpp:572
-msgid "Sol"
+msgid "West Island"
 msgstr ""
 
 #: data.cpp:573
-msgid "Solar System Barycenter"
+msgid "Willemstad"
 msgstr ""
 
 #: data.cpp:574
-msgid "Sun"
+msgid "Windhoek"
 msgstr ""
 
 #: data.cpp:575
-msgid "Alpheratz"
+msgid "Yamoussoukro"
 msgstr ""
 
 #: data.cpp:576
-msgid "Sirrah"
+msgid "Yaounde"
 msgstr ""
 
 #: data.cpp:577
-msgid "Caph"
+msgid "Yaren District"
 msgstr ""
 
 #: data.cpp:578
-msgid "Algenib"
+msgid "Yerevan"
 msgstr ""
 
 #: data.cpp:579
-msgid "Citadelle"
+msgid "Zagreb"
 msgstr ""
 
 #: data.cpp:580
-msgid "Schemali"
+msgid "Sol"
 msgstr ""
 
 #: data.cpp:581
-msgid "Ankaa"
+msgid "Solar System Barycenter"
 msgstr ""
 
 #: data.cpp:582
-msgid "Felixvarela"
+msgid "Sun"
 msgstr ""
 
 #: data.cpp:583
-msgid "Fulu"
+msgid "Alpheratz"
 msgstr ""
 
 #: data.cpp:584
-msgid "Schedar"
+msgid "Sirrah"
 msgstr ""
 
 #: data.cpp:585
-msgid "Shedir"
+msgid "Caph"
 msgstr ""
 
 #: data.cpp:586
-msgid "Diphda"
+msgid "Algenib"
 msgstr ""
 
 #: data.cpp:587
-msgid "Deneb Kaitos"
+msgid "Citadelle"
 msgstr ""
 
 #: data.cpp:588
-msgid "Cocibolca"
+msgid "Schemali"
 msgstr ""
 
 #: data.cpp:589
-msgid "Achird"
+msgid "Ankaa"
 msgstr ""
 
 #: data.cpp:590
-msgid "Van Maanen 2"
+msgid "Felixvarela"
 msgstr ""
 
 #: data.cpp:591
-msgid "Castula"
+msgid "Fulu"
 msgstr ""
 
 #: data.cpp:592
-msgid "Navi"
+msgid "Schedar"
 msgstr ""
 
 #: data.cpp:593
-msgid "Nenque"
+msgid "Shedir"
 msgstr ""
 
 #: data.cpp:594
-msgid "Wurren"
+msgid "Diphda"
 msgstr ""
 
 #: data.cpp:595
-msgid "Mirach"
+msgid "Deneb Kaitos"
 msgstr ""
 
 #: data.cpp:596
-msgid "Emiw"
+msgid "Cocibolca"
 msgstr ""
 
 #: data.cpp:597
-msgid "Revati"
+msgid "Achird"
 msgstr ""
 
 #: data.cpp:598
-msgid "Adhil"
+msgid "Van Maanen 2"
 msgstr ""
 
 #: data.cpp:599
-msgid "Bélénos"
+msgid "Castula"
 msgstr ""
 
 #: data.cpp:600
-msgid "Ruchbah"
+msgid "Navi"
 msgstr ""
 
 #: data.cpp:601
-msgid "Alpherg"
+msgid "Nenque"
 msgstr ""
 
 #: data.cpp:602
-msgid "Titawin"
+msgid "Wurren"
 msgstr ""
 
 #: data.cpp:603
-msgid "Achernar"
+msgid "Mirach"
 msgstr ""
 
 #: data.cpp:604
-msgid "Nembus"
+msgid "Emiw"
 msgstr ""
 
 #: data.cpp:605
-msgid "Torcular"
+msgid "Revati"
 msgstr ""
 
 #: data.cpp:606
-msgid "Torcularis Septentrionalis"
+msgid "Adhil"
 msgstr ""
 
 #: data.cpp:607
-msgid "Baten Kaitos"
+msgid "Bélénos"
 msgstr ""
 
 #: data.cpp:608
-msgid "Mothallah"
+msgid "Ruchbah"
 msgstr ""
 
 #: data.cpp:609
-msgid "Caput Trianguli"
+msgid "Alpherg"
 msgstr ""
 
 #: data.cpp:610
-msgid "Mesarthim"
+msgid "Titawin"
 msgstr ""
 
 #: data.cpp:611
-msgid "Segin"
+msgid "Achernar"
 msgstr ""
 
 #: data.cpp:612
-msgid "Sheratan"
+msgid "Nembus"
 msgstr ""
 
 #: data.cpp:613
-msgid "Alrescha"
+msgid "Torcular"
 msgstr ""
 
 #: data.cpp:614
-msgid "Al Rescha"
+msgid "Torcularis Septentrionalis"
 msgstr ""
 
 #: data.cpp:615
-msgid "Almach"
+msgid "Baten Kaitos"
 msgstr ""
 
 #: data.cpp:616
-msgid "Almaak"
+msgid "Mothallah"
 msgstr ""
 
 #: data.cpp:617
-msgid "Alamak"
+msgid "Caput Trianguli"
 msgstr ""
 
 #: data.cpp:618
-msgid "Hamal"
+msgid "Mesarthim"
 msgstr ""
 
 #: data.cpp:619
-msgid "Mira"
+msgid "Segin"
 msgstr ""
 
 #: data.cpp:620
-msgid "Polaris"
+msgid "Sheratan"
 msgstr ""
 
 #: data.cpp:621
-msgid "Buna"
+msgid "Alrescha"
 msgstr ""
 
 #: data.cpp:622
-msgid "Kaffaljidhma"
+msgid "Al Rescha"
 msgstr ""
 
 #: data.cpp:623
-msgid "Koeia"
+msgid "Almach"
 msgstr ""
 
 #: data.cpp:624
-msgid "Lilii Borea"
+msgid "Almaak"
 msgstr ""
 
 #: data.cpp:625
-msgid "Nushagak"
+msgid "Alamak"
 msgstr ""
 
 #: data.cpp:626
-msgid "Bharani"
+msgid "Hamal"
 msgstr ""
 
 #: data.cpp:627
-msgid "Miram"
+msgid "Mira"
 msgstr ""
 
 #: data.cpp:628
-msgid "Angetenar"
+msgid "Polaris"
 msgstr ""
 
 #: data.cpp:629
-msgid "Azha"
+msgid "Buna"
 msgstr ""
 
 #: data.cpp:630
-msgid "Acamar"
+msgid "Kaffaljidhma"
 msgstr ""
 
 #: data.cpp:631
-msgid "Ayeyarwady"
+msgid "Koeia"
 msgstr ""
 
 #: data.cpp:632
-msgid "Menkar"
+msgid "Lilii Borea"
 msgstr ""
 
 #: data.cpp:633
-msgid "Menkab"
+msgid "Nushagak"
 msgstr ""
 
 #: data.cpp:634
-msgid "Algol"
+msgid "Bharani"
 msgstr ""
 
 #: data.cpp:635
-msgid "Misam"
+msgid "Miram"
 msgstr ""
 
 #: data.cpp:636
-msgid "Botein"
+msgid "Angetenar"
 msgstr ""
 
 #: data.cpp:637
-msgid "Dalim"
+msgid "Azha"
 msgstr ""
 
 #: data.cpp:638
-msgid "Zibal"
+msgid "Acamar"
 msgstr ""
 
 #: data.cpp:639
-msgid "Intan"
+msgid "Ayeyarwady"
 msgstr ""
 
 #: data.cpp:640
-msgid "Mirfak"
+msgid "Menkar"
 msgstr ""
 
 #: data.cpp:641
-msgid "Mirphak"
+msgid "Menkab"
 msgstr ""
 
 #: data.cpp:642
-msgid "Marfak"
+msgid "Algol"
 msgstr ""
 
 #: data.cpp:643
-msgid "Ran"
+msgid "Misam"
 msgstr ""
 
 #: data.cpp:644
-msgid "Tupi"
+msgid "Botein"
 msgstr ""
 
 #: data.cpp:645
-msgid "Rana"
+msgid "Dalim"
 msgstr ""
 
 #: data.cpp:646
-msgid "Atik"
+msgid "Zibal"
 msgstr ""
 
 #: data.cpp:647
-msgid "Celaeno"
+msgid "Intan"
 msgstr ""
 
 #: data.cpp:648
-msgid "Electra"
+msgid "Mirfak"
 msgstr ""
 
 #: data.cpp:649
-msgid "Taygeta"
+msgid "Mirphak"
 msgstr ""
 
 #: data.cpp:650
-msgid "Maia"
+msgid "Marfak"
 msgstr ""
 
 #: data.cpp:651
-msgid "Asterope"
+msgid "Ran"
 msgstr ""
 
 #: data.cpp:652
-msgid "Merope"
+msgid "Tupi"
 msgstr ""
 
 #: data.cpp:653
-msgid "Alcyone"
+msgid "Rana"
 msgstr ""
 
 #: data.cpp:654
-msgid "Pleione"
+msgid "Atik"
 msgstr ""
 
 #: data.cpp:655
-msgid "Zaurak"
+msgid "Celaeno"
 msgstr ""
 
 #: data.cpp:656
-msgid "Menkib"
+msgid "Electra"
 msgstr ""
 
 #: data.cpp:657
-msgid "Beid"
+msgid "Taygeta"
 msgstr ""
 
 #: data.cpp:658
-msgid "Keid"
+msgid "Maia"
 msgstr ""
 
 #: data.cpp:659
-msgid "Prima Hyadum"
+msgid "Asterope"
 msgstr ""
 
 #: data.cpp:660
-msgid "Secunda Hyadum"
+msgid "Merope"
 msgstr ""
 
 #: data.cpp:661
-msgid "Beemim"
+msgid "Alcyone"
 msgstr ""
 
 #: data.cpp:662
-msgid "Ain"
+msgid "Pleione"
 msgstr ""
 
 #: data.cpp:663
-msgid "Chamukuy"
+msgid "Zaurak"
 msgstr ""
 
 #: data.cpp:664
-msgid "Hoggar"
+msgid "Menkib"
 msgstr ""
 
 #: data.cpp:665
-msgid "Theemin"
+msgid "Beid"
 msgstr ""
 
 #: data.cpp:666
-msgid "Aldebaran"
+msgid "Keid"
 msgstr ""
 
 #: data.cpp:667
-msgid "Sceptrum"
+msgid "Prima Hyadum"
 msgstr ""
 
 #: data.cpp:668
-msgid "Tabit"
+msgid "Secunda Hyadum"
 msgstr ""
 
 #: data.cpp:669
-msgid "Mouhoun"
+msgid "Beemim"
 msgstr ""
 
 #: data.cpp:670
-msgid "Hassaleh"
+msgid "Ain"
 msgstr ""
 
 #: data.cpp:671
-msgid "Hind's Crimson Star"
+msgid "Chamukuy"
 msgstr ""
 
 #: data.cpp:672
-msgid "Almaaz"
+msgid "Hoggar"
 msgstr ""
 
 #: data.cpp:673
-msgid "Saclateni"
+msgid "Theemin"
 msgstr ""
 
 #: data.cpp:674
-msgid "Sadatoni"
+msgid "Aldebaran"
 msgstr ""
 
 #: data.cpp:675
-msgid "Haedus"
+msgid "Sceptrum"
 msgstr ""
 
 #: data.cpp:676
-msgid "Cursa"
+msgid "Tabit"
 msgstr ""
 
 #: data.cpp:677
-msgid "Mago"
+msgid "Mouhoun"
 msgstr ""
 
 #: data.cpp:678
-msgid "Kapteyn's Star"
+msgid "Hassaleh"
 msgstr ""
 
 #: data.cpp:679
-msgid "Rigel"
+msgid "Hind's Crimson Star"
 msgstr ""
 
 #: data.cpp:680
-msgid "Capella"
+msgid "Almaaz"
 msgstr ""
 
 #: data.cpp:681
-msgid "Bellatrix"
+msgid "Saclateni"
 msgstr ""
 
 #: data.cpp:682
-msgid "Elnath"
+msgid "Sadatoni"
 msgstr ""
 
 #: data.cpp:683
-msgid "Alnath"
+msgid "Haedus"
 msgstr ""
 
 #: data.cpp:684
-msgid "Nihal"
+msgid "Cursa"
 msgstr ""
 
 #: data.cpp:685
-msgid "Thabit"
+msgid "Mago"
 msgstr ""
 
 #: data.cpp:686
-msgid "Mintaka"
+msgid "Kapteyn's Star"
 msgstr ""
 
 #: data.cpp:687
-msgid "Arneb"
+msgid "Rigel"
 msgstr ""
 
 #: data.cpp:688
-msgid "Meissa"
+msgid "Capella"
 msgstr ""
 
 #: data.cpp:689
-msgid "Heka"
+msgid "Bellatrix"
 msgstr ""
 
 #: data.cpp:690
-msgid "Hatysa"
+msgid "Elnath"
 msgstr ""
 
 #: data.cpp:691
-msgid "Alnilam"
+msgid "Alnath"
 msgstr ""
 
 #: data.cpp:692
-msgid "Bubup"
+msgid "Nihal"
 msgstr ""
 
 #: data.cpp:693
-msgid "Tianguan"
+msgid "Thabit"
 msgstr ""
 
 #: data.cpp:694
-msgid "Phact"
+msgid "Mintaka"
 msgstr ""
 
 #: data.cpp:695
-msgid "Alnitak"
+msgid "Arneb"
 msgstr ""
 
 #: data.cpp:696
-msgid "Saiph"
+msgid "Meissa"
 msgstr ""
 
 #: data.cpp:697
-msgid "Wazn"
+msgid "Heka"
 msgstr ""
 
 #: data.cpp:698
-msgid "Betelgeuse"
+msgid "Hatysa"
 msgstr ""
 
 #: data.cpp:699
-msgid "Prijipati"
+msgid "Alnilam"
 msgstr ""
 
 #: data.cpp:700
-msgid "Menkalinan"
+msgid "Bubup"
 msgstr ""
 
 #: data.cpp:701
-msgid "Mahasim"
+msgid "Tianguan"
 msgstr ""
 
 #: data.cpp:702
-msgid "Elkurud"
+msgid "Phact"
 msgstr ""
 
 #: data.cpp:703
-msgid "Amadioha"
+msgid "Alnitak"
 msgstr ""
 
 #: data.cpp:704
-msgid "Propus"
+msgid "Saiph"
 msgstr ""
 
 #: data.cpp:705
-msgid "Red Rectangle"
+msgid "Wazn"
 msgstr ""
 
 #: data.cpp:706
-msgid "Furud"
+msgid "Betelgeuse"
 msgstr ""
 
 #: data.cpp:707
-msgid "Mirzam"
+msgid "Prijipati"
 msgstr ""
 
 #: data.cpp:708
-msgid "Murzim"
+msgid "Menkalinan"
 msgstr ""
 
 #: data.cpp:709
-msgid "Tejat"
+msgid "Mahasim"
 msgstr ""
 
 #: data.cpp:710
-msgid "Canopus"
+msgid "Elkurud"
 msgstr ""
 
 #: data.cpp:711
-msgid "Suhel"
+msgid "Amadioha"
 msgstr ""
 
 #: data.cpp:712
-msgid "Lucilinburhuc"
+msgid "Propus"
 msgstr ""
 
 #: data.cpp:713
-msgid "Lusitânia"
+msgid "Red Rectangle"
 msgstr ""
 
 #: data.cpp:714
-msgid "Plaskett's Star"
+msgid "Furud"
 msgstr ""
 
 #: data.cpp:715
-msgid "Alhena"
+msgid "Mirzam"
 msgstr ""
 
 #: data.cpp:716
-msgid "Almeisan"
+msgid "Murzim"
 msgstr ""
 
 #: data.cpp:717
-msgid "Nosaxa"
+msgid "Tejat"
 msgstr ""
 
 #: data.cpp:718
-msgid "Mebsuta"
+msgid "Canopus"
 msgstr ""
 
 #: data.cpp:719
-msgid "Sirius"
+msgid "Suhel"
 msgstr ""
 
 #: data.cpp:720
-msgid "Alzirr"
+msgid "Lucilinburhuc"
 msgstr ""
 
 #: data.cpp:721
-msgid "Nervia"
+msgid "Lusitânia"
 msgstr ""
 
 #: data.cpp:722
-msgid "Adhara"
+msgid "Plaskett's Star"
 msgstr ""
 
 #: data.cpp:723
-msgid "Adara"
+msgid "Alhena"
 msgstr ""
 
 #: data.cpp:724
-msgid "Citalá"
+msgid "Almeisan"
 msgstr ""
 
 #: data.cpp:725
-msgid "Unurgunite"
+msgid "Nosaxa"
 msgstr ""
 
 #: data.cpp:726
-msgid "Muliphein"
+msgid "Mebsuta"
 msgstr ""
 
 #: data.cpp:727
-msgid "Mekbuda"
+msgid "Sirius"
 msgstr ""
 
 #: data.cpp:728
-msgid "Wezen"
+msgid "Alzirr"
 msgstr ""
 
 #: data.cpp:729
-msgid "Bernes 135"
+msgid "Nervia"
 msgstr ""
 
 #: data.cpp:730
-msgid "Wasat"
+msgid "Adhara"
 msgstr ""
 
 #: data.cpp:731
-msgid "Aludra"
+msgid "Adara"
 msgstr ""
 
 #: data.cpp:732
-msgid "Gomeisa"
+msgid "Citalá"
 msgstr ""
 
 #: data.cpp:733
-msgid "Luyten's Star"
+msgid "Unurgunite"
 msgstr ""
 
 #: data.cpp:734
-msgid "Castor"
+msgid "Muliphein"
 msgstr ""
 
 #: data.cpp:735
-msgid "Jishui"
+msgid "Mekbuda"
 msgstr ""
 
 #: data.cpp:736
-msgid "Procyon"
+msgid "Wezen"
 msgstr ""
 
 #: data.cpp:737
-msgid "Elgomaisa"
+msgid "Bernes 135"
 msgstr ""
 
 #: data.cpp:738
-msgid "Ceibo"
+msgid "Wasat"
 msgstr ""
 
 #: data.cpp:739
-msgid "Pollux"
+msgid "Aludra"
 msgstr ""
 
 #: data.cpp:740
-msgid "Tapecue"
+msgid "Gomeisa"
 msgstr ""
 
 #: data.cpp:741
-msgid "Azmidi"
+msgid "Luyten's Star"
 msgstr ""
 
 #: data.cpp:742
-msgid "Asmidiske"
+msgid "Castor"
 msgstr ""
 
 #: data.cpp:743
-msgid "Naos"
+msgid "Jishui"
 msgstr ""
 
 #: data.cpp:744
-msgid "Tureis"
+msgid "Procyon"
 msgstr ""
 
 #: data.cpp:745
-msgid "Regor"
+msgid "Elgomaisa"
 msgstr ""
 
 #: data.cpp:746
-msgid "Tegmine"
+msgid "Ceibo"
 msgstr ""
 
 #: data.cpp:747
-msgid "Tarf"
+msgid "Pollux"
 msgstr ""
 
 #: data.cpp:748
-msgid "Al Tarf"
+msgid "Tapecue"
 msgstr ""
 
 #: data.cpp:749
-msgid "Násti"
+msgid "Azmidi"
 msgstr ""
 
 #: data.cpp:750
-msgid "Piautos"
+msgid "Asmidiske"
 msgstr ""
 
 #: data.cpp:751
-msgid "Avior"
+msgid "Naos"
 msgstr ""
 
 #: data.cpp:752
-msgid "Alsciaukat"
+msgid "Tureis"
 msgstr ""
 
 #: data.cpp:753
-msgid "Muscida"
+msgid "Regor"
 msgstr ""
 
 #: data.cpp:754
-msgid "Minchir"
+msgid "Tegmine"
 msgstr ""
 
 #: data.cpp:755
-msgid "Gakyid"
+msgid "Tarf"
 msgstr ""
 
 #: data.cpp:756
-msgid "Meleph"
+msgid "Al Tarf"
 msgstr ""
 
 #: data.cpp:757
-msgid "Asellus Borealis"
+msgid "Násti"
 msgstr ""
 
 #: data.cpp:758
-msgid "Asellus Australis"
+msgid "Piautos"
 msgstr ""
 
 #: data.cpp:759
-msgid "Alsephina"
+msgid "Avior"
 msgstr ""
 
 #: data.cpp:760
-msgid "Ashlesha"
+msgid "Alsciaukat"
 msgstr ""
 
 #: data.cpp:761
-msgid "Copernicus"
+msgid "Muscida"
 msgstr ""
 
 #: data.cpp:762
-msgid "Stribor"
+msgid "Minchir"
 msgstr ""
 
 #: data.cpp:763
-msgid "Acubens"
+msgid "Gakyid"
 msgstr ""
 
 #: data.cpp:764
-msgid "Talitha"
+msgid "Meleph"
 msgstr ""
 
 #: data.cpp:765
-msgid "Dnoces"
+msgid "Asellus Borealis"
 msgstr ""
 
 #: data.cpp:766
-msgid "Alkaphrah"
+msgid "Asellus Australis"
 msgstr ""
 
 #: data.cpp:767
-msgid "Talitha Australis"
+msgid "Alsephina"
 msgstr ""
 
 #: data.cpp:768
-msgid "Suhail"
+msgid "Ashlesha"
 msgstr ""
 
 #: data.cpp:769
-msgid "Nahn"
+msgid "Copernicus"
 msgstr ""
 
 #: data.cpp:770
-msgid "Miaplacidus"
+msgid "Stribor"
 msgstr ""
 
 #: data.cpp:771
-msgid "Aspidiske"
+msgid "Acubens"
 msgstr ""
 
 #: data.cpp:772
-msgid "Markeb"
+msgid "Talitha"
 msgstr ""
 
 #: data.cpp:773
-msgid "Alphard"
+msgid "Dnoces"
 msgstr ""
 
 #: data.cpp:774
-msgid "Cor Hydrae"
+msgid "Alkaphrah"
 msgstr ""
 
 #: data.cpp:775
-msgid "Intercrus"
+msgid "Talitha Australis"
 msgstr ""
 
 #: data.cpp:776
-msgid "Alterf"
+msgid "Suhail"
 msgstr ""
 
 #: data.cpp:777
-msgid "Illyrian"
+msgid "Nahn"
 msgstr ""
 
 #: data.cpp:778
-msgid "Kalausi"
+msgid "Miaplacidus"
 msgstr ""
 
 #: data.cpp:779
-msgid "Ukdah"
+msgid "Aspidiske"
 msgstr ""
 
 #: data.cpp:780
-msgid "Subra"
+msgid "Markeb"
 msgstr ""
 
 #: data.cpp:781
-msgid "Ras Elased Australis"
+msgid "Alphard"
 msgstr ""
 
 #: data.cpp:782
-msgid "Natasha"
+msgid "Cor Hydrae"
 msgstr ""
 
 #: data.cpp:783
-msgid "Zhang"
+msgid "Intercrus"
 msgstr ""
 
 #: data.cpp:784
-msgid "Rasalas"
+msgid "Alterf"
 msgstr ""
 
 #: data.cpp:785
-msgid "Ras Elased Borealis"
+msgid "Illyrian"
 msgstr ""
 
 #: data.cpp:786
-msgid "Felis"
+msgid "Kalausi"
 msgstr ""
 
 #: data.cpp:787
-msgid "Bibhā"
+msgid "Ukdah"
 msgstr ""
 
 #: data.cpp:788
-msgid "Regulus"
+msgid "Subra"
 msgstr ""
 
 #: data.cpp:789
-msgid "Kabeleced"
+msgid "Ras Elased Australis"
 msgstr ""
 
 #: data.cpp:790
-msgid "Cor Leonis"
+msgid "Natasha"
 msgstr ""
 
 #: data.cpp:791
-msgid "Adhafera"
+msgid "Zhang"
 msgstr ""
 
 #: data.cpp:792
-msgid "Aldhafera"
+msgid "Rasalas"
 msgstr ""
 
 #: data.cpp:793
-msgid "Tania Borealis"
+msgid "Ras Elased Borealis"
 msgstr ""
 
 #: data.cpp:794
-msgid "Algieba"
+msgid "Felis"
 msgstr ""
 
 #: data.cpp:795
-msgid "Tania Australis"
+msgid "Bibhā"
 msgstr ""
 
 #: data.cpp:796
-msgid "Macondo"
+msgid "Regulus"
 msgstr ""
 
 #: data.cpp:797
-msgid "Praecipua"
+msgid "Kabeleced"
 msgstr ""
 
 #: data.cpp:798
-msgid "Chalawan"
+msgid "Cor Leonis"
 msgstr ""
 
 #: data.cpp:799
-msgid "Alkes"
+msgid "Adhafera"
 msgstr ""
 
 #: data.cpp:800
-msgid "Merak"
+msgid "Aldhafera"
 msgstr ""
 
 #: data.cpp:801
-msgid "Lalande 21185"
+msgid "Tania Borealis"
 msgstr ""
 
 #: data.cpp:802
-msgid "Dubhe"
+msgid "Algieba"
 msgstr ""
 
 #: data.cpp:803
-msgid "Dubb"
+msgid "Tania Australis"
 msgstr ""
 
 #: data.cpp:804
-msgid "Dingolay"
+msgid "Macondo"
 msgstr ""
 
 #: data.cpp:805
-msgid "Zosma"
+msgid "Praecipua"
 msgstr ""
 
 #: data.cpp:806
-msgid "Duhr"
+msgid "Chalawan"
 msgstr ""
 
 #: data.cpp:807
-msgid "Chertan"
+msgid "Alkes"
 msgstr ""
 
 #: data.cpp:808
-msgid "Coxa"
+msgid "Merak"
 msgstr ""
 
 #: data.cpp:809
-msgid "Chort"
+msgid "Lalande 21185"
 msgstr ""
 
 #: data.cpp:810
-msgid "Innes' Star"
+msgid "Dubhe"
 msgstr ""
 
 #: data.cpp:811
-msgid "Hunahpú"
+msgid "Dubb"
 msgstr ""
 
 #: data.cpp:812
-msgid "Alula Australis"
+msgid "Dingolay"
 msgstr ""
 
 #: data.cpp:813
-msgid "Alula Borealis"
+msgid "Zosma"
 msgstr ""
 
 #: data.cpp:814
-msgid "Tsze Tseang"
+msgid "Duhr"
 msgstr ""
 
 #: data.cpp:815
-msgid "Shama"
+msgid "Chertan"
 msgstr ""
 
 #: data.cpp:816
-msgid "Giausar"
+msgid "Coxa"
 msgstr ""
 
 #: data.cpp:817
-msgid "Formosa"
+msgid "Chort"
 msgstr ""
 
 #: data.cpp:818
-msgid "Sagarmatha"
+msgid "Innes' Star"
 msgstr ""
 
 #: data.cpp:819
-msgid "Przybylski's Star"
+msgid "Hunahpú"
 msgstr ""
 
 #: data.cpp:820
-msgid "Uklun"
+msgid "Alula Australis"
 msgstr ""
 
 #: data.cpp:821
-msgid "Flegetonte"
+msgid "Alula Borealis"
 msgstr ""
 
 #: data.cpp:822
-msgid "Taiyangshou"
+msgid "Tsze Tseang"
 msgstr ""
 
 #: data.cpp:823
-msgid "Denebola"
+msgid "Shama"
 msgstr ""
 
 #: data.cpp:824
-msgid "Zavijava"
+msgid "Giausar"
 msgstr ""
 
 #: data.cpp:825
-msgid "Alaraph"
+msgid "Formosa"
 msgstr ""
 
 #: data.cpp:826
-msgid "Aniara"
+msgid "Sagarmatha"
 msgstr ""
 
 #: data.cpp:827
-msgid "Groombridge 1830"
+msgid "Przybylski's Star"
 msgstr ""
 
 #: data.cpp:828
-msgid "Phecda"
+msgid "Uklun"
 msgstr ""
 
 #: data.cpp:829
-msgid "Phad"
+msgid "Flegetonte"
 msgstr ""
 
 #: data.cpp:830
-msgid "Tonatiuh"
+msgid "Taiyangshou"
 msgstr ""
 
 #: data.cpp:831
-msgid "Alchiba"
+msgid "Denebola"
 msgstr ""
 
 #: data.cpp:832
-msgid "Imai"
+msgid "Zavijava"
 msgstr ""
 
 #: data.cpp:833
-msgid "Megrez"
+msgid "Alaraph"
 msgstr ""
 
 #: data.cpp:834
-msgid "Gienah"
+msgid "Aniara"
 msgstr ""
 
 #: data.cpp:835
-msgid "Zaniah"
+msgid "Groombridge 1830"
 msgstr ""
 
 #: data.cpp:836
-msgid "Ginan"
+msgid "Phecda"
 msgstr ""
 
 #: data.cpp:837
-msgid "Tupã"
+msgid "Phad"
 msgstr ""
 
 #: data.cpp:838
-msgid "Acrux"
+msgid "Tonatiuh"
 msgstr ""
 
 #: data.cpp:839
-msgid "Algorab"
+msgid "Alchiba"
 msgstr ""
 
 #: data.cpp:840
-msgid "Gacrux"
+msgid "Imai"
 msgstr ""
 
 #: data.cpp:841
-msgid "Funi"
+msgid "Megrez"
 msgstr ""
 
 #: data.cpp:842
-msgid "Chara"
+msgid "Gienah"
 msgstr ""
 
 #: data.cpp:843
-msgid "Kraz"
+msgid "Zaniah"
 msgstr ""
 
 #: data.cpp:844
-msgid "Muhlifain"
+msgid "Ginan"
 msgstr ""
 
 #: data.cpp:845
-msgid "Porrima"
+msgid "Tupã"
 msgstr ""
 
 #: data.cpp:846
-msgid "La Superba"
+msgid "Acrux"
 msgstr ""
 
 #: data.cpp:847
-msgid "Tianyi"
+msgid "Algorab"
 msgstr ""
 
 #: data.cpp:848
-msgid "Mimosa"
+msgid "Gacrux"
 msgstr ""
 
 #: data.cpp:849
-msgid "Alioth"
+msgid "Funi"
 msgstr ""
 
 #: data.cpp:850
-msgid "Taiyi"
+msgid "Chara"
 msgstr ""
 
 #: data.cpp:851
-msgid "Minelauva"
+msgid "Kraz"
 msgstr ""
 
 #: data.cpp:852
-msgid "Auva"
+msgid "Muhlifain"
 msgstr ""
 
 #: data.cpp:853
-msgid "Cor Caroli"
+msgid "Porrima"
 msgstr ""
 
 #: data.cpp:854
-msgid "Vindemiatrix"
+msgid "La Superba"
 msgstr ""
 
 #: data.cpp:855
-msgid "Almuredin"
+msgid "Tianyi"
 msgstr ""
 
 #: data.cpp:856
-msgid "Diadem"
+msgid "Mimosa"
 msgstr ""
 
 #: data.cpp:857
-msgid "Mizar"
+msgid "Alioth"
 msgstr ""
 
 #: data.cpp:858
-msgid "Spica"
+msgid "Taiyi"
 msgstr ""
 
 #: data.cpp:859
-msgid "Azimech"
+msgid "Minelauva"
 msgstr ""
 
 #: data.cpp:860
-msgid "Alcor"
+msgid "Auva"
 msgstr ""
 
 #: data.cpp:861
-msgid "Dofida"
+msgid "Cor Caroli"
 msgstr ""
 
 #: data.cpp:862
-msgid "Liesma"
+msgid "Vindemiatrix"
 msgstr ""
 
 #: data.cpp:863
-msgid "Heze"
+msgid "Almuredin"
 msgstr ""
 
 #: data.cpp:864
-msgid "Alkaid"
+msgid "Diadem"
 msgstr ""
 
 #: data.cpp:865
-msgid "Benetnasch"
+msgid "Mizar"
 msgstr ""
 
 #: data.cpp:866
-msgid "Muphrid"
+msgid "Spica"
 msgstr ""
 
 #: data.cpp:867
-msgid "Hadar"
+msgid "Azimech"
 msgstr ""
 
 #: data.cpp:868
-msgid "Agena"
+msgid "Alcor"
 msgstr ""
 
 #: data.cpp:869
-msgid "Thuban"
+msgid "Dofida"
 msgstr ""
 
 #: data.cpp:870
-msgid "Menkent"
+msgid "Liesma"
 msgstr ""
 
 #: data.cpp:871
-msgid "Kang"
+msgid "Heze"
 msgstr ""
 
 #: data.cpp:872
-msgid "Arcturus"
+msgid "Alkaid"
 msgstr ""
 
 #: data.cpp:873
-msgid "Syrma"
+msgid "Benetnasch"
 msgstr ""
 
 #: data.cpp:874
-msgid "Xuange"
+msgid "Muphrid"
 msgstr ""
 
 #: data.cpp:875
-msgid "Elgafar"
+msgid "Hadar"
 msgstr ""
 
 #: data.cpp:876
-msgid "Proxima"
+msgid "Agena"
 msgstr ""
 
 #: data.cpp:877
-msgid "Seginus"
+msgid "Thuban"
 msgstr ""
 
 #: data.cpp:878
-msgid "Ceginus"
+msgid "Menkent"
 msgstr ""
 
 #: data.cpp:879
-msgid "Toliman"
+msgid "Kang"
 msgstr ""
 
 #: data.cpp:880
-msgid "Rigil Kentaurus"
+msgid "Arcturus"
 msgstr ""
 
 #: data.cpp:881
-msgid "Izar"
+msgid "Syrma"
 msgstr ""
 
 #: data.cpp:882
-msgid "Mirak"
+msgid "Xuange"
 msgstr ""
 
 #: data.cpp:883
-msgid "Pulcherrima"
+msgid "Elgafar"
 msgstr ""
 
 #: data.cpp:884
-msgid "Mönch"
+msgid "Proxima"
 msgstr ""
 
 #: data.cpp:885
-msgid "Merga"
+msgid "Seginus"
 msgstr ""
 
 #: data.cpp:886
-msgid "Kochab"
+msgid "Ceginus"
 msgstr ""
 
 #: data.cpp:887
-msgid "Kocab"
+msgid "Toliman"
 msgstr ""
 
 #: data.cpp:888
-msgid "Zubenelgenubi"
+msgid "Rigil Kentaurus"
 msgstr ""
 
 #: data.cpp:889
-msgid "Arcalís"
+msgid "Izar"
 msgstr ""
 
 #: data.cpp:890
-msgid "Baekdu"
+msgid "Mirak"
 msgstr ""
 
 #: data.cpp:891
-msgid "Zuben Elakribi"
+msgid "Pulcherrima"
 msgstr ""
 
 #: data.cpp:892
-msgid "Nekkar"
+msgid "Mönch"
 msgstr ""
 
 #: data.cpp:893
-msgid "Brachium"
+msgid "Merga"
 msgstr ""
 
 #: data.cpp:894
-msgid "Zubeneschamali"
+msgid "Kochab"
 msgstr ""
 
 #: data.cpp:895
-msgid "Pherkad Minor"
+msgid "Kocab"
 msgstr ""
 
 #: data.cpp:896
-msgid "Nikawiy"
+msgid "Zubenelgenubi"
 msgstr ""
 
 #: data.cpp:897
-msgid "Pherkad"
+msgid "Arcalís"
 msgstr ""
 
 #: data.cpp:898
-msgid "Alkalurops"
+msgid "Baekdu"
 msgstr ""
 
 #: data.cpp:899
-msgid "Edasich"
+msgid "Zuben Elakribi"
 msgstr ""
 
 #: data.cpp:900
-msgid "Nusakan"
+msgid "Nekkar"
 msgstr ""
 
 #: data.cpp:901
-msgid "Alphecca"
+msgid "Brachium"
 msgstr ""
 
 #: data.cpp:902
-msgid "Gemma"
+msgid "Zubeneschamali"
 msgstr ""
 
 #: data.cpp:903
-msgid "Zubenelhakrabi"
+msgid "Pherkad Minor"
 msgstr ""
 
 #: data.cpp:904
-msgid "Zuben Elakrab"
+msgid "Nikawiy"
 msgstr ""
 
 #: data.cpp:905
-msgid "Karaka"
+msgid "Pherkad"
 msgstr ""
 
 #: data.cpp:906
-msgid "Unukalhai"
+msgid "Alkalurops"
 msgstr ""
 
 #: data.cpp:907
-msgid "Chow"
+msgid "Edasich"
 msgstr ""
 
 #: data.cpp:908
-msgid "Gudja"
+msgid "Nusakan"
 msgstr ""
 
 #: data.cpp:909
-msgid "Iklil"
+msgid "Alphecca"
 msgstr ""
 
 #: data.cpp:910
-msgid "Fang"
+msgid "Gemma"
 msgstr ""
 
 #: data.cpp:911
-msgid "Dschubba"
+msgid "Zubenelhakrabi"
 msgstr ""
 
 #: data.cpp:912
-msgid "Acrab"
+msgid "Zuben Elakrab"
 msgstr ""
 
 #: data.cpp:913
-msgid "Graffias"
+msgid "Karaka"
 msgstr ""
 
 #: data.cpp:914
-msgid "Akrab"
+msgid "Unukalhai"
 msgstr ""
 
 #: data.cpp:915
-msgid "Marsic"
+msgid "Chow"
 msgstr ""
 
 #: data.cpp:916
-msgid "Jabbah"
+msgid "Gudja"
 msgstr ""
 
 #: data.cpp:917
-msgid "Sharjah"
+msgid "Iklil"
 msgstr ""
 
 #: data.cpp:918
-msgid "Yed Prior"
+msgid "Fang"
 msgstr ""
 
 #: data.cpp:919
-msgid "Yed Posterior"
+msgid "Dschubba"
 msgstr ""
 
 #: data.cpp:920
-msgid "Hunor"
+msgid "Acrab"
 msgstr ""
 
 #: data.cpp:921
-msgid "Alniyat"
+msgid "Graffias"
 msgstr ""
 
 #: data.cpp:922
-msgid "Al Niyat"
+msgid "Akrab"
 msgstr ""
 
 #: data.cpp:923
-msgid "Athebyne"
+msgid "Marsic"
 msgstr ""
 
 #: data.cpp:924
-msgid "Cujam"
+msgid "Jabbah"
 msgstr ""
 
 #: data.cpp:925
-msgid "Timir"
+msgid "Sharjah"
 msgstr ""
 
 #: data.cpp:926
-msgid "Antares"
+msgid "Yed Prior"
 msgstr ""
 
 #: data.cpp:927
-msgid "Kornephoros"
+msgid "Yed Posterior"
 msgstr ""
 
 #: data.cpp:928
-msgid "Ogma"
+msgid "Hunor"
 msgstr ""
 
 #: data.cpp:929
-msgid "Marfik"
+msgid "Alniyat"
 msgstr ""
 
 #: data.cpp:930
-msgid "Rosalíadecastro"
+msgid "Al Niyat"
 msgstr ""
 
 #: data.cpp:931
-msgid "Paikauhale"
+msgid "Athebyne"
 msgstr ""
 
 #: data.cpp:932
-msgid "Atria"
+msgid "Cujam"
 msgstr ""
 
 #: data.cpp:933
-msgid "Larawag"
+msgid "Timir"
 msgstr ""
 
 #: data.cpp:934
-msgid "Xamidimura"
+msgid "Antares"
 msgstr ""
 
 #: data.cpp:935
-msgid "Pipirima"
+msgid "Kornephoros"
 msgstr ""
 
 #: data.cpp:936
-msgid "Mahsati"
+msgid "Ogma"
 msgstr ""
 
 #: data.cpp:937
-msgid "Rapeto"
+msgid "Marfik"
 msgstr ""
 
 #: data.cpp:938
-msgid "Alrakis"
+msgid "Rosalíadecastro"
 msgstr ""
 
 #: data.cpp:939
-msgid "Arrakis"
+msgid "Paikauhale"
 msgstr ""
 
 #: data.cpp:940
-msgid "Aldhibah"
+msgid "Atria"
 msgstr ""
 
 #: data.cpp:941
-msgid "Sabik"
+msgid "Larawag"
 msgstr ""
 
 #: data.cpp:942
-msgid "Rasalgethi"
+msgid "Xamidimura"
 msgstr ""
 
 #: data.cpp:943
-msgid "Ras Algethi"
+msgid "Pipirima"
 msgstr ""
 
 #: data.cpp:944
-msgid "Sarin"
+msgid "Mahsati"
 msgstr ""
 
 #: data.cpp:945
-msgid "Guniibuu"
+msgid "Rapeto"
 msgstr ""
 
 #: data.cpp:946
-msgid "Inquill"
+msgid "Alrakis"
 msgstr ""
 
 #: data.cpp:947
-msgid "Rastaban"
+msgid "Arrakis"
 msgstr ""
 
 #: data.cpp:948
-msgid "Maasym"
+msgid "Aldhibah"
 msgstr ""
 
 #: data.cpp:949
-msgid "Lesath"
+msgid "Sabik"
 msgstr ""
 
 #: data.cpp:950
-msgid "Lesuth"
+msgid "Rasalgethi"
 msgstr ""
 
 #: data.cpp:951
-msgid "Kuma"
+msgid "Ras Algethi"
 msgstr ""
 
 #: data.cpp:952
-msgid "Yildun"
+msgid "Sarin"
 msgstr ""
 
 #: data.cpp:953
-msgid "Shaula"
+msgid "Guniibuu"
 msgstr ""
 
 #: data.cpp:954
-msgid "Rasalhague"
+msgid "Inquill"
 msgstr ""
 
 #: data.cpp:955
-msgid "Ras Alhague"
+msgid "Rastaban"
 msgstr ""
 
 #: data.cpp:956
-msgid "Sargas"
+msgid "Maasym"
 msgstr ""
 
 #: data.cpp:957
-msgid "Dziban"
+msgid "Lesath"
 msgstr ""
 
 #: data.cpp:958
-msgid "Girtab"
+msgid "Lesuth"
 msgstr ""
 
 #: data.cpp:959
-msgid "Cebalrai"
+msgid "Kuma"
 msgstr ""
 
 #: data.cpp:960
-msgid "Alruba"
+msgid "Yildun"
 msgstr ""
 
 #: data.cpp:961
-msgid "Cervantes"
+msgid "Shaula"
 msgstr ""
 
 #: data.cpp:962
-msgid "Fuyue"
+msgid "Rasalhague"
 msgstr ""
 
 #: data.cpp:963
-msgid "Grumium"
+msgid "Ras Alhague"
 msgstr ""
 
 #: data.cpp:964
-msgid "Eltanin"
+msgid "Sargas"
 msgstr ""
 
 #: data.cpp:965
-msgid "Etamin"
+msgid "Dziban"
 msgstr ""
 
 #: data.cpp:966
-msgid "Barnard's Star"
+msgid "Girtab"
 msgstr ""
 
 #: data.cpp:967
-msgid "Pincoya"
+msgid "Cebalrai"
 msgstr ""
 
 #: data.cpp:968
-msgid "Alnasl"
+msgid "Alruba"
 msgstr ""
 
 #: data.cpp:969
-msgid "Polis"
+msgid "Cervantes"
 msgstr ""
 
 #: data.cpp:970
-msgid "Kaus Media"
+msgid "Fuyue"
 msgstr ""
 
 #: data.cpp:971
-msgid "Alasia"
+msgid "Grumium"
 msgstr ""
 
 #: data.cpp:972
-msgid "Kaus Australis"
+msgid "Eltanin"
 msgstr ""
 
 #: data.cpp:973
-msgid "Al Athfar"
+msgid "Etamin"
 msgstr ""
 
 #: data.cpp:974
-msgid "Fafnir"
+msgid "Barnard's Star"
 msgstr ""
 
 #: data.cpp:975
-msgid "Kaus Borealis"
+msgid "Pincoya"
 msgstr ""
 
 #: data.cpp:976
-msgid "Vega"
+msgid "Alnasl"
 msgstr ""
 
 #: data.cpp:977
-msgid "Xihe"
+msgid "Polis"
 msgstr ""
 
 #: data.cpp:978
-msgid "Sheliak"
+msgid "Kaus Media"
 msgstr ""
 
 #: data.cpp:979
-msgid "Ainalrami"
+msgid "Alasia"
 msgstr ""
 
 #: data.cpp:980
-msgid "Nunki"
+msgid "Kaus Australis"
 msgstr ""
 
 #: data.cpp:981
-msgid "Kaveh"
+msgid "Al Athfar"
 msgstr ""
 
 #: data.cpp:982
-msgid "Alya"
+msgid "Fafnir"
 msgstr ""
 
 #: data.cpp:983
-msgid "Sulafat"
+msgid "Kaus Borealis"
 msgstr ""
 
 #: data.cpp:984
-msgid "Ascella"
+msgid "Vega"
 msgstr ""
 
 #: data.cpp:985
-msgid "Okab"
+msgid "Xihe"
 msgstr ""
 
 #: data.cpp:986
-msgid "Deneb el Okab"
+msgid "Sheliak"
 msgstr ""
 
 #: data.cpp:987
-msgid "Meridiana"
+msgid "Ainalrami"
 msgstr ""
 
 #: data.cpp:988
-msgid "Albaldah"
+msgid "Nunki"
 msgstr ""
 
 #: data.cpp:989
-msgid "Altais"
+msgid "Kaveh"
 msgstr ""
 
 #: data.cpp:990
-msgid "Al Tais"
+msgid "Alya"
 msgstr ""
 
 #: data.cpp:991
-msgid "Nodus Secundus"
+msgid "Sulafat"
 msgstr ""
 
 #: data.cpp:992
-msgid "Aladfar"
+msgid "Ascella"
 msgstr ""
 
 #: data.cpp:993
-msgid "Gumala"
+msgid "Okab"
 msgstr ""
 
 #: data.cpp:994
-msgid "Belel"
+msgid "Deneb el Okab"
 msgstr ""
 
 #: data.cpp:995
-msgid "Arkab Prior"
+msgid "Meridiana"
 msgstr ""
 
 #: data.cpp:996
-msgid "Arkab"
+msgid "Albaldah"
 msgstr ""
 
 #: data.cpp:997
-msgid "Sika"
+msgid "Altais"
 msgstr ""
 
 #: data.cpp:998
-msgid "Arkab Posterior"
+msgid "Al Tais"
 msgstr ""
 
 #: data.cpp:999
-msgid "Rukbat"
+msgid "Nodus Secundus"
 msgstr ""
 
 #: data.cpp:1000
-msgid "Anser"
+msgid "Aladfar"
 msgstr ""
 
 #: data.cpp:1001
-msgid "Albireo"
+msgid "Gumala"
 msgstr ""
 
 #: data.cpp:1002
-msgid "Uruk"
+msgid "Belel"
 msgstr ""
 
 #: data.cpp:1003
-msgid "Alsafi"
+msgid "Arkab Prior"
 msgstr ""
 
 #: data.cpp:1004
-msgid "Campbell's Star"
+msgid "Arkab"
 msgstr ""
 
 #: data.cpp:1005
-msgid "Sham"
+msgid "Sika"
 msgstr ""
 
 #: data.cpp:1006
-msgid "Fawaris"
+msgid "Arkab Posterior"
 msgstr ""
 
 #: data.cpp:1007
-msgid "Tarazed"
+msgid "Rukbat"
 msgstr ""
 
 #: data.cpp:1008
-msgid "Tyl"
+msgid "Anser"
 msgstr ""
 
 #: data.cpp:1009
-msgid "Altair"
+msgid "Albireo"
 msgstr ""
 
 #: data.cpp:1010
-msgid "Atair"
+msgid "Uruk"
 msgstr ""
 
 #: data.cpp:1011
-msgid "Libertas"
+msgid "Alsafi"
 msgstr ""
 
 #: data.cpp:1012
-msgid "Alshain"
+msgid "Campbell's Star"
 msgstr ""
 
 #: data.cpp:1013
-msgid "Terebellum"
+msgid "Sham"
 msgstr ""
 
 #: data.cpp:1014
-msgid "Phoenicia"
+msgid "Fawaris"
 msgstr ""
 
 #: data.cpp:1015
-msgid "Chechia"
+msgid "Tarazed"
 msgstr ""
 
 #: data.cpp:1016
-msgid "Algedi"
+msgid "Tyl"
 msgstr ""
 
 #: data.cpp:1017
-msgid "Alshat"
+msgid "Altair"
 msgstr ""
 
 #: data.cpp:1018
-msgid "Dabih"
+msgid "Atair"
 msgstr ""
 
 #: data.cpp:1019
-msgid "Sadr"
+msgid "Libertas"
 msgstr ""
 
 #: data.cpp:1020
-msgid "Peacock"
+msgid "Alshain"
 msgstr ""
 
 #: data.cpp:1021
-msgid "Aldulfin"
+msgid "Terebellum"
 msgstr ""
 
 #: data.cpp:1022
-msgid "Rotanev"
+msgid "Phoenicia"
 msgstr ""
 
 #: data.cpp:1023
-msgid "Sualocin"
+msgid "Chechia"
 msgstr ""
 
 #: data.cpp:1024
-msgid "Deneb"
+msgid "Algedi"
 msgstr ""
 
 #: data.cpp:1025
-msgid "Aljanah"
+msgid "Alshat"
 msgstr ""
 
 #: data.cpp:1026
-msgid "Albali"
+msgid "Dabih"
 msgstr ""
 
 #: data.cpp:1027
-msgid "Musica"
+msgid "Sadr"
 msgstr ""
 
 #: data.cpp:1028
-msgid "Polaris Australis"
+msgid "Peacock"
 msgstr ""
 
 #: data.cpp:1029
-msgid "Solaris"
+msgid "Aldulfin"
 msgstr ""
 
 #: data.cpp:1030
-msgid "Kitalpha"
+msgid "Rotanev"
 msgstr ""
 
 #: data.cpp:1031
-msgid "Lacaille 8760"
+msgid "Sualocin"
 msgstr ""
 
 #: data.cpp:1032
-msgid "Alderamin"
+msgid "Deneb"
 msgstr ""
 
 #: data.cpp:1033
-msgid "Alfirk"
+msgid "Aljanah"
 msgstr ""
 
 #: data.cpp:1034
-msgid "Sadalsuud"
+msgid "Albali"
 msgstr ""
 
 #: data.cpp:1035
-msgid "Bunda"
+msgid "Musica"
 msgstr ""
 
 #: data.cpp:1036
-msgid "Sāmaya"
+msgid "Polaris Australis"
 msgstr ""
 
 #: data.cpp:1037
-msgid "Nashira"
+msgid "Solaris"
 msgstr ""
 
 #: data.cpp:1038
-msgid "Azelfafage"
+msgid "Kitalpha"
 msgstr ""
 
 #: data.cpp:1039
-msgid "Bosona"
+msgid "Lacaille 8760"
 msgstr ""
 
 #: data.cpp:1040
-msgid "Herschel's Garnet Star"
+msgid "Alderamin"
 msgstr ""
 
 #: data.cpp:1041
-msgid "Erakis"
+msgid "Alfirk"
 msgstr ""
 
 #: data.cpp:1042
-msgid "Enif"
+msgid "Sadalsuud"
 msgstr ""
 
 #: data.cpp:1043
-msgid "Deneb Algedi"
+msgid "Bunda"
 msgstr ""
 
 #: data.cpp:1044
-msgid "Aldhanab"
+msgid "Sāmaya"
 msgstr ""
 
 #: data.cpp:1045
-msgid "Al Dhanab"
+msgid "Nashira"
 msgstr ""
 
 #: data.cpp:1046
-msgid "Itonda"
+msgid "Azelfafage"
 msgstr ""
 
 #: data.cpp:1047
-msgid "Kurhah"
+msgid "Bosona"
 msgstr ""
 
 #: data.cpp:1048
-msgid "Sadalmelik"
+msgid "Herschel's Garnet Star"
 msgstr ""
 
 #: data.cpp:1049
-msgid "Alnair"
+msgid "Erakis"
 msgstr ""
 
 #: data.cpp:1050
-msgid "Al Nair"
+msgid "Enif"
 msgstr ""
 
 #: data.cpp:1051
-msgid "Biham"
+msgid "Deneb Algedi"
 msgstr ""
 
 #: data.cpp:1052
-msgid "Ancha"
+msgid "Aldhanab"
 msgstr ""
 
 #: data.cpp:1053
-msgid "Sadachbia"
+msgid "Al Dhanab"
 msgstr ""
 
 #: data.cpp:1054
-msgid "Seat"
+msgid "Itonda"
 msgstr ""
 
 #: data.cpp:1055
-msgid "Lionrock"
+msgid "Kurhah"
 msgstr ""
 
 #: data.cpp:1056
-msgid "Kruger 60"
+msgid "Sadalmelik"
 msgstr ""
 
 #: data.cpp:1057
-msgid "Situla"
+msgid "Alnair"
 msgstr ""
 
 #: data.cpp:1058
-msgid "Homam"
+msgid "Al Nair"
 msgstr ""
 
 #: data.cpp:1059
-msgid "Tiaki"
+msgid "Biham"
 msgstr ""
 
 #: data.cpp:1060
-msgid "Matar"
+msgid "Ancha"
 msgstr ""
 
 #: data.cpp:1061
-msgid "Babcock's Star"
+msgid "Sadachbia"
 msgstr ""
 
 #: data.cpp:1062
-msgid "Sadalbari"
+msgid "Seat"
 msgstr ""
 
 #: data.cpp:1063
-msgid "Hydor"
+msgid "Lionrock"
 msgstr ""
 
 #: data.cpp:1064
-msgid "Skat"
+msgid "Kruger 60"
 msgstr ""
 
 #: data.cpp:1065
-msgid "Helvetios"
+msgid "Situla"
 msgstr ""
 
 #: data.cpp:1066
-msgid "Fomalhaut"
+msgid "Homam"
 msgstr ""
 
 #: data.cpp:1067
-msgid "Scheat"
+msgid "Tiaki"
 msgstr ""
 
 #: data.cpp:1068
-msgid "Fumalsamakah"
+msgid "Matar"
 msgstr ""
 
 #: data.cpp:1069
-msgid "Fum al Samakah"
+msgid "Babcock's Star"
 msgstr ""
 
 #: data.cpp:1070
-msgid "Markab"
+msgid "Sadalbari"
 msgstr ""
 
 #: data.cpp:1071
-msgid "Marchab"
+msgid "Hydor"
 msgstr ""
 
 #: data.cpp:1072
-msgid "Ebla"
+msgid "Skat"
 msgstr ""
 
 #: data.cpp:1073
-msgid "Bradley 3077"
+msgid "Helvetios"
 msgstr ""
 
 #: data.cpp:1074
-msgid "Salm"
+msgid "Fomalhaut"
 msgstr ""
 
 #: data.cpp:1075
-msgid "Alkarab"
+msgid "Scheat"
 msgstr ""
 
 #: data.cpp:1076
-msgid "Veritate"
+msgid "Fumalsamakah"
 msgstr ""
 
 #: data.cpp:1077
-msgid "Poerava"
+msgid "Fum al Samakah"
 msgstr ""
 
 #: data.cpp:1078
-msgid "Errai"
+msgid "Markab"
 msgstr ""
 
 #: data.cpp:1079
-msgid "Axólotl"
+msgid "Marchab"
 msgstr ""
 
 #: data.cpp:1080
-msgid "Milky Way"
+msgid "Ebla"
 msgstr ""
 
 #: data.cpp:1081
-msgid "LMC"
+msgid "Bradley 3077"
 msgstr ""
 
 #: data.cpp:1082
-msgid "SMC"
+msgid "Salm"
 msgstr ""
 
 #: data.cpp:1083
-msgid "Pleiades"
+msgid "Alkarab"
 msgstr ""
 
 #: data.cpp:1084
-msgid "Hyades"
+msgid "Veritate"
 msgstr ""
 
 #: data.cpp:1085
-msgid "Praesepe"
+msgid "Poerava"
 msgstr ""
 
 #: data.cpp:1086
-msgid "Beehive Cluster"
+msgid "Errai"
 msgstr ""
 
 #: data.cpp:1087
-msgid "Maffei 1"
+msgid "Axólotl"
 msgstr ""
 
 #: data.cpp:1088
-msgid "Maffei 2"
+msgid "Milky Way"
 msgstr ""
 
 #: data.cpp:1089
-msgid "Leo A"
+msgid "LMC"
 msgstr ""
 
 #: data.cpp:1090
-msgid "Sextans B"
+msgid "SMC"
 msgstr ""
 
 #: data.cpp:1091
-msgid "Leo I"
+msgid "Pleiades"
 msgstr ""
 
 #: data.cpp:1092
-msgid "Sextans A"
+msgid "Hyades"
+msgstr ""
+
+#: data.cpp:1093
+msgid "Praesepe"
 msgstr ""
 
 #: data.cpp:1094
-msgid "Andromeda Galaxy"
+msgid "Beehive Cluster"
 msgstr ""
 
 #: data.cpp:1095
-msgid "Triangulum Galaxy"
+msgid "Maffei 1"
 msgstr ""
 
 #: data.cpp:1096
-msgid "Holmberg VI"
+msgid "Maffei 2"
 msgstr ""
 
 #: data.cpp:1097
-msgid "Fath 703"
+msgid "Leo A"
 msgstr ""
 
 #: data.cpp:1098
-msgid "47 Tuc"
+msgid "Sextans B"
+msgstr ""
+
+#: data.cpp:1099
+msgid "Leo I"
+msgstr ""
+
+#: data.cpp:1100
+msgid "Sextans A"
 msgstr ""
 
 #: data.cpp:1101
+msgid "Circinus"
+msgstr ""
+
+#: data.cpp:1102
+msgid "Andromeda Galaxy"
+msgstr ""
+
+#: data.cpp:1103
+msgid "Triangulum Galaxy"
+msgstr ""
+
+#: data.cpp:1104
+msgid "Holmberg VI"
+msgstr ""
+
+#: data.cpp:1105
+msgid "Fath 703"
+msgstr ""
+
+#: data.cpp:1106
+msgid "47 Tuc"
+msgstr ""
+
+#: data.cpp:1107
+msgid "Eridanus"
+msgstr ""
+
+#: data.cpp:1108
+msgid "Pyxis"
+msgstr ""
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-02-07 21:38+0100\n"
 "Last-Translator: Steffen Schreiber <SchreiberSte@web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -22,358 +22,447 @@ msgstr ""
 "X-Generator: KBabel 1.9.1\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Luftpumpe"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradiesvogel"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Wassermann"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Adler"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Widder"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Fuhrmann"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Bootes (Bärenhüter)"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Grabstichel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Giraffe"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Krebs"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Jagdhunde"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Großer Hund"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Kleiner Hund"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Steinbock"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Schiffskiel"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentaur"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Kepheus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Walfisch"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Chamäleon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Zirkel"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Taube"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Haar der Berenike"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Südliche Krone"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Nördliche Krone"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Rabe"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Becher"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Kreuz des Südens"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Schwan"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delphin"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Schwertfisch"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Drache"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Füllen"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanus"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Ofen"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Zwillinge"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Kranich"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Pendeluhr"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Wasserschlange"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Kleine Wasserschlange"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indianer"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Eidechse"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Löwe"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Kleiner Löwe"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Hase"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Waage"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Wolf"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Luchs"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Leier"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Tafelberg"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskop"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Einhorn"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Fliege"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Winkelmaß"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Schlangenträger"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pfau"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasus"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseus"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Phönix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Maler"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Fische"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Südlicher Fisch"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Achterdeck"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompaß"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Netz"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Pfeil"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Schütze"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpion"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Bildhauer"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Schild"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Kopf der Schlange"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Schwanz der Schlange"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextant"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Stier"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Teleskop"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Dreieck"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Südliches Dreieck"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Großer Wagen"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Kleiner Wagen"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Segel"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Jungfrau"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Fliegender Fisch"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Füchschen"
 
@@ -529,3964 +618,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Wasserschlange"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Dreieck"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Kallisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Kallisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Knapp"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturn"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Ofen"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturn"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Ofen"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturn"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mär"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxien"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymed"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sonne"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "SÜDAMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIEN"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIEN"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTIK"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SÜDATLANTIK"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORDPAZIFIK"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SÜDPAZIFIK"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDISCHER OZEAN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ARKTISCHER OZEAN"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Algier"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Aşgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Astana"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Athen"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bischkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brüssel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Kapstadt"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhagen"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Dschibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Duschanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havanna"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiew"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "London"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexiko-Stadt"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadischu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskau"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Maskat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Neu Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nikosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prag"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pjöngjang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rom"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapur"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taschkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tiflis"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Jaffa"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripolis"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikanstadt"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Wien"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Wilna"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Warschau"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D. C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Distrikt Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Eriwan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sonne"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Schwerezentrum des Sternsystems"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sonne"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Schedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Aktuell"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polarstern"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirfak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hinds Purpurstern"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxien"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyns Stern"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Dreieck"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Beteigeuze"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Rotes Rechteck"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Sterne anzeigen"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luytens Stern"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Prokyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "London"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phekda"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arktur"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kochab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Athen"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorien"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnards Pfeilstern"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbells Stern"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Svalocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polarstern"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Grenzen"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschels Granatstern"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcocks Stern"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Milchstraße"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Große Magellansche Wolke"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Kleine Magellansche Wolke"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejaden"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyaden"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Messier 44"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Bienenkorb-Haufen"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Zirkel"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc/NGC 104"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanus"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompaß"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/el.po
+++ b/po/el.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: en\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2009-05-08 13:14+0200\n"
 "Last-Translator: Kouzinopoulos Charis <ckouz@uom.gr>\n"
 "Language-Team: English\n"
@@ -21,358 +21,447 @@ msgstr ""
 "X-Generator: KBabel 1.10\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Ανδρομέδα"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Αντλία"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Πτηνόν"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Υδροχόος"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Αετός"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Βωμός"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Κριός"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Ηνίοχος"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Βοώτης"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Γλυφείον"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Καμηλοπάρδαλη"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Καρκίνος"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Κύνες Θηρευτικοί"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Κύων Μέγας"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Κύων Μικρός"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Αιγόκερω"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Τρόπις"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Κασσιόπη"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Κένταυρος"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Κηφέας"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Κήτος"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Χαμαιλέων"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Διαβήτης"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Περιστερά"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Κόμη Βερενίκης"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Στέφανος Νότιος"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Στέφανος Βόρειος"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Κόραξ"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Κρατήρ"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Νότιος Σταυρός"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Κύκνος"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Δελφίν"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Δοράς"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Δράκων"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Ιππάριον"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Ηριδανός"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Κάμινος"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Δίδυμοι"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Γερανός"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Ηρακλής"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Ωρολόγιον"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Ύδρα"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Ύδρος"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Ινδός"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Σαύρα"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Λέων"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Λέων Μικρός"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Λαγωός"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Ζυγός"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Λύκος"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Λυγξ"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Λύρα"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Τράπεζα"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Μικροσκόπιον"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Μονόκερως"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Μυία"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Γνώμων"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Οκτάς"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Οφιούχος"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Ωρίων"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Ταώς"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Πήγασος"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Περσέας"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Φοίνιξ"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Οκρίβας"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Ιχθύες"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Ιχθύς Νότιος"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Πρύμνη"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Πυξίς"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Δίκτυον"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Βέλος"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Τοξότης"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Σκορπιός"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Γλύπτης"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Ασπίς"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Κεφαλή του Όφεως"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Ουρά του Όφεως"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Εξάς"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Ταύρος"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Τηλεσκόπιον"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Τρίγωνον"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Τρίγωνον Νότιον"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Τουκάνα"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Μεγάλη Άρκτος"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Μικρή Άρκτος"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Ιστία"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Παρθένος"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Ιχθύς Ιπτάμενος"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Αλώπηξ"
 
@@ -528,3968 +617,4021 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Ύδρα"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
-msgid "Haumea"
+msgid "Orcus-Vanth"
 msgstr ""
 
 #: data.cpp:131
-msgid "Namaka"
+msgid "Orcus"
 msgstr ""
 
 #: data.cpp:132
-msgid "Hi'iaka"
+msgid "Vanth"
 msgstr ""
 
 #: data.cpp:133
-msgid "Makemake"
+msgid "Haumea"
 msgstr ""
 
 #: data.cpp:134
-msgid "S 2015 (136472) 1"
+msgid "Namaka"
 msgstr ""
 
 #: data.cpp:135
-msgid "Eris"
+msgid "Hi'iaka"
 msgstr ""
 
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Αμάλθεια"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Τρίγωνον"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Πανδώρα"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Αμάλθεια"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Δίφδα"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Δίας "
+msgid "Pandia"
+msgstr "Πανδώρα"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Δίφδα"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Δίας "
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Δίας "
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Δίας "
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Δίας "
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Δίας "
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Δίας "
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Αλκυόνη"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Δίας "
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Δίας "
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Καλλιστώ"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Δίας "
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Δίας "
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Δίας "
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Δίας "
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Δίας "
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Δίας "
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Δίας "
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Δίας "
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Δίας "
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Δίας "
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Καλλιστώ"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Περιεκτικός "
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Δίας "
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Δίας "
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Δίας "
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Ιαν"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Προμηθέας"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Πανδώρα"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Επιμηθέας"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Ιανός"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Σκατ"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Σκατ"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Αλμπίρεο"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Κρόνος "
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Κρόνος "
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Κάμινος"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Κρόνος "
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Πορ Λουί"
+msgid "Fornjot"
+msgstr "Κάμινος"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Κρόνος "
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Πορ Λουί"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Μαρ"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Γαλαξίες"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Λάρισσα"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Γανυμήδης"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Ήλιος"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ΒΟΡΕΙΑ ΑΜΕΡΙΚΗ"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ΝΟΤΙΑ ΑΜΕΡΙΚΗ"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ΕΥΡΑΣΙΑ"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "ΑΦΡΙΚΗ"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "ΑΥΣΤΡΑΛΙΑ"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ΑΝΤΑΡΚΤΙΚΗ"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ΒΟΡΕΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ΝΟΤΙΟΑΤΛΑΝΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ΒΟΡΕΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ΝΟΤΙΟΣ ΕΙΡΗΝΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ΙΝΔΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ΑΡΚΤΙΚΟΣ ΩΚΕΑΝΟΣ"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Αμπού Ντάμπι"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr ""
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr ""
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr ""
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Αντίς Αμπέμπα"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Αλγέρι"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr ""
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Αμμάν"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Άμστερνταμ"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr ""
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Άγκυρα"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr ""
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr ""
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr ""
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr ""
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr ""
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Αθήνα"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Αβαρούα"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Βαγδάτη"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr ""
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr ""
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr ""
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Μπανγκόκ"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr ""
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr ""
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr ""
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr ""
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Πεκίνο"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Βηρυτός"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Βελιγράδι"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr ""
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Βερολίνο"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Βέρνη"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr ""
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr ""
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr ""
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Μπογκοτά"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr ""
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Μπρατισλάβα"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr ""
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr ""
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Βρυξέλλες"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Βουκουρέστι"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Βουδαπέστη"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Μπουένος Άιρες"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr ""
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Κάιρο"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr ""
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Κέιπ Τάουν"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Καράκας"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr ""
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr ""
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr ""
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr ""
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Κολόμπο"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr ""
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Κοπεγχάγη"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr ""
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Ντακάρ"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Δαμασκός"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr ""
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr ""
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr ""
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Τζιμπουτί"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr ""
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr ""
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Δουβλίνο"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr ""
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr ""
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr ""
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr ""
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr ""
 
-#: data.cpp:405
+#: data.cpp:413
 #, fuzzy
 msgid "George Town"
 msgstr "Κέιπ Τάουν"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr ""
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Γιβραλτάρ"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr ""
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Γουατεμάλα"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr ""
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Χάγη"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr ""
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Ανόι"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr ""
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Αβάνα"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Ελσίνκι"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr ""
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Ισλαμαμπάντ"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Τζακάρτα"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr ""
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Ιερουσαλήμ"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Καμπούλ"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Καμπάλα"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Κατμαντού"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Χαρτούμ"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Κίεβο"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr ""
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr ""
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr ""
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Κινσάσα"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr ""
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Κουάλα Λουμπούρ"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Κουβέιτ"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr ""
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr ""
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr ""
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr ""
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Λίμα"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Λισαβόνα"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Λιουμπλιάνα"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr ""
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr ""
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Λονδίνο"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr ""
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr ""
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr ""
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Λουξεμβούργο"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Μαδρίτη"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr ""
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr ""
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr ""
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr ""
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr ""
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr ""
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Μανίλα"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr ""
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr ""
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr ""
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr ""
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Πόλη του Μεξικό"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Μινσκ"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Μογκαντίσου"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Μονακό"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr ""
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Μοντεβιδέο"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr ""
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Μόσχα"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr ""
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Ναϊρόμπι"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr ""
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr ""
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Νέο Δελχί"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr ""
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Λευκωσία"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr ""
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr ""
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr ""
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr ""
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr ""
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Όσλο"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Οτάβα"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ουαγκαντούγκου"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Πάγκο Πάγκο"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr ""
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Παναμάς"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr ""
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Παραμαρίμπο"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Παρίσι"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Πνομ Πενχ"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr ""
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Πορ Λουί"
 
-#: data.cpp:494
+#: data.cpp:502
 #, fuzzy
 msgid "Port Moresby"
 msgstr "Πορτ οφ Σπέιν"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Πορτ-ο-Πρενς"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Πορτ οφ Σπέιν"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Πόρτο Νόβο"
 
-#: data.cpp:498
+#: data.cpp:506
 #, fuzzy
 msgid "Port-Vila"
 msgstr "Πορ Λουί"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Πράγα"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr ""
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr ""
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr ""
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr ""
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr ""
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr ""
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Ρέικιαβικ"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Ρίγα"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr ""
 
-#: data.cpp:509
+#: data.cpp:517
 #, fuzzy
 msgid "Road Town"
 msgstr "Κέιπ Τάουν"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Ρώμη"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr ""
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Σεντ Τζόρτζες"
 
-#: data.cpp:513
+#: data.cpp:521
 #, fuzzy
 msgid "Saint Helier"
 msgstr "Σεντ Τζονς"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Σεντ Τζονς"
 
-#: data.cpp:515
+#: data.cpp:523
 #, fuzzy
 msgid "Saint Peter Port"
 msgstr "Πορ Λουί"
 
-#: data.cpp:516
+#: data.cpp:524
 #, fuzzy
 msgid "Saint-Denis"
 msgstr "Σεντ Τζονς"
 
-#: data.cpp:517
+#: data.cpp:525
 #, fuzzy
 msgid "Saint-Pierre"
 msgstr "Σεντ Τζονς"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr ""
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "Σαν Χοσέ"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "Σαν Χουάν"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Σαν Μαρίνο"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Σαν Σαλβαδόρ"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr ""
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Σαντιάγο"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Σάντο Ντομίνγκο"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr ""
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Σεράγεβο"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Σεούλ"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr ""
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Σιγκαπούρη"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Σκόπια"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Σόφια"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr ""
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Στοκχόλμη"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Σούκρε"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr ""
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Ταϊπέι"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr ""
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr ""
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Τασκένδη"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Τιφλίδα"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr ""
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Τεχεράνη"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Τελ Αβίβ"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr ""
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Τίρανα"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Τόκιο"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr ""
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Τρίπολη"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr ""
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr ""
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Βαλέττα"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr ""
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Βατικανό"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Βικτόρια"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Βιέννη"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr ""
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Βίλνιους"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Βαρσοβία"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Ουάσιγκτον"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Ουέλλιγκτον"
 
-#: data.cpp:564
+#: data.cpp:572
 #, fuzzy
 msgid "West Island"
 msgstr "Δυτικά"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr ""
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr ""
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr ""
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr ""
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr ""
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr ""
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Ζάγκρεμπ "
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Ήλιος"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Βαρύκεντρο Ηλιακού Συστήματος"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Ήλιος"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Αλφεράτζ"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Καφ"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Αλγκενίμπ"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ανκάα"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Δίφδα"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Κάστωρ"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Ναβί"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Τρέχον"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Μιράχ"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ρουχμπά"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Αλφεράτζ"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Τιτάνας"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ακερνάρ"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Μεσαρθίμ"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Σερατάν"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Χαμάλ"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Μίρα"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Πολικός Αστέρας"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Χαρά"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Μίρα"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Άζχα"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Άκαμαρ"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Αλγκόλ"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Μποτάιν"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Ράνα"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Ράνα"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Ατίκ"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Αλκυόνη"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Ζαουράκ (βάρκα)"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Μενκίμπ"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Μπεΐντ"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Αΐν"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Λαμπαδίας ή Αλδεβαράν"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Γαλαξίες"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Κούρσα"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn's Star"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Ρίγκελ"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Δίφρος"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Μπέλατριξ"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Άλναθ"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Νιχάλ"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Μιντάκα"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Αρνέμπ"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Αλνιλάμ"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Τρίγωνο"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Αλνιτάκ"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Σαΐφ"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Βαζν (Βάρος)"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Βετελγέζης"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Μενκαλινάν"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Φουρούντ"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Κάνωπος"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Red Rectangle"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Φουρούντ"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Μιρζάμ"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Τεγιάτ"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Κάνωπος"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Εμφάνιση Αστέρων"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Αλένα"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Μεμπσούτα"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Σείριος"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Αδάρα"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Μουλιφέιν"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Μεκμπούντα"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Ουέζεν"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Βασάτ"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Αλούδρα"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Γκομέισα"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten's Star"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Κάστωρ"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Προκύων"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Πολυδεύκης"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Ασμιδίσκη"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Ασμιδίσκη"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Ναός"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Ρέγκορ"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Αβιόρ"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Μουσκίντα"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Όνος Μπορεάλις"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Ακουμπένς (δαγκάνες)"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Σουχαΐλ (Κάνωπος)"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Μιαπλασίντους"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Ασπιδίσκη"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Μαρκάβ"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Άλφαρντ"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Ρασάλας"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Βασιλίσκος"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Αδαφέρα"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Τάνια Μπορεάλις"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Τάνια Αουστράλις"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Λονδίνο"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Αλκές"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Μέρακ"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Ντουμπέ"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Τσερτάν"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Αλούλα Μπορεάλις"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Μορφή: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr ""
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Δηνεβόλα"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr ""
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Μεγκρέζ"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Γκιενάχ"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Άκρουζ"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Αλγκοράμπ"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Γκάκρουζ"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Χαρά"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Κραζ"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Μιμόζα"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Αλιόθ"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Άουβα"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Καρδία Καρόλου"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Αμπελοσυλλέκτης (Βιντεμιατρίζ)"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Μιζάρ"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Στάχυς"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Χέζε"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Αλκάιντ"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Μουφρίντ"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Χάνταρ"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Θουμπάν"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Μένκεντ"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Αρκτούρος"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Σύρμα"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Σεγίνος"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Κοκάμπ"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Νεκκάρ"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Αλ Καλαύροψ (Ραβδί βοσκού)"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Εντασίχ"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Νουσάκαν"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Ουνουκαλχάι"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Ντσούμπα"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Γραφφίας"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Άρης"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Αλ Νιγιάτ"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Αλ Νιγιάτ"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Αθήνα"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Κουγιάμ"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Αντάρης"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Κερασφόρος"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Μάρφικ"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr ""
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Ιάπετος"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Σαρίν"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Ρασταμπάν"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Λεσάθ"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Σάουλα"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Ρας Αλχάγκ"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Σάργκας"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Τζιμπάν"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Αστεροσκοπεία"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Γκρούμιουμ"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnard's Star"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Κάους Μέντια"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Κάους Αουστράλις"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Κάους Μπορεάλις"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Βέγας"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Σελιάκ"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Αλντεραμίν"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Νούνκι"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Άλυα"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Αλμπάλι"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Αλταΐς"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Γουατεμάλα"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Αλμπίρεο"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell's Star"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Παρίσι"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Ταραζέντ"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Αλτάιρ"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Αλσαΐν"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Αλσαΐν"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Νταμπί"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Σαντρ"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "α Ταώ (Παγώνι)"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Ροτανέβ"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Ντένεμπ"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Λιουμπλιάνα"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Αλμπάλι"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Κάους Αουστράλις"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Πολικός Αστέρας"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Κιτάλφα"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Αλντεραμίν"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Σύνορα"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Νασίρα"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Ενίφ"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Αλ Ντανάμπ"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Αλ Ντανάμπ"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Σανταλμελίκ"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Άνκα"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Σαντάχβια"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Ματάρ"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock's Star"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Σανταλμπαρί"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Σκατ"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Φομαλχούτ"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Σχεάτ"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Μαρκάβ"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Άγκυρα"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Γαλαξίας"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Πλειάδες"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Σμήνος Φάτνη"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Διαβήτης"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Τουκάνας"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Ηριδανός"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Πυξίς"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/en.po
+++ b/po/en.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: en\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2005-08-06 12:13+0200\n"
 "Last-Translator: Christophe Teyssier <chris@teyssier.org>\n"
 "Language-Team: English\n"
@@ -21,358 +21,447 @@ msgstr ""
 "X-Generator: KBabel 1.10\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "The Air Pump"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Bird of Paradise"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Water Carrier"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "The Eagle"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "The Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "The Ram"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "The Charioteer"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "The Herdsman"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "The Chisel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "The Giraffe"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "The Crab"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Hunting Dogs"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "The Greater Dog"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "The Lesser Dog"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "The Sea Goat"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "The Keel"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "The Centaur"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cepheus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "The Whale"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Chamaeleon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "The Drafting Compass"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "The Dove"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenice's Hair"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Southern Crown"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Northern Crown"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "The Crow"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "The Goblet"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Southern Cross"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "The Swan"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "The Dolphin"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "The Goldfish"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "The Dragon"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "The Little Horse"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "The River"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "The Furnace"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "The Twins"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "The Crane"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hercules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "The Pendulum Clock"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "The Water Serpent"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "The Lesser Water Snake"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "The Indian"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "The Lizard"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "The Lion"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "The Lesser Lion"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "The Hare"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "The Scales"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "The Wolf"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lynx"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "The Lyre"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "The Table Mountain"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "The Microscope"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "The Unicorn"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "The Fly"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "The Level"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "The Octant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Serpent Holder"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "The Hunter"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "The Peacock"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "The Winged Horse"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseus"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "The Phoenix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "The Painter's Easel"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "The Fish"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "The Southern Fish"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "The Stern"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "The Compass"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "The Reticle"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "The Arrow"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "The Archer"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "The Scorpion"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "The Sculptor"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "The Shield"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "The Serpent's head"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "The Serpent's tail"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "The Sextant"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "The Bull"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "The Telescope"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "The Triangle"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Southern Triangle"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "The Toucan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "The Great Bear"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "The Lesser Bear"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "The Sails"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "The Virgin"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "The Flying Fish"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "The Fox "
 
@@ -528,3878 +617,3931 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "The Water Serpent"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
-msgid "Haumea"
+msgid "Orcus-Vanth"
 msgstr ""
 
 #: data.cpp:131
-msgid "Namaka"
+msgid "Orcus"
 msgstr ""
 
 #: data.cpp:132
-msgid "Hi'iaka"
+msgid "Vanth"
 msgstr ""
 
 #: data.cpp:133
-msgid "Makemake"
+msgid "Haumea"
 msgstr ""
 
 #: data.cpp:134
-msgid "S 2015 (136472) 1"
+msgid "Namaka"
 msgstr ""
 
 #: data.cpp:135
-msgid "Eris"
+msgid "Hi'iaka"
 msgstr ""
 
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
+msgid "S 2015 (136472) 1"
 msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "The Triangle"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-msgid "Pandia"
+msgid "Sedna"
 msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
+msgid "Amalthea"
 msgstr ""
 
 #: data.cpp:148
-msgid "Dia"
+msgid "Thebe"
 msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
-msgid "Jupiter LV"
+msgid "Pandia"
 msgstr ""
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
-msgid "Jupiter LXVIII"
+msgid "Elara"
 msgstr ""
 
 #: data.cpp:156
-msgid "Ananke"
+msgid "Dia"
 msgstr ""
 
 #: data.cpp:157
-msgid "Harpalyke"
+msgid "Carpo"
 msgstr ""
 
 #: data.cpp:158
-msgid "S 2003 J 12"
+msgid "Valetudo"
 msgstr ""
 
 #: data.cpp:159
-msgid "Jupiter LII"
+msgid "Euporie"
 msgstr ""
 
 #: data.cpp:160
-msgid "Praxidike"
+msgid "Jupiter LV"
 msgstr ""
 
 #: data.cpp:161
-msgid "S 2003 J 2"
+msgid "Eupheme"
 msgstr ""
 
 #: data.cpp:162
-msgid "Euanthe"
+msgid "S 2003 J 16"
 msgstr ""
 
 #: data.cpp:163
-msgid "Orthosie"
+msgid "Jupiter LXVIII"
 msgstr ""
 
 #: data.cpp:164
-msgid "Jupiter LXIV"
+msgid "Ananke"
 msgstr ""
 
 #: data.cpp:165
-msgid "Iocaste"
+msgid "Harpalyke"
 msgstr ""
 
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
-msgid "Thyone"
+msgid "Jupiter LII"
 msgstr ""
 
 #: data.cpp:168
-msgid "Jupiter LIV"
+msgid "Praxidike"
 msgstr ""
 
 #: data.cpp:169
-msgid "Thelxinoe"
+msgid "S 2003 J 2"
 msgstr ""
 
 #: data.cpp:170
-msgid "Helike"
+msgid "Euanthe"
 msgstr ""
 
 #: data.cpp:171
-msgid "Hermippe"
+msgid "Orthosie"
 msgstr ""
 
 #: data.cpp:172
-msgid "Philophrosyne"
+msgid "Jupiter LXIV"
 msgstr ""
 
 #: data.cpp:173
-msgid "Jupiter LVI"
+msgid "Iocaste"
 msgstr ""
 
 #: data.cpp:174
-msgid "Kallichore"
+msgid "Mneme"
 msgstr ""
 
 #: data.cpp:175
-msgid "Chaldene"
+msgid "Thyone"
 msgstr ""
 
 #: data.cpp:176
-msgid "Arche"
+msgid "Jupiter LIV"
 msgstr ""
 
 #: data.cpp:177
-msgid "Jupiter LXIX"
+msgid "Thelxinoe"
 msgstr ""
 
 #: data.cpp:178
-msgid "Kale"
+msgid "Helike"
 msgstr ""
 
 #: data.cpp:179
-msgid "Jupiter LXXII"
+msgid "Hermippe"
 msgstr ""
 
 #: data.cpp:180
-msgid "Jupiter LXI"
+msgid "Philophrosyne"
 msgstr ""
 
 #: data.cpp:181
-msgid "Cyllene"
+msgid "Jupiter LVI"
 msgstr ""
 
 #: data.cpp:182
-msgid "Taygete"
+msgid "Kallichore"
 msgstr ""
 
 #: data.cpp:183
-msgid "Jupiter LXX"
+msgid "Chaldene"
 msgstr ""
 
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr ""
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr ""
 
 #: data.cpp:188
-msgid "Aitne"
+msgid "Jupiter LXI"
 msgstr ""
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
-msgid "Callirrhoe"
+msgid "Taygete"
 msgstr ""
 
 #: data.cpp:191
-msgid "Erinome"
+msgid "Jupiter LXX"
 msgstr ""
 
 #: data.cpp:192
-msgid "Pasithee"
+msgid "Eurydome"
 msgstr ""
 
 #: data.cpp:193
-msgid "Eirene"
+msgid "Jupiter LI"
 msgstr ""
 
 #: data.cpp:194
-msgid "S 2003 J 24"
+msgid "S 2003 J 9"
 msgstr ""
 
 #: data.cpp:195
-msgid "Sinope"
+msgid "Jupiter LXVII"
 msgstr ""
 
 #: data.cpp:196
-msgid "Eukelade"
+msgid "Aitne"
 msgstr ""
 
 #: data.cpp:197
-msgid "Isonoe"
+msgid "Carme"
 msgstr ""
 
 #: data.cpp:198
-msgid "S 2003 J 4"
+msgid "Callirrhoe"
 msgstr ""
 
 #: data.cpp:199
-msgid "Autonoe"
+msgid "Erinome"
 msgstr ""
 
 #: data.cpp:200
-msgid "Herse"
+msgid "Pasithee"
 msgstr ""
 
 #: data.cpp:201
-msgid "Pasiphae"
+msgid "Eirene"
 msgstr ""
 
 #: data.cpp:202
-msgid "S 2003 J 10"
+msgid "S 2003 J 24"
 msgstr ""
 
 #: data.cpp:203
-msgid "Kore"
+msgid "Sinope"
 msgstr ""
 
 #: data.cpp:204
-msgid "Jupiter LXIII"
+msgid "Eukelade"
 msgstr ""
 
 #: data.cpp:205
-msgid "Hegemone"
+msgid "Isonoe"
 msgstr ""
 
 #: data.cpp:206
-msgid "Sponde"
+msgid "S 2003 J 4"
 msgstr ""
 
 #: data.cpp:207
-msgid "Kalyke"
+msgid "Autonoe"
 msgstr ""
 
 #: data.cpp:208
-msgid "Aoede"
+msgid "Herse"
 msgstr ""
 
 #: data.cpp:209
-msgid "Megaclite"
+msgid "Pasiphae"
 msgstr ""
 
 #: data.cpp:210
-msgid "S 2003 J 23"
+msgid "S 2003 J 10"
 msgstr ""
 
 #: data.cpp:211
-msgid "Jupiter LXVI"
+msgid "Kore"
 msgstr ""
 
 #: data.cpp:212
-msgid "Jupiter LIX"
+msgid "Jupiter LXIII"
 msgstr ""
 
 #: data.cpp:213
-msgid "S 2009 S 1"
+msgid "Hegemone"
 msgstr ""
 
 #: data.cpp:214
-msgid "Pan"
+msgid "Sponde"
 msgstr ""
 
 #: data.cpp:215
-msgid "Daphnis"
+msgid "Kalyke"
 msgstr ""
 
 #: data.cpp:216
-msgid "Atlas"
+msgid "Aoede"
 msgstr ""
 
 #: data.cpp:217
-msgid "Prometheus"
+msgid "Megaclite"
 msgstr ""
 
 #: data.cpp:218
-msgid "Pandora"
+msgid "S 2003 J 23"
 msgstr ""
 
 #: data.cpp:219
-msgid "Epimetheus"
+msgid "Jupiter LXVI"
 msgstr ""
 
 #: data.cpp:220
-msgid "Janus"
+msgid "Jupiter LIX"
 msgstr ""
 
 #: data.cpp:221
-msgid "Aegaeon"
+msgid "S 2009 S 1"
 msgstr ""
 
 #: data.cpp:222
-msgid "Methone"
+msgid "Pan"
 msgstr ""
 
 #: data.cpp:223
-msgid "Anthe"
+msgid "Daphnis"
 msgstr ""
 
 #: data.cpp:224
-msgid "Pallene"
+msgid "Atlas"
 msgstr ""
 
 #: data.cpp:225
-msgid "Telesto"
+msgid "Prometheus"
 msgstr ""
 
 #: data.cpp:226
-msgid "Calypso"
+msgid "Pandora"
 msgstr ""
 
 #: data.cpp:227
-msgid "Polydeuces"
+msgid "Epimetheus"
 msgstr ""
 
 #: data.cpp:228
-msgid "Helene"
+msgid "Janus"
 msgstr ""
 
 #: data.cpp:229
-msgid "S 2019 S 1"
+msgid "Aegaeon"
 msgstr ""
 
 #: data.cpp:230
-msgid "Kiviuq"
+msgid "Methone"
 msgstr ""
 
 #: data.cpp:231
-msgid "Ijiraq"
+msgid "Anthe"
 msgstr ""
 
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
-msgid "Skathi"
+msgid "Telesto"
 msgstr ""
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
-msgid "Albiorix"
+msgid "Helene"
 msgstr ""
 
 #: data.cpp:237
-msgid "Bebhionn"
+msgid "S 2019 S 1"
 msgstr ""
 
 #: data.cpp:238
-msgid "S 2004 S 31"
+msgid "Kiviuq"
 msgstr ""
 
 #: data.cpp:239
-msgid "Saturn LX"
+msgid "Ijiraq"
 msgstr ""
 
 #: data.cpp:240
-msgid "Skoll"
+msgid "Paaliaq"
 msgstr ""
 
 #: data.cpp:241
-msgid "Tarqeq"
+msgid "Skathi"
 msgstr ""
 
 #: data.cpp:242
-msgid "Tarvos"
+msgid "S 2004 S 37"
 msgstr ""
 
 #: data.cpp:243
-msgid "Erriapus"
+msgid "S 2007 S 2"
 msgstr ""
 
 #: data.cpp:244
-msgid "Siarnaq"
+msgid "Albiorix"
 msgstr ""
 
 #: data.cpp:245
-msgid "Greip"
+msgid "Bebhionn"
 msgstr ""
 
 #: data.cpp:246
-msgid "Hyrrokkin"
+msgid "S 2004 S 31"
 msgstr ""
 
 #: data.cpp:247
-msgid "Mundilfari"
+msgid "Saturn LX"
 msgstr ""
 
 #: data.cpp:248
-msgid "S 2006 S 1"
+msgid "Skoll"
 msgstr ""
 
 #: data.cpp:249
-msgid "S 2004 S 13"
+msgid "Tarqeq"
 msgstr ""
 
 #: data.cpp:250
-msgid "S 2007 S 3"
+msgid "Tarvos"
 msgstr ""
 
 #: data.cpp:251
-msgid "Suttungr"
+msgid "Erriapus"
 msgstr ""
 
 #: data.cpp:252
-msgid "Gridr"
+msgid "Siarnaq"
 msgstr ""
 
 #: data.cpp:253
-msgid "Narvi"
+msgid "Greip"
 msgstr ""
 
 #: data.cpp:254
-msgid "Jarnsaxa"
+msgid "Hyrrokkin"
 msgstr ""
 
 #: data.cpp:255
-msgid "S 2004 S 12"
+msgid "Mundilfari"
 msgstr ""
 
 #: data.cpp:256
-msgid "Bergelmir"
+msgid "S 2006 S 1"
 msgstr ""
 
 #: data.cpp:257
-msgid "Eggther"
+msgid "S 2004 S 13"
 msgstr ""
 
 #: data.cpp:258
-msgid "S 2004 S 17"
+msgid "S 2007 S 3"
 msgstr ""
 
 #: data.cpp:259
-msgid "Hati"
+msgid "Suttungr"
 msgstr ""
 
 #: data.cpp:260
-msgid "Farbauti"
+msgid "Gridr"
 msgstr ""
 
 #: data.cpp:261
-msgid "Thrymr"
+msgid "Narvi"
 msgstr ""
 
 #: data.cpp:262
-msgid "S 2004 S 7"
+msgid "Jarnsaxa"
 msgstr ""
 
 #: data.cpp:263
-msgid "Beli"
+msgid "S 2004 S 12"
 msgstr ""
 
 #: data.cpp:264
-msgid "Bestla"
+msgid "Bergelmir"
 msgstr ""
 
 #: data.cpp:265
-msgid "Gerd"
+msgid "Eggther"
 msgstr ""
 
 #: data.cpp:266
-msgid "Angrboda"
+msgid "S 2004 S 17"
 msgstr ""
 
 #: data.cpp:267
-msgid "Gunnlod"
+msgid "Hati"
 msgstr ""
 
 #: data.cpp:268
-msgid "Aegir"
+msgid "Farbauti"
 msgstr ""
 
 #: data.cpp:269
-msgid "S 2006 S 3"
+msgid "Thrymr"
 msgstr ""
 
 #: data.cpp:270
-msgid "Alvaldi"
+msgid "S 2004 S 7"
 msgstr ""
 
 #: data.cpp:271
-msgid "Kari"
+msgid "Beli"
 msgstr ""
 
 #: data.cpp:272
-msgid "Skrymir"
+msgid "Bestla"
 msgstr ""
 
 #: data.cpp:273
-msgid "S 2004 S 28"
+msgid "Gerd"
 msgstr ""
 
 #: data.cpp:274
-msgid "Fenrir"
+msgid "Angrboda"
 msgstr ""
 
 #: data.cpp:275
-msgid "Loge"
+msgid "Gunnlod"
 msgstr ""
 
 #: data.cpp:276
-msgid "S 2004 S 21"
+msgid "Aegir"
 msgstr ""
 
 #: data.cpp:277
-msgid "Geirrod"
+msgid "S 2006 S 3"
 msgstr ""
 
 #: data.cpp:278
-msgid "S 2004 S 24"
+msgid "Alvaldi"
 msgstr ""
 
 #: data.cpp:279
-msgid "S 2004 S 36"
+msgid "Kari"
 msgstr ""
 
 #: data.cpp:280
-msgid "Ymir"
+msgid "Skrymir"
 msgstr ""
 
 #: data.cpp:281
-msgid "Surtur"
+msgid "S 2004 S 28"
 msgstr ""
 
 #: data.cpp:282
-msgid "S 2004 S 39"
+msgid "Fenrir"
 msgstr ""
 
 #: data.cpp:283
-msgid "Saturn LXIV"
+msgid "Loge"
 msgstr ""
 
 #: data.cpp:284
-msgid "Thiazzi"
+msgid "S 2004 S 21"
 msgstr ""
 
 #: data.cpp:285
-msgid "Fornjot"
+msgid "Geirrod"
 msgstr ""
 
 #: data.cpp:286
-msgid "Saturn LVIII"
+msgid "S 2004 S 24"
 msgstr ""
 
 #: data.cpp:287
-msgid "Cordelia"
+msgid "S 2004 S 36"
 msgstr ""
 
 #: data.cpp:288
-msgid "Ophelia"
+msgid "Ymir"
 msgstr ""
 
 #: data.cpp:289
-msgid "Bianca"
+msgid "Surtur"
 msgstr ""
 
 #: data.cpp:290
-msgid "Cressida"
+msgid "S 2004 S 39"
 msgstr ""
 
 #: data.cpp:291
-msgid "Desdemona"
+msgid "Saturn LXIV"
 msgstr ""
 
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
-msgid "Portia"
+msgid "Fornjot"
 msgstr ""
 
 #: data.cpp:294
-msgid "Rosalind"
+msgid "Saturn LVIII"
 msgstr ""
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
-msgid "Mab"
+msgid "Desdemona"
 msgstr ""
 
 #: data.cpp:300
-msgid "Francisco"
+msgid "Juliet"
 msgstr ""
 
 #: data.cpp:301
-msgid "Caliban"
+msgid "Portia"
 msgstr ""
 
 #: data.cpp:302
-msgid "Stephano"
+msgid "Rosalind"
 msgstr ""
 
 #: data.cpp:303
-msgid "Trinculo"
+msgid "Cupid"
 msgstr ""
 
 #: data.cpp:304
-msgid "Sycorax"
+msgid "Belinda"
 msgstr ""
 
 #: data.cpp:305
-msgid "Margaret"
+msgid "Perdita"
 msgstr ""
 
 #: data.cpp:306
-msgid "Prospero"
+msgid "Puck"
 msgstr ""
 
 #: data.cpp:307
-msgid "Setebos"
+msgid "Mab"
 msgstr ""
 
 #: data.cpp:308
-msgid "Ferdinand"
+msgid "Francisco"
 msgstr ""
 
 #: data.cpp:309
-msgid "Naiad"
+msgid "Caliban"
 msgstr ""
 
 #: data.cpp:310
-msgid "Thalassa"
+msgid "Stephano"
 msgstr ""
 
 #: data.cpp:311
-msgid "Despina"
+msgid "Trinculo"
 msgstr ""
 
 #: data.cpp:312
-msgid "Galatea"
+msgid "Sycorax"
 msgstr ""
 
 #: data.cpp:313
-msgid "Larissa"
+msgid "Margaret"
 msgstr ""
 
 #: data.cpp:314
-msgid "Hippocamp"
+msgid "Prospero"
 msgstr ""
 
 #: data.cpp:315
-msgid "Halimede"
+msgid "Setebos"
 msgstr ""
 
 #: data.cpp:316
-msgid "Sao"
+msgid "Ferdinand"
 msgstr ""
 
 #: data.cpp:317
-msgid "Laomedeia"
+msgid "Naiad"
 msgstr ""
 
 #: data.cpp:318
-msgid "Psamathe"
+msgid "Thalassa"
 msgstr ""
 
 #: data.cpp:319
-msgid "Neso"
+msgid "Despina"
 msgstr ""
 
 #: data.cpp:320
-msgid "NORTH AMERICA"
+msgid "Galatea"
 msgstr ""
 
 #: data.cpp:321
-msgid "SOUTH AMERICA"
+msgid "Larissa"
 msgstr ""
 
 #: data.cpp:322
-msgid "EURASIA"
+msgid "Hippocamp"
 msgstr ""
 
 #: data.cpp:323
-msgid "AFRICA"
+msgid "Halimede"
 msgstr ""
 
 #: data.cpp:324
-msgid "AUSTRALIA"
+msgid "Sao"
 msgstr ""
 
 #: data.cpp:325
-msgid "ANTARCTICA"
+msgid "Laomedeia"
 msgstr ""
 
 #: data.cpp:326
-msgid "NORTH ATLANTIC OCEAN"
+msgid "Psamathe"
 msgstr ""
 
 #: data.cpp:327
-msgid "SOUTH ATLANTIC OCEAN"
+msgid "Neso"
 msgstr ""
 
 #: data.cpp:328
-msgid "NORTH PACIFIC OCEAN"
+msgid "NORTH AMERICA"
 msgstr ""
 
 #: data.cpp:329
-msgid "SOUTH PACIFIC OCEAN"
+msgid "SOUTH AMERICA"
 msgstr ""
 
 #: data.cpp:330
-msgid "INDIAN OCEAN"
+msgid "EURASIA"
 msgstr ""
 
 #: data.cpp:331
-msgid "ARCTIC OCEAN"
+msgid "AFRICA"
 msgstr ""
 
 #: data.cpp:332
-msgid "Abu Dhabi"
+msgid "AUSTRALIA"
 msgstr ""
 
 #: data.cpp:333
-msgid "Abuja"
+msgid "ANTARCTICA"
 msgstr ""
 
 #: data.cpp:334
-msgid "Accra"
+msgid "NORTH ATLANTIC OCEAN"
 msgstr ""
 
 #: data.cpp:335
-msgid "Adamstown"
+msgid "SOUTH ATLANTIC OCEAN"
 msgstr ""
 
 #: data.cpp:336
-msgid "Addis Ababa"
+msgid "NORTH PACIFIC OCEAN"
 msgstr ""
 
 #: data.cpp:337
-msgid "Algiers"
+msgid "SOUTH PACIFIC OCEAN"
 msgstr ""
 
 #: data.cpp:338
-msgid "Alofi"
+msgid "INDIAN OCEAN"
 msgstr ""
 
 #: data.cpp:339
-msgid "Amman"
+msgid "ARCTIC OCEAN"
 msgstr ""
 
 #: data.cpp:340
-msgid "Amsterdam"
+msgid "Abu Dhabi"
 msgstr ""
 
 #: data.cpp:341
-msgid "Andorra la Vella"
+msgid "Abuja"
 msgstr ""
 
 #: data.cpp:342
-msgid "Ankara"
+msgid "Accra"
 msgstr ""
 
 #: data.cpp:343
-msgid "Antananarivo"
+msgid "Adamstown"
 msgstr ""
 
 #: data.cpp:344
-msgid "Apia"
+msgid "Addis Ababa"
 msgstr ""
 
 #: data.cpp:345
-msgid "Ashgabat"
+msgid "Algiers"
 msgstr ""
 
 #: data.cpp:346
-msgid "Asmara"
+msgid "Alofi"
 msgstr ""
 
 #: data.cpp:347
-msgid "Astana"
+msgid "Amman"
 msgstr ""
 
 #: data.cpp:348
-msgid "Asuncion"
+msgid "Amsterdam"
 msgstr ""
 
 #: data.cpp:349
-msgid "Athens"
+msgid "Andorra la Vella"
 msgstr ""
 
 #: data.cpp:350
-msgid "Avarua"
+msgid "Ankara"
 msgstr ""
 
 #: data.cpp:351
-msgid "Baghdad"
+msgid "Antananarivo"
 msgstr ""
 
 #: data.cpp:352
-msgid "Baku"
+msgid "Apia"
 msgstr ""
 
 #: data.cpp:353
-msgid "Bamako"
+msgid "Ashgabat"
 msgstr ""
 
 #: data.cpp:354
-msgid "Bandar Seri Begawan"
+msgid "Asmara"
 msgstr ""
 
 #: data.cpp:355
-msgid "Bangkok"
+msgid "Astana"
 msgstr ""
 
 #: data.cpp:356
-msgid "Bangui"
+msgid "Asuncion"
 msgstr ""
 
 #: data.cpp:357
-msgid "Banjul"
+msgid "Athens"
 msgstr ""
 
 #: data.cpp:358
-msgid "Basse-Terre"
+msgid "Avarua"
 msgstr ""
 
 #: data.cpp:359
-msgid "Basseterre"
+msgid "Baghdad"
 msgstr ""
 
 #: data.cpp:360
-msgid "Beijing"
+msgid "Baku"
 msgstr ""
 
 #: data.cpp:361
-msgid "Beirut"
+msgid "Bamako"
 msgstr ""
 
 #: data.cpp:362
-msgid "Belgrade"
+msgid "Bandar Seri Begawan"
 msgstr ""
 
 #: data.cpp:363
-msgid "Belmopan"
+msgid "Bangkok"
 msgstr ""
 
 #: data.cpp:364
-msgid "Berlin"
+msgid "Bangui"
 msgstr ""
 
 #: data.cpp:365
-msgid "Bern"
+msgid "Banjul"
 msgstr ""
 
 #: data.cpp:366
-msgid "Bishkek"
+msgid "Basse-Terre"
 msgstr ""
 
 #: data.cpp:367
-msgid "Bissau"
+msgid "Basseterre"
 msgstr ""
 
 #: data.cpp:368
-msgid "Bloemfontein"
+msgid "Beijing"
 msgstr ""
 
 #: data.cpp:369
-msgid "Bogota"
+msgid "Beirut"
 msgstr ""
 
 #: data.cpp:370
-msgid "Brasilia"
+msgid "Belgrade"
 msgstr ""
 
 #: data.cpp:371
-msgid "Bratislava"
+msgid "Belmopan"
 msgstr ""
 
 #: data.cpp:372
-msgid "Brazzaville"
+msgid "Berlin"
 msgstr ""
 
 #: data.cpp:373
-msgid "Bridgetown"
+msgid "Bern"
 msgstr ""
 
 #: data.cpp:374
-msgid "Brussels"
+msgid "Bishkek"
 msgstr ""
 
 #: data.cpp:375
-msgid "Bucharest"
+msgid "Bissau"
 msgstr ""
 
 #: data.cpp:376
-msgid "Budapest"
+msgid "Bloemfontein"
 msgstr ""
 
 #: data.cpp:377
-msgid "Buenos Aires"
+msgid "Bogota"
 msgstr ""
 
 #: data.cpp:378
-msgid "Bujumbura"
+msgid "Brasilia"
 msgstr ""
 
 #: data.cpp:379
-msgid "Cairo"
+msgid "Bratislava"
 msgstr ""
 
 #: data.cpp:380
-msgid "Canberra"
+msgid "Brazzaville"
 msgstr ""
 
 #: data.cpp:381
-msgid "Cape Town"
+msgid "Bridgetown"
 msgstr ""
 
 #: data.cpp:382
-msgid "Caracas"
+msgid "Brussels"
 msgstr ""
 
 #: data.cpp:383
-msgid "Castries"
+msgid "Bucharest"
 msgstr ""
 
 #: data.cpp:384
-msgid "Cayenne"
+msgid "Budapest"
 msgstr ""
 
 #: data.cpp:385
-msgid "Charlotte Amalie"
+msgid "Buenos Aires"
 msgstr ""
 
 #: data.cpp:386
-msgid "Chisinau"
+msgid "Bujumbura"
 msgstr ""
 
 #: data.cpp:387
-msgid "Colombo"
+msgid "Cairo"
 msgstr ""
 
 #: data.cpp:388
-msgid "Conakry"
+msgid "Canberra"
 msgstr ""
 
 #: data.cpp:389
-msgid "Copenhagen"
+msgid "Cape Town"
 msgstr ""
 
 #: data.cpp:390
-msgid "Cotonou"
+msgid "Caracas"
 msgstr ""
 
 #: data.cpp:391
-msgid "Dakar"
+msgid "Castries"
 msgstr ""
 
 #: data.cpp:392
-msgid "Damascus"
+msgid "Cayenne"
 msgstr ""
 
 #: data.cpp:393
-msgid "Dar es Salaam"
+msgid "Charlotte Amalie"
 msgstr ""
 
 #: data.cpp:394
-msgid "Dhaka"
+msgid "Chisinau"
 msgstr ""
 
 #: data.cpp:395
-msgid "Dili"
+msgid "Colombo"
 msgstr ""
 
 #: data.cpp:396
-msgid "Djibouti"
+msgid "Conakry"
 msgstr ""
 
 #: data.cpp:397
-msgid "Doha"
+msgid "Copenhagen"
 msgstr ""
 
 #: data.cpp:398
-msgid "Douglas"
+msgid "Cotonou"
 msgstr ""
 
 #: data.cpp:399
-msgid "Dublin"
+msgid "Dakar"
 msgstr ""
 
 #: data.cpp:400
-msgid "Dushanbe"
+msgid "Damascus"
 msgstr ""
 
 #: data.cpp:401
-msgid "Fongafale"
+msgid "Dar es Salaam"
 msgstr ""
 
 #: data.cpp:402
-msgid "Fort-de-France"
+msgid "Dhaka"
 msgstr ""
 
 #: data.cpp:403
-msgid "Freetown"
+msgid "Dili"
 msgstr ""
 
 #: data.cpp:404
-msgid "Gaborone"
+msgid "Djibouti"
 msgstr ""
 
 #: data.cpp:405
-msgid "George Town"
+msgid "Doha"
 msgstr ""
 
 #: data.cpp:406
-msgid "Georgetown"
+msgid "Douglas"
 msgstr ""
 
 #: data.cpp:407
-msgid "Gibraltar"
+msgid "Dublin"
 msgstr ""
 
 #: data.cpp:408
-msgid "Grand Turk"
+msgid "Dushanbe"
 msgstr ""
 
 #: data.cpp:409
-msgid "Guatemala"
+msgid "Fongafale"
 msgstr ""
 
 #: data.cpp:410
-msgid "Hagatna"
+msgid "Fort-de-France"
 msgstr ""
 
 #: data.cpp:411
-msgid "The Hague"
+msgid "Freetown"
 msgstr ""
 
 #: data.cpp:412
-msgid "Hamilton"
+msgid "Gaborone"
 msgstr ""
 
 #: data.cpp:413
-msgid "Hanoi"
+msgid "George Town"
 msgstr ""
 
 #: data.cpp:414
-msgid "Harare"
+msgid "Georgetown"
 msgstr ""
 
 #: data.cpp:415
-msgid "Havana"
+msgid "Gibraltar"
 msgstr ""
 
 #: data.cpp:416
-msgid "Helsinki"
+msgid "Grand Turk"
 msgstr ""
 
 #: data.cpp:417
-msgid "Hong Kong"
+msgid "Guatemala"
 msgstr ""
 
 #: data.cpp:418
-msgid "Honiara"
+msgid "Hagatna"
 msgstr ""
 
 #: data.cpp:419
-msgid "Islamabad"
+msgid "The Hague"
 msgstr ""
 
 #: data.cpp:420
-msgid "Jakarta"
+msgid "Hamilton"
 msgstr ""
 
 #: data.cpp:421
-msgid "Jamestown"
+msgid "Hanoi"
 msgstr ""
 
 #: data.cpp:422
-msgid "Jerusalem"
+msgid "Harare"
 msgstr ""
 
 #: data.cpp:423
-msgid "Kabul"
+msgid "Havana"
 msgstr ""
 
 #: data.cpp:424
-msgid "Kampala"
+msgid "Helsinki"
 msgstr ""
 
 #: data.cpp:425
-msgid "Kathmandu"
+msgid "Hong Kong"
 msgstr ""
 
 #: data.cpp:426
-msgid "Khartoum"
+msgid "Honiara"
 msgstr ""
 
 #: data.cpp:427
-msgid "Kiev"
+msgid "Islamabad"
 msgstr ""
 
 #: data.cpp:428
-msgid "Kigali"
+msgid "Jakarta"
 msgstr ""
 
-#: data.cpp:429 data.cpp:430
-msgid "Kingston"
+#: data.cpp:429
+msgid "Jamestown"
+msgstr ""
+
+#: data.cpp:430
+msgid "Jerusalem"
 msgstr ""
 
 #: data.cpp:431
-msgid "Kingstown"
+msgid "Kabul"
 msgstr ""
 
 #: data.cpp:432
-msgid "Kinshasa"
+msgid "Kampala"
 msgstr ""
 
 #: data.cpp:433
-msgid "Koror"
+msgid "Kathmandu"
 msgstr ""
 
 #: data.cpp:434
-msgid "Kuala Lumpur"
+msgid "Khartoum"
 msgstr ""
 
 #: data.cpp:435
-msgid "Kuwait"
+msgid "Kiev"
 msgstr ""
 
 #: data.cpp:436
-msgid "La'youn"
+msgid "Kigali"
 msgstr ""
 
-#: data.cpp:437
-msgid "La Paz"
-msgstr ""
-
-#: data.cpp:438
-msgid "Libreville"
+#: data.cpp:437 data.cpp:438
+msgid "Kingston"
 msgstr ""
 
 #: data.cpp:439
-msgid "Lilongwe"
+msgid "Kingstown"
 msgstr ""
 
 #: data.cpp:440
-msgid "Lima"
+msgid "Kinshasa"
 msgstr ""
 
 #: data.cpp:441
-msgid "Lisbon"
+msgid "Koror"
 msgstr ""
 
 #: data.cpp:442
-msgid "Ljubljana"
+msgid "Kuala Lumpur"
 msgstr ""
 
 #: data.cpp:443
-msgid "Lobamba"
+msgid "Kuwait"
 msgstr ""
 
 #: data.cpp:444
-msgid "Lome"
+msgid "La'youn"
 msgstr ""
 
 #: data.cpp:445
-msgid "London"
+msgid "La Paz"
 msgstr ""
 
 #: data.cpp:446
-msgid "Longyearbyen"
+msgid "Libreville"
 msgstr ""
 
 #: data.cpp:447
-msgid "Luanda"
+msgid "Lilongwe"
 msgstr ""
 
 #: data.cpp:448
-msgid "Lusaka"
+msgid "Lima"
 msgstr ""
 
 #: data.cpp:449
-msgid "Luxembourg"
+msgid "Lisbon"
 msgstr ""
 
 #: data.cpp:450
-msgid "Madrid"
+msgid "Ljubljana"
 msgstr ""
 
 #: data.cpp:451
-msgid "Majuro"
+msgid "Lobamba"
 msgstr ""
 
 #: data.cpp:452
-msgid "Malabo"
+msgid "Lome"
 msgstr ""
 
 #: data.cpp:453
-msgid "Male"
+msgid "London"
 msgstr ""
 
 #: data.cpp:454
-msgid "Mamoutzou"
+msgid "Longyearbyen"
 msgstr ""
 
 #: data.cpp:455
-msgid "Managua"
+msgid "Luanda"
 msgstr ""
 
 #: data.cpp:456
-msgid "Manama"
+msgid "Lusaka"
 msgstr ""
 
 #: data.cpp:457
-msgid "Manila"
+msgid "Luxembourg"
 msgstr ""
 
 #: data.cpp:458
-msgid "Maputo"
+msgid "Madrid"
 msgstr ""
 
 #: data.cpp:459
-msgid "Maseru"
+msgid "Majuro"
 msgstr ""
 
 #: data.cpp:460
-msgid "Mata-Utu"
+msgid "Malabo"
 msgstr ""
 
 #: data.cpp:461
-msgid "Mbabane"
+msgid "Male"
 msgstr ""
 
 #: data.cpp:462
-msgid "Mexico City"
+msgid "Mamoutzou"
 msgstr ""
 
 #: data.cpp:463
-msgid "Minsk"
+msgid "Managua"
 msgstr ""
 
 #: data.cpp:464
-msgid "Mogadishu"
+msgid "Manama"
 msgstr ""
 
 #: data.cpp:465
-msgid "Monaco"
+msgid "Manila"
 msgstr ""
 
 #: data.cpp:466
-msgid "Monrovia"
+msgid "Maputo"
 msgstr ""
 
 #: data.cpp:467
-msgid "Montevideo"
+msgid "Maseru"
 msgstr ""
 
 #: data.cpp:468
-msgid "Moroni"
+msgid "Mata-Utu"
 msgstr ""
 
 #: data.cpp:469
-msgid "Moscow"
+msgid "Mbabane"
 msgstr ""
 
 #: data.cpp:470
-msgid "Muscat"
+msgid "Mexico City"
 msgstr ""
 
 #: data.cpp:471
-msgid "Nairobi"
+msgid "Minsk"
 msgstr ""
 
 #: data.cpp:472
-msgid "Nassau"
+msgid "Mogadishu"
 msgstr ""
 
 #: data.cpp:473
-msgid "N'Djamena"
+msgid "Monaco"
 msgstr ""
 
 #: data.cpp:474
-msgid "New Delhi"
+msgid "Monrovia"
 msgstr ""
 
 #: data.cpp:475
-msgid "Niamey"
+msgid "Montevideo"
 msgstr ""
 
 #: data.cpp:476
-msgid "Nicosia"
+msgid "Moroni"
 msgstr ""
 
 #: data.cpp:477
-msgid "Nouakchott"
+msgid "Moscow"
 msgstr ""
 
 #: data.cpp:478
-msgid "Noumea"
+msgid "Muscat"
 msgstr ""
 
 #: data.cpp:479
-msgid "Nuku'alofa"
+msgid "Nairobi"
 msgstr ""
 
 #: data.cpp:480
-msgid "Nuuk"
+msgid "Nassau"
 msgstr ""
 
 #: data.cpp:481
-msgid "Oranjestad"
+msgid "N'Djamena"
 msgstr ""
 
 #: data.cpp:482
-msgid "Oslo"
+msgid "New Delhi"
 msgstr ""
 
 #: data.cpp:483
-msgid "Ottawa"
+msgid "Niamey"
 msgstr ""
 
 #: data.cpp:484
-msgid "Ouagadougou"
+msgid "Nicosia"
 msgstr ""
 
 #: data.cpp:485
-msgid "Pago Pago"
+msgid "Nouakchott"
 msgstr ""
 
 #: data.cpp:486
-msgid "Palikir"
+msgid "Noumea"
 msgstr ""
 
 #: data.cpp:487
-msgid "Panama"
+msgid "Nuku'alofa"
 msgstr ""
 
 #: data.cpp:488
-msgid "Papeete"
+msgid "Nuuk"
 msgstr ""
 
 #: data.cpp:489
-msgid "Paramaribo"
+msgid "Oranjestad"
 msgstr ""
 
 #: data.cpp:490
-msgid "Paris"
+msgid "Oslo"
 msgstr ""
 
 #: data.cpp:491
-msgid "Phnom Penh"
+msgid "Ottawa"
 msgstr ""
 
 #: data.cpp:492
-msgid "Plymouth"
+msgid "Ouagadougou"
 msgstr ""
 
 #: data.cpp:493
-msgid "Port Louis"
+msgid "Pago Pago"
 msgstr ""
 
 #: data.cpp:494
-msgid "Port Moresby"
+msgid "Palikir"
 msgstr ""
 
 #: data.cpp:495
-msgid "Port-au-Prince"
+msgid "Panama"
 msgstr ""
 
 #: data.cpp:496
-msgid "Port-of-Spain"
+msgid "Papeete"
 msgstr ""
 
 #: data.cpp:497
-msgid "Porto-Novo"
+msgid "Paramaribo"
 msgstr ""
 
 #: data.cpp:498
-msgid "Port-Vila"
+msgid "Paris"
 msgstr ""
 
 #: data.cpp:499
-msgid "Prague"
+msgid "Phnom Penh"
 msgstr ""
 
 #: data.cpp:500
-msgid "Praia"
+msgid "Plymouth"
 msgstr ""
 
 #: data.cpp:501
-msgid "Pretoria"
+msgid "Port Louis"
 msgstr ""
 
 #: data.cpp:502
-msgid "P'yongyang"
+msgid "Port Moresby"
 msgstr ""
 
 #: data.cpp:503
-msgid "Quito"
+msgid "Port-au-Prince"
 msgstr ""
 
 #: data.cpp:504
-msgid "Rabat"
+msgid "Port-of-Spain"
 msgstr ""
 
 #: data.cpp:505
-msgid "Rangoon"
+msgid "Porto-Novo"
 msgstr ""
 
 #: data.cpp:506
-msgid "Reykjavik"
+msgid "Port-Vila"
 msgstr ""
 
 #: data.cpp:507
-msgid "Riga"
+msgid "Prague"
 msgstr ""
 
 #: data.cpp:508
-msgid "Riyadh"
+msgid "Praia"
 msgstr ""
 
 #: data.cpp:509
-msgid "Road Town"
+msgid "Pretoria"
 msgstr ""
 
 #: data.cpp:510
-msgid "Rome"
+msgid "P'yongyang"
 msgstr ""
 
 #: data.cpp:511
-msgid "Roseau"
+msgid "Quito"
 msgstr ""
 
 #: data.cpp:512
-msgid "Saint George's"
+msgid "Rabat"
 msgstr ""
 
 #: data.cpp:513
-msgid "Saint Helier"
+msgid "Rangoon"
 msgstr ""
 
 #: data.cpp:514
-msgid "Saint John's"
+msgid "Reykjavik"
 msgstr ""
 
 #: data.cpp:515
-msgid "Saint Peter Port"
+msgid "Riga"
 msgstr ""
 
 #: data.cpp:516
-msgid "Saint-Denis"
+msgid "Riyadh"
 msgstr ""
 
 #: data.cpp:517
-msgid "Saint-Pierre"
+msgid "Road Town"
 msgstr ""
 
 #: data.cpp:518
-msgid "Saipan"
+msgid "Rome"
 msgstr ""
 
 #: data.cpp:519
-msgid "San Jose"
+msgid "Roseau"
 msgstr ""
 
 #: data.cpp:520
-msgid "San Juan"
+msgid "Saint George's"
 msgstr ""
 
 #: data.cpp:521
-msgid "San Marino"
+msgid "Saint Helier"
 msgstr ""
 
 #: data.cpp:522
-msgid "San Salvador"
+msgid "Saint John's"
 msgstr ""
 
 #: data.cpp:523
-msgid "Sanaa"
+msgid "Saint Peter Port"
 msgstr ""
 
 #: data.cpp:524
-msgid "Santiago"
+msgid "Saint-Denis"
 msgstr ""
 
 #: data.cpp:525
-msgid "Santo Domingo"
+msgid "Saint-Pierre"
 msgstr ""
 
 #: data.cpp:526
-msgid "Sao Tome"
+msgid "Saipan"
 msgstr ""
 
 #: data.cpp:527
-msgid "Sarajevo"
+msgid "San Jose"
 msgstr ""
 
 #: data.cpp:528
-msgid "Seoul"
+msgid "San Juan"
 msgstr ""
 
 #: data.cpp:529
-msgid "The Settlement"
+msgid "San Marino"
 msgstr ""
 
 #: data.cpp:530
-msgid "Singapore"
+msgid "San Salvador"
 msgstr ""
 
 #: data.cpp:531
-msgid "Skopje"
+msgid "Sanaa"
 msgstr ""
 
 #: data.cpp:532
-msgid "Sofia"
+msgid "Santiago"
 msgstr ""
 
 #: data.cpp:533
-msgid "Sri Jayewardenepura Kotte"
+msgid "Santo Domingo"
 msgstr ""
 
 #: data.cpp:534
-msgid "Stanley"
+msgid "Sao Tome"
 msgstr ""
 
 #: data.cpp:535
-msgid "Stockholm"
+msgid "Sarajevo"
 msgstr ""
 
 #: data.cpp:536
-msgid "Sucre"
+msgid "Seoul"
 msgstr ""
 
 #: data.cpp:537
-msgid "Suva"
+msgid "The Settlement"
 msgstr ""
 
 #: data.cpp:538
-msgid "Taipei"
+msgid "Singapore"
 msgstr ""
 
 #: data.cpp:539
-msgid "Tallinn"
+msgid "Skopje"
 msgstr ""
 
 #: data.cpp:540
-msgid "Tarawa"
+msgid "Sofia"
 msgstr ""
 
 #: data.cpp:541
-msgid "Tashkent"
+msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
 #: data.cpp:542
-msgid "T'bilisi"
+msgid "Stanley"
 msgstr ""
 
 #: data.cpp:543
-msgid "Tegucigalpa"
+msgid "Stockholm"
 msgstr ""
 
 #: data.cpp:544
-msgid "Tehran"
+msgid "Sucre"
 msgstr ""
 
 #: data.cpp:545
-msgid "Tel Aviv"
+msgid "Suva"
 msgstr ""
 
 #: data.cpp:546
-msgid "Thimphu"
+msgid "Taipei"
 msgstr ""
 
 #: data.cpp:547
-msgid "Tirana"
+msgid "Tallinn"
 msgstr ""
 
 #: data.cpp:548
-msgid "Tokyo"
+msgid "Tarawa"
 msgstr ""
 
 #: data.cpp:549
-msgid "Torshavn"
+msgid "Tashkent"
 msgstr ""
 
 #: data.cpp:550
-msgid "Tripoli"
+msgid "T'bilisi"
 msgstr ""
 
 #: data.cpp:551
-msgid "Tunis"
+msgid "Tegucigalpa"
 msgstr ""
 
 #: data.cpp:552
-msgid "Ulaanbaatar"
+msgid "Tehran"
 msgstr ""
 
 #: data.cpp:553
-msgid "Vaduz"
+msgid "Tel Aviv"
 msgstr ""
 
 #: data.cpp:554
-msgid "Valletta"
+msgid "Thimphu"
 msgstr ""
 
 #: data.cpp:555
-msgid "The Valley"
+msgid "Tirana"
 msgstr ""
 
 #: data.cpp:556
-msgid "Vatican City"
+msgid "Tokyo"
 msgstr ""
 
 #: data.cpp:557
-msgid "Victoria"
+msgid "Torshavn"
 msgstr ""
 
 #: data.cpp:558
-msgid "Vienna"
+msgid "Tripoli"
 msgstr ""
 
 #: data.cpp:559
-msgid "Vientiane"
+msgid "Tunis"
 msgstr ""
 
 #: data.cpp:560
-msgid "Vilnius"
+msgid "Ulaanbaatar"
 msgstr ""
 
 #: data.cpp:561
-msgid "Warsaw"
+msgid "Vaduz"
 msgstr ""
 
 #: data.cpp:562
-msgid "Washington D.C."
+msgid "Valletta"
 msgstr ""
 
 #: data.cpp:563
-msgid "Wellington"
+msgid "The Valley"
 msgstr ""
 
 #: data.cpp:564
-msgid "West Island"
+msgid "Vatican City"
 msgstr ""
 
 #: data.cpp:565
-msgid "Willemstad"
+msgid "Victoria"
 msgstr ""
 
 #: data.cpp:566
-msgid "Windhoek"
+msgid "Vienna"
 msgstr ""
 
 #: data.cpp:567
-msgid "Yamoussoukro"
+msgid "Vientiane"
 msgstr ""
 
 #: data.cpp:568
-msgid "Yaounde"
+msgid "Vilnius"
 msgstr ""
 
 #: data.cpp:569
-msgid "Yaren District"
+msgid "Warsaw"
 msgstr ""
 
 #: data.cpp:570
-msgid "Yerevan"
+msgid "Washington D.C."
 msgstr ""
 
 #: data.cpp:571
-msgid "Zagreb"
+msgid "Wellington"
 msgstr ""
 
 #: data.cpp:572
-msgid "Sol"
+msgid "West Island"
 msgstr ""
 
 #: data.cpp:573
-msgid "Solar System Barycenter"
+msgid "Willemstad"
 msgstr ""
 
 #: data.cpp:574
-msgid "Sun"
+msgid "Windhoek"
 msgstr ""
 
 #: data.cpp:575
-msgid "Alpheratz"
+msgid "Yamoussoukro"
 msgstr ""
 
 #: data.cpp:576
-msgid "Sirrah"
+msgid "Yaounde"
 msgstr ""
 
 #: data.cpp:577
-msgid "Caph"
+msgid "Yaren District"
 msgstr ""
 
 #: data.cpp:578
-msgid "Algenib"
+msgid "Yerevan"
 msgstr ""
 
 #: data.cpp:579
-msgid "Citadelle"
+msgid "Zagreb"
 msgstr ""
 
 #: data.cpp:580
-msgid "Schemali"
+msgid "Sol"
 msgstr ""
 
 #: data.cpp:581
-msgid "Ankaa"
+msgid "Solar System Barycenter"
 msgstr ""
 
 #: data.cpp:582
-msgid "Felixvarela"
+msgid "Sun"
 msgstr ""
 
 #: data.cpp:583
-msgid "Fulu"
+msgid "Alpheratz"
 msgstr ""
 
 #: data.cpp:584
-msgid "Schedar"
+msgid "Sirrah"
 msgstr ""
 
 #: data.cpp:585
-msgid "Shedir"
+msgid "Caph"
 msgstr ""
 
 #: data.cpp:586
-msgid "Diphda"
+msgid "Algenib"
 msgstr ""
 
 #: data.cpp:587
-msgid "Deneb Kaitos"
+msgid "Citadelle"
 msgstr ""
 
 #: data.cpp:588
-msgid "Cocibolca"
+msgid "Schemali"
 msgstr ""
 
 #: data.cpp:589
-msgid "Achird"
+msgid "Ankaa"
 msgstr ""
 
 #: data.cpp:590
-msgid "Van Maanen 2"
+msgid "Felixvarela"
 msgstr ""
 
 #: data.cpp:591
-msgid "Castula"
+msgid "Fulu"
 msgstr ""
 
 #: data.cpp:592
-msgid "Navi"
+msgid "Schedar"
 msgstr ""
 
 #: data.cpp:593
-msgid "Nenque"
+msgid "Shedir"
 msgstr ""
 
 #: data.cpp:594
-msgid "Wurren"
+msgid "Diphda"
 msgstr ""
 
 #: data.cpp:595
-msgid "Mirach"
+msgid "Deneb Kaitos"
 msgstr ""
 
 #: data.cpp:596
-msgid "Emiw"
+msgid "Cocibolca"
 msgstr ""
 
 #: data.cpp:597
-msgid "Revati"
+msgid "Achird"
 msgstr ""
 
 #: data.cpp:598
-msgid "Adhil"
+msgid "Van Maanen 2"
 msgstr ""
 
 #: data.cpp:599
-msgid "Bélénos"
+msgid "Castula"
 msgstr ""
 
 #: data.cpp:600
-msgid "Ruchbah"
+msgid "Navi"
 msgstr ""
 
 #: data.cpp:601
-msgid "Alpherg"
+msgid "Nenque"
 msgstr ""
 
 #: data.cpp:602
-msgid "Titawin"
+msgid "Wurren"
 msgstr ""
 
 #: data.cpp:603
-msgid "Achernar"
+msgid "Mirach"
 msgstr ""
 
 #: data.cpp:604
-msgid "Nembus"
+msgid "Emiw"
 msgstr ""
 
 #: data.cpp:605
-msgid "Torcular"
+msgid "Revati"
 msgstr ""
 
 #: data.cpp:606
-msgid "Torcularis Septentrionalis"
+msgid "Adhil"
 msgstr ""
 
 #: data.cpp:607
-msgid "Baten Kaitos"
+msgid "Bélénos"
 msgstr ""
 
 #: data.cpp:608
-msgid "Mothallah"
+msgid "Ruchbah"
 msgstr ""
 
 #: data.cpp:609
-msgid "Caput Trianguli"
+msgid "Alpherg"
 msgstr ""
 
 #: data.cpp:610
-msgid "Mesarthim"
+msgid "Titawin"
 msgstr ""
 
 #: data.cpp:611
-msgid "Segin"
+msgid "Achernar"
 msgstr ""
 
 #: data.cpp:612
-msgid "Sheratan"
+msgid "Nembus"
 msgstr ""
 
 #: data.cpp:613
-msgid "Alrescha"
+msgid "Torcular"
 msgstr ""
 
 #: data.cpp:614
-msgid "Al Rescha"
+msgid "Torcularis Septentrionalis"
 msgstr ""
 
 #: data.cpp:615
-msgid "Almach"
+msgid "Baten Kaitos"
 msgstr ""
 
 #: data.cpp:616
-msgid "Almaak"
+msgid "Mothallah"
 msgstr ""
 
 #: data.cpp:617
-msgid "Alamak"
+msgid "Caput Trianguli"
 msgstr ""
 
 #: data.cpp:618
-msgid "Hamal"
+msgid "Mesarthim"
 msgstr ""
 
 #: data.cpp:619
-msgid "Mira"
+msgid "Segin"
 msgstr ""
 
 #: data.cpp:620
-msgid "Polaris"
+msgid "Sheratan"
 msgstr ""
 
 #: data.cpp:621
-msgid "Buna"
+msgid "Alrescha"
 msgstr ""
 
 #: data.cpp:622
-msgid "Kaffaljidhma"
+msgid "Al Rescha"
 msgstr ""
 
 #: data.cpp:623
-msgid "Koeia"
+msgid "Almach"
 msgstr ""
 
 #: data.cpp:624
-msgid "Lilii Borea"
+msgid "Almaak"
 msgstr ""
 
 #: data.cpp:625
-msgid "Nushagak"
+msgid "Alamak"
 msgstr ""
 
 #: data.cpp:626
-msgid "Bharani"
+msgid "Hamal"
 msgstr ""
 
 #: data.cpp:627
-msgid "Miram"
+msgid "Mira"
 msgstr ""
 
 #: data.cpp:628
-msgid "Angetenar"
+msgid "Polaris"
 msgstr ""
 
 #: data.cpp:629
-msgid "Azha"
+msgid "Buna"
 msgstr ""
 
 #: data.cpp:630
-msgid "Acamar"
+msgid "Kaffaljidhma"
 msgstr ""
 
 #: data.cpp:631
-msgid "Ayeyarwady"
+msgid "Koeia"
 msgstr ""
 
 #: data.cpp:632
-msgid "Menkar"
+msgid "Lilii Borea"
 msgstr ""
 
 #: data.cpp:633
-msgid "Menkab"
+msgid "Nushagak"
 msgstr ""
 
 #: data.cpp:634
-msgid "Algol"
+msgid "Bharani"
 msgstr ""
 
 #: data.cpp:635
-msgid "Misam"
+msgid "Miram"
 msgstr ""
 
 #: data.cpp:636
-msgid "Botein"
+msgid "Angetenar"
 msgstr ""
 
 #: data.cpp:637
-msgid "Dalim"
+msgid "Azha"
 msgstr ""
 
 #: data.cpp:638
-msgid "Zibal"
+msgid "Acamar"
 msgstr ""
 
 #: data.cpp:639
-msgid "Intan"
+msgid "Ayeyarwady"
 msgstr ""
 
 #: data.cpp:640
-msgid "Mirfak"
+msgid "Menkar"
 msgstr ""
 
 #: data.cpp:641
-msgid "Mirphak"
+msgid "Menkab"
 msgstr ""
 
 #: data.cpp:642
-msgid "Marfak"
+msgid "Algol"
 msgstr ""
 
 #: data.cpp:643
-msgid "Ran"
+msgid "Misam"
 msgstr ""
 
 #: data.cpp:644
-msgid "Tupi"
+msgid "Botein"
 msgstr ""
 
 #: data.cpp:645
-msgid "Rana"
+msgid "Dalim"
 msgstr ""
 
 #: data.cpp:646
-msgid "Atik"
+msgid "Zibal"
 msgstr ""
 
 #: data.cpp:647
-msgid "Celaeno"
+msgid "Intan"
 msgstr ""
 
 #: data.cpp:648
-msgid "Electra"
+msgid "Mirfak"
 msgstr ""
 
 #: data.cpp:649
-msgid "Taygeta"
+msgid "Mirphak"
 msgstr ""
 
 #: data.cpp:650
-msgid "Maia"
+msgid "Marfak"
 msgstr ""
 
 #: data.cpp:651
-msgid "Asterope"
+msgid "Ran"
 msgstr ""
 
 #: data.cpp:652
-msgid "Merope"
+msgid "Tupi"
 msgstr ""
 
 #: data.cpp:653
-msgid "Alcyone"
+msgid "Rana"
 msgstr ""
 
 #: data.cpp:654
-msgid "Pleione"
+msgid "Atik"
 msgstr ""
 
 #: data.cpp:655
-msgid "Zaurak"
+msgid "Celaeno"
 msgstr ""
 
 #: data.cpp:656
-msgid "Menkib"
+msgid "Electra"
 msgstr ""
 
 #: data.cpp:657
-msgid "Beid"
+msgid "Taygeta"
 msgstr ""
 
 #: data.cpp:658
-msgid "Keid"
+msgid "Maia"
 msgstr ""
 
 #: data.cpp:659
-msgid "Prima Hyadum"
+msgid "Asterope"
 msgstr ""
 
 #: data.cpp:660
-msgid "Secunda Hyadum"
+msgid "Merope"
 msgstr ""
 
 #: data.cpp:661
-msgid "Beemim"
+msgid "Alcyone"
 msgstr ""
 
 #: data.cpp:662
-msgid "Ain"
+msgid "Pleione"
 msgstr ""
 
 #: data.cpp:663
-msgid "Chamukuy"
+msgid "Zaurak"
 msgstr ""
 
 #: data.cpp:664
-msgid "Hoggar"
+msgid "Menkib"
 msgstr ""
 
 #: data.cpp:665
-msgid "Theemin"
+msgid "Beid"
 msgstr ""
 
 #: data.cpp:666
-msgid "Aldebaran"
+msgid "Keid"
 msgstr ""
 
 #: data.cpp:667
-msgid "Sceptrum"
+msgid "Prima Hyadum"
 msgstr ""
 
 #: data.cpp:668
-msgid "Tabit"
+msgid "Secunda Hyadum"
 msgstr ""
 
 #: data.cpp:669
-msgid "Mouhoun"
+msgid "Beemim"
 msgstr ""
 
 #: data.cpp:670
-msgid "Hassaleh"
+msgid "Ain"
 msgstr ""
 
 #: data.cpp:671
-msgid "Hind's Crimson Star"
+msgid "Chamukuy"
 msgstr ""
 
 #: data.cpp:672
-msgid "Almaaz"
+msgid "Hoggar"
 msgstr ""
 
 #: data.cpp:673
-msgid "Saclateni"
+msgid "Theemin"
 msgstr ""
 
 #: data.cpp:674
-msgid "Sadatoni"
+msgid "Aldebaran"
 msgstr ""
 
 #: data.cpp:675
-msgid "Haedus"
+msgid "Sceptrum"
 msgstr ""
 
 #: data.cpp:676
-msgid "Cursa"
+msgid "Tabit"
 msgstr ""
 
 #: data.cpp:677
-msgid "Mago"
+msgid "Mouhoun"
 msgstr ""
 
 #: data.cpp:678
-msgid "Kapteyn's Star"
+msgid "Hassaleh"
 msgstr ""
 
 #: data.cpp:679
-msgid "Rigel"
+msgid "Hind's Crimson Star"
 msgstr ""
 
 #: data.cpp:680
-msgid "Capella"
+msgid "Almaaz"
 msgstr ""
 
 #: data.cpp:681
-msgid "Bellatrix"
+msgid "Saclateni"
 msgstr ""
 
 #: data.cpp:682
-msgid "Elnath"
+msgid "Sadatoni"
 msgstr ""
 
 #: data.cpp:683
-msgid "Alnath"
+msgid "Haedus"
 msgstr ""
 
 #: data.cpp:684
-msgid "Nihal"
+msgid "Cursa"
 msgstr ""
 
 #: data.cpp:685
-msgid "Thabit"
+msgid "Mago"
 msgstr ""
 
 #: data.cpp:686
-msgid "Mintaka"
+msgid "Kapteyn's Star"
 msgstr ""
 
 #: data.cpp:687
-msgid "Arneb"
+msgid "Rigel"
 msgstr ""
 
 #: data.cpp:688
-msgid "Meissa"
+msgid "Capella"
 msgstr ""
 
 #: data.cpp:689
-msgid "Heka"
+msgid "Bellatrix"
 msgstr ""
 
 #: data.cpp:690
-msgid "Hatysa"
+msgid "Elnath"
 msgstr ""
 
 #: data.cpp:691
-msgid "Alnilam"
+msgid "Alnath"
 msgstr ""
 
 #: data.cpp:692
-msgid "Bubup"
+msgid "Nihal"
 msgstr ""
 
 #: data.cpp:693
-msgid "Tianguan"
+msgid "Thabit"
 msgstr ""
 
 #: data.cpp:694
-msgid "Phact"
+msgid "Mintaka"
 msgstr ""
 
 #: data.cpp:695
-msgid "Alnitak"
+msgid "Arneb"
 msgstr ""
 
 #: data.cpp:696
-msgid "Saiph"
+msgid "Meissa"
 msgstr ""
 
 #: data.cpp:697
-msgid "Wazn"
+msgid "Heka"
 msgstr ""
 
 #: data.cpp:698
-msgid "Betelgeuse"
+msgid "Hatysa"
 msgstr ""
 
 #: data.cpp:699
-msgid "Prijipati"
+msgid "Alnilam"
 msgstr ""
 
 #: data.cpp:700
-msgid "Menkalinan"
+msgid "Bubup"
 msgstr ""
 
 #: data.cpp:701
-msgid "Mahasim"
+msgid "Tianguan"
 msgstr ""
 
 #: data.cpp:702
-msgid "Elkurud"
+msgid "Phact"
 msgstr ""
 
 #: data.cpp:703
-msgid "Amadioha"
+msgid "Alnitak"
 msgstr ""
 
 #: data.cpp:704
-msgid "Propus"
+msgid "Saiph"
 msgstr ""
 
 #: data.cpp:705
-msgid "Red Rectangle"
+msgid "Wazn"
 msgstr ""
 
 #: data.cpp:706
-msgid "Furud"
+msgid "Betelgeuse"
 msgstr ""
 
 #: data.cpp:707
-msgid "Mirzam"
+msgid "Prijipati"
 msgstr ""
 
 #: data.cpp:708
-msgid "Murzim"
+msgid "Menkalinan"
 msgstr ""
 
 #: data.cpp:709
-msgid "Tejat"
+msgid "Mahasim"
 msgstr ""
 
 #: data.cpp:710
-msgid "Canopus"
+msgid "Elkurud"
 msgstr ""
 
 #: data.cpp:711
-msgid "Suhel"
+msgid "Amadioha"
 msgstr ""
 
 #: data.cpp:712
-msgid "Lucilinburhuc"
+msgid "Propus"
 msgstr ""
 
 #: data.cpp:713
-msgid "Lusitânia"
+msgid "Red Rectangle"
 msgstr ""
 
 #: data.cpp:714
-msgid "Plaskett's Star"
+msgid "Furud"
 msgstr ""
 
 #: data.cpp:715
-msgid "Alhena"
+msgid "Mirzam"
 msgstr ""
 
 #: data.cpp:716
-msgid "Almeisan"
+msgid "Murzim"
 msgstr ""
 
 #: data.cpp:717
-msgid "Nosaxa"
+msgid "Tejat"
 msgstr ""
 
 #: data.cpp:718
-msgid "Mebsuta"
+msgid "Canopus"
 msgstr ""
 
 #: data.cpp:719
-msgid "Sirius"
+msgid "Suhel"
 msgstr ""
 
 #: data.cpp:720
-msgid "Alzirr"
+msgid "Lucilinburhuc"
 msgstr ""
 
 #: data.cpp:721
-msgid "Nervia"
+msgid "Lusitânia"
 msgstr ""
 
 #: data.cpp:722
-msgid "Adhara"
+msgid "Plaskett's Star"
 msgstr ""
 
 #: data.cpp:723
-msgid "Adara"
+msgid "Alhena"
 msgstr ""
 
 #: data.cpp:724
-msgid "Citalá"
+msgid "Almeisan"
 msgstr ""
 
 #: data.cpp:725
-msgid "Unurgunite"
+msgid "Nosaxa"
 msgstr ""
 
 #: data.cpp:726
-msgid "Muliphein"
+msgid "Mebsuta"
 msgstr ""
 
 #: data.cpp:727
-msgid "Mekbuda"
+msgid "Sirius"
 msgstr ""
 
 #: data.cpp:728
-msgid "Wezen"
+msgid "Alzirr"
 msgstr ""
 
 #: data.cpp:729
-msgid "Bernes 135"
+msgid "Nervia"
 msgstr ""
 
 #: data.cpp:730
-msgid "Wasat"
+msgid "Adhara"
 msgstr ""
 
 #: data.cpp:731
-msgid "Aludra"
+msgid "Adara"
 msgstr ""
 
 #: data.cpp:732
-msgid "Gomeisa"
+msgid "Citalá"
 msgstr ""
 
 #: data.cpp:733
-msgid "Luyten's Star"
+msgid "Unurgunite"
 msgstr ""
 
 #: data.cpp:734
-msgid "Castor"
+msgid "Muliphein"
 msgstr ""
 
 #: data.cpp:735
-msgid "Jishui"
+msgid "Mekbuda"
 msgstr ""
 
 #: data.cpp:736
-msgid "Procyon"
+msgid "Wezen"
 msgstr ""
 
 #: data.cpp:737
-msgid "Elgomaisa"
+msgid "Bernes 135"
 msgstr ""
 
 #: data.cpp:738
-msgid "Ceibo"
+msgid "Wasat"
 msgstr ""
 
 #: data.cpp:739
-msgid "Pollux"
+msgid "Aludra"
 msgstr ""
 
 #: data.cpp:740
-msgid "Tapecue"
+msgid "Gomeisa"
 msgstr ""
 
 #: data.cpp:741
-msgid "Azmidi"
+msgid "Luyten's Star"
 msgstr ""
 
 #: data.cpp:742
-msgid "Asmidiske"
+msgid "Castor"
 msgstr ""
 
 #: data.cpp:743
-msgid "Naos"
+msgid "Jishui"
 msgstr ""
 
 #: data.cpp:744
-msgid "Tureis"
+msgid "Procyon"
 msgstr ""
 
 #: data.cpp:745
-msgid "Regor"
+msgid "Elgomaisa"
 msgstr ""
 
 #: data.cpp:746
-msgid "Tegmine"
+msgid "Ceibo"
 msgstr ""
 
 #: data.cpp:747
-msgid "Tarf"
+msgid "Pollux"
 msgstr ""
 
 #: data.cpp:748
-msgid "Al Tarf"
+msgid "Tapecue"
 msgstr ""
 
 #: data.cpp:749
-msgid "Násti"
+msgid "Azmidi"
 msgstr ""
 
 #: data.cpp:750
-msgid "Piautos"
+msgid "Asmidiske"
 msgstr ""
 
 #: data.cpp:751
-msgid "Avior"
+msgid "Naos"
 msgstr ""
 
 #: data.cpp:752
-msgid "Alsciaukat"
+msgid "Tureis"
 msgstr ""
 
 #: data.cpp:753
-msgid "Muscida"
+msgid "Regor"
 msgstr ""
 
 #: data.cpp:754
-msgid "Minchir"
+msgid "Tegmine"
 msgstr ""
 
 #: data.cpp:755
-msgid "Gakyid"
+msgid "Tarf"
 msgstr ""
 
 #: data.cpp:756
-msgid "Meleph"
+msgid "Al Tarf"
 msgstr ""
 
 #: data.cpp:757
-msgid "Asellus Borealis"
+msgid "Násti"
 msgstr ""
 
 #: data.cpp:758
-msgid "Asellus Australis"
+msgid "Piautos"
 msgstr ""
 
 #: data.cpp:759
-msgid "Alsephina"
+msgid "Avior"
 msgstr ""
 
 #: data.cpp:760
-msgid "Ashlesha"
+msgid "Alsciaukat"
 msgstr ""
 
 #: data.cpp:761
-msgid "Copernicus"
+msgid "Muscida"
 msgstr ""
 
 #: data.cpp:762
-msgid "Stribor"
+msgid "Minchir"
 msgstr ""
 
 #: data.cpp:763
-msgid "Acubens"
+msgid "Gakyid"
 msgstr ""
 
 #: data.cpp:764
-msgid "Talitha"
+msgid "Meleph"
 msgstr ""
 
 #: data.cpp:765
-msgid "Dnoces"
+msgid "Asellus Borealis"
 msgstr ""
 
 #: data.cpp:766
-msgid "Alkaphrah"
+msgid "Asellus Australis"
 msgstr ""
 
 #: data.cpp:767
-msgid "Talitha Australis"
+msgid "Alsephina"
 msgstr ""
 
 #: data.cpp:768
-msgid "Suhail"
+msgid "Ashlesha"
 msgstr ""
 
 #: data.cpp:769
-msgid "Nahn"
+msgid "Copernicus"
 msgstr ""
 
 #: data.cpp:770
-msgid "Miaplacidus"
+msgid "Stribor"
 msgstr ""
 
 #: data.cpp:771
-msgid "Aspidiske"
+msgid "Acubens"
 msgstr ""
 
 #: data.cpp:772
-msgid "Markeb"
+msgid "Talitha"
 msgstr ""
 
 #: data.cpp:773
-msgid "Alphard"
+msgid "Dnoces"
 msgstr ""
 
 #: data.cpp:774
-msgid "Cor Hydrae"
+msgid "Alkaphrah"
 msgstr ""
 
 #: data.cpp:775
-msgid "Intercrus"
+msgid "Talitha Australis"
 msgstr ""
 
 #: data.cpp:776
-msgid "Alterf"
+msgid "Suhail"
 msgstr ""
 
 #: data.cpp:777
-msgid "Illyrian"
+msgid "Nahn"
 msgstr ""
 
 #: data.cpp:778
-msgid "Kalausi"
+msgid "Miaplacidus"
 msgstr ""
 
 #: data.cpp:779
-msgid "Ukdah"
+msgid "Aspidiske"
 msgstr ""
 
 #: data.cpp:780
-msgid "Subra"
+msgid "Markeb"
 msgstr ""
 
 #: data.cpp:781
-msgid "Ras Elased Australis"
+msgid "Alphard"
 msgstr ""
 
 #: data.cpp:782
-msgid "Natasha"
+msgid "Cor Hydrae"
 msgstr ""
 
 #: data.cpp:783
-msgid "Zhang"
+msgid "Intercrus"
 msgstr ""
 
 #: data.cpp:784
-msgid "Rasalas"
+msgid "Alterf"
 msgstr ""
 
 #: data.cpp:785
-msgid "Ras Elased Borealis"
+msgid "Illyrian"
 msgstr ""
 
 #: data.cpp:786
-msgid "Felis"
+msgid "Kalausi"
 msgstr ""
 
 #: data.cpp:787
-msgid "Bibhā"
+msgid "Ukdah"
 msgstr ""
 
 #: data.cpp:788
-msgid "Regulus"
+msgid "Subra"
 msgstr ""
 
 #: data.cpp:789
-msgid "Kabeleced"
+msgid "Ras Elased Australis"
 msgstr ""
 
 #: data.cpp:790
-msgid "Cor Leonis"
+msgid "Natasha"
 msgstr ""
 
 #: data.cpp:791
-msgid "Adhafera"
+msgid "Zhang"
 msgstr ""
 
 #: data.cpp:792
-msgid "Aldhafera"
+msgid "Rasalas"
 msgstr ""
 
 #: data.cpp:793
-msgid "Tania Borealis"
+msgid "Ras Elased Borealis"
 msgstr ""
 
 #: data.cpp:794
-msgid "Algieba"
+msgid "Felis"
 msgstr ""
 
 #: data.cpp:795
-msgid "Tania Australis"
+msgid "Bibhā"
 msgstr ""
 
 #: data.cpp:796
-msgid "Macondo"
+msgid "Regulus"
 msgstr ""
 
 #: data.cpp:797
-msgid "Praecipua"
+msgid "Kabeleced"
 msgstr ""
 
 #: data.cpp:798
-msgid "Chalawan"
+msgid "Cor Leonis"
 msgstr ""
 
 #: data.cpp:799
-msgid "Alkes"
+msgid "Adhafera"
 msgstr ""
 
 #: data.cpp:800
-msgid "Merak"
+msgid "Aldhafera"
 msgstr ""
 
 #: data.cpp:801
-msgid "Lalande 21185"
+msgid "Tania Borealis"
 msgstr ""
 
 #: data.cpp:802
-msgid "Dubhe"
+msgid "Algieba"
 msgstr ""
 
 #: data.cpp:803
-msgid "Dubb"
+msgid "Tania Australis"
 msgstr ""
 
 #: data.cpp:804
-msgid "Dingolay"
+msgid "Macondo"
 msgstr ""
 
 #: data.cpp:805
-msgid "Zosma"
+msgid "Praecipua"
 msgstr ""
 
 #: data.cpp:806
-msgid "Duhr"
+msgid "Chalawan"
 msgstr ""
 
 #: data.cpp:807
-msgid "Chertan"
+msgid "Alkes"
 msgstr ""
 
 #: data.cpp:808
-msgid "Coxa"
+msgid "Merak"
 msgstr ""
 
 #: data.cpp:809
-msgid "Chort"
+msgid "Lalande 21185"
 msgstr ""
 
 #: data.cpp:810
-msgid "Innes' Star"
+msgid "Dubhe"
 msgstr ""
 
 #: data.cpp:811
-msgid "Hunahpú"
+msgid "Dubb"
 msgstr ""
 
 #: data.cpp:812
-msgid "Alula Australis"
+msgid "Dingolay"
 msgstr ""
 
 #: data.cpp:813
-msgid "Alula Borealis"
+msgid "Zosma"
 msgstr ""
 
 #: data.cpp:814
-msgid "Tsze Tseang"
+msgid "Duhr"
 msgstr ""
 
 #: data.cpp:815
-msgid "Shama"
+msgid "Chertan"
 msgstr ""
 
 #: data.cpp:816
-msgid "Giausar"
+msgid "Coxa"
 msgstr ""
 
 #: data.cpp:817
-msgid "Formosa"
+msgid "Chort"
 msgstr ""
 
 #: data.cpp:818
-msgid "Sagarmatha"
+msgid "Innes' Star"
 msgstr ""
 
 #: data.cpp:819
-msgid "Przybylski's Star"
+msgid "Hunahpú"
 msgstr ""
 
 #: data.cpp:820
-msgid "Uklun"
+msgid "Alula Australis"
 msgstr ""
 
 #: data.cpp:821
-msgid "Flegetonte"
+msgid "Alula Borealis"
 msgstr ""
 
 #: data.cpp:822
-msgid "Taiyangshou"
+msgid "Tsze Tseang"
 msgstr ""
 
 #: data.cpp:823
-msgid "Denebola"
+msgid "Shama"
 msgstr ""
 
 #: data.cpp:824
-msgid "Zavijava"
+msgid "Giausar"
 msgstr ""
 
 #: data.cpp:825
-msgid "Alaraph"
+msgid "Formosa"
 msgstr ""
 
 #: data.cpp:826
-msgid "Aniara"
+msgid "Sagarmatha"
 msgstr ""
 
 #: data.cpp:827
-msgid "Groombridge 1830"
+msgid "Przybylski's Star"
 msgstr ""
 
 #: data.cpp:828
-msgid "Phecda"
+msgid "Uklun"
 msgstr ""
 
 #: data.cpp:829
-msgid "Phad"
+msgid "Flegetonte"
 msgstr ""
 
 #: data.cpp:830
-msgid "Tonatiuh"
+msgid "Taiyangshou"
 msgstr ""
 
 #: data.cpp:831
-msgid "Alchiba"
+msgid "Denebola"
 msgstr ""
 
 #: data.cpp:832
-msgid "Imai"
+msgid "Zavijava"
 msgstr ""
 
 #: data.cpp:833
-msgid "Megrez"
+msgid "Alaraph"
 msgstr ""
 
 #: data.cpp:834
-msgid "Gienah"
+msgid "Aniara"
 msgstr ""
 
 #: data.cpp:835
-msgid "Zaniah"
+msgid "Groombridge 1830"
 msgstr ""
 
 #: data.cpp:836
-msgid "Ginan"
+msgid "Phecda"
 msgstr ""
 
 #: data.cpp:837
-msgid "Tupã"
+msgid "Phad"
 msgstr ""
 
 #: data.cpp:838
-msgid "Acrux"
+msgid "Tonatiuh"
 msgstr ""
 
 #: data.cpp:839
-msgid "Algorab"
+msgid "Alchiba"
 msgstr ""
 
 #: data.cpp:840
-msgid "Gacrux"
+msgid "Imai"
 msgstr ""
 
 #: data.cpp:841
-msgid "Funi"
+msgid "Megrez"
 msgstr ""
 
 #: data.cpp:842
-msgid "Chara"
+msgid "Gienah"
 msgstr ""
 
 #: data.cpp:843
-msgid "Kraz"
+msgid "Zaniah"
 msgstr ""
 
 #: data.cpp:844
-msgid "Muhlifain"
+msgid "Ginan"
 msgstr ""
 
 #: data.cpp:845
-msgid "Porrima"
+msgid "Tupã"
 msgstr ""
 
 #: data.cpp:846
-msgid "La Superba"
+msgid "Acrux"
 msgstr ""
 
 #: data.cpp:847
-msgid "Tianyi"
+msgid "Algorab"
 msgstr ""
 
 #: data.cpp:848
-msgid "Mimosa"
+msgid "Gacrux"
 msgstr ""
 
 #: data.cpp:849
-msgid "Alioth"
+msgid "Funi"
 msgstr ""
 
 #: data.cpp:850
-msgid "Taiyi"
+msgid "Chara"
 msgstr ""
 
 #: data.cpp:851
-msgid "Minelauva"
+msgid "Kraz"
 msgstr ""
 
 #: data.cpp:852
-msgid "Auva"
+msgid "Muhlifain"
 msgstr ""
 
 #: data.cpp:853
-msgid "Cor Caroli"
+msgid "Porrima"
 msgstr ""
 
 #: data.cpp:854
-msgid "Vindemiatrix"
+msgid "La Superba"
 msgstr ""
 
 #: data.cpp:855
-msgid "Almuredin"
+msgid "Tianyi"
 msgstr ""
 
 #: data.cpp:856
-msgid "Diadem"
+msgid "Mimosa"
 msgstr ""
 
 #: data.cpp:857
-msgid "Mizar"
+msgid "Alioth"
 msgstr ""
 
 #: data.cpp:858
-msgid "Spica"
+msgid "Taiyi"
 msgstr ""
 
 #: data.cpp:859
-msgid "Azimech"
+msgid "Minelauva"
 msgstr ""
 
 #: data.cpp:860
-msgid "Alcor"
+msgid "Auva"
 msgstr ""
 
 #: data.cpp:861
-msgid "Dofida"
+msgid "Cor Caroli"
 msgstr ""
 
 #: data.cpp:862
-msgid "Liesma"
+msgid "Vindemiatrix"
 msgstr ""
 
 #: data.cpp:863
-msgid "Heze"
+msgid "Almuredin"
 msgstr ""
 
 #: data.cpp:864
-msgid "Alkaid"
+msgid "Diadem"
 msgstr ""
 
 #: data.cpp:865
-msgid "Benetnasch"
+msgid "Mizar"
 msgstr ""
 
 #: data.cpp:866
-msgid "Muphrid"
+msgid "Spica"
 msgstr ""
 
 #: data.cpp:867
-msgid "Hadar"
+msgid "Azimech"
 msgstr ""
 
 #: data.cpp:868
-msgid "Agena"
+msgid "Alcor"
 msgstr ""
 
 #: data.cpp:869
-msgid "Thuban"
+msgid "Dofida"
 msgstr ""
 
 #: data.cpp:870
-msgid "Menkent"
+msgid "Liesma"
 msgstr ""
 
 #: data.cpp:871
-msgid "Kang"
+msgid "Heze"
 msgstr ""
 
 #: data.cpp:872
-msgid "Arcturus"
+msgid "Alkaid"
 msgstr ""
 
 #: data.cpp:873
-msgid "Syrma"
+msgid "Benetnasch"
 msgstr ""
 
 #: data.cpp:874
-msgid "Xuange"
+msgid "Muphrid"
 msgstr ""
 
 #: data.cpp:875
-msgid "Elgafar"
+msgid "Hadar"
 msgstr ""
 
 #: data.cpp:876
-msgid "Proxima"
+msgid "Agena"
 msgstr ""
 
 #: data.cpp:877
-msgid "Seginus"
+msgid "Thuban"
 msgstr ""
 
 #: data.cpp:878
-msgid "Ceginus"
+msgid "Menkent"
 msgstr ""
 
 #: data.cpp:879
-msgid "Toliman"
+msgid "Kang"
 msgstr ""
 
 #: data.cpp:880
-msgid "Rigil Kentaurus"
+msgid "Arcturus"
 msgstr ""
 
 #: data.cpp:881
-msgid "Izar"
+msgid "Syrma"
 msgstr ""
 
 #: data.cpp:882
-msgid "Mirak"
+msgid "Xuange"
 msgstr ""
 
 #: data.cpp:883
-msgid "Pulcherrima"
+msgid "Elgafar"
 msgstr ""
 
 #: data.cpp:884
-msgid "Mönch"
+msgid "Proxima"
 msgstr ""
 
 #: data.cpp:885
-msgid "Merga"
+msgid "Seginus"
 msgstr ""
 
 #: data.cpp:886
-msgid "Kochab"
+msgid "Ceginus"
 msgstr ""
 
 #: data.cpp:887
-msgid "Kocab"
+msgid "Toliman"
 msgstr ""
 
 #: data.cpp:888
-msgid "Zubenelgenubi"
+msgid "Rigil Kentaurus"
 msgstr ""
 
 #: data.cpp:889
-msgid "Arcalís"
+msgid "Izar"
 msgstr ""
 
 #: data.cpp:890
-msgid "Baekdu"
+msgid "Mirak"
 msgstr ""
 
 #: data.cpp:891
-msgid "Zuben Elakribi"
+msgid "Pulcherrima"
 msgstr ""
 
 #: data.cpp:892
-msgid "Nekkar"
+msgid "Mönch"
 msgstr ""
 
 #: data.cpp:893
-msgid "Brachium"
+msgid "Merga"
 msgstr ""
 
 #: data.cpp:894
-msgid "Zubeneschamali"
+msgid "Kochab"
 msgstr ""
 
 #: data.cpp:895
-msgid "Pherkad Minor"
+msgid "Kocab"
 msgstr ""
 
 #: data.cpp:896
-msgid "Nikawiy"
+msgid "Zubenelgenubi"
 msgstr ""
 
 #: data.cpp:897
-msgid "Pherkad"
+msgid "Arcalís"
 msgstr ""
 
 #: data.cpp:898
-msgid "Alkalurops"
+msgid "Baekdu"
 msgstr ""
 
 #: data.cpp:899
-msgid "Edasich"
+msgid "Zuben Elakribi"
 msgstr ""
 
 #: data.cpp:900
-msgid "Nusakan"
+msgid "Nekkar"
 msgstr ""
 
 #: data.cpp:901
-msgid "Alphecca"
+msgid "Brachium"
 msgstr ""
 
 #: data.cpp:902
-msgid "Gemma"
+msgid "Zubeneschamali"
 msgstr ""
 
 #: data.cpp:903
-msgid "Zubenelhakrabi"
+msgid "Pherkad Minor"
 msgstr ""
 
 #: data.cpp:904
-msgid "Zuben Elakrab"
+msgid "Nikawiy"
 msgstr ""
 
 #: data.cpp:905
-msgid "Karaka"
+msgid "Pherkad"
 msgstr ""
 
 #: data.cpp:906
-msgid "Unukalhai"
+msgid "Alkalurops"
 msgstr ""
 
 #: data.cpp:907
-msgid "Chow"
+msgid "Edasich"
 msgstr ""
 
 #: data.cpp:908
-msgid "Gudja"
+msgid "Nusakan"
 msgstr ""
 
 #: data.cpp:909
-msgid "Iklil"
+msgid "Alphecca"
 msgstr ""
 
 #: data.cpp:910
-msgid "Fang"
+msgid "Gemma"
 msgstr ""
 
 #: data.cpp:911
-msgid "Dschubba"
+msgid "Zubenelhakrabi"
 msgstr ""
 
 #: data.cpp:912
-msgid "Acrab"
+msgid "Zuben Elakrab"
 msgstr ""
 
 #: data.cpp:913
-msgid "Graffias"
+msgid "Karaka"
 msgstr ""
 
 #: data.cpp:914
-msgid "Akrab"
+msgid "Unukalhai"
 msgstr ""
 
 #: data.cpp:915
-msgid "Marsic"
+msgid "Chow"
 msgstr ""
 
 #: data.cpp:916
-msgid "Jabbah"
+msgid "Gudja"
 msgstr ""
 
 #: data.cpp:917
-msgid "Sharjah"
+msgid "Iklil"
 msgstr ""
 
 #: data.cpp:918
-msgid "Yed Prior"
+msgid "Fang"
 msgstr ""
 
 #: data.cpp:919
-msgid "Yed Posterior"
+msgid "Dschubba"
 msgstr ""
 
 #: data.cpp:920
-msgid "Hunor"
+msgid "Acrab"
 msgstr ""
 
 #: data.cpp:921
-msgid "Alniyat"
+msgid "Graffias"
 msgstr ""
 
 #: data.cpp:922
-msgid "Al Niyat"
+msgid "Akrab"
 msgstr ""
 
 #: data.cpp:923
-msgid "Athebyne"
+msgid "Marsic"
 msgstr ""
 
 #: data.cpp:924
-msgid "Cujam"
+msgid "Jabbah"
 msgstr ""
 
 #: data.cpp:925
-msgid "Timir"
+msgid "Sharjah"
 msgstr ""
 
 #: data.cpp:926
-msgid "Antares"
+msgid "Yed Prior"
 msgstr ""
 
 #: data.cpp:927
-msgid "Kornephoros"
+msgid "Yed Posterior"
 msgstr ""
 
 #: data.cpp:928
-msgid "Ogma"
+msgid "Hunor"
 msgstr ""
 
 #: data.cpp:929
-msgid "Marfik"
+msgid "Alniyat"
 msgstr ""
 
 #: data.cpp:930
-msgid "Rosalíadecastro"
+msgid "Al Niyat"
 msgstr ""
 
 #: data.cpp:931
-msgid "Paikauhale"
+msgid "Athebyne"
 msgstr ""
 
 #: data.cpp:932
-msgid "Atria"
+msgid "Cujam"
 msgstr ""
 
 #: data.cpp:933
-msgid "Larawag"
+msgid "Timir"
 msgstr ""
 
 #: data.cpp:934
-msgid "Xamidimura"
+msgid "Antares"
 msgstr ""
 
 #: data.cpp:935
-msgid "Pipirima"
+msgid "Kornephoros"
 msgstr ""
 
 #: data.cpp:936
-msgid "Mahsati"
+msgid "Ogma"
 msgstr ""
 
 #: data.cpp:937
-msgid "Rapeto"
+msgid "Marfik"
 msgstr ""
 
 #: data.cpp:938
-msgid "Alrakis"
+msgid "Rosalíadecastro"
 msgstr ""
 
 #: data.cpp:939
-msgid "Arrakis"
+msgid "Paikauhale"
 msgstr ""
 
 #: data.cpp:940
-msgid "Aldhibah"
+msgid "Atria"
 msgstr ""
 
 #: data.cpp:941
-msgid "Sabik"
+msgid "Larawag"
 msgstr ""
 
 #: data.cpp:942
-msgid "Rasalgethi"
+msgid "Xamidimura"
 msgstr ""
 
 #: data.cpp:943
-msgid "Ras Algethi"
+msgid "Pipirima"
 msgstr ""
 
 #: data.cpp:944
-msgid "Sarin"
+msgid "Mahsati"
 msgstr ""
 
 #: data.cpp:945
-msgid "Guniibuu"
+msgid "Rapeto"
 msgstr ""
 
 #: data.cpp:946
-msgid "Inquill"
+msgid "Alrakis"
 msgstr ""
 
 #: data.cpp:947
-msgid "Rastaban"
+msgid "Arrakis"
 msgstr ""
 
 #: data.cpp:948
-msgid "Maasym"
+msgid "Aldhibah"
 msgstr ""
 
 #: data.cpp:949
-msgid "Lesath"
+msgid "Sabik"
 msgstr ""
 
 #: data.cpp:950
-msgid "Lesuth"
+msgid "Rasalgethi"
 msgstr ""
 
 #: data.cpp:951
-msgid "Kuma"
+msgid "Ras Algethi"
 msgstr ""
 
 #: data.cpp:952
-msgid "Yildun"
+msgid "Sarin"
 msgstr ""
 
 #: data.cpp:953
-msgid "Shaula"
+msgid "Guniibuu"
 msgstr ""
 
 #: data.cpp:954
-msgid "Rasalhague"
+msgid "Inquill"
 msgstr ""
 
 #: data.cpp:955
-msgid "Ras Alhague"
+msgid "Rastaban"
 msgstr ""
 
 #: data.cpp:956
-msgid "Sargas"
+msgid "Maasym"
 msgstr ""
 
 #: data.cpp:957
-msgid "Dziban"
+msgid "Lesath"
 msgstr ""
 
 #: data.cpp:958
-msgid "Girtab"
+msgid "Lesuth"
 msgstr ""
 
 #: data.cpp:959
-msgid "Cebalrai"
+msgid "Kuma"
 msgstr ""
 
 #: data.cpp:960
-msgid "Alruba"
+msgid "Yildun"
 msgstr ""
 
 #: data.cpp:961
-msgid "Cervantes"
+msgid "Shaula"
 msgstr ""
 
 #: data.cpp:962
-msgid "Fuyue"
+msgid "Rasalhague"
 msgstr ""
 
 #: data.cpp:963
-msgid "Grumium"
+msgid "Ras Alhague"
 msgstr ""
 
 #: data.cpp:964
-msgid "Eltanin"
+msgid "Sargas"
 msgstr ""
 
 #: data.cpp:965
-msgid "Etamin"
+msgid "Dziban"
 msgstr ""
 
 #: data.cpp:966
-msgid "Barnard's Star"
+msgid "Girtab"
 msgstr ""
 
 #: data.cpp:967
-msgid "Pincoya"
+msgid "Cebalrai"
 msgstr ""
 
 #: data.cpp:968
-msgid "Alnasl"
+msgid "Alruba"
 msgstr ""
 
 #: data.cpp:969
-msgid "Polis"
+msgid "Cervantes"
 msgstr ""
 
 #: data.cpp:970
-msgid "Kaus Media"
+msgid "Fuyue"
 msgstr ""
 
 #: data.cpp:971
-msgid "Alasia"
+msgid "Grumium"
 msgstr ""
 
 #: data.cpp:972
-msgid "Kaus Australis"
+msgid "Eltanin"
 msgstr ""
 
 #: data.cpp:973
-msgid "Al Athfar"
+msgid "Etamin"
 msgstr ""
 
 #: data.cpp:974
-msgid "Fafnir"
+msgid "Barnard's Star"
 msgstr ""
 
 #: data.cpp:975
-msgid "Kaus Borealis"
+msgid "Pincoya"
 msgstr ""
 
 #: data.cpp:976
-msgid "Vega"
+msgid "Alnasl"
 msgstr ""
 
 #: data.cpp:977
-msgid "Xihe"
+msgid "Polis"
 msgstr ""
 
 #: data.cpp:978
-msgid "Sheliak"
+msgid "Kaus Media"
 msgstr ""
 
 #: data.cpp:979
-msgid "Ainalrami"
+msgid "Alasia"
 msgstr ""
 
 #: data.cpp:980
-msgid "Nunki"
+msgid "Kaus Australis"
 msgstr ""
 
 #: data.cpp:981
-msgid "Kaveh"
+msgid "Al Athfar"
 msgstr ""
 
 #: data.cpp:982
-msgid "Alya"
+msgid "Fafnir"
 msgstr ""
 
 #: data.cpp:983
-msgid "Sulafat"
+msgid "Kaus Borealis"
 msgstr ""
 
 #: data.cpp:984
-msgid "Ascella"
+msgid "Vega"
 msgstr ""
 
 #: data.cpp:985
-msgid "Okab"
+msgid "Xihe"
 msgstr ""
 
 #: data.cpp:986
-msgid "Deneb el Okab"
+msgid "Sheliak"
 msgstr ""
 
 #: data.cpp:987
-msgid "Meridiana"
+msgid "Ainalrami"
 msgstr ""
 
 #: data.cpp:988
-msgid "Albaldah"
+msgid "Nunki"
 msgstr ""
 
 #: data.cpp:989
-msgid "Altais"
+msgid "Kaveh"
 msgstr ""
 
 #: data.cpp:990
-msgid "Al Tais"
+msgid "Alya"
 msgstr ""
 
 #: data.cpp:991
-msgid "Nodus Secundus"
+msgid "Sulafat"
 msgstr ""
 
 #: data.cpp:992
-msgid "Aladfar"
+msgid "Ascella"
 msgstr ""
 
 #: data.cpp:993
-msgid "Gumala"
+msgid "Okab"
 msgstr ""
 
 #: data.cpp:994
-msgid "Belel"
+msgid "Deneb el Okab"
 msgstr ""
 
 #: data.cpp:995
-msgid "Arkab Prior"
+msgid "Meridiana"
 msgstr ""
 
 #: data.cpp:996
-msgid "Arkab"
+msgid "Albaldah"
 msgstr ""
 
 #: data.cpp:997
-msgid "Sika"
+msgid "Altais"
 msgstr ""
 
 #: data.cpp:998
-msgid "Arkab Posterior"
+msgid "Al Tais"
 msgstr ""
 
 #: data.cpp:999
-msgid "Rukbat"
+msgid "Nodus Secundus"
 msgstr ""
 
 #: data.cpp:1000
-msgid "Anser"
+msgid "Aladfar"
 msgstr ""
 
 #: data.cpp:1001
-msgid "Albireo"
+msgid "Gumala"
 msgstr ""
 
 #: data.cpp:1002
-msgid "Uruk"
+msgid "Belel"
 msgstr ""
 
 #: data.cpp:1003
-msgid "Alsafi"
+msgid "Arkab Prior"
 msgstr ""
 
 #: data.cpp:1004
-msgid "Campbell's Star"
+msgid "Arkab"
 msgstr ""
 
 #: data.cpp:1005
-msgid "Sham"
+msgid "Sika"
 msgstr ""
 
 #: data.cpp:1006
-msgid "Fawaris"
+msgid "Arkab Posterior"
 msgstr ""
 
 #: data.cpp:1007
-msgid "Tarazed"
+msgid "Rukbat"
 msgstr ""
 
 #: data.cpp:1008
-msgid "Tyl"
+msgid "Anser"
 msgstr ""
 
 #: data.cpp:1009
-msgid "Altair"
+msgid "Albireo"
 msgstr ""
 
 #: data.cpp:1010
-msgid "Atair"
+msgid "Uruk"
 msgstr ""
 
 #: data.cpp:1011
-msgid "Libertas"
+msgid "Alsafi"
 msgstr ""
 
 #: data.cpp:1012
-msgid "Alshain"
+msgid "Campbell's Star"
 msgstr ""
 
 #: data.cpp:1013
-msgid "Terebellum"
+msgid "Sham"
 msgstr ""
 
 #: data.cpp:1014
-msgid "Phoenicia"
+msgid "Fawaris"
 msgstr ""
 
 #: data.cpp:1015
-msgid "Chechia"
+msgid "Tarazed"
 msgstr ""
 
 #: data.cpp:1016
-msgid "Algedi"
+msgid "Tyl"
 msgstr ""
 
 #: data.cpp:1017
-msgid "Alshat"
+msgid "Altair"
 msgstr ""
 
 #: data.cpp:1018
-msgid "Dabih"
+msgid "Atair"
 msgstr ""
 
 #: data.cpp:1019
-msgid "Sadr"
+msgid "Libertas"
 msgstr ""
 
 #: data.cpp:1020
-msgid "Peacock"
+msgid "Alshain"
 msgstr ""
 
 #: data.cpp:1021
-msgid "Aldulfin"
+msgid "Terebellum"
 msgstr ""
 
 #: data.cpp:1022
-msgid "Rotanev"
+msgid "Phoenicia"
 msgstr ""
 
 #: data.cpp:1023
-msgid "Sualocin"
+msgid "Chechia"
 msgstr ""
 
 #: data.cpp:1024
-msgid "Deneb"
+msgid "Algedi"
 msgstr ""
 
 #: data.cpp:1025
-msgid "Aljanah"
+msgid "Alshat"
 msgstr ""
 
 #: data.cpp:1026
-msgid "Albali"
+msgid "Dabih"
 msgstr ""
 
 #: data.cpp:1027
-msgid "Musica"
+msgid "Sadr"
 msgstr ""
 
 #: data.cpp:1028
-msgid "Polaris Australis"
+msgid "Peacock"
 msgstr ""
 
 #: data.cpp:1029
-msgid "Solaris"
+msgid "Aldulfin"
 msgstr ""
 
 #: data.cpp:1030
-msgid "Kitalpha"
+msgid "Rotanev"
 msgstr ""
 
 #: data.cpp:1031
-msgid "Lacaille 8760"
+msgid "Sualocin"
 msgstr ""
 
 #: data.cpp:1032
-msgid "Alderamin"
+msgid "Deneb"
 msgstr ""
 
 #: data.cpp:1033
-msgid "Alfirk"
+msgid "Aljanah"
 msgstr ""
 
 #: data.cpp:1034
-msgid "Sadalsuud"
+msgid "Albali"
 msgstr ""
 
 #: data.cpp:1035
-msgid "Bunda"
+msgid "Musica"
 msgstr ""
 
 #: data.cpp:1036
-msgid "Sāmaya"
+msgid "Polaris Australis"
 msgstr ""
 
 #: data.cpp:1037
-msgid "Nashira"
+msgid "Solaris"
 msgstr ""
 
 #: data.cpp:1038
-msgid "Azelfafage"
+msgid "Kitalpha"
 msgstr ""
 
 #: data.cpp:1039
-msgid "Bosona"
+msgid "Lacaille 8760"
 msgstr ""
 
 #: data.cpp:1040
-msgid "Herschel's Garnet Star"
+msgid "Alderamin"
 msgstr ""
 
 #: data.cpp:1041
-msgid "Erakis"
+msgid "Alfirk"
 msgstr ""
 
 #: data.cpp:1042
-msgid "Enif"
+msgid "Sadalsuud"
 msgstr ""
 
 #: data.cpp:1043
-msgid "Deneb Algedi"
+msgid "Bunda"
 msgstr ""
 
 #: data.cpp:1044
-msgid "Aldhanab"
+msgid "Sāmaya"
 msgstr ""
 
 #: data.cpp:1045
-msgid "Al Dhanab"
+msgid "Nashira"
 msgstr ""
 
 #: data.cpp:1046
-msgid "Itonda"
+msgid "Azelfafage"
 msgstr ""
 
 #: data.cpp:1047
-msgid "Kurhah"
+msgid "Bosona"
 msgstr ""
 
 #: data.cpp:1048
-msgid "Sadalmelik"
+msgid "Herschel's Garnet Star"
 msgstr ""
 
 #: data.cpp:1049
-msgid "Alnair"
+msgid "Erakis"
 msgstr ""
 
 #: data.cpp:1050
-msgid "Al Nair"
+msgid "Enif"
 msgstr ""
 
 #: data.cpp:1051
-msgid "Biham"
+msgid "Deneb Algedi"
 msgstr ""
 
 #: data.cpp:1052
-msgid "Ancha"
+msgid "Aldhanab"
 msgstr ""
 
 #: data.cpp:1053
-msgid "Sadachbia"
+msgid "Al Dhanab"
 msgstr ""
 
 #: data.cpp:1054
-msgid "Seat"
+msgid "Itonda"
 msgstr ""
 
 #: data.cpp:1055
-msgid "Lionrock"
+msgid "Kurhah"
 msgstr ""
 
 #: data.cpp:1056
-msgid "Kruger 60"
+msgid "Sadalmelik"
 msgstr ""
 
 #: data.cpp:1057
-msgid "Situla"
+msgid "Alnair"
 msgstr ""
 
 #: data.cpp:1058
-msgid "Homam"
+msgid "Al Nair"
 msgstr ""
 
 #: data.cpp:1059
-msgid "Tiaki"
+msgid "Biham"
 msgstr ""
 
 #: data.cpp:1060
-msgid "Matar"
+msgid "Ancha"
 msgstr ""
 
 #: data.cpp:1061
-msgid "Babcock's Star"
+msgid "Sadachbia"
 msgstr ""
 
 #: data.cpp:1062
-msgid "Sadalbari"
+msgid "Seat"
 msgstr ""
 
 #: data.cpp:1063
-msgid "Hydor"
+msgid "Lionrock"
 msgstr ""
 
 #: data.cpp:1064
-msgid "Skat"
+msgid "Kruger 60"
 msgstr ""
 
 #: data.cpp:1065
-msgid "Helvetios"
+msgid "Situla"
 msgstr ""
 
 #: data.cpp:1066
-msgid "Fomalhaut"
+msgid "Homam"
 msgstr ""
 
 #: data.cpp:1067
-msgid "Scheat"
+msgid "Tiaki"
 msgstr ""
 
 #: data.cpp:1068
-msgid "Fumalsamakah"
+msgid "Matar"
 msgstr ""
 
 #: data.cpp:1069
-msgid "Fum al Samakah"
+msgid "Babcock's Star"
 msgstr ""
 
 #: data.cpp:1070
-msgid "Markab"
+msgid "Sadalbari"
 msgstr ""
 
 #: data.cpp:1071
-msgid "Marchab"
+msgid "Hydor"
 msgstr ""
 
 #: data.cpp:1072
-msgid "Ebla"
+msgid "Skat"
 msgstr ""
 
 #: data.cpp:1073
-msgid "Bradley 3077"
+msgid "Helvetios"
 msgstr ""
 
 #: data.cpp:1074
-msgid "Salm"
+msgid "Fomalhaut"
 msgstr ""
 
 #: data.cpp:1075
-msgid "Alkarab"
+msgid "Scheat"
 msgstr ""
 
 #: data.cpp:1076
-msgid "Veritate"
+msgid "Fumalsamakah"
 msgstr ""
 
 #: data.cpp:1077
-msgid "Poerava"
+msgid "Fum al Samakah"
 msgstr ""
 
 #: data.cpp:1078
-msgid "Errai"
+msgid "Markab"
 msgstr ""
 
 #: data.cpp:1079
-msgid "Axólotl"
+msgid "Marchab"
 msgstr ""
 
 #: data.cpp:1080
-msgid "Milky Way"
+msgid "Ebla"
 msgstr ""
 
 #: data.cpp:1081
-msgid "LMC"
+msgid "Bradley 3077"
 msgstr ""
 
 #: data.cpp:1082
-msgid "SMC"
+msgid "Salm"
 msgstr ""
 
 #: data.cpp:1083
-msgid "Pleiades"
+msgid "Alkarab"
 msgstr ""
 
 #: data.cpp:1084
-msgid "Hyades"
+msgid "Veritate"
 msgstr ""
 
 #: data.cpp:1085
-msgid "Praesepe"
+msgid "Poerava"
 msgstr ""
 
 #: data.cpp:1086
-msgid "Beehive Cluster"
+msgid "Errai"
 msgstr ""
 
 #: data.cpp:1087
-msgid "Maffei 1"
+msgid "Axólotl"
 msgstr ""
 
 #: data.cpp:1088
-msgid "Maffei 2"
+msgid "Milky Way"
 msgstr ""
 
 #: data.cpp:1089
-msgid "Leo A"
+msgid "LMC"
 msgstr ""
 
 #: data.cpp:1090
-msgid "Sextans B"
+msgid "SMC"
 msgstr ""
 
 #: data.cpp:1091
-msgid "Leo I"
+msgid "Pleiades"
 msgstr ""
 
 #: data.cpp:1092
-msgid "Sextans A"
+msgid "Hyades"
+msgstr ""
+
+#: data.cpp:1093
+msgid "Praesepe"
 msgstr ""
 
 #: data.cpp:1094
-msgid "Andromeda Galaxy"
+msgid "Beehive Cluster"
 msgstr ""
 
 #: data.cpp:1095
-msgid "Triangulum Galaxy"
+msgid "Maffei 1"
 msgstr ""
 
 #: data.cpp:1096
-msgid "Holmberg VI"
+msgid "Maffei 2"
 msgstr ""
 
 #: data.cpp:1097
-msgid "Fath 703"
+msgid "Leo A"
 msgstr ""
 
 #: data.cpp:1098
-msgid "47 Tuc"
+msgid "Sextans B"
+msgstr ""
+
+#: data.cpp:1099
+msgid "Leo I"
+msgstr ""
+
+#: data.cpp:1100
+msgid "Sextans A"
 msgstr ""
 
 #: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "The Drafting Compass"
+
+#: data.cpp:1102
+msgid "Andromeda Galaxy"
+msgstr ""
+
+#: data.cpp:1103
+msgid "Triangulum Galaxy"
+msgstr ""
+
+#: data.cpp:1104
+msgid "Holmberg VI"
+msgstr ""
+
+#: data.cpp:1105
+msgid "Fath 703"
+msgstr ""
+
+#: data.cpp:1106
+msgid "47 Tuc"
+msgstr ""
+
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "The River"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "The Compass"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-02-03 15:33+0100\n"
 "Last-Translator: ElChristou\n"
 "Language-Team: Spanish\n"
@@ -21,358 +21,447 @@ msgstr ""
 "X-Generator: KBabel 1.11\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andrómeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Máquina Neumática"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Ave del Paraíso"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Acuario"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Águila"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Carnero"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Cochero"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boyero"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Cincel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Jirafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Cangrejo"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Los Perros de Caza"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Can Mayor"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Can Menor"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricornio"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Quilla"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Casiopea"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centauro"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeo"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Ballena"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Camaleón"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compás"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Paloma"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Cabellera de Berenices"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Corona Austral"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Corona Boreal"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Cuervo"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Copa"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Cruz del Sur"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cisne"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfín"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Pez Dorado"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragón"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Pequeño Caballo"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Erídano"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Horno"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Géminis"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Grulla"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hércules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Reloj"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hidra macho"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indio"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lagartija"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leo"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "León Menor"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Liebre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Libra"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lobo"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lince"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Mesa"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscopio"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Unicornio"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mosca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Regla"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octante"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofiuco"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orión"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavo"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegaso"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseo"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fénix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Paleta del Pintor"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Piscis"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Pez Austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Popa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Brújula"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Retícula"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Flecha"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Sagitario"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Escorpio"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Escultor"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Escudo"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "La cabeza de la Serpiente"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "La cola de la Serpiente"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextante"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Tauro"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescopio"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triángulo"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triángulo Austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucán"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Osa Mayor"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Osa Menor"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Virgo"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Pez Volador"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Zorra"
 
@@ -528,3964 +617,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triángulo"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Júpiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Júpiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Júpiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Júpiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Júpiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Júpiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Júpiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcíone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Júpiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Júpiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Calixto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Júpiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Júpiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Júpiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Júpiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Júpiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Júpiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Júpiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Júpiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Júpiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Júpiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Calixto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Sucinta"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Júpiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Júpiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Júpiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Ene"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometeo"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimeteo"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Jano"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturno"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturno"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Horno"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturno"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Horno"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturno"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxias"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larisa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganímedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sol"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DEL NORTE"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DEL SUR"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTÁRTIDA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCÉANO ATLÁNTICO NORTE"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCÉANO ATLÁNTICO SUR"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCÉANO PACÍFICO NORTE"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCÉANO PACÍFICO SUR"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCÉANO ÍNDICO"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCÉANO ÁRTICO"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuya"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Argel"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Ammán"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vieja"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Asjabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atenas"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Bakú"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Beijing"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlín"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berna"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruselas"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "El Cairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Ciudad del Cabo"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonú"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damasco"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublín"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "De Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagåtña"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "La Haya"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "La Habana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Yakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalén"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandú"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Jartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomé"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londres"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Macho"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Ciudad de México"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Mónaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moscú"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muscat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Yamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nueva Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panamá"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "París"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Puerto España"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangún"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Santo Tomé"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seúl"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "El Acuerdo"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapur"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofía"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallin"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teherán"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Túnez"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "El Valle"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Ciudad del Vaticano"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viena"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsovia"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Distrito de Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Ereván"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sol"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Baricentro del sistema estelar"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sol"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Actual"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ksora"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titán"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Alamak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Estrella Polar"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirfak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Astérope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Mérope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcíone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pléyone"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebarán"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Estrella carmesí de Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Alamak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxias"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Estrella de Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Elnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triángulo"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Rectángulo Rojo"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Murzim"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Mostrar estrellas"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirio"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Estrella de Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Proción"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Régulo"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londres"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Gianfar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formato: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denébola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arturo"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Próxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atenas"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Japeto"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorios"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Estrella de Banard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamín"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Estrella de Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "París"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Estrella Polar"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamín"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Mostrar fronteras"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Estrella Garnet de Herschel"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Estrella de Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Funda"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Vía Láctea"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Nube Mayor de Magallanes"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Nube Menor de Magallanes"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pléyades"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Híades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "El Pesebre"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Cúmulo de la Colmena"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compás"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Erídano"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Brújula"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2019-02-14 21:32+0300\n"
 "Last-Translator: Hleb Valoshka <375gnu@gmail.com>\n"
 "Language-Team: French (https://www.transifex.com/celestia/teams/93131/fr/)\n"
@@ -25,358 +25,447 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromède"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "La Machine pneumatique"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "L’Oiseau de Paradis"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Le Verseau"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "L’Aigle"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "L’Autel"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Le Bélier"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Le Cocher"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Le Bouvier"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Le Burin"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "La Girafe"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Le Cancer"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Les Chiens de Chasse"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Le Grand Chien"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Le Petit Chien"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Le Capricorne"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "La Carène"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopée"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Le Centaure"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Céphée"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "La Baleine"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Le Caméléon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Le Compas"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "La Colombe"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "La Chevelure de Bérénice"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "La Couronne australe"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "La Couronne boréale"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Le Corbeau"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "La Coupe"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "La Croix du Sud"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Le Cygne"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Le Dauphin"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "La Dorade"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Le Dragon"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Le Petit Cheval"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "L’Éridan"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Le Fourneau"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Les Gémeaux"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "La Grue"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hercule"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "L’Horloge"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "L’Hydre femelle"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "L’Hydre mâle"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "L’Oiseau indien"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Le Lézard"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Le Lion"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Le Petit Lyon"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Le Lièvre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "La Balance"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Le Loup"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Le Lynx"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "La Lyre"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "La Table"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Le Microscope"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "La Licorne"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "La Mouche"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "La Règle"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "L’Octant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ophiuchus"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Le Paon"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pégase"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Persée"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Le Phénix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Le Peintre"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Les Poissons"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Le Poisson austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "La Poupe"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "La Boussole"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Le Réticule"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "La Flèche"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Le Sagittaire"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Le Scorpion"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Le Sculpteur"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "L’Écu"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "La Tête du Serpent"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "La Queue du Serpent"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Le Sextant"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Le Taureau"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Le Téléscope"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Le Triangle"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Le Triangle austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Le Toucan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "La Grande Ourse"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "La Petite Ourse"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Les Voiles"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "La Vierge"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Le Poisson volant"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Le Renard"
 
@@ -532,3963 +621,4016 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "L’Hydre femelle"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Nouméa"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthée"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Le Triangle"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandore"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthée"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandore"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Concis"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prométhée"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandore"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Épiméthée"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturne"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturne"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Le Fourneau"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturne"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Le Fourneau"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturne"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxies"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymède"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Soleil"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMÉRIQUE DU NORD"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMÉRIQUE DU SUD"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIE"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIQUE"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIE"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARCTIQUE"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCÉAN ATLANTIQUE NORD"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCÉAN ATLANTIQUE SUD"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCÉAN PACIFIQUE NORD"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCÉAN PACIFIQUE SUD"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCÉAN INDIEN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCÉAN ARCTIQUE"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis-Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alger"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorre-la-Vieille"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Achgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Athènes"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Bakou"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pékin"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beyrouth"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrade"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berne"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bichkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruxelles"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Le Caire"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Le Cap"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damas"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Douchanbé"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Agana"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "La Haye"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoï"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "La Havane"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jérusalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kaboul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandou"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Koweït"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Laâyoune"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisbonne"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomé"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londres"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malé"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manille"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moscou"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Mascate"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N’Djaména"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosie"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku‘alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port-Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prague"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rome"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George’s"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint-Hélier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John’s"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Saint-Marin"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Saint Domingue"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tomé"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Séoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapour"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tachkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilissi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Téhéran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Oulan-Bator"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "La Valette"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "La Vallée"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Cité du Vatican"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Vienne"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsovie"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Erevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Soleil"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Barycentre du Système solaire"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Soleil"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr ""
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Étoile Polaire"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Célaéno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Électre"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygète"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maïa"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Astérope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Mérope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pléioné"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldébaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Étoile cramoisie de Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxies"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Étoile de Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triangle"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saïph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Bételgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Le Rectangle rouge"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Étoile de Kapteyn"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Étoile de Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londres"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format : "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaïd"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben el Akrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben el Akrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Athènes"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antarès"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Japet"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatoires"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Étoile de Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Véga"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altaïs"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Étoile de Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altaïr"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshaïn"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshaïn"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Étoile Polaire"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Limites"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnaïr"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Étoile de Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Voie lactée"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Grand Nuage de Magellan"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Petit Nuage de Magellan"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pléiades"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "la Crèche (ou la Ruche)"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Amas de la Crèche"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Le Compas"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "L’Éridan"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "La Boussole"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2010-04-08 19:34+0100\n"
 "Last-Translator: Xabier Cancela <xabiercs@terra.es>\n"
 "Language-Team:  <xabiercs@terra.es>\n"
@@ -24,358 +24,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andrómeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Máquina Pneumática"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Ave do Paraíso"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Acuario"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Aguia"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Carneiro"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Auriga"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Pastor"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Cicel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Xirafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Cangrexo"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Os Cans de Caza"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Can Maior"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Can Menor"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricornio"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Quilla"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Casiopea"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centauro"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeo"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Balea"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Camaleón"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compás"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Pomba"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "A Cabeleira de Berenice"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Corona Austral"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Corona Boreal"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corvo"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Cunca"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Cruz do Sur"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cisne"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Golfiño"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Peixe Dorado"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragón"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Cabalo Pequeno"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridano"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Forno"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Xémini"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Grúa"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hércules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Reloxo"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hidra macho"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indio"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lagarto"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leo"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "León Menor"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Lebre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Libra"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lobo"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lince"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Meseta"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscopio"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Unicornio"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mosca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Regra"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octante"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofiuco"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orión"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavo"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegaso"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseo"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fénix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Cabalete de Pintor"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Peixes"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Peixe Austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Popa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Compás Náutico"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Retícula"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Frecha"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Saxitario"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Escorpión"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Escultor"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Escudo"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "A Cabeza da Serpe"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "A Cola da Serpe"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextante"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Touro"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescopio"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triángulo"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triángulo Austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucano"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Osa Maior"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Osa Menor"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Virgo"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Peixe Voador"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Raposa"
 
@@ -531,3964 +620,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triángulo"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Xúpiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Xúpiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Xúpiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Xúpiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Xúpiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Xúpiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Xúpiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alción"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Xúpiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Xúpiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Calisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Xúpiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Xúpiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Xúpiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Xúpiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Xúpiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Xúpiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Xúpiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Xúpiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Xúpiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Xúpiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Calisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Reducida"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Xúpiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Xúpiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Xúpiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Xan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prométeo"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epiméteo"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Xano"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturno"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturno"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Forno"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturno"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Forno"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturno"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxias"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larisa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sol"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NORTEAMERICA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "SURAMERICA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARCTICA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO DO ATLANTICO NORTE"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO DO ATLANTICO SUR"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO DO PACIFICO NORTE"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO DO PACIFICO SUR"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEANO INDICO"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ARTICO"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Ababa"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alxer"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atenas"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Baghdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Beijing"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruselas"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Bos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Cairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Camberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damasco"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "The Hague"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "La'youn"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "London"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico DF"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadisio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Mónaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moscova"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muscat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nova Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panamá"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Puerto España"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prague"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Saraxevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seúl"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapore"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "T'bilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teherán"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viena"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsovia"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sol"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Centro de Masas do Sistema Solar"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sol"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Engadir un marcador relativo para o documento actual"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titán"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polar"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alción"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebarán"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Estrela de Crimson Hinds"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxias"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Estrela Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capela"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triángulo"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgueuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopo"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Rectángulo Vermello"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopo"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Estrelas"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirio"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Estrela de Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Proción"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Corazón de Hydra"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Régulo"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Corazón de León"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Boreal"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Austral"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "London"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Austral"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Boreal"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formato:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denébola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Artur"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Xema"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atenas"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapeto"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorios"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Estrela de Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Estrela de Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Pavo"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polar"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Bordes"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Estrela de Babcok"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Vía Láctea"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pleiades"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Presebe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Cúmulo da Colmea"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextante B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextante A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compás"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridano"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Compás Náutico"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: Celestia Development Team, Translators
 # SPDX-License-Identifier: GPL-2.0-or-later
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Konstellációk\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2009-01-15 15:06+0100\n"
 "Last-Translator: Székely Zoltán <zoltanszekely@hotmail.com>\n"
 "Language-Team:  <zoltanszekely@hotmail.com>\n"
@@ -18,358 +17,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Légszivattyú"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradicsommadár"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vízöntő"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Sas"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Oltár"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Kos"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Szekeres"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Ökörhajcsár"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Véső"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Zsiráf"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Rák"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Vadászebek"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Nagy Kutya"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Kis Kutya"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Bak"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Hajógerinc"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kassziopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentaur"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeusz"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Cet"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Kaméleon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Körző"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Galamb"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Bereniké Haja"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Déli Korona"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Északi Korona"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Holló"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Serleg"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Dél Keresztje"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Hattyú"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfin"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Aranyhal"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Sárkány"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Csikó"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridánusz"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Kemence"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Ikrek"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Daru"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Ingaóra"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Északi Vízikígyó"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Déli Vízikígyó"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Hindu"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Gyík"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Oroszlán"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Kis Oroszlán"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Nyúl"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Mérleg"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Farkas"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Hiúz"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lant"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Táblahegy"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroszkóp"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Egyszarvú"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Légy"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Szögmérő"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktáns"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Kígyótartó"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Páva"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegazus"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perzeusz"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Főnix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Festő"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Halak"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Déli Hal"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Hajófar"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Tájoló"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Háló"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Nyíl"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Nyilas"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpió"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Szobrász"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Pajzs"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Kígyó feje"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Kígyó farka"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Szextáns"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Bika"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Távcső"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Háromszög"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Déli Háromszög"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukán"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Nagy Medve"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Kis Medve "
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vitorla"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Szűz"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Repülőhal"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Kis Róka"
 
@@ -525,3964 +613,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Északi Vízikígyó"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamakó"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Háromszög"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Kallisztó"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Kallisztó"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Tömör"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prométheusz"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Szaturnusz"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Szaturnusz"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Kemence"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Szaturnusz"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Kemence"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Szaturnusz"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Márc"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxisok"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganümédész"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Nap"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ÉSZAK AMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "DÉL AMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURÁZSIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSZTRÁLIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTISZ"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ÉSZAK-ATLANTI ÓCEÁN"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "DÉL ATLANTI ÓCEÁN"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ÉSZAKI CSENDES ÓCEÁN"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "DÉLI CSENDES ÓCEÁN"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDIAI ÓCEÁN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ÉSZAKI ÓCEÁN"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu-Dabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addisz-Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Algír"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Asgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Aszmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción "
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Athén"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamakó"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bender Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrád"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brazília"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Pozsony"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brüsszel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumburai"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kairó"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Fokváros"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castriest"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kisinyov"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombó"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Koppenhága"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaszkusz"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Dzsibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "A Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltár"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Hága"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havanna"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Iszlamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Dzsakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jeruzsálem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Kartúm"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kijev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuvait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisszabon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "London"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputó"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexikóváros"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minszk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moróni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moszkva"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Maszkat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Újdelhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Párizs"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Pénh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prága"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quitó"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Róma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Szanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Szarajevó"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Szöul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Szingapúr"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Szkopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Szófia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Tajvan"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taskent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbiliszi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teherán"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Timpu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokió"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunisz"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulán Bátor"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikánváros"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Viktória"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Bécs"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientián"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsó"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D. C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren kerület"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Jereván"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zágráb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Nap"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Csillagrendszer tömegközéppontja"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Nap"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Jelenlegi"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titán"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Sarkcsillag"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind Karmazsin Csillaga"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxisok"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn-csillag"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Háromszög"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Vörös háromszög"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Csillagok"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Szíriusz"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten-csillag"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "London"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formátum:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "A Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneshamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Athén"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethy"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Csillagvizsgálók"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnard csillaga"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell csillaga"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Párizs"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Páva"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Sarkcsillag"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Határok"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock csillaga"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Tejút"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Nagy Magellán Felhő"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Kis Magellán Felhő"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejádok"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hiádok"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Praesepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Méhkas csoport"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Körző"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridánusz"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Tájoló"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/it.po
+++ b/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia_constellations\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-08-11 16:56+0100\n"
 "Last-Translator: Mauro Santandrea <mausan66@tiscali.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -24,358 +24,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Macchina Pneumatica"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Uccello del Paradiso"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Acquario"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Aquila"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altare"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Ariete"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Auriga"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boötes"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Bulino"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Giraffa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Cancro"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Cani da Caccia"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Cane Maggiore"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Cane Minore"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricorno"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Carena"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopea"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centauro"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeo"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Balena"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Camaleonte"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compasso"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Colomba"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Chioma di Berenice"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Corona Australe"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Corona Boreale"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corvo"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Cratere"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Croce del Sud"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cigno"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfino"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Dorado"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Drago"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Cavallino"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridano"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Fornace"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Gemelli"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Gru"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Ercole"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Orologio"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Idra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Idra Maschio"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indiano"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lucertola"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leone"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Leone Minore"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Lepre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Bilancia"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lupo"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lince"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Mensa"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscopio"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Unicorno"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mosca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Norma"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Ottante"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofiuco"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orione"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavone"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegaso"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseo"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fenice"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Pittore"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Pesci"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Pesce Australe"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Poppa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Bussola"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Reticolo"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Freccia"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Sagittario"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Scorpione"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Scultore"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Scudo"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Testa del Serpente"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Coda del Serpente"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sestante"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Toro"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescopio"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triangolo"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triangolo Australe"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucano"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Orsa Maggiore"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Orsa Minore"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Vergine"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Pesce Volante"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Volpetta"
 
@@ -531,3965 +620,4018 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Idra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triangolo"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Giove"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Giove"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Giove"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Giove"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Giove"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Giove"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Giove"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcione"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Giove"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Giove"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Giove"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Giove"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Giove"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Giove"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Giove"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Giove"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Giove"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Giove"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Giove"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Giove"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 #, fuzzy
 msgid "Autonoe"
 msgstr "Automatico"
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Conciso"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Giove"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Giove"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Giove"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Gen"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometeo"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimeteo"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Giano"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturno"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturno"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Fornace"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturno"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Fornace"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturno"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galassie"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimede"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sole"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NORD AMERICA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "SUD AMERICA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARTIDE"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLANTICO DEL NORD"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLANTICO DEL SUD"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACIFICO DEL NORD"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACIFICO DEL SUD"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEANO INDIANO"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ARTICO"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Algeri"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Aşgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción "
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atene"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Baghdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pechino"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlino"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berna"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruxelles"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Il Cairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Città del Capo"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenaghen"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Dimasco"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Gibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublino"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibilterra"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "The Hague"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "L'Avana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Giacarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Gerusalemme"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiun"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisbona"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Lubiana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londra"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Lussemburgo"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Maschile"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Città del Messico"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Mosca"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muscat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nuova Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapore"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayawardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stoccolma"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Tehran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Giaffa"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunisi"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "La Valle"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Città del Vaticano"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Vienna"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsavia"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagabria "
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sole"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Baricentro del sistema solare"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sole"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castore"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Attuale"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titano"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Stella Polare"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Elettra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcione"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "la stella cremisi di Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galassie"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Stella di Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triangolo"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Rettangolo rosso"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Stelle"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirio"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Stella di Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castore"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procione"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Polluce"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regolo"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londra"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formato:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arturo"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kochab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atene"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Giapeto"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Osservatori"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Stella di Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australe"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Boreale"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Stella di Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Pavone"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Lubiana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australe"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Stella Polare"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Confini"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Sedia"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Stella di Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Guaina"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Via Lattea"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pleiadi"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Presepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Ammasso Alveare"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compasso"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridano"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Bussola"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia-Japanese\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-08-07 22:19+0900\n"
 "Last-Translator: Sui Ota <aqua@aqsp.net>\n"
 "Language-Team: Japanese\n"
@@ -24,358 +24,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "アンドロメダ"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "ポンプ"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "ふうちょう"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "みずがめ"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "わし"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "さいだん"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "おひつじ"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "ぎょしゃ"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "うしかい"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "ちょうこくぐ"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "きりん"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "かに"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "りょうけん"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "おおいぬ"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "こいぬ"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "やぎ"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "りゅうこつ"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "カシオペヤ"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "ケンタウルス"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "ケフェウス"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "くじら"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "カメレオン"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "コンパス"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "はと"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "かみのけ"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "みなみのかんむり"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "かんむり"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "からす"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "コップ"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "みなみじゅうじ"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "はくちょう"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "いるか"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "かじき"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "りゅう"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "こうま"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "エリダヌス"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "ろ"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "ふたご"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "つる"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "ヘルクレス"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "とけい"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "うみへび"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "みずへび"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "インディアン"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "とかげ"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "しし"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "こじし"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "うさぎ"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "てんびん"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "おおかみ"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "やまねこ"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "こと"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "テーブルさん"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "けんびきょう"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "いっかくじゅう"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "はえ"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "じょうぎ"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "はちぶんぎ"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "へびつかい"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "オリオン"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "くじゃく"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "ペガスス"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "ペルセウス"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "ほうおう"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "がか"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "うお"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "みなみのうお"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "とも"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "らしんばん"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "レチクル"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "や"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "いて"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "さそり"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "ちょうこくしつ"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "たて"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "へび(頭)"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "へび(尾)"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "ろくぶんぎ"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "おうし"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "ぼうえんきょう"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "さんかく"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "みなみのさんかく"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "きょしちょう"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "おおぐま"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "こぐま"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "ほ"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "おとめ"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "とびうお"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "こぎつね"
 
@@ -531,3964 +620,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "うみへび"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "ヌーメア"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "バマコ"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "アマルテア"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "さんかく"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "パンドラ"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "アマルテア"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "ディフダ"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "木星"
+msgid "Pandia"
+msgstr "パンドラ"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "ディフダ"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "木星"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "木星"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "木星"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "木星"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "木星"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "木星"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "アルキオーネ"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "木星"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "木星"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "カリスト"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "木星"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "木星"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "木星"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "木星"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "木星"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "木星"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "木星"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "木星"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "木星"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "木星"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "カリスト"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 #, fuzzy
 msgid "Autonoe"
 msgstr "自動"
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "普通"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "木星"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "木星"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "木星"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "1"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "プロメテウス"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "パンドラ"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "エピメテウス"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "ヤヌス"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "スカット"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "スカット"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "アルビレオ"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "土星"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "土星"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "ろ"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "土星"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "ポートビラ"
+msgid "Fornjot"
+msgstr "ろ"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "土星"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "ポートビラ"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "タブ"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "銀河"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "ラリッサ"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "ガニメデ"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "太陽"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "北アメリカ"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "南アメリカ"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ユーラシア"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "アフリカ"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "オーストラリア"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "南極"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "北大西洋"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "南大西洋"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "北太平洋"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "南太平洋"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "インド洋"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "北極海"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "アブダビ"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "アブジャ"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "アクラ"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "アダムスタウン"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "アジスアベバ"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "アルジェ"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "アロフィ"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "アンマン"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "アムステルダム"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "アンドラ・ラ・ベリャ"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "アンカラ"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "アンタナナリボ"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "アピア"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "アシュガバート"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "アスマラ"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "アスンシオン"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "アテネ"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "アバルア"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "バグダード"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "バクー"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "バマコ"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "バンダルスリブガワン"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "バンコク"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "バンギ"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "バンジュール"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "バセ・テール"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "バセテール"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "北京"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "ベイルート"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "ベオグラード"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "ベルモパン"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "ベルリン"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "ベルン"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "ビシュケク"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "ビサウ"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "ブルームフォンテーン"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "ボゴタ"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "ブラジリア"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "ブラチスラヴァ"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "ブラザビル"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "ブリッジタウン"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "ブリュッセル"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "ブカレスト"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "ブダペスト"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "ブエノスアイレス"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "ブジュンブラ"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "カイロ"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "キャンベラ"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "ケープタウン"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "カラカス"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "カストリーズ"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "カエンヌ"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "シャーロット・アマリー"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "キシナウ"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "コロンボ"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "コナクリ"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "コペンハーゲン"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "コトヌー"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "ダカール"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "ダマスカス"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "ダルエスサラーム"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "ダッカ"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "ディリ"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "ジブチ"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "ドーハ"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "ダグラス"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "ダブリン"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "ドゥシャンベ"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "フォンガファレ"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "フォール・ド・フランス"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "フリータウン"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "ハボローネ"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "ジョージタウン"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "ジョージタウン"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "ジブラルタル"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "グランド・ターク"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "グアテマラ"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "ハガニア"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "ハーグ"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "ハミルトン"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "ハノイ"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "ハラレ"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "ハバナ"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "ヘルシンキ"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "ホニアラ"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "イスラマバード"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "ジャカルタ"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "ジェームズタウン"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "エルサレム"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "カブール"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "カンパラ"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "カトマンズ"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "ハルツーム"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "キエフ"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "キガリ"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "キングストン"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "キングスタウン"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "キンシャサ"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "コロール"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "クアラルンプール"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "クウェート"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "アイウン"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "ラパス"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "リーブルヴィル"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "リロングウェ"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "リマ"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "リスボン"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "リュブリャナ"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "ロバンバ"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "ロメ"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "ロンドン"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "ロングイェールビーン"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "ルアンダ"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "ルサカ"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "ルクセンブルク"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "マドリード"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "マジュロ"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "マラボ"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "マレ"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "マムズ"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "マナグア"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "マナーマ"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "マニラ"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "マプト"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "マセル"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "マタウトゥ"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "ムババネ"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "メキシコシティ"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "ミンスク"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "モガディシュ"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "モナコ"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "モンロビア"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "モンテビデオ"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "モロニ"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "モスクワ"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "マスカット"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "ナイロビ"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "ナッソー"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "ンジャメナ"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "ニューデリー"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "ニアメ"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "ニコシア"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "ヌアクショット"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "ヌーメア"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "ヌクアロファ"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "ヌーク"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "オラニエスタッド"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "オスロ"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "オタワ"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "ワガドゥグー"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "パゴパゴ"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "パリキール"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "パナマ"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "パペーテ"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "パラマリボ"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "パリ"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "プノンペン"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "プリマス"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "ポートルイス"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "ポートモレスビー"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "ポルトープランス"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "ポートオブスペイン"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "ポルトノボ"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "ポートビラ"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "プラハ"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "プライア"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "プレトリア"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "平壌"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "キト"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "ラバト"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "ヤンゴン"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "レイキャビク"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "リガ"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "リヤド"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "ロードタウン"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "ローマ"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "ロゾー"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "セントジョージズ"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "セントヘリア"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "セントジョンズ"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "セントピーターポート"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "サンドニ"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "サンピエール"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "サイパン"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "サンホセ"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "サンフアン"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "サンマリノ"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "サンサルバドル"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "サナア"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "サンティアゴ"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "サントドミンゴ"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "サントメ"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "サラエヴォ"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "ソウル"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "セトルメント地区"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "シンガポール"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "スコピエ"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "ソフィア"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "スリジャヤワルダナプラコッテ"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "スタンレー"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "ストックホルム"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "スクレ"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "スバ"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "台北"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "タリン"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "タラワ"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "タシュケント"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "トビリシ"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "テグシガルパ"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "テヘラン"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "テルアビブ"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "ティンプー"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "ティラナ"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "東京"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "トースハウン"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "トリポリ"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "チュニス"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "ウランバートル"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "ファドゥーツ"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "バレッタ"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "バレー"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "バチカン"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "ヴィクトリア"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "ウィーン"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "ビエンチャン"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "ヴィリニュス"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "ワルシャワ"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "ワシントンD.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "ウェリントン"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "ウェスト島"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "ウィレムスタッド"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "ウィントフック"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "ヤムスクロ"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "ヤウンデ"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "ヤレン地区"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "エレバン"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "ザグレブ"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "太陽"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "太陽系重心"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "太陽"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "アルフェラッツ"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "シラー"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "カフ"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "アルゲニブ"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "シェマリ"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "アンカー"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "スケダル"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "セディル"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "ディフダ"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "デネブ・カイトス"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "アキルド"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "ファン・マーネン2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "カストル"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "ナビ"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr ""
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "ミラク"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "アディル"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "ルクバー"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "アルフェラッツ"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "タイタン"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "アケルナル"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "バテン・カイトス"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "カプト・トリアングリ"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "メサルティム"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "セギン"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "シェラタン"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "アル・レカ"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "アル・レカ"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "アルマク"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "アルマーク"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "アラマク"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "ハマル"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "ミラ"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "北極星(ポラリス)"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "カラ"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "ミラ"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "アンゲテナール"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "アザー"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "アカマル"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "メンカル"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "メンカブ"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "アルゴル"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "ボテイン"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "ミルファク"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "ミルファク"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "マルファク"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "ラナ"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "ラナ"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "アティク"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "ケレノ"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "エレクトラ"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "タイゲタ"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "マイア"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "アステローペ"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "メローペ"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "アルキオーネ"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "プレイオネ"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "ザウラク"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "メンキブ"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "ベイド"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "ケイド"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "アイン"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "アルデバラン"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "タビト"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "ハインドの深紅色星(クリムソン・スター)"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "アルマーク"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "銀河"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "サダトニ"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "クルサ"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "カプテイン星"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "リゲル"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "カペラ"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "ベラトリックス"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "エルナト"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "アルナト"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "ニハル"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "タビト"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "ミンタカ"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "アルネブ"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "メイサ"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "ヘカ"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "アルニラム"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "三角形(△)"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "ファクト"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "アルニタク"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "サイフ"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "ワズン"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "ベテルギウス"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "メンカリナン"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "フルド"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "カノープス"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "赤い長方形"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "フルド"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "ミルザム"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "ムルジム"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "タヤト"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "カノープス"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "スヘル"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "近い恒星"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "アルヘナ"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "アルメイサン"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "メブスタ"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "シリウス"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "アダラ"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "アダラ"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "ムリフェイン"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "メクブダ"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "ウェゼン"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "バーンズ135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "ワサト"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "アルドラ"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "ゴメイサ"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "ルイテン星"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "カストル"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "プロキオン"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "エルゴマイサ"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "ポルックス"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "アスミディスケ"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "アスミディスケ"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "ナオス"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "レゴル"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "テグミン"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "アル・タルフ"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "アル・タルフ"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "アウィオル"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "ムシダ"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "アキルド"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "アセルス・ボレアリス"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "アルセス・アウストラリス"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "アクベンス"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "ドゥノケス"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "スハイル"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "ミアプラキドス"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "アスピディスケ"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "マルカブ"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "アルファルド"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "コル・ヒドラエ(蛇の心臓)"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "アルテルフ"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "ウクダ"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "スブラ"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "ラス・エルアセド・アウストラリス"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "ラサラス"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "ラス・エルアセド・ボレアリス"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "レグルス"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "カベレケド"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "コル・レオニス"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "アダフェラ"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "アルダフェラ"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "タニア・ボレアリス"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "アルギエバ"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "タニア・アウストラリス"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "ロンドン"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "アルケス"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "メラク"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "ラランド21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "ドゥベー"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "デゥッブ"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "ゾスマ"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "ドゥール"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "シェルタン"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "コクサ"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "コルト"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "アルラ・アウストラリス"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "アルラ・ボレアリス"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "シャム"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "ギャウサル"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "形式: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "ジョージタウン"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "デネボラ"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "ザウィヤワ"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "アルアラフ"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "ホニアラ"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "グルームブリッジ1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "フェクダ"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "ファド"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "アルキバ"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "メグレズ"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "ギエナ"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "ザニア"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "アクルクス"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "アルゴラブ"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "ガクルクス"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "カラ"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "クラズ"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "ムフリファイン"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "ポリマ"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "ミモザ"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "アリオト"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "ミネラウバ"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "アウバ"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "コルカロリ"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "ウィンデミアトリクス"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "アルムレディン"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "ミザール"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "スピカ"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "アジメク"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "アルコル"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "ヘゼ"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "アルカイド"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "ベネトナッシュ"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "ムフリド"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "ハダル"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "アゲナ"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "ツバン"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "メンケント"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "アルクトゥルス"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "シルマ"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "プロキシマ"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "セギヌス"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "ケギヌス"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "イザル"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "ミラク"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "プルケリマ"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "コカブ"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "コカブ"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "ズベネルゲヌビ"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "ズベン・エルアクリビ"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "ネッカル"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "ズベネスカマリ"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "フェルカド"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "フェルカド"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "アルカルロプス"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "エダシク"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "ヌサカン"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "アルフェッカ"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "ゲンマ"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "ズベン・エルアクラブ"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "ズベン・エルアクラブ"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "ウヌカルハイ"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "ドゥスクッバ"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "グラフィアス"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "アクラブ"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "火星"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "ヤッバ"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "アル・ニヤト"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "アル・ニヤト"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "アテネ"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "クヤム"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "アンタレス"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "コルネポロス"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "マルフィク"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "アトリア"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "タラワ"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "ポリマ"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "イアペトゥス"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "アラキス"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "アラキス"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "アルキバ"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "サビク"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "ラスアルゲティ"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "ラス・アルゲティ"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "サリン"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "ラスタバン"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "マシム"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "レサート"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "レスート"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "クマ"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "イルドゥン"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "シャウラ"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "ラスアルハゲ"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "ラス・アルハグエ"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "サルガズ"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "ジバン"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "ケバルライ"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "観測所・天文台"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "グルミウム"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "エルタニン"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "エタミン"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "バーナード星"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "アルナスル"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "カウス・メディア"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "カウス・アウストラリス"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "アル・アトファル"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "カウス・ボレアリス"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "ベガ"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "シェリアク"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "アルデラミン"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "ヌンキ"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "アリア"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "スラファト"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "アスケラ"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "デネブ・エル・オカブ"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "アルバリ"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "アルタイス"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "アル・タイス"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "ノドゥス・セクンドゥス"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "アラドファル"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "グアテマラ"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "アルカブ"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "アルカブ"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "ルクバト"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "アルビレオ"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "アルサフィ"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "キャンベル星"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "シャム"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "パリ"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "タラゼド"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "ティル"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "アルタイル"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "アルシャイン"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "アルゲディ"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "アルシャイン"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "ダビー"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "サドル"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "ピーコック"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "ロタネウ"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "スワロキン"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "デネブ"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "リュブリャナ"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "アルバリ"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "カウス・アウストラリス"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "北極星(ポラリス)"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "キタルファ"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "ラカイユ8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "アルデラミン"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "アルフィルク"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "サダルスウド"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "星座境界線"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "ナシラ"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "アゼルファファゲ"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "ハーシェルのガーネット・スター"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "アラキス"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "エニフ"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "デネブ・アルゲディ"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "アル・ダナブ"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "アル・ダナブ"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "クラー"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "サダルメリク"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "アルナイル"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "アル・ナイル"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "ビハム"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "アンカ"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "サドアクビア"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "セアト"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "クルーガー60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "シトゥラ"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "ホマム"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "マタール"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "バブコック星"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "サダルバリ"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "スカット"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "フォーマルハウト"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "シェアト"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "フム・アル・サマカー"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "フム・アル・サマカー"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "マルカブ"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "マルカブ"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "ブラッドレー3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "アンカラ"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "エライ"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "銀河系"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "大マゼラン銀河"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "小マゼラン銀河"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "プレアデス"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "ヒアデス"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "プレセペ"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "はちの巣(ビーハイブ)"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "マフェイ1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "マフェイ2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "しし座A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "ろくぶんぎ座B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "しし座I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "ろくぶんぎ座A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "コンパス"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "ホルムベルクVI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "きょしちょう座47(NGC 104)"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "エリダヌス"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "らしんばん"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "トナンツィントラ2"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2023-11-03 13:47+0200\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023\n"
 "Language-Team: Georgian (https://app.transifex.com/celestia/teams/93131/"
@@ -26,358 +26,447 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "ანდრომედა"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "ტუმბო"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "სამოთხის ჩიტი"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "მერწყული"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "არწივი"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "არრაჰი"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "ვერძი"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "მეეტლე"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "მენახირე"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "საჭრისი"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "ჟირაფი"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "კიბო"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "მეძებარი ძაღლები"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "დიდი ქოფაკი"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "პატარა ქოფაკი"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "თხის რქა"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "გემის ხერხემალი"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "კასიოპეა"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "კენტავრი"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "ცეფევსი"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "ვეშაპი"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "ქამელეონი"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "ფარგალი"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "მტრედის"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "ბერენიკეს თმები"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "სამხრეთის გვირგვინი"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "ჩრდილოეთის გვირგვინი"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "ყორნის"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "ფიალის"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "ჯვრის"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "გედი"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "დელფინი"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "დორადო"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "გველეშაპი"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "კვიცი"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "ერიდანუსი"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "ღუმელის"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "მარჩბივი"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "წერო"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "ჰერკულესი"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "საათი"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "ჰიდრა"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "სამხრეთი ჰიდრა"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "ინდი"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "ხვლიკი"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "ლომი"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "პატარა ლომი"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "კურდღელი"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "სასწორი"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "მგელი"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "ფოცხვერი"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "ქნარი"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "მაგიდა მთა"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "მიკროსკოპი"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "მარტორქა"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "ბუზი"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "გონიო"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "ოქტანტი"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "გველისმჭერი"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "ორიონი"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "ფარშევანგი"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "პეგასი"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "პერსევსი"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "ფენიქსი"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "მხატვარი"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "თევზები"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "სამხრეთი თევზი"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "კიჩო"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "კომპასი"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "ბადურა"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "ისარი"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "მშვილდოსანი"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "ღრიანკალი"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "მოქანდაკე"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "ფარი"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "გველი"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "გველი"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "სექსტანტი"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "კურო"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "ტელესკოპი"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "სამკუთხედი"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "სამხრეთი სამკუთხედი"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "ტუკანა"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "დიდი დათვი"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "პატარა დათვი"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "იალქანი"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "ქალწული"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "მფრინავი თევზი"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "მელია"
 
@@ -533,3881 +622,3934 @@ msgstr "ქალთევზა"
 msgid "Kerberos"
 msgstr "Kerberos"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "ჰიდრა"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr "ცერერა"
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+#, fuzzy
+msgid "Vanth"
+msgstr "ეუანთე"
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "Haumea"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "ნამაკა"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "ჰიიაკა"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "მაკემაკე"
 
-#: data.cpp:134
+#: data.cpp:139
 msgid "S 2015 (136472) 1"
 msgstr "S 2015 (136472) 1"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "სამკუთხედი"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "ერისი"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "დისნომია"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "მეტისი"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "ადრასთეა"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "ამალთეა"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "თებე"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "თემისტო"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "ლედა"
 
-#: data.cpp:143
+#: data.cpp:151
 msgid "Ersa"
 msgstr "ერსა"
 
-#: data.cpp:144
+#: data.cpp:152
 msgid "Pandia"
 msgstr "პანდია"
 
-#: data.cpp:145
+#: data.cpp:153
 msgid "Himalia"
 msgstr "ჰიმალია"
 
-#: data.cpp:146
+#: data.cpp:154
 msgid "Lysithea"
 msgstr "ლისითეა"
 
-#: data.cpp:147
+#: data.cpp:155
 msgid "Elara"
 msgstr "ელარა"
 
-#: data.cpp:148
+#: data.cpp:156
 msgid "Dia"
 msgstr "დია"
 
-#: data.cpp:149
+#: data.cpp:157
 msgid "Carpo"
 msgstr "ქარპო"
 
-#: data.cpp:150
+#: data.cpp:158
 msgid "Valetudo"
 msgstr "ვალეტუდო"
 
-#: data.cpp:151
+#: data.cpp:159
 msgid "Euporie"
 msgstr "ევპორიე"
 
-#: data.cpp:152
+#: data.cpp:160
 msgid "Jupiter LV"
 msgstr "იუპიტერი LV"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr "ეუფემე"
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr "S 2003 J 16"
 
-#: data.cpp:155
+#: data.cpp:163
 msgid "Jupiter LXVIII"
 msgstr "იუპიტერი LXVIII"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "ანანკე"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "ჰარპალიკე"
 
-#: data.cpp:158
+#: data.cpp:166
 msgid "S 2003 J 12"
 msgstr "S 2003 J 12"
 
-#: data.cpp:159
+#: data.cpp:167
 msgid "Jupiter LII"
 msgstr "იუპიტერი LII"
 
-#: data.cpp:160
+#: data.cpp:168
 msgid "Praxidike"
 msgstr "პრაქსიდიკე"
 
-#: data.cpp:161
+#: data.cpp:169
 msgid "S 2003 J 2"
 msgstr "S 2003 J 2"
 
-#: data.cpp:162
+#: data.cpp:170
 msgid "Euanthe"
 msgstr "ეუანთე"
 
-#: data.cpp:163
+#: data.cpp:171
 msgid "Orthosie"
 msgstr "ორთოსიე"
 
-#: data.cpp:164
+#: data.cpp:172
 msgid "Jupiter LXIV"
 msgstr "იუპიტერი LXIV"
 
-#: data.cpp:165
+#: data.cpp:173
 msgid "Iocaste"
 msgstr "ლოკასტე"
 
-#: data.cpp:166
+#: data.cpp:174
 msgid "Mneme"
 msgstr "მნემე"
 
-#: data.cpp:167
+#: data.cpp:175
 msgid "Thyone"
 msgstr "თიონე"
 
-#: data.cpp:168
+#: data.cpp:176
 msgid "Jupiter LIV"
 msgstr "იუპიტერი LIV"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr "თელქსინოე"
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr "ჰელიკე"
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr "ჰერმიპე"
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr "ფილოფროსინე"
 
-#: data.cpp:173
+#: data.cpp:181
 msgid "Jupiter LVI"
 msgstr "იუპიტერი LVI"
 
-#: data.cpp:174
+#: data.cpp:182
 msgid "Kallichore"
 msgstr "კალიხორე"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "ჩალდენე"
 
-#: data.cpp:176
+#: data.cpp:184
 msgid "Arche"
 msgstr "არჩე"
 
-#: data.cpp:177
+#: data.cpp:185
 msgid "Jupiter LXIX"
 msgstr "იუპიტერი LXIX"
 
-#: data.cpp:178
+#: data.cpp:186
 msgid "Kale"
 msgstr "ხუჭუჭა კომბოსტო"
 
-#: data.cpp:179
+#: data.cpp:187
 msgid "Jupiter LXXII"
 msgstr "იუპიტერი LXII"
 
-#: data.cpp:180
+#: data.cpp:188
 msgid "Jupiter LXI"
 msgstr "იუპიტერი LXI"
 
-#: data.cpp:181
+#: data.cpp:189
 msgid "Cyllene"
 msgstr "ქილენე"
 
-#: data.cpp:182
+#: data.cpp:190
 msgid "Taygete"
 msgstr "ტაიგეტე"
 
-#: data.cpp:183
+#: data.cpp:191
 msgid "Jupiter LXX"
 msgstr "იუპიტერი LXX"
 
-#: data.cpp:184
+#: data.cpp:192
 msgid "Eurydome"
 msgstr "ეურიდომე"
 
-#: data.cpp:185
+#: data.cpp:193
 msgid "Jupiter LI"
 msgstr "იუპიტერი LI"
 
-#: data.cpp:186
+#: data.cpp:194
 msgid "S 2003 J 9"
 msgstr "S 2003 J 9"
 
-#: data.cpp:187
+#: data.cpp:195
 msgid "Jupiter LXVII"
 msgstr "იუპიტერი LXVII"
 
-#: data.cpp:188
+#: data.cpp:196
 msgid "Aitne"
 msgstr "აიტნე"
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "ქარმე"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "კალიროე"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "ერინომე"
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr "პასითეე"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr "ეირენე"
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr "S 2003 J 24"
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "სინოპე"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr "ეუკელადე"
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "ისონოე"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr "S 2003 J 4"
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr "აუტონოე"
 
-#: data.cpp:200
+#: data.cpp:208
 msgid "Herse"
 msgstr "ჰერსე"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "პესიფაე"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr "S 2003 J 10"
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr "კორე"
 
-#: data.cpp:204
+#: data.cpp:212
 msgid "Jupiter LXIII"
 msgstr "იუპიტერი LXIII"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr "ჰეგემონე"
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr "სპონდე"
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "კალიკე"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr "აოედე"
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "მეგაქლიტე"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr "S 2003 J 23"
 
-#: data.cpp:211
+#: data.cpp:219
 msgid "Jupiter LXVI"
 msgstr "იუპიტერი LXVI"
 
-#: data.cpp:212
+#: data.cpp:220
 msgid "Jupiter LIX"
 msgstr "იუპიტერი LIX"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr "S 2009 S 1"
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "Pan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr "დაფნისი"
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "ატლასი"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "პანდორა"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "ეპიმეთეუსი"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "იანუსი"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr "ეგეონი"
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr "მეთონი"
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr "ანთე"
 
-#: data.cpp:224
+#: data.cpp:232
 msgid "Pallene"
 msgstr "პალენი"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "ტელესტო"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "კალიფსო"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr "სატურნი XXXIV"
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "ჰელენე"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr "S 2019 S 1"
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr "კივიუქი"
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr "იჯირაქი"
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr "პაალიაქი"
 
-#: data.cpp:233
+#: data.cpp:241
 msgid "Skathi"
 msgstr "სკათი"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr "S 2004 S 37"
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr "S 2007 S 2"
 
-#: data.cpp:236
+#: data.cpp:244
 msgid "Albiorix"
 msgstr "ალბიორიქსი"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr "ბებჰიონი"
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr "S 2004 S 31"
 
-#: data.cpp:239
+#: data.cpp:247
 msgid "Saturn LX"
 msgstr "სატურნი LX"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr "სკოლი"
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr "ტარქექი"
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr "ტარვოსი"
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr "ერიაპუსი"
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr "სიარნაქი"
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr "გრეიპი"
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr "ჰიროკინი"
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr "მუნდილფარი"
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr "S 2006 S 1"
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr "S 2004 S 13"
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr "S 2007 S 3"
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr "სუტუნგრი"
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr "ნარვი"
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr "იარნსაქსა"
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr "S 2004 S 12"
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr "ბერგელმირი"
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr "S 2004 S 17"
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr "ჰატი"
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr "ფარბაუტი"
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr "თრიმრი"
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr "S 2004 S 7"
 
-#: data.cpp:263
+#: data.cpp:271
 #, fuzzy
-#| msgid "Belinda"
 msgid "Beli"
 msgstr "ბელინდა"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr "ბესტლა"
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr "აეგირი"
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr "S 2006 S 3"
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr "კარი"
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr "S 2004 S 28"
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr "ფერნირი"
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr "ლოგე"
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr "S 2004 S 21"
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr "S 2004 S 24"
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr "S 2004 S 36"
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr "იმირი"
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr "სურტური"
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr "S 2004 S 39"
 
-#: data.cpp:283
+#: data.cpp:291
 msgid "Saturn LXIV"
 msgstr "სატურნი LXIV"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr ""
 
-#: data.cpp:285
+#: data.cpp:293
 msgid "Fornjot"
 msgstr "ფორნიოტი"
 
-#: data.cpp:286
+#: data.cpp:294
 msgid "Saturn LVIII"
 msgstr "სატურნი LVIII"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "ქორდელია"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "ოფელია"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "ბიანკა"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "კრესიდა"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "დეზდემონა"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "ჯულიეტა"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "პორტია"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "როსალინდი"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr "კუპიდი"
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "ბელინდა"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr "პერდიტა"
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "პაქი"
 
-#: data.cpp:299
+#: data.cpp:307
 msgid "Mab"
 msgstr "მაბი"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr "ფრანცისკო"
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "ქალიფანი"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "სტეფანო"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr "ტრინკულო"
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "სიკორაქსი"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr "მარგარეტი"
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "პროსპერო"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "სეტებოსი"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr "ფერდნანდი"
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "ნაიადი"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "თალასა"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "დესპინა"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "გალათეა"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "ლარისა"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr "ჰიპოკამპუსი"
 
-#: data.cpp:315
+#: data.cpp:323
 msgid "Halimede"
 msgstr "ჰალიმედე"
 
-#: data.cpp:316
+#: data.cpp:324
 msgid "Sao"
 msgstr "საო"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr "ლაომედეა"
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr "ფსამათე"
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr "ნესო"
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ჩრდილოეთ ამერიკა"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "სამხრეთ ამერიკა"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ევრაზია"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "აფრიკა"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "ავსტრალია"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ანტარქტიკა"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ჩრდილო-ატლანტიკის ოკეანე"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "სამხრეთ-ატლანტიკის ოკეანე"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ჩრდილო-წყნარი ოკეანე"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "სამხრეთ-წყნარი ოკეანე"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ინდოეთის ოკეანე"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "არქტიკული ოკეანე"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "აბუ დაბი"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "აბუჯა"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "აკრა"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "ადამსტაუნი"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "ადის აბება"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "ალჟირი"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "ალოფი"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "ამანი"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "ამსტერდამი"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "ანდორა ლა ველა"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "ანკარა"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "ანტანანარივო"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "აპია"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "აშხაბადი"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "ასმარა"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "ასუნსიონი"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "ათენი"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "ავარუა"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "ბაღდადი"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "ბაქო"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "ბამაკო"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "ბანდარ სერი ბეგავანი"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "ბანკოკი"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "ბანგუი"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "ბანჯული"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "ბას-ტერი"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "ბასტერი"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "პეკინი"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "ბეირუტი"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "ბელგრადი"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "ბელმოპანი"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "ბერლინი"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "ბერნი"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "ბიშკეკი"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "ბისაუ"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "ბლუმფონტეინი"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "ბოგოტა"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "ბრაზილია"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "ბრატისლავა"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "ბრაზავილი"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "ბრიჯთაუნი"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "ბრუსელი"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "ბუქარესტი"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "ბუდაპეშტი"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "ბუენოს აირესი"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "ბუჟუმბურა"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "ქაირო"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "კანბერა"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "კეიპტაუნი"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "კარაკასი"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "კასტრი"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "კაიენი"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "შარლოტ-ამალია"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "კიშინიოვი"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "კოლომბო"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "კონაკრი"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "კოპენჰაგენი"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "კოტონუ"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "დაკარი"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "დამასკო"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "დარ ეს სალაამი"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "დაკა"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "დილი"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "ჯიბუტი"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "დოჰა"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "დუგლასი"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "დუბლინი"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "დუშანბე"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "ფონგაფალე"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "ფორტ-დე-ფრანსი"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "ფრითაუნი"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "გაბონი"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "ჯორჯთაუნი"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "ჯორჯთაუნი"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "გიბრალტარი"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "გრანდ ტურკი"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "გვატემალა"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "ჰაგატნა"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "ჰააგა"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "ჰამილტონი"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "ჰანოი"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "ჰარარე"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "ჰავანა"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "ჰელსინკი"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr "ჰონგკონგი"
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "ჰონიარა"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "ისლამაბადი"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "ჯაკარტა"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "ჯეიმსტაუნი"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "იერუსალიმი"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "ქაბული"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "კამპალა"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "კატმანდუ"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "ხართუმი"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "კიევი"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "კიგალი"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "კინგსტონი"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "კინგსტაუნი"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "კინშასა"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "კორორი"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "კუალა ლუმპური"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "ქუვეიტი"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "ლაიოუნი"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "ლა პასი"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "ლიბერვილი"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "ლილონგვე"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "ლიმა"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "ლისაბონი"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "ლუბლანა"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "ლობამბა"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "ლომი"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "ლონდონი"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "ლონგირი"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "ლუანდა"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "ლუსაკა"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "ლუქსემბურგი"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "მადრიდი"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "მაჯურო"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "მალაბო"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "მამრობითი"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "მამუცუ"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "მანაგუა"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "მანამა"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "მანილა"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "მაპუტუ"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "მასერუ"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "მატა-უტუ"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "მბაბანე"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "მეხიკო სითი"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "მინსკი"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "მოგადიშუ"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "მონაკო"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "მონროვია"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "მონტევიდეო"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "მორონი"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "მოსკოვი"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "მუსკატი"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "ნაირობი"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "ნასაუ"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "ნჯამენა"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "ახალი დელი"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "ნიამეი"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "ნიკოსია"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "ნოიაკჩოტი"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "ნუმეა"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "ნუკუალოფა"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "ნუუკი"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "ორანესტადი"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "ოსლო"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "ოტავა"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "უაგადუგუ"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "პაგო პაგო"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "პალიკირი"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "პანამა"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "პაპეეტე"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "პარამარიბო"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "პარიზი"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "ფნომ ფენჰი"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "პლიმუთი"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "პორტ ლუისი"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "პორტ მორესბი"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "პორტ-აუ-პრინსი"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "პორტ-ოვ-სპეინი"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "პორტო-ნოვო"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "პორტ ვილა"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "პრაღა"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "პრაია"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "პრეტორია"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "ფხენიანი"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "კიტო"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "რაბატი"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "რენგუნი"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "რეიკიავიკი"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "რიგა"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "რიადი"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "როუდთაუნი"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "რომი"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "როსო"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "სენტ ჯორჯისი"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "სენტ-ჰელიერი"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "სტ. ჯონის"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "სენტ-პიტერ-პორტი"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "სენტ-დენსი"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "სენ პიერი"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "სეიპანი"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "სან ხოსე"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "სან ხუანი"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "სან მარინო"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "სან სალვადორი"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "სანა"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "სანტიაგო"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "სანტო დომინიგო"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "საო ტომე"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "სარაევო"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "სეული"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "დასახლება"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "სინგაპური"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "სკოპიე"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "სოფია"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "შრი-ჯაიავარდენეპურა-კოტე"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "სტენლი"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "სტოქჰოლმი"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "სუკრე"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "სუვა"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "ტაიპეი"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "ტალინი"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "ტარავა"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "ტაშკენტი"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "თბილისი"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "ტეგუსიგალპა"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "თეირანი"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "თელ ავივი"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "თხიმფხუ"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "ტირანა"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "ტოკიო"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "ტორსჰავნი"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "ტრიპოლი"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "ტუნისი"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "ულაანბატორი"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "ვადუზი"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "ვალეტა"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "ვალი"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "ვატიკანი"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "ვიქტორია"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "ვენა"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "ვიენტიანი"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "ვილნუსი"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "ვარშავა"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "ვაშინგტონი დი.სი."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "უელინგტონი"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "უესტ აილენდი"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "ვილემსტადი"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "ვინდჰოეკი"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "იამუსუკრო"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "იაუნდე"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "იარენის ოლქი"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "ერევანი"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "ზაგრები"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "პერუული ახალი სოლი"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "ბარიცენტრი"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "მზე"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "ალფა ანდრომედასი"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "სირა"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "ბეტა კასიოპეა"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "ალგენიბი"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr "ციტადელი"
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "შემალი"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "ალფა ფენიქსი"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr "ფელიქსვარელა"
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr "ფულუ"
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "ალფა კასიოპეასი"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "შედირი"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "ბეტა ვეშაპისა"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "დენებ კაიტოსი"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr "HD 4208"
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "აჩერდი"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "ვან მაანენი 2"
 
-#: data.cpp:591
+#: data.cpp:599
 msgid "Castula"
 msgstr "ქასტულა"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "გამა კასიოპეასი"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr "ნენქვი"
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr "ფენიქსის ძეტა"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "ბეტა ანდრომედასი"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr "HD 7199"
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr "რევატი"
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "ადჰლი"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr "ბელენოსი"
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "რუკბახი"
 
-#: data.cpp:601
+#: data.cpp:609
 msgid "Alpherg"
 msgstr "ალფერგი"
 
-#: data.cpp:602
+#: data.cpp:610
 msgid "Titawin"
 msgstr "ტიტავინი"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "ახერნარი"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr "ნემბუსი"
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr "ტორქულარი"
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr "ომიკრონი თევზებისა"
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "ბატენ კაიტოსი"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr "მოთალა"
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "კაპუტ ტრიანგული"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "მესართიმი"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "გამა მენახირე"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "ბეტა ვერძი"
 
-#: data.cpp:613
+#: data.cpp:621
 msgid "Alrescha"
 msgstr "ალრიშა"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "ალ რიშა"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "გამა ანდრომედასი"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "ალმააკი"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "ალამაკი"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "ჰამალი"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "მირა"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "პოლარისი"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr "ბუნა"
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr "კაფალიჯიდმა"
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr "კოეია"
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr "ლილი ბორეა"
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr "ნუშაგაკი"
 
-#: data.cpp:626
+#: data.cpp:634
 msgid "Bharani"
 msgstr "ბარანი"
 
-#: data.cpp:627
+#: data.cpp:635
 msgid "Miram"
 msgstr "მირამი"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "ანგეტენარი"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "აჟა"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "აკამარი"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr "აიეიარვადი"
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "მენკარი"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "მენკაბი"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "ბეტა პერსევსისა"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr "მისამი"
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "ბოტეინი"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr "დალიმი"
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr "ზიბალი"
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr "ინტანი"
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "მირფაკი"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "მირფაკი"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "მარფაკი"
 
-#: data.cpp:643
+#: data.cpp:651
 msgid "Ran"
 msgstr "რანი"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr "ტუპი"
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "რანა"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "ომიკრონი პერსევსისა"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "ცელენო"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "ელექტრა"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "ტეიგეტა"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "მაია"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "ასტეროპი"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "მეროპე"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "ალციონი"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "პლეიონე"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "ზაურაკი"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "მენკიბი"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "ბეიდი"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "კეიდი"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr "პრიმა ჰიადუმი"
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr "სეკუნდა ჰიადუმი"
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr "ბეემიმი"
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "ენი"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr "ჩამუკუი"
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr "ჰოგარი"
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr "თიიმინი"
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "ალდებარანი"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr "სკეპტრუმი"
 
-#: data.cpp:668
+#: data.cpp:676
 msgid "Tabit"
 msgstr "ტაბიტი"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr "მუჰუნი"
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr "ჰასალე"
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "ჰინდის მეწამული ვარსკვლავი"
 
-#: data.cpp:672
+#: data.cpp:680
 msgid "Almaaz"
 msgstr "ალმაზი"
 
-#: data.cpp:673
+#: data.cpp:681
 msgid "Saclateni"
 msgstr "საკლეტენი"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "სადატონი"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr "ჰაედუსი"
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "ბეტა ერიდანუსი"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr "მაგო"
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "კაპტეინის ვარსკვლავი"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "რიგელი"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "კაპელა"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "ბელატრიქსი"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "ელნათი"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "ბეტა-კუროსი"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "ნიჰალი"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "თაბიტი"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "დელტა ორიონი"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "არნები"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "მეისა"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "ჰეკა"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr "ჰატისა"
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "ალნილამი"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr "ბუბუპი"
 
-#: data.cpp:693
+#: data.cpp:701
 msgid "Tianguan"
 msgstr "ტიანგუანი"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "ფაქტი"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "ალნიტაკი"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "საკაპა ორიონი"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "ვეზნი"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "ბეთელგეიზე"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "პრიჯიპატი"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "ბეტა მეეტლესი"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr "მაჰასიმი"
 
-#: data.cpp:702
+#: data.cpp:710
 msgid "Elkurud"
 msgstr "ელკურუდი"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr "ამადიოჰა"
 
-#: data.cpp:704
+#: data.cpp:712
 msgid "Propus"
 msgstr "პროპუსი"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "წითელი მართკუთხედი"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "ფურუდი"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "მირცამი"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "მურზიმი"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "ტეიატი"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "კანოპუსი"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "სუჰელი"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr "ლუცილინბურჰუცი"
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr "ლუსიტანია"
 
-#: data.cpp:714
+#: data.cpp:722
 msgid "Plaskett's Star"
 msgstr "პლასკეტის ვარსკვლავი"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "გამა მარჩვიბისა"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "ალმეისანი"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr "ნოსაქსა"
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "მებსუტა"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "სირიუსი"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr "ალზირი"
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr "ნერვია"
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "ადარა"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "ადარა"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr "ჩიტალა"
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr "ურუნგუნიტე"
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "მულიფეინი"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "მეკბუდა"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "ვეზენი"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "ბერნეს 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "ვასატი"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "ეტა დიდი ქოფაკისა"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "გომეისა"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "ლუიტენის ვარსკვლავი"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "კასტორი"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr "ჯიშუი"
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "პროციონი"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "ელგომაისა"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr "ცეიბო"
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "პოლუქსი"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr "ტაპექუე"
 
-#: data.cpp:741
+#: data.cpp:749
 msgid "Azmidi"
 msgstr "აზმიდი"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "ქსი კიჩოსი"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "ზეტა კიჩო"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr "ტურეისი"
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "გამა აფრის"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "ტეგმინე"
 
-#: data.cpp:747
+#: data.cpp:755
 msgid "Tarf"
 msgstr "ტარფი"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "ალ ტარფი"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr "ნასტი"
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr "პიაუტოსი"
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "ავიორი"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr "ალსკიაუკატი"
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "მუსციდა"
 
-#: data.cpp:754
+#: data.cpp:762
 msgid "Minchir"
 msgstr "მინჩირი"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr "გაკიიდი"
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr "მელეფი"
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "ალესუს ბორეალისი"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "ასელუს ოსტრალისი"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr "ასლეფინა"
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr "აშლეშა"
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr "კოპერნიკი"
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr "სტრიბორი"
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "აკუბენსი"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr "ტალითა"
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "დნოცესი"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr "ალკაფრა"
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "ტალიტა სამხრეთის"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "ლამბდა იალქნისა"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr "ნანი"
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "ბეტა გემის ხერხემლისა"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "იოტა გემის ხერხემალისა"
 
-#: data.cpp:772
+#: data.cpp:780
 msgid "Markeb"
 msgstr "მარკები"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "ალფარდი"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "კორ-ჰიდრა"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr "ინტერკრუსი"
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "ალტერფი"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr "ილირიანი"
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr "ლაკაუსი"
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "უკდა"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "სუბრა"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "რას ელასედ ავსტრალისი"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr "ნატაშა"
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr "ჟანგი"
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "რასალასი"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "რას ელასედ ბორეალისი"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr "ფელისი"
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr "ბიბა"
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "რეგული"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "კაბელეცედი"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "კორ-ლეონისი"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "ადჰაფერა"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "ალდაფერა"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "ტეინია ბორეალისი"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "ალგიება"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "ტანიინა სამხრეთის"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr "მაკონდო"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr "პრაეციპუა"
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr "ჩალავან"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "ალკესი"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "ბეტა დიდი დათვი"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "ლალანდე 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "დუბჰე"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "დუბი"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr "დინგოლაი"
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "ზოსმა"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "დური"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "თეტა ლომისსა"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "კოქსა"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "ჩორტი"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr "ინესის ვარსკვლავი"
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr "ჰუნაჰპუ"
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "ალულა ავსტრალისი"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "ალულა ბორეალისი"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "ცზე ცენგი"
 
-#: data.cpp:815
+#: data.cpp:823
 msgid "Shama"
 msgstr "შამა"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "გიაუსარი"
 
-#: data.cpp:817
+#: data.cpp:825
 msgid "Formosa"
 msgstr "ფორმოსი"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr "საგარმატჰა"
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr "პრჟიბილსკის ვარსკვლავი"
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr "უკლუნი"
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr "ფლეფოტონტე"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr "ტაიანგშოუ"
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "ბეტა ლომისა"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "ზავიჯავა"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "ალარაფი"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr "ანიარა"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "გრუმბრიჯი 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "გამა დიდი დათვი"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "ფადი"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr "ტონატიუ"
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "ალჩიბა"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr "ლმაი"
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "მეგრეცი"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "გიენა"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "ზანია"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr "გინანი"
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr "ტუპა"
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "აკრუქსი"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "ალგორაბი"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "გაკრუქსი"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr "ფუნი"
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "კარა"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "კრაზი"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "მუჰლიფაინი"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "პორიმა"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr "ლა სუპერბა"
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr "ტიანიი"
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "მიმოზა"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "ალიოტი"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr "ტაიი"
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "მინელაუვა"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "მინელაუვა"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "კორ კეროლაი"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "ვინდემიატრიქსი"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "ალმურედინი"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr "დიადემა"
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "მიცარი"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "სპიკა"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "აზიმერჩი"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "ალკორი"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr "დოფიდა"
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr "ლიესმა"
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "ჰიზი"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "ბენეტნაში"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "ბენეტნაში"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "ეტა მერწყულისა"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "ჰადარი"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "აგენა"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "თუბანი"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "თეტა ცენტავრისა"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr "კანგი"
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "არქტურუსი"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "სირმა"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr "ქსუანგე"
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr "ელგაფარი"
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "პროქსიმა"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "გამა მენახირე"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "ცეგინუსი"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr "ტოლიმანი"
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr "ალფა კენტავრისა"
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "იზარი"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "მირაკი"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "ეფსილონი მენახირესი"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr "მონჩი"
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr "მერგა"
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "კოჩაბი"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "ბეტა პატარა დათვისა"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "ზუბენელგენუბი"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr "არქალისი"
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr "ბაეკდუ"
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "ზუბენ ელაკრიბი"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "ნეკარი"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr "ბრაჩიუმი"
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "ზუბენესჩამალი"
 
-#: data.cpp:895
+#: data.cpp:903
 msgid "Pherkad Minor"
 msgstr "ფერკად მინორი"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr "ნიკავიი"
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "ფერკადი"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "ალკალუროპსი"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "იოტა დრაკონისა"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "ნუსაკანი"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "ალფა ჩრდილოეთი გვირგვინისა"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "გემა"
 
-#: data.cpp:903
+#: data.cpp:911
 msgid "Zubenelhakrabi"
 msgstr "ზუბენელჰაკრაბი"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "ბუბენ ელაკრაბი"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr "კარაკა"
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "ალფა გველი"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "ჩოუ"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr "გუდჯა"
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr "იკლილი"
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr "ფანგი"
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "დელტა ღრიანკალი"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr "აქრაბი"
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "ქსი სკორპიონისა"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "აკრაბ"
 
-#: data.cpp:915
+#: data.cpp:923
 msgid "Marsic"
 msgstr "მარსიკი"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "ჯაბა"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr "შარჯა"
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr "დელტა გველისმჭერი"
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr "ეფსილონ გველისმჭერისა"
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr "ჰუნორი"
 
-#: data.cpp:921
+#: data.cpp:929
 msgid "Alniyat"
 msgstr "ალნიიატი"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "ელნაიეტი"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr "ათებინე"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "ქაჯემი"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr "ტიმირი"
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "ანტარესი"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "ბეტა ჰერკულესი"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr "ოგმა"
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "მარფიკი"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr "როსალიადეკასტრო"
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr "პაიკაუჰალე"
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "ატრია"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr "ლარავაგი"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr "ქსამიდიმურა"
 
-#: data.cpp:935
+#: data.cpp:943
 msgid "Pipirima"
 msgstr "პიპირიმა"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr "მაჰსატი"
 
-#: data.cpp:937
+#: data.cpp:945
 msgid "Rapeto"
 msgstr "რაპეტო"
 
-#: data.cpp:938
+#: data.cpp:946
 msgid "Alrakis"
 msgstr "ალრაკისი"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "არაკისი"
 
-#: data.cpp:940
+#: data.cpp:948
 msgid "Aldhibah"
 msgstr "ალდიბა"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "საბიკი"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "რასალგეთი"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "ალფა ჰერკულესი"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "სარინი"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr "გუნიიბუუ"
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr "ინქვილი"
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "ბეტა დრაკონი"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "მაასიმი"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "ლისა"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "ლესუთი"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "კუმა"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "იილდუნი"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "შაულა"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "ალფა გველისმჭერისა"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "ალფა ჰერკულესი"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "სარგასი"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "ძიბანი"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr "გირტაბი"
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "ქებალრაი"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr "ალრუბა"
 
-#: data.cpp:961
+#: data.cpp:969
 msgid "Cervantes"
 msgstr "სერვანტესი"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr "ფუიუე"
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "გრუმიუმი"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "გამა გველეშაპისა"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "ეტამინი"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "ბერნარდის ვარსკვლავი"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr "პინკოია"
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "ალნასლი"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr "პოლისი"
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "კაუს მედია"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr "ალასია"
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "კაუს აუსტრალისი"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "ალ ათფარი"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr "ფაფნირი"
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "ლამბდა მშვილდოსნისა"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "ვეგა"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr "ქსიე"
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "შელიაკი"
 
-#: data.cpp:979
+#: data.cpp:987
 msgid "Ainalrami"
 msgstr "აინალრამი"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "სიგმა მშვილდოსნისა"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr "კავე"
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "ალია"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "სულუფატი"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "ასქელა"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr "ოკაბი"
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "ეფსილონი არწივისა"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr "მერიდიანა"
 
-#: data.cpp:988
+#: data.cpp:996
 msgid "Albaldah"
 msgstr "ალბალდა"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "ალტაისი"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "ალ ტაისი"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "ნოდუს სეკუნდუსი"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "ალადფარი"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr "გუმალა"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr "ბელელი"
 
-#: data.cpp:995
+#: data.cpp:1003
 msgid "Arkab Prior"
 msgstr "არკაბ პრიორი"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "არკაბი"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr "სიკა"
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr "ბეტა მშვილდოსნისა"
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "რუკბატი"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr "ანსერი"
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "ალბირეო"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr "ურუკი"
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "ალსაფი"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "კემპბელის ვარსკვლავი"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "შამი"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr "ფავარისი"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "ტარაზედი"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "ტილი"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "ალტაირი"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "ატაირი"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr "ლიბერტასი"
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "ალშეინი"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr "ტერებელუმი"
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr "ფოენიცია"
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr "ჩეჩია"
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "ალგედი"
 
-#: data.cpp:1017
+#: data.cpp:1025
 msgid "Alshat"
 msgstr "ალშატი"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "ბეტა თხის რქა"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "გამა გედისა"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "ალფა ფარშევანგისა"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr "ალდულფინი"
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "როტანევი"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "სუალოქინი"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "დენები"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr "ალჯანა"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "ალბალი"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr "მუსიკა"
 
-#: data.cpp:1028
+#: data.cpp:1036
 msgid "Polaris Australis"
 msgstr "პოლარის ავსტრალისი"
 
-#: data.cpp:1029
+#: data.cpp:1037
 msgid "Solaris"
 msgstr "Solaris"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "კიტალფა"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "ლაკაილი 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "ალდერამინი"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "ალფირკი"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "სადალკსუუდი"
 
-#: data.cpp:1035
+#: data.cpp:1043
 msgid "Bunda"
 msgstr "ბუნდა"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr "სამაია"
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "ნაშირა"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "აზელფაფაგე"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr "ბოსონა"
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "ჰერშელ გარნეტის ვარსკვლავი"
 
-#: data.cpp:1041
+#: data.cpp:1049
 msgid "Erakis"
 msgstr "ერაკისი"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "ეფსილონი პეგასისა"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "დენებ ალგედი"
 
-#: data.cpp:1044
+#: data.cpp:1052
 msgid "Aldhanab"
 msgstr "ალდანაბი"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "ალ დანაბი"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr "იტონდა"
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "კურჰა"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "სადალმელიკი"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "ალნაირი"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "ალნაირი"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "ბიჰამი"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "ანკა"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "გამა მერწყულისა"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "სავარძელი"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr "HD 212771"
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "კრუგერი 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "სიტულა"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "ჰომამი"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr "ტიაკი"
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "მეიტარი"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "ბაბკოკის ვარსკვლავი"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "სედალბარი"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr "ჰიდორი"
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "სკატი"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr "ჰელვეტიოსი"
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "ფომალჰაუტი"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "ბეტა პეგასი"
 
-#: data.cpp:1068
+#: data.cpp:1076
 msgid "Fumalsamakah"
 msgstr "ფუმალსამაკა"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "ფუმ ალ სამაკა"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "მარკაბი"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "მარჩაბი"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr "ებლა"
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "ბრედლი 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr "სალმი"
 
-#: data.cpp:1075
+#: data.cpp:1083
 msgid "Alkarab"
 msgstr "ალკარაბი"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr "ვერიტატე"
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr "პოერავა"
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "ერაი"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr "აქსოლოტლი"
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "ირმის ნახტომი"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "პლეიადები"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "ჰიადები"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "სკის კლასტერი"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "NGC 2632"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "მაფეი 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "მაფეი 1"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "ლომი A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "სექსტანტი B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "ლომი I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "სექსტანტი A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "ფარგალი"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr "ანდრომედას გალაქტიკა"
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr "სამკუთხედი გალაქტიკა"
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "ჰოლმბერგი VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "NGC5892"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "ერიდანუსი"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "კომპასი"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "ტონანცინტლა 2"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia-Korean\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2010-01-26 19:20+0900\n"
 "Last-Translator: Jacob Lee <jaeuck@gmail.com>\n"
 "Language-Team: Korean\n"
@@ -25,358 +25,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "안드로메다"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "공기펌프"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "극락조"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "물병"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "독수리"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "제단"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "양"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "마차부"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "목동"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "조각칼"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "기린"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "게"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "사냥개"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "큰개"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "작은개"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "염소"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "용골"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "카시오페이아"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "센타우루스"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "세페우스"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "고래"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "카멜레온"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "컴퍼스"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "비둘기"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "머리털"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "남쪽왕관"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "북쪽왕관"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "까마귀"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "컵"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "남십자"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "백조"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "돌고래"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "황새치"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "용"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "조랑말"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "에리다누스"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "화로"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "쌍둥이"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "두루미"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "헤르쿨레스"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "시계"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "바다뱀"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "물뱀"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "인디언"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "도마뱀"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "사자"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "작은사자"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "토끼"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "천칭"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "이리"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "살쾡이"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "거문고"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "테이블산"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "현미경"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "외뿔소"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "파리"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "직각자"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "팔분의"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "뱀주인"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "오리온"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "공작"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "페가수스"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "페르세우스"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "봉황"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "화가"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "물고기"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "남쪽물고기"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "고물"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "나침반"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "그물"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "화살"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "궁수"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "전갈"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "조각가"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "방패"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "뱀머리"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "뱀꼬리"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "육분의"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "황소"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "망원경"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "삼각형"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "남쪽삼각형"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "큰부리새"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "큰곰"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "작은곰"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "돛"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "처녀"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "날치"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "작은여우"
 
@@ -532,3964 +621,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "바다뱀"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "누메아"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "바마코"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "아말테아"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "삼각형"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "판도라"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "아말테아"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "디프다"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "목성"
+msgid "Pandia"
+msgstr "판도라"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "디프다"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "목성"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "목성"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "목성"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "목성"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "목성"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "목성"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "알키오네"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "목성"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "목성"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "칼리스토"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "목성"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "목성"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "목성"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "목성"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "목성"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "목성"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "목성"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "목성"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "목성"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "목성"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "칼리스토"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "보통"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "목성"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "목성"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "목성"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "1"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "프로메테우스"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "판도라"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "에피메테우스"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "야누스"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "셀레스티아"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "스캇"
+msgid "Telesto"
+msgstr "셀레스티아"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "스캇"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "알비레오"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "토성"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "토성"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "화로"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "토성"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "포트빌라"
+msgid "Fornjot"
+msgstr "화로"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "토성"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "포트빌라"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "3"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "은하"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "라리사"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "가니메데"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "태양"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "북아메리카"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "남아메리카"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "유라시아"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "아프리카"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "오스트레일리아"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "남극"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "북대서양"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "남대서양"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "북태평양"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "남태평양"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "인도양"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "북극해"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "아부다비"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "아부자"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "아크라"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "아담스타운"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "아디스아바바"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "알제"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "알로피"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "암만"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "암스테르담"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "안도라라베야"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "앙카라"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "안타나나리보"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "아피아"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "아시가바트"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "아스마라"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "아순시온"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "아테네"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "아바루아"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "바그다드"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "바쿠"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "바마코"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "반다르스리브가완"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "방콕"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "방기"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "반줄"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "바스테르"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "바스테르"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "베이징"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "베이루트"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "베오그라드"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "벨모판"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "베를린"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "베른"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "비슈케크"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "비사우"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "블룸 폰 테인"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "보고타"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "브라질리아"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "블라티슬라바"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "브라자빌"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "비리지타운"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "브뤼셀"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "부카레스트"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "부다페스트"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "부에노스아이레스"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "부줌부라"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "카이로"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "캔버라"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "케이프타운"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "카라카스"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "캐스트리스"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "카옌"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "샬롯아말리에"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "키시나우"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "콜롬보"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "코나크리"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "코펜하겐"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "코토누"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "다카르"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "다마스쿠스"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "다르에스살람"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "다카"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "딜리"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "지부티"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "도하"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "더글라스"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "더블린"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "두샨베"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "퐁아팔레"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "포르드프랑스"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "프리타운"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "가보로네"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "조지타운"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "조지타운"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "지브롤터"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "그랜드터크"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "과테말라"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "하갓냐"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "헤이그"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "해밀턴"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "하노이"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "하라레"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "하바나"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "헬싱키"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "호니아라"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "이슬라마바드"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "자카르타"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "제임스타운"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "예루살렘"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "카불"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "캄팔라"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "카트만두"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "카르툼"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "키예프"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "키갈리"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "킹스턴"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "킹스타운"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "킨샤사"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "코로르"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "쿠알라룸푸르"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "쿠웨이트"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "엘아윤"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "라파스"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "리브르빌"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "릴롱궤"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "리마"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "리스본"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "류블랴나"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "로밤바"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "로메"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "런던"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "롱위에아르비엔"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "루안다"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "루사카"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "룩셈부르크"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "마드리드"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "마주로"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "말라보"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "멀레"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "마무주"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "마나과"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "마나나"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "마닐라"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "마푸토"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "마세루"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "마타우투"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "음바바네"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "멕시코 시티"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "민스크"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "모가디슈"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "모나코"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "몬로비아"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "몬테비데오"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "모로니"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "모스크바"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "무스카트"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "나이로비"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "나소"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "은자메나"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "뉴델리"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "니아메"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "니코시아"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "누악쇼트"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "누메아"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "누쿠알로파"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "누크"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "오란예스타트"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "오슬로"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "오타와"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "와가두구"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "파고파고"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "팔라키르"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "파나마"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "파페에테"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr ""
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "파리"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "프놈펜"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "플리머스"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "포트루이스"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "포트모르즈비"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "포토프린스"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "포트오브스페인"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "포르토노보"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "포트빌라"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "프라하"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "프라이아"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "프레토리아"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "평양"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "퀴토"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "라바트"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "양곤"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "레이캬비크"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "리가"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "리야드"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "로드타운"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "로마"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "로조"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "세인트조지스"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "세인트헬리어"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "세인트존스"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "세인트피터포트"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "생드니"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "쌩삐에르"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "사이판"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "산호세"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "산후안"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "산마리노"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "산살바도르"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "사나"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "산티아고"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "산토도밍고"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "상투메"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "사라예보"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "서울"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "더세틀먼트"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "싱가폴"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "스코페"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "소피아"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "스리자야와르데네푸라코테"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "스탠리"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "스톡홀름"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "수크레"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "수바"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "타이베이"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "탈린"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "타라와"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "타슈켄트"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "트빌리시"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "테구시갈파"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "테헤란"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "텔아비브"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "팀푸"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "티라나"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "도쿄"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "토르스하운"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "트리폴리"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "튀니스"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "울란바토르"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "파두츠"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "발레타"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "더밸리"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "비티칸 시국"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "빅토리아"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "빈"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "비엔티안"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "빌니우스"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "바르샤바"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "워싱턴 DC"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "웰링턴"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "웨스트아일랜드"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "빌렘스타트"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "빈트후크"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "야무수크로"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "야운데"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "야렌 지구"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "예레반"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "자그레브"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "태양"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "태양계 중심"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "태양"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "알페라츠"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "시라흐"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "카프"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "알게니브"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "셰말리"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "안카"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "쉐다르"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "디프다"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "데네브 칼토스"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "아키르드"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "반 마넨 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "카스토르"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "나비"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "현재"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "미라크"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "아딜"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "루크바"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "알페라츠"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "타이탄"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "아케르나르"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "바텐 카이토스"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "삼각형자리 머리"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "메사르팀"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "세긴"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "셰라탄"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "알 레스챠"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "알 레스챠"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "알마크"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "알마크"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "하말"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "미라"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "폴라리스 (북극성)"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "차라"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "미라"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "안게테나르"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "아자"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "아카마"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "멘카르"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "멘카브"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "알골"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "보테인"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "미르팍"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "미르팍"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "마르팍"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "라나"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "라나"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "아틱"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "켈라에노"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "엘렉트라"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "타이게타"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "마이아"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "아스테로페"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "메로페"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "알키오네"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "플레이오네"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "자우락"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "멘키브"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "베이드"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "케이드"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "아인"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "알데바란"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "타비트"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "힌드의 진홍색 별"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "알마크"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "은하"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "사다토니"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "쿠르사"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "캅테인의 별"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "리겔"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "카펠라"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "벨라트릭스"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "엘나스"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "엘나스"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "니할"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "타비트"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "민타카"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "아르네브"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "메이사"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "헤카"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "알닐람"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "삼각형(△)"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "팍트"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "알니탁"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "사이프"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "와즌"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "베텔게우스"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "멘칼리난"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "퍼러드"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "카노푸스"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "붉은 삼각형"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "퍼러드"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "미르잠"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "머르짐"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "테얏"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "카노푸스"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "수헬"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "항성 보기"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "알레나"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "알메이산"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "멥수타"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "시리우스"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "아다라"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "무리훼인"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "메크부다"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "웨젠"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "버너스 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "와사트"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "알루드라"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "고메이사"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "루이텐의 별"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "카스토르"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "프로키온"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "엘고메이사"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "폴룩스"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "아스미디스케"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "아스미디스케"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "나오스"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "레고르"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "테그미네"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "알 타르프"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "알 타르프"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "아비오르"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "머스시다"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "아키르드"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "북쪽 아셀루스"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "남쪽 아셀루스"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "아쿠벤스"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "드노세스"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "수하일"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "미아플라시두스"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "아스피디스케"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "마르카브"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "알파드"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "코르 히드라에"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "알터프"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "우크다흐"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "수브라"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "남쪽 라스 엘라세드"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "라살라스"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "북쪽 라스 엘라세드"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "레굴루스"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "카벨레세드"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "코 레오니스"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "아드하페라"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "알드하페라"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "북쪽 타니아"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "알기에바"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "남쪽 타니아"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "런던"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "알케스"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "메라크"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "랄랑드 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "두베"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "두브"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "조스마"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "뒤르"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "셰르탄"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "코사"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "초트"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "남쪽 알룰라"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "북쪽 알룰라"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "샴"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "쟈우사르"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "초당 프레임수:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "조지타운"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "데네볼라"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "자비야바"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "호니아라"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "그룸브릿지 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "펙다"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "파드"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "알키바"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "메그레즈"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "기에나흐"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "자니아흐"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "아크룩스"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "알고라브"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "가크룩스"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "차라"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "크라즈"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "물리파인"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "포리마"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "미모사"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "알리오스"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "미네로바"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "아우바"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "코르 카롤리"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "반데미아트릭스"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "알무레딘"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "미자르"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "스피카"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "아지멕"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "알코르"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "헤제"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "알카이드"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "베넷나쉬"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "무프리드"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "하다르"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "아제나"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "투반"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "멘켄트"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "아크투루스"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "시르마"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "프록시마"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "세기너스"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "세그누스"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "이자르"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "미라크"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "풀체리마"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "코카브"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "코카브"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "주벤엘게누비"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "주벤 엘라크리비"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "네카르"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "주벤에샤마리"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "페르카드"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "페르카드"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "알카루롭스"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "에다시크"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "누사칸"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "알페카"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "겜마"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "주벤 엘라크라브"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "주벤 엘라크라브"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "우누칼하이"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "드슈바"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "그라피아스"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "아크라브"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "화성"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "야바흐"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "알 니얏"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "알 니얏"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "아테네"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "쿠잠"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "안타레스"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "코르네포러스"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "마르픽"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "아트리아"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "타라와"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "포리마"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "이아페투스"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "아라키스"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "아라키스"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "알키바"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "사비크"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "라스알게티"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "라스 알게티"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "사린"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "라스타반"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "마심"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "레사스"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "레수스"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "쿠마"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "일둔"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "샤울라"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "라스알하게"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "사르가스"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "드지반"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "세발라이"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "관측소·천문대"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "그루미움"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "엘타닌"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "엘타닌"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "버나드별"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "알나슬"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "중앙 카우스"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "남쪽 카우스"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "알 아트파르"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "북쪽 카우스"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "베가 (직녀성)"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "셸리아크"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "알데라민"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "눈키"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "알야"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "술라파트"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "아셀라"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "데네브 알 오카브"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "알발리"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "알타이스"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "알 타이스"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "둘째 노두스"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "알라드파르"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "과테말라"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "아르카브"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "아르카브"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "루크바트"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "알비레오"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "알사피"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "캠벨의 별"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "샴"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "파리"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "타라제드"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "틸"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "알타이르 (견우성)"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "알샤인"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "알게디"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "알샤인"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "다비흐"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "사드르"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "피콕"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "로타네브"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "수알로신"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "데네브"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "류블랴나"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "알발리"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "남쪽 카우스"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "폴라리스 (북극성)"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "키탈파"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "알데라민"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "알피르크"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "사달수드"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "별자리 경계선 보기"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "나시라"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "아젤파파게"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "아라키스"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "에니프"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "데네브 알게디"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "알 드하나브"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "알 드하나브"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "쿠르하"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "사달멜리크"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "알나이르"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "비함"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "안차"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "사다크비아"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "시트"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "크루거 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "시툴라"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "호맘"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "마타르"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "밥콕의 별"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "사달바리"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "스캇"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "포말하우트"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "쉬트"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "품 알 사마카흐"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "품 알 사마카흐"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "마르카브"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "마르챠브"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "앙카라"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "엘라이"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "은하수"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "플레이아데스"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "히아데스"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "프레세페"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "벌집 성단"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "마페이 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "마페이 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "사자자리 A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "육분의자리 B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "사자자리 I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "육분의자리 A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "컴퍼스"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "홈버그 VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "패덤 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "큰부리새자리 47"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "에리다누스"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "나침반"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "토난친틀라 2"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia 1.4.1\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2008-12-05 10:41+0200\n"
 "Last-Translator: Marius Mikalainis <neoromancer@gmail.com>\n"
 "Language-Team: Russian <leserg@ua.fm>\n"
@@ -18,364 +18,453 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Poedit-Language: Russian\n"
 "X-Poedit-Country: UKRAINE\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Siurblys"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Rojaus Paukštis"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vandenis"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Erelis"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Aukuras"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Avinas"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Vežėjas"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Jaučiaganis"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Skaptukas"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Žirafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Vėžys"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Skalikai"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Šuo"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Šuniukas"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Ožiaragis"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kilis"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kasiopėja"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentauras"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefėjas"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Banginis"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Chameleonas"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Skriestuvas"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Balandis"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenikės Garbanos"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Pietinis Vainikas"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Šiaurės Vainikas"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Varnas"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Taurė"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Kryžius"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Gulbė"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfinas"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Auksinė Žuvis"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Slibinas"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Žirgelis"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanas"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Krosnis"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Dvyniai"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Gervė"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Heraklis"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Laikrodis"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Pietinė Hidra"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indėnas"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Driežas"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Lūtas"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Liūtukas"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Kiškis"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Svarstyklės"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Vilkas"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lūšis"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lyra"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Stalkalnis"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskopas"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Vienaragis"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Musė"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Kampainis"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktantas"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Gyvatnešis"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orionas"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Povas"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasas"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Persėjas"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Feniksas"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Tapytojas"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Žuvys"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Pietinė Žuvis"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Laivagalis"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompasas"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Tinklelis"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Strėlė"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Šaulys"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpionas"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Skulptorius"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Skydas"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Gyvatės Galva"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Gyvatės Uodega"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sekstantas"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Tauras"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Teleskopas"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Trikampis"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Pietinis Trikampis"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukana"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Grįžulo Ratai"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Grįžulo Rateliai"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Burės"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Mergelė"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Skraidančioji Žuvis"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Laputė"
 
@@ -531,3965 +620,4018 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Numėja"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltėja"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Trikampis"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltėja"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diena"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiteris"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diena"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiteris"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiteris"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiteris"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiteris"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiteris"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiteris"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alkionė"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiteris"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiteris"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Kalista"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiteris"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiteris"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiteris"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiteris"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiteris"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiteris"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiteris"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiteris"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiteris"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiteris"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Kalista"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Glaustas"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiteris"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiteris"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiteris"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Saus"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometėjas"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Efimetėjus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janas"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albirėjas"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturnas"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturnas"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Krosnis"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturnas"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port Vila"
+msgid "Fornjot"
+msgstr "Krosnis"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturnas"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Kov"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaktikos"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larisa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimedas"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Saulė"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ŠIAURĖS AMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "PIETŲ AMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURAZIJA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIJA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTIDA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ŠIAURĖS ATLANTO VANDENYNAS"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "PIETŲ ATLANTO VANDENYNAS"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ŠIAURĖS RAMUSIS VANDENYNAS"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "PIETŲ RAMUSIS VANDENYNAS"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDIJOS VANDENYNAS"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ARKTIES VANDENYNAS"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dabis"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abudža"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Akra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstaunas"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Adis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alžyras"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Omanas"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdamas"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andora"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananaryvas"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apija"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ašchabadas"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Astana"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunsjonas"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atėnai"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avauja"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdadas"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Bedžavanas"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bankokas"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangis"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Bandžulis"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Base Tera"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basteras"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pekinas"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirutas"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgradas"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopanas"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlynas"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bernas"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Biškekas"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Gvinėja"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bliūfonteinas"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brazilija"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazavilis"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridžtounas"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Briuselis"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukareštas"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapeštas"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Airės"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujambara"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kairas"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Kanbera"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Keiptaunas"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Karakasas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Kastris"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Kaena"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Šarlote Amali"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kišiniovas"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Kolumbija"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Konakris"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhaga"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Kotonu"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakaras"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaskas"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar el Salamas"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Daka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Džibutis"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr ""
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublinas"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dušambė"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafalė"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Prancūzijos uostas"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Frytounas"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Džaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Džordžtaunas"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Džordžtounas"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltaras"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Did. Turkija"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Gvatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Haga"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamiltonas"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanojus"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Hararė"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinkis"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabadas"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Džakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Džemimstounas"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jeruzalė"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabulas"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Chartumas"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kijevas"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigalis"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingstonas"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstovnas"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinšasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Kororas"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kvala Lumpūras"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuveitas"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Ajūna"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Pazas"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Librevilis"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongvė"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisabona"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Liublijana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomė"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londonas"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longerbeinas"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Liuksemburgas"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madridas"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Madžūras"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malis"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamucū"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managva"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Menama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputa"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata Uta"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabanas"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Meksikas"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minskas"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadišas"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monakas"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovjia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevidėjas"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moronis"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Maskva"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Maskatas"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobis"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nasau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Ndžamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Naujasis Delis"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Nemėja"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nikosija"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nuakšotas"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Numėja"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nukalofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuukas"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Orandžestadas"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslas"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Otava"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Uagadugu"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr ""
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribas"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paryžius"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Pnompenis"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plimutas"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Liuisas"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Morsbis"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-a-Princas"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Ispanijos uostas"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto Novas"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praha"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praja"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretorija"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pijongjanas"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Kitas"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabatas"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangūnas"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reikjavíkas"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Ryga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Rijadas"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Roadtovnas"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseu"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Senžordžas"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Heleris"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Šventasis Peterio uostas"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint Denisas"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint Pjeras"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Ispanija"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Chosė"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juanis"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marinas"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Salvadoras"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sana"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Sandjiegas"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santa Domingas"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tomė"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevas"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seulas"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Setlementas"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapūras"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopjė"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofija"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Šri Džeivardepura Kota"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stenlis"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stokholmas"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sukrė"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipėjus"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Talinas"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarava"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taškentas"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisis"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheranas"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Avivas"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Timpu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokijas"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Toršuvanas"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripolis"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunisas"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulan Batoras"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaducas"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valeta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Slėnis"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikanas"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Viktorija"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viena"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientianas"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varšuva"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Vašingtonas D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Velingtonas"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Vakarų sala"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Viliamštadas"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Vindhokas"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Janmasukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Juandė"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Jarenas"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Jerevanas"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagrebas"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Saulė"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Saulės sistemos baricentras"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Saulė"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alferatas"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Kafas"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenibas"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Anka"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Difda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Kastoras"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Dabartinis"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirakas"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Rukba"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alferatas"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titanas"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernaras"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Šeratanas"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamalis"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Šiaurinė žvaigždė"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algolis"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirfakas"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asteropė"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Meropė"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alkionė"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Plejonė"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurakas"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ainė"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaranas"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaktikos"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Kursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteino žvaigždė"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigelis"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Kapela"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Belatriksė"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnatas"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihalas"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arnebas"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilamas"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Trikampis"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitakas"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saifas"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeizė"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinanas"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Kanopas"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Raudonasis stačiakampis"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzamas"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Kanopas"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Filtruoti žvaigždes"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirijus"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Alvazas"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten's Star"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Kastoras"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Prokionas"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Poluksas"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naosas"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regoras"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avioras"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Akubenas"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidas"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Turajas"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markabas"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alfardas"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulas"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londonas"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merakas"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhė"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 #, fuzzy
 msgid "Innes' Star"
 msgstr "%s Žvaigždė"
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formatas: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Džordžtounas"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrecas"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienachas"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Akruksas"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gakruksas"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimoza"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Aliotas"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Karolio Širdis"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatriksė"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Micaras"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spika"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alkoras"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaidas"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Mufridas"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkentas"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arktūras"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proksima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginas"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocha­bas"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekaras"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukas"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dšuba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marsas"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Alniatas"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Alniatas"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atėnai"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antaris"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Korneforas"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarava"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Japetas"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Ras Algetis"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastabanas"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Šaulė"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Ras Alhagas"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorijos"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnardo žvaigždė"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Šeliakas"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderaminas"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Sadira"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altajas"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Gvatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkabas"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkabas"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albirėjas"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell's Star"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paryžius"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazedas"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altayras"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alšainas"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alšainas"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabihas"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadiras"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Povas"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Denebas"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Liublijana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Šiaurinė žvaigždė"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderaminas"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Ribos"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enifas"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelikė"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock's Star"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhautas"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Šeatas"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markabas"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Paukščių takas"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Didysis Magelano debesis"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Mažasis Magelano debesis"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Sietynas"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Praesepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Skriestuvas"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanas"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompasas"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-12-14 10:29+0200\n"
 "Last-Translator: Jānis Jātnieks <sg30022@lanet.lv>\n"
 "Language-Team: Latviešu\n"
@@ -23,358 +23,447 @@ msgstr ""
 "X-Poedit-Country: LATVIA\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Sūknis"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradīzes Putns"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Ūdensvīrs"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Ērglis"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altāris"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Auns"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Vedējs"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Vēršu Dzinējs"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Greblis"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Žirafe"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Vēzis"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Medību Suņi"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Lielais Suns"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Mazais Suns"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Mežāzis"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kuģa Ķīlis"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kasiopeja"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentaurs"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefejs"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Valis"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Hameleons"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Cirkulis"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Balodis"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenikes Mati"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Dienvidu Vainags"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Ziemeļu Vainags"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Krauklis"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Kauss"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Krusts"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Gulbis"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfīns"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Zelta Zivs"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Pūķis"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Mazais Zirgs"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridāna"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Krāsns"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Dvīņi"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Dzērve"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkuless"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Pulkstenis"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Dienvidu Hidra"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indiānis"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Ķirzaka"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Lauva"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Mazais Lauva"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Zaķis"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Svari"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Vilks"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lūsis"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Galds"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskops"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Vienradzis"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Muša"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Leņķmērs"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktants"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Čūsknesis"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orions"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pāvs"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegazs"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Persejs"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fenikss"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Gleznotājs"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Zivis"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Dienvidu Zivs"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Kuģa Gals"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompass"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Tīkliņš"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Bulta"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Strēlnieks"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpions"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Tēlnieks"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Vairogs"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Čūskas Galva"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Čūskas Aste"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sekstants"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Vērsis"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Teleskops"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Trīsstūris"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Dienvidu Trīsstūris"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukans"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Lielais Lācis"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Mazais Lācis"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Buras"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Jaunava"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Lidojošā Zivs"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Lapsiņa"
 
@@ -530,3972 +619,4025 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Niameja"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalteja"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Trīsstūris"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalteja"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Difda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiters"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Difda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiters"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiters"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiters"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiters"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiters"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiters"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiters"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiters"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Kalisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiters"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiters"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiters"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiters"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiters"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiters"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiters"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiters"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiters"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiters"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Kalisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "īss"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiters"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiters"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiters"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometejs"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetejs"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Jānuss"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skats"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skats"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturns"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturns"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Krāsns"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturns"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Portvila"
+msgid "Fornjot"
+msgstr "Krāsns"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturns"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Portvila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaktikas"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Lārisa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimēds"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sol"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ZIEMEĻAMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "DIENVIDAMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EIRĀZIJA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "ĀFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRĀLIJA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTIKA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ATLANTIJAS OKEĀNA ZIEMEĻI"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ATLANTIJAS OKEĀNA DIENVIDI"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "KLUSĀ OKEĀNA ZIEMEĻI"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "KLUSĀ OKEĀNA DIENVIDI"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDIJAS OKEĀNS"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ZIEMEĻU LEDUS OKEĀNS"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abū Dabī"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abudža"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Akra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstauna"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Adis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alžīra"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Ammāna"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdama"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andora la Velje"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivu"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ašgabata"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmera"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunsjona"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atēnas"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdāde"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr ""
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bankoka"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangi"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Bandžula"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Bastēra"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Bastēra"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pekina"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirūta"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrada"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopāna"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlīne"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berne"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Biškeka"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissava"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr ""
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brazilja"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazavila"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridžtauna"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brisele"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukareste"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapešta"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenosairesa"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bužumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kaira"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Kanbera"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Keiptauna"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Karakasa"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr ""
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Kajēnas"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr ""
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kišiņeva"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Kolombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Konrakrī"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhāgena"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr ""
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakāra"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaska"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dāresalāma"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Daka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Džibutija"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Duglāzija"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublina"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dušanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr ""
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr ""
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Frītauna"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gabarone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Džordžtauna"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Džordžtauna"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltāra"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr ""
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Gvatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr ""
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Hāga"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamiltona"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoja"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harāre"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr ""
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabada"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Džakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Džeimstauna"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jeruzāleme"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabula"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Kartūma"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kijeva"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingstona"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr ""
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinšasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr ""
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpura"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuveita"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Ajūna"
 
-#: data.cpp:437
+#: data.cpp:445
 #, fuzzy
 msgid "La Paz"
 msgstr "Andora la Velje"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Librevila"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongve"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisabona"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ļubļana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr ""
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr ""
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londona"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr ""
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luksemburga"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madride"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr ""
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr ""
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr ""
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr ""
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr ""
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr ""
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr ""
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mehiko"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minska"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadīšu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monako"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovija"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Maskava"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Maskata"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Naso"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Ndžamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Jaundelī"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niameja"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nikosija"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nuakšota"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Niameja"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuka"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr ""
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Otava"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Vagadugu"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr ""
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr ""
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Parīze"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Pnompeņa"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plimuta"
 
-#: data.cpp:493
+#: data.cpp:501
 #, fuzzy
 msgid "Port Louis"
 msgstr "Portvila"
 
-#: data.cpp:494
+#: data.cpp:502
 #, fuzzy
 msgid "Port Moresby"
 msgstr "Portvila"
 
-#: data.cpp:495
+#: data.cpp:503
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr " AU/s"
 
-#: data.cpp:496
+#: data.cpp:504
 #, fuzzy
 msgid "Port-of-Spain"
 msgstr "Portvila"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr ""
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Portvila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prāga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr ""
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Phenjana"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Čita"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabāta"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Jangona"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reikjavīka"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Rīga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Rijāda"
 
-#: data.cpp:509
+#: data.cpp:517
 #, fuzzy
 msgid "Road Town"
 msgstr "Keiptauna"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr ""
 
-#: data.cpp:512
+#: data.cpp:520
 #, fuzzy
 msgid "Saint George's"
 msgstr "Džordžtauna"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr ""
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr ""
 
-#: data.cpp:515
+#: data.cpp:523
 #, fuzzy
 msgid "Saint Peter Port"
 msgstr "Portvila"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr ""
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr ""
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipana"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Džozē"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Huana"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Sanmarīno"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Sansalvadora"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sana"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santjago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr ""
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr ""
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajeva"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seula"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr ""
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapūra"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofija"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stenlija"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stokholma"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sukre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipeja"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallina"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Taravā"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taškenta"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegučigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teherāna"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Telaviva"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Timpu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirāna"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokija"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Toršavna"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripole"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunisa"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulanbatora"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduca"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valeta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr ""
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikāns"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Viktorija"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Vīne"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vjančana"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Viļņa"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varšava"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Vašingtona"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Velingtona"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Vestailenda"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Villemsteda"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Vindhuka"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Jamasukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Jaunde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr ""
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Eerevāna"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreba"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sol"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Zvaigžņu sistēmas baricentrs"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Saule"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alferacs"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Kafs"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenibs"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Šedirs"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Difda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Mānena zvaigzne"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Kastors"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Pašreizējā"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Miraks"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhils"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Rukbahs"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alferacs"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titāns"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ahernars"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Šeratans"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Alamaks"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamals"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polārzvaigzne"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkars"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algols"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirfaks"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkibs"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beids"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebarans"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Alamaks"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaktikas"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn's Star"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigels"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Kapella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatriksa"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnats"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Trijstūris"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saifs"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeize"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinans"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Kanopuss"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Red Rectangle"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Kanopuss"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Rādīt zvaigznes"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sīriuss"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten's Star"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Kastors"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procions"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollukss"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muskida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Ziemeļu Ēzelis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Dienvidu Ēzelis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markabs"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alfards"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Reguls"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londona"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Meraks"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formāts: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Džordžtauna"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Fads"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienahs"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Aliots"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Kārļa Sirds"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Micars"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spika"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaids"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arkturs"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proksima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izars"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kohabs"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubenelšamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Ferkads"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Ferkads"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakans"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marss"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atēnas"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antaress"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Taravā"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Japets"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastabans"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorijas"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamins"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnard's Star"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Gvatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell's Star"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Parīze"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altairs"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadors"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Denebs"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ļubļana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polārzvaigzne"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirks"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Rādīt robežas"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enifs"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock's Star"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skats"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhauts"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Šeats"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markabs"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Erai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Piena Ceļš"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejādes (Sietiņš)"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Praesepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Cirkulis"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc miglājs"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridāna"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompass"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: no\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2010-12-05 09:32+0100\n"
 "Last-Translator: FreewareTips <http://home.c2i.net/freewaretips/>\n"
 "Language-Team: \n"
@@ -20,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Luftpumpen"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradisfuglen"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vannmannen"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Ørnen"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Alteret"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Væren"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Kusken"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Bjørnevokteren"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Meiselen"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Giraffen"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Krepsen"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Jakthundene"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Stor hund"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Lille hund"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Steinbukken"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kjølen"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentauren"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Kefeus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Hvalfisken"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Kameleonen"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Passeren"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Duen"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenikes hår"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "krone, den sydlige"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "krone, den nordlige"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Ravnen"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Begeret"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Sydkorset"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Svanen"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfinen"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Gullfisken"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragen"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "hest, den lille"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Floden"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Smelteovnen"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Tvillingene"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Tranen"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Uret"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Vannslangen"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "vannslange, den sydlige"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indianeren"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Firfislen"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Løven"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "løve, den lille"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Haren"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Vekten"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Ulven"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Gaupen"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lyren"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Bordet"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskopet"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Enhjørningen"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Fluen"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Vinkelhaken"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktanten"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Slangebæreren"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Påfuglen"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasus"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Persevs"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Føniks"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Maleren"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Fiskene"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "fisk, den sydlige"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Akterstavnen"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompasset"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Nettet"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Pilen"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Skytten"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpionen"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Billedhuggeren"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Skjoldet"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Slangens hode"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Slangens hale"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sekstanten"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Tyren"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Teleskopet"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triangelet"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "triangelet, det sydlige"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukanen"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Store bjørn"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Lille bjørn"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Seilet"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Jomfruen"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Flygefisken"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Reven"
 
@@ -527,3934 +616,3987 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Vannslangen"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triangelet"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diamant"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diamant"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
+#: data.cpp:166
 msgid "S 2003 J 12"
 msgstr ""
 
-#: data.cpp:159
+#: data.cpp:167
 #, fuzzy
 msgid "Jupiter LII"
 msgstr "Jupiter"
 
-#: data.cpp:160
+#: data.cpp:168
 msgid "Praxidike"
 msgstr ""
 
-#: data.cpp:161
+#: data.cpp:169
 msgid "S 2003 J 2"
 msgstr ""
 
-#: data.cpp:162
+#: data.cpp:170
 msgid "Euanthe"
 msgstr ""
 
-#: data.cpp:163
+#: data.cpp:171
 msgid "Orthosie"
 msgstr ""
 
-#: data.cpp:164
+#: data.cpp:172
 #, fuzzy
 msgid "Jupiter LXIV"
 msgstr "Jupiter"
 
-#: data.cpp:165
+#: data.cpp:173
 msgid "Iocaste"
 msgstr ""
 
-#: data.cpp:166
+#: data.cpp:174
 msgid "Mneme"
 msgstr ""
 
-#: data.cpp:167
+#: data.cpp:175
 msgid "Thyone"
 msgstr ""
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Knapp"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
+#: data.cpp:232
 msgid "Pallene"
 msgstr ""
 
-#: data.cpp:225
+#: data.cpp:233
 #, fuzzy
 msgid "Telesto"
 msgstr "Celestia"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr ""
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr ""
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr ""
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr ""
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr ""
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr ""
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr ""
 
-#: data.cpp:233
+#: data.cpp:241
 msgid "Skathi"
 msgstr ""
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr ""
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr ""
 
-#: data.cpp:236
+#: data.cpp:244
 msgid "Albiorix"
 msgstr ""
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturn"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Smelteovnen"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturn"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Smelteovnen"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturn"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galakser"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymede"
 
-#: data.cpp:316
+#: data.cpp:324
 msgid "Sao"
 msgstr ""
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "SØRAMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTEREN"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SØRATLANTEREN"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORDLIGE STILLEHAVET"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SØRLIGE STILLEHAVET"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDISKE HAV"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "NORDISHAVET"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alger"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Aten"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Beograd"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brussel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucuresti"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Cape Town"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "København"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dusjanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havanna"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsingfors"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "London"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Manlig"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskva"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muskat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praha"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yŏngyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sana"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapore"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikanstaten"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Wien"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr ""
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Solsystemets massesentrum"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sol"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr ""
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr ""
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr ""
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr ""
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr ""
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr ""
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr ""
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr ""
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr ""
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr ""
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr ""
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr ""
 
-#: data.cpp:591
+#: data.cpp:599
 msgid "Castula"
 msgstr ""
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr ""
 
-#: data.cpp:593
-msgid "Nenque"
-msgstr ""
-
-#: data.cpp:594
-#, fuzzy
-msgid "Wurren"
-msgstr "Legg til et relativt bokmerke for gjeldende dokument"
-
-#: data.cpp:595
-msgid "Mirach"
-msgstr ""
-
-#: data.cpp:596
-msgid "Emiw"
-msgstr ""
-
-#: data.cpp:597
-msgid "Revati"
-msgstr ""
-
-#: data.cpp:598
-msgid "Adhil"
-msgstr ""
-
-#: data.cpp:599
-msgid "Bélénos"
-msgstr ""
-
-#: data.cpp:600
-msgid "Ruchbah"
-msgstr ""
-
 #: data.cpp:601
-msgid "Alpherg"
+msgid "Nenque"
 msgstr ""
 
 #: data.cpp:602
 #, fuzzy
-msgid "Titawin"
-msgstr "Titan"
+msgid "Wurren"
+msgstr "Legg til et relativt bokmerke for gjeldende dokument"
 
 #: data.cpp:603
-msgid "Achernar"
+msgid "Mirach"
 msgstr ""
 
 #: data.cpp:604
-msgid "Nembus"
+msgid "Emiw"
 msgstr ""
 
 #: data.cpp:605
-msgid "Torcular"
+msgid "Revati"
 msgstr ""
 
 #: data.cpp:606
-msgid "Torcularis Septentrionalis"
+msgid "Adhil"
 msgstr ""
 
 #: data.cpp:607
-msgid "Baten Kaitos"
+msgid "Bélénos"
 msgstr ""
 
 #: data.cpp:608
-msgid "Mothallah"
+msgid "Ruchbah"
 msgstr ""
 
 #: data.cpp:609
-msgid "Caput Trianguli"
+msgid "Alpherg"
 msgstr ""
 
 #: data.cpp:610
-msgid "Mesarthim"
-msgstr ""
+#, fuzzy
+msgid "Titawin"
+msgstr "Titan"
 
 #: data.cpp:611
-msgid "Segin"
+msgid "Achernar"
 msgstr ""
 
 #: data.cpp:612
-msgid "Sheratan"
+msgid "Nembus"
 msgstr ""
 
 #: data.cpp:613
-msgid "Alrescha"
+msgid "Torcular"
 msgstr ""
 
 #: data.cpp:614
-msgid "Al Rescha"
+msgid "Torcularis Septentrionalis"
 msgstr ""
 
 #: data.cpp:615
-msgid "Almach"
+msgid "Baten Kaitos"
 msgstr ""
 
 #: data.cpp:616
-msgid "Almaak"
+msgid "Mothallah"
 msgstr ""
 
 #: data.cpp:617
-msgid "Alamak"
+msgid "Caput Trianguli"
 msgstr ""
 
 #: data.cpp:618
-msgid "Hamal"
+msgid "Mesarthim"
 msgstr ""
 
 #: data.cpp:619
-msgid "Mira"
+msgid "Segin"
 msgstr ""
 
 #: data.cpp:620
-msgid "Polaris"
+msgid "Sheratan"
 msgstr ""
 
 #: data.cpp:621
-msgid "Buna"
+msgid "Alrescha"
 msgstr ""
 
 #: data.cpp:622
-msgid "Kaffaljidhma"
+msgid "Al Rescha"
 msgstr ""
 
 #: data.cpp:623
-msgid "Koeia"
+msgid "Almach"
 msgstr ""
 
 #: data.cpp:624
-msgid "Lilii Borea"
+msgid "Almaak"
 msgstr ""
 
 #: data.cpp:625
-msgid "Nushagak"
+msgid "Alamak"
 msgstr ""
 
 #: data.cpp:626
-msgid "Bharani"
+msgid "Hamal"
 msgstr ""
 
 #: data.cpp:627
+msgid "Mira"
+msgstr ""
+
+#: data.cpp:628
+msgid "Polaris"
+msgstr ""
+
+#: data.cpp:629
+msgid "Buna"
+msgstr ""
+
+#: data.cpp:630
+msgid "Kaffaljidhma"
+msgstr ""
+
+#: data.cpp:631
+msgid "Koeia"
+msgstr ""
+
+#: data.cpp:632
+msgid "Lilii Borea"
+msgstr ""
+
+#: data.cpp:633
+msgid "Nushagak"
+msgstr ""
+
+#: data.cpp:634
+msgid "Bharani"
+msgstr ""
+
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Miranda"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr ""
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr ""
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr ""
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr ""
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr ""
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr ""
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr ""
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr ""
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr ""
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr ""
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Jan"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr ""
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr ""
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr ""
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr ""
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr ""
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr ""
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr ""
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr ""
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr ""
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr ""
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr ""
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr ""
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr ""
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr ""
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr ""
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr ""
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 msgid "Tabit"
 msgstr ""
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr ""
 
-#: data.cpp:672
+#: data.cpp:680
 msgid "Almaaz"
 msgstr ""
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galakser"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr ""
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr ""
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr ""
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr ""
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr ""
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr ""
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr ""
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr ""
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr ""
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr ""
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr ""
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr ""
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr ""
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr ""
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr ""
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triangel"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr ""
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr ""
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr ""
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr ""
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr ""
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr ""
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr ""
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 msgid "Elkurud"
 msgstr ""
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 msgid "Propus"
 msgstr ""
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr ""
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr ""
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr ""
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr ""
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr ""
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr ""
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr ""
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Vis stjerner"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr ""
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr ""
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr ""
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr ""
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr ""
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr ""
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr ""
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr ""
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr ""
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr ""
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr ""
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr ""
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr ""
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr ""
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr ""
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr ""
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr ""
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr ""
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 msgid "Azmidi"
 msgstr ""
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr ""
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr ""
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr ""
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr ""
 
-#: data.cpp:747
+#: data.cpp:755
 msgid "Tarf"
 msgstr ""
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr ""
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr ""
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr ""
 
-#: data.cpp:754
+#: data.cpp:762
 msgid "Minchir"
 msgstr ""
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr ""
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr ""
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr ""
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr ""
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr ""
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr ""
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr ""
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr ""
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markører"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr ""
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr ""
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr ""
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr ""
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr ""
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr ""
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr ""
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr ""
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr ""
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr ""
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr ""
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr ""
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr ""
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr ""
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr ""
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr ""
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "London"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr ""
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr ""
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr ""
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr ""
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr ""
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr ""
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr ""
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr ""
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr ""
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr ""
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr ""
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr ""
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr ""
 
-#: data.cpp:815
+#: data.cpp:823
 msgid "Shama"
 msgstr ""
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr ""
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr ""
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr ""
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr ""
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr ""
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr ""
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr ""
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr ""
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr ""
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr ""
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr ""
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr ""
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr ""
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr ""
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr ""
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr ""
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr ""
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr ""
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr ""
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr ""
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr ""
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr ""
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr ""
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr ""
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr ""
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr ""
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr ""
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr ""
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr ""
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr ""
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr ""
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr ""
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr ""
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr ""
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr ""
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr ""
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr ""
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr ""
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr ""
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr ""
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr ""
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr ""
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr ""
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr ""
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr ""
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr ""
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr ""
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr ""
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr ""
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr ""
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr ""
 
-#: data.cpp:895
+#: data.cpp:903
 msgid "Pherkad Minor"
 msgstr ""
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr ""
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr ""
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr ""
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr ""
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr ""
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr ""
 
-#: data.cpp:903
+#: data.cpp:911
 msgid "Zubenelhakrabi"
 msgstr ""
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr ""
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr ""
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr ""
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr ""
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr ""
 
-#: data.cpp:914
-msgid "Akrab"
-msgstr ""
-
-#: data.cpp:915
-#, fuzzy
-msgid "Marsic"
-msgstr "Mars"
-
-#: data.cpp:916
-msgid "Jabbah"
-msgstr ""
-
-#: data.cpp:917
-msgid "Sharjah"
-msgstr ""
-
-#: data.cpp:918
-msgid "Yed Prior"
-msgstr ""
-
-#: data.cpp:919
-msgid "Yed Posterior"
-msgstr ""
-
-#: data.cpp:920
-msgid "Hunor"
-msgstr ""
-
-#: data.cpp:921
-msgid "Alniyat"
-msgstr ""
-
 #: data.cpp:922
-msgid "Al Niyat"
+msgid "Akrab"
 msgstr ""
 
 #: data.cpp:923
 #, fuzzy
-msgid "Athebyne"
-msgstr "Aten"
+msgid "Marsic"
+msgstr "Mars"
 
 #: data.cpp:924
-msgid "Cujam"
+msgid "Jabbah"
 msgstr ""
 
 #: data.cpp:925
-msgid "Timir"
+msgid "Sharjah"
 msgstr ""
 
 #: data.cpp:926
-msgid "Antares"
+msgid "Yed Prior"
 msgstr ""
 
 #: data.cpp:927
-msgid "Kornephoros"
+msgid "Yed Posterior"
 msgstr ""
 
 #: data.cpp:928
-msgid "Ogma"
+msgid "Hunor"
 msgstr ""
 
 #: data.cpp:929
-msgid "Marfik"
+msgid "Alniyat"
 msgstr ""
 
 #: data.cpp:930
-msgid "Rosalíadecastro"
+msgid "Al Niyat"
 msgstr ""
 
 #: data.cpp:931
-msgid "Paikauhale"
-msgstr ""
+#, fuzzy
+msgid "Athebyne"
+msgstr "Aten"
 
 #: data.cpp:932
-msgid "Atria"
+msgid "Cujam"
 msgstr ""
 
 #: data.cpp:933
+msgid "Timir"
+msgstr ""
+
+#: data.cpp:934
+msgid "Antares"
+msgstr ""
+
+#: data.cpp:935
+msgid "Kornephoros"
+msgstr ""
+
+#: data.cpp:936
+msgid "Ogma"
+msgstr ""
+
+#: data.cpp:937
+msgid "Marfik"
+msgstr ""
+
+#: data.cpp:938
+msgid "Rosalíadecastro"
+msgstr ""
+
+#: data.cpp:939
+msgid "Paikauhale"
+msgstr ""
+
+#: data.cpp:940
+msgid "Atria"
+msgstr ""
+
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 msgid "Pipirima"
 msgstr ""
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 msgid "Alrakis"
 msgstr ""
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr ""
 
-#: data.cpp:940
+#: data.cpp:948
 msgid "Aldhibah"
 msgstr ""
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr ""
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr ""
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr ""
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr ""
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr ""
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr ""
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr ""
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr ""
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr ""
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr ""
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr ""
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr ""
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr ""
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr ""
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr ""
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr ""
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorier"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr ""
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr ""
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr ""
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr ""
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr ""
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr ""
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr ""
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr ""
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr ""
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr ""
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr ""
 
-#: data.cpp:979
+#: data.cpp:987
 msgid "Ainalrami"
 msgstr ""
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr ""
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr ""
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr ""
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr ""
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr ""
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 msgid "Albaldah"
 msgstr ""
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr ""
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr ""
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr ""
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr ""
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 msgid "Arkab Prior"
 msgstr ""
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr ""
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr ""
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr ""
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr ""
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr ""
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr ""
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr ""
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr ""
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr ""
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr ""
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr ""
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr ""
 
-#: data.cpp:1017
+#: data.cpp:1025
 msgid "Alshat"
 msgstr ""
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr ""
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr ""
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr ""
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr ""
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr ""
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr ""
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr ""
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 msgid "Polaris Australis"
 msgstr ""
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Solformørkelser"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr ""
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr ""
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr ""
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr ""
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr ""
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Grenser"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr ""
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr ""
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr ""
 
-#: data.cpp:1041
+#: data.cpp:1049
 msgid "Erakis"
 msgstr ""
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr ""
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr ""
 
-#: data.cpp:1044
+#: data.cpp:1052
 msgid "Aldhanab"
 msgstr ""
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr ""
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr ""
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr ""
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr ""
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr ""
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr ""
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr ""
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr ""
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr ""
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr ""
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr ""
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr ""
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr ""
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr ""
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr ""
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr ""
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr ""
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr ""
 
-#: data.cpp:1068
+#: data.cpp:1076
 msgid "Fumalsamakah"
 msgstr ""
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr ""
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr ""
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr ""
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr ""
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr ""
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Melkevei"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr ""
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr ""
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr ""
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr ""
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr ""
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr ""
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr ""
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr ""
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr ""
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr ""
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Passeren"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr ""
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr ""
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr ""
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Floden"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompasset"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Celestia-1.4.1\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-08-02 19:02+0100\n"
 "Last-Translator: Myckel Habets <myckel@sdf.lonestar.org>\n"
 "Language-Team: Dutch <LL@li.org>\n"
@@ -20,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Luchtpomp"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradijsvogel"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Waterman"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Arend"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altaar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Ram"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Voerman"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Ossenhoeder"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Graveerstift"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Giraffe"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Kreeft"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Jachthonden"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Grote Hond"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Kleine Hond"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Steenbok"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kiel"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centaur"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cepheus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Walvis"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Kameleon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Passer"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Duif"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Hoofdhaar"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Zuiderkroon"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Noorderkroon"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Raaf"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Beker"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Zuiderkruis"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Zwaan"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Dolfijn"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Goudvis"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Draak"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Veulen"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanus"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Oven"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Tweelingen"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Kraanvogel"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hercules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Slingeruurwerk"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Waterslang"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Kleine Waterslang"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indiaan"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Hagedis"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leeuw"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Kleine Leeuw"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Haas"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Weegschaal"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Wolf"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lynx"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lier"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Tafelberg"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscoop"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Eenhoorn"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Vlieg"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Winkelhaak"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Slangendrager"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pauw"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasus"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseus"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Phoenix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Schilder"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Vissen"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Zuidervis"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Achtersteven"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompas"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Net"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Pijl"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Boogschutter"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Schorpioen"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Beeldhouwer"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Schild"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "hoofd van de slang"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "staart van de slang"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextant"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Stier"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescoop"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Driehoek"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Zuiderdriehoek"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Toekan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Grote Beer"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Kleine Beer"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Zeilen"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Maagd"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Vliegende Vis"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Vosje"
 
@@ -527,3964 +616,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Waterslang"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Nouméa"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Driehoek"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Beknopt"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturnus"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturnus"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Oven"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturnus"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port Vila"
+msgid "Fornjot"
+msgstr "Oven"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturnus"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mrt"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Sterrenstelsels"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Zon"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NOORD-AMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ZUID-AMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIË"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIË"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARTICA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NOORD-ATLANTISCHE OCEAAN"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ZUID-ATLANTISCHE OCEAAN"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NOORD-STILLE OCEAAN"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ZUID-STILLE OCEAAN"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDISCHE OCEAAN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "ARCTISCHE OCEAAN"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Algiers"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Athene"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Bakoe"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beiroet"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlijn"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bisjkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brussel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Boekarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Boedapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Caïro"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Kaapstad"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhagen"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damascus"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Doesjanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagåtña"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Den Haag"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jeruzalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoem"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Koeweit"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomé"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londen"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malé"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manamah"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manilla"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Matâ'utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico-stad"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskou"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Masqat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Ndjamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Parijs"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom-Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praag"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rome"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tomé"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapore"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenapura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vaticaanstad"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Wenen"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Warschau"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Jerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Zon"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Massamiddelpunt van zonnestelsel"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Zon"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Huidige"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Poolster"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hinds karmozijnrode ster"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Sterrenstelsels"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyns ster"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Driehoek"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuze"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Rode rechthoek"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Sterren weergeven"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luytens ster"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londen"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formaat:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Athene"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Lapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Sterrewachten"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnards ster"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbells ster"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Parijs"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Poolster"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Grenzen"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Granaatster"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Zetel"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcocks ster"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Schede"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Melkweg"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Grote Magellaanse Wolken"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Kleine Magellaanse Wolken"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejaden"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyaden"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Praesepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Bijenkorfcluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leeuw A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextant B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leeuw I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextant A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Passer"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanus"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompas"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia constellations\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2008-10-21 16:43+0100\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: \n"
@@ -21,358 +21,447 @@ msgstr ""
 "X-Poedit-Country: POLAND\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Pompa"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Rajski Ptak"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Wodnik"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Orzeł"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Ołtarz"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Baran"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Woźnica"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Wolarz"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Rylec"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Żyrafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Rak"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Psy Gończe"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Wielki Pies"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Mały Pies"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Koziorożec"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kil"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kasjopej"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centaur"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeusz"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Wieloryb"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Kameleon"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Cyrkiel"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Gołąb"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Warkocz Bereniki"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Korona Południowa"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Korona Północna"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Kruk"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Puchar"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Krzyż Południa"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Łabędź"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfin"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Złota Ryba"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Smok"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Źrebię"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Erydan"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Piec"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Bliźnięta"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Żuraw"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Zegar"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hydra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Wąż Wodny"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indianin"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Jaszczurka"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Lew"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Mały Lew"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Zając"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Waga"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Wilk"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Ryś"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lutnia"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Góra Stołowa"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskop"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Jednorożec"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mucha"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Węgielnica"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Wężownik"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Paw"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegaz"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseusz"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Feniks"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Malarz"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Ryby"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Ryba Południowa"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Rufa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompas"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Sieć"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Strzała"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Strzelec"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpion"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Rzeźbiarz"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Tarcza"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Głowa Węża"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Ogon Węża"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sekstans"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Byk"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Teleskop"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Trójkąt"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Trójkąt Południowy"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Wielka Niedźwiedzica"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Mała Niedźwiedzica"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Żagiel"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Panna"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Latająca Ryba"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Lis"
 
@@ -528,3963 +617,4016 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hydra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Trójkąt"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jowisz"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jowisz"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jowisz"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jowisz"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jowisz"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jowisz"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jowisz"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alkione"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jowisz"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jowisz"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Kallisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jowisz"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jowisz"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jowisz"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jowisz"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jowisz"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jowisz"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jowisz"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jowisz"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jowisz"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jowisz"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Kallisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Krótkie"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jowisz"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jowisz"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jowisz"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Sty"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometeusz"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimeteusz"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturn"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Piec"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturn"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port Vila"
+msgid "Fornjot"
+msgstr "Piec"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturn"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaktyki"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Słońce"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMERYKA PÓŁNOCNA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMERYKA POŁUDNIOWA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURAZJA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRYKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTYKA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "PÓŁNOCNY OCEAN ATLANTYCKI"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "POŁUDNIOWY OCEAN ATLANTYCKI"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "PÓŁNOCNY OCEAN SPOKOJNY"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "POŁUDNIOWY OCEAN SPOKOJNY"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEAN INDYJSKI"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEAN ARKTYCZNY"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Zabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abudża"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Akra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Algier"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andora"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarywa"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Aszchabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Ateny"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangi"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Bandżul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pekin"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Biszkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfointein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratysława"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruksela"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukareszt"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapeszt"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bużumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kair"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Kapsztad"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Kajenna"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kiszyniów"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Kolombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Konakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhaga"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Kotonu"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaszek"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Dżibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Ad-Dauha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Duszanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Wielki Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Gwatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Haga"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Hawana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Dżakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerozolima"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Chartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kijów"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinszasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwejt"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Al-Ujun"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lizbona"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Lublana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londyn"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luksemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madryt"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malé"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoudzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Meksyk"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Mińsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiszu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monako"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskwa"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Maskat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Ndżamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nowe Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nikozja"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nawakszut"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Wagadugu"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paryż"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pjongjang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavík"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Ryga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Rijad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rzym"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sana"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajewo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapur"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Dźajawardanapura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Sztokholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Tajpej"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taszkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Awiw-Jafa"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Thorshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trypolis"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ułan Bator"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Watykan"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Wiedeń"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Wientian"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Wilno"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Waszyngton D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Jamusukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Jaunde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Okręg Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Erywań"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagrzeb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Słońce"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Układ Słoneczny Barycentrum"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Słońce"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Szedar"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Gwiazda van Maanena"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Kastor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr ""
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Tytan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira (Cudowna)"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Gwiazda Polarna"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira (Cudowna)"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirfak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Elektra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Tajgeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maja"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alkione"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Plejone"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaktyki"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Gwiazda Kapteyna"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Kapella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Trójkąt"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeza"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Kanopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Czerwony Czworokąt"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Kanopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Gwiazda Kapteyna"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Syriusz"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Gwiazda Luytena"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Kastor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procjon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Polluks"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmen"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londyn"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spika"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alkor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Agena (Hadar)"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arktur"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kochab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Ed Asich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Ateny"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Japet"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Obserwatoria"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Gwiazda Barnarda"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Wega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Gwatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Gwiazda Campbella"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paryż"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Lublana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Gwiazda Polarna"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Granice"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Baham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Gwiazda Babcocka"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Droga Mleczna"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejady"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hiady (Dżdżownica)"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Żłóbek"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Gromada Ul"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Cyrkiel"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "NGC 5892"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Erydan"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompas"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: Celestia Development Team, Translators
 # SPDX-License-Identifier: GPL-2.0-or-later
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Celestia Constellations-pt\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-12-30 08:05-0000\n"
 "Last-Translator: José Raeiro <zeraeiro@gmail.com>\n"
 "Language-Team: Portuguese <zeraeiro@gmail.com>\n"
@@ -18,358 +17,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andrómeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Máquina Pneumática"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Ave do Paraíso"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Aquário"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Águia"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Carneiro"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Cocheiro"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boieiro"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Cinzel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Girafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Caranguejo"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Cães de Caça"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Cão Maior"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Cão Menor"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricónio"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Quilha"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centauro"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeu"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Baleia"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Camaleão"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compasso"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Pomba"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Cabeleira de Berenice"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Coroa Austral"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Coroa Boreal"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corvo"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Taça"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Cruzeiro do Sul"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cisne"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfim"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Dourado"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragão"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Potro"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Erídano"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Fornalha"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Gémeos"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Grou"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hércules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Relógio"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hidra Macho"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Índio"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lagarto"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leão"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Leão Menor"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Lebre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Balança"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lobo"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lince"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Mesa"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscópio"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Unicórnio"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mosca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Esquadro"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octante"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofíuco"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orionte (O Caçador)"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavão"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pégaso"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseu"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fénix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Pintor"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Peixes"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Peixe Austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Popa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Bússola"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Retículo"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Seta"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Sagitário"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Escorpião"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Escultor"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Escudo"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Cabeça da Serpente"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Cauda da Serpente"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextante"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Touro"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescópio"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triângulo"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triângulo Austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucano"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Ursa Maior"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Ursa Menor"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Virgem"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Peixe Voador"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Raposa"
 
@@ -525,3964 +613,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Nouméa"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltéia"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triângulo"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltéia"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Júpiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Júpiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Júpiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Júpiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Júpiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Júpiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Júpiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Júpiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Júpiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Calisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Júpiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Júpiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Júpiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Júpiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Júpiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Júpiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Júpiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Júpiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Júpiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Júpiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Calisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Conciso"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Júpiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Júpiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Júpiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometeu"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimeteu"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Jano"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturno"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturno"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Fornalha"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturno"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Fornalha"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturno"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galáxias"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Lárissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sol"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DO NORTE"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DO SUL"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURÁSIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTÁRCTICA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO NORTE"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO SUL"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO NORTE"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO SUL"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEANO ÍNDICO"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ÁRTICO"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Acra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Argel"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amã"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ancara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ashgabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Assunção"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atenas"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdá"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Banguecoque"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pequim"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirute"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlim"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berna"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasília"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruxelas"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucareste"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapeste"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Cairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Camberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Caiena"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conacry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damasco"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar-es-Salam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dacca"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "The Hague"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanói"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinque"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jacarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalém"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Cabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Cartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Liubliana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomé"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londres"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longuiarbien"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madri"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malé"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamuzu"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Manágua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Cidade do México"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Mônaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monróvia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevidéu"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moscou"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Mascate"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nova Deli"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicósia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Otawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panamá"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretória"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "St Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipão"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago do Chile"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "São Tomé e Príncipe"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Saraievo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Cingapura"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipé"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa-Sul"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teerã"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tóquio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Túnis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulan Bator"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valeta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "O Vale"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Vitória"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viena"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Viantiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsóvia"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sol"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Baricentro do Sistema Solar"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sol"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Actual"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titã"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polar"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Estrela Vermelha de Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galáxias"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Estrela de Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triângulo"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Retângulo Vermelho"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Estrelas"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Estrela de Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londres"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formato: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gema"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atenas"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa-Sul"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Jápeto"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatórios"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Estrela de Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Estrela de Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Liubliana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polar"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Mostrar Fronteiras"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Estrela de Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ancara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Via Láctea"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "GNM"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "PNM"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pleiades"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Híades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Presépio"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextante B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextante A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compasso"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Erídano"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Bússola"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: Celestia Development Team, Translators
 # SPDX-License-Identifier: GPL-2.0-or-later
-
 msgid ""
 msgstr ""
 "Project-Id-Version: Celestia Constellations-pt\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2009-02-18 12:45-0300\n"
 "Last-Translator: Igor Borgo <igorborgo@gmail.com>\n"
 "Language-Team: Portuguese <zeraeiro@gmail.com>\n"
@@ -18,358 +17,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andrômeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Máquina Pneumática"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Ave do Paraíso"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Aquário"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Águia"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altar"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Carneiro"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Cocheiro"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boieiro"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Cinzel"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Girafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Caranguejo"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Cães de Caça"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Cão Maior"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Cão Menor"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricónio"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Quilha"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopéia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centauro"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeu"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Baleia"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Camaleão"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compasso"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Pomba"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Cabeleira de Berenice"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Coroa Austral"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Coroa Boreal"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corvo"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Taça"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Cruzeiro do Sul"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cisne"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfim"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Dourado"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragão"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Potro"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Erídano"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Fornalha"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Gêmeos"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Grou"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hércules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Relógio"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hidra Macho"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Índio"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lagarto"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leão"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Leão Menor"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Lebre"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Balança"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lobo"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lince"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Mesa"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscópio"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Unicórnio"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mosca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Esquadro"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octante"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofíuco"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Órion (O Caçador)"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavão"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pégaso"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseu"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fênix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Pintor"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Peixes"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Peixe Austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Popa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Bússola"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Retículo"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Seta"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Sagitário"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Escorpião"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Escultor"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Escudo"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Cabeça da Serpente"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Cauda da Serpente"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextante"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Touro"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescópio"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triângulo"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triângulo Austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucano"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Ursa Maior"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Ursa Menor"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Virgem"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Peixe Voador"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Raposa"
 
@@ -525,3964 +613,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Nouméa"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amaltéia"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triângulo"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amaltéia"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Júpiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Júpiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Júpiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Júpiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Júpiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Júpiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Júpiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcione"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Júpiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Júpiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Calisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Júpiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Júpiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Júpiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Júpiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Júpiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Júpiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Júpiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Júpiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Júpiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Júpiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Calisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Conciso"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Júpiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Júpiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Júpiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometeu"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimeteu"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Jano"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturno"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturno"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Fornalha"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturno"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Fornalha"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturno"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galáxias"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Lárissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganimedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Sol"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMÉRICA DO NORTE"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMÉRICA DO SUL"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURÁSIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "ÁFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTÁRCTICA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO NORTE"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANO ATLÂNTICO SUL"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO NORTE"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANO PACÍFICO SUL"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEANO ÍNDICO"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEANO ÁRTICO"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Acra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Adís Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Argel"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amã"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ancara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ashgabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Assunção"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atenas"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdá"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Banguecoque"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pequim"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirute"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrado"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlim"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Berna"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogotá"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasília"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bruxelas"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bucareste"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapeste"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Cairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Camberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Cidade do Cabo"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Caiena"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conacry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Copenhague"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damasco"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar-es-Salam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dacca"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dushanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "The Hague"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanói"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinque"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jacarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalém"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Cabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Cartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisboa"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Liubliana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lomé"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londres"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longuiarbien"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburgo"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madri"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Malé"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamuzu"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Manágua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Cidade do México"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadiscio"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Mônaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monróvia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevidéu"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moscou"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Mascate"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Nova Deli"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicósia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Otawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panamá"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port of Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praga"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretória"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangun"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "St Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipão"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San José"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago do Chile"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "São Tomé e Príncipe"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Saraievo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Cingapura"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Estocolmo"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipé"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa-Sul"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tashkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teerã"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tóquio"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Tórshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trípoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Túnis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulan Bator"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valeta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "O Vale"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Cidade do Vaticano"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Vitória"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viena"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Viantiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilna"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varsóvia"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaoundé"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Sol"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Baricentro do Sistema Solar"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Sol"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Actual"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titã"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polaris"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcione"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Estrela Vermelha de Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galáxias"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Estrela de Kapteyn"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triângulo"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Retângulo Vermelho"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Mostrar Estrelas"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Estrela de Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londres"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formato: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gema"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atenas"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa-Sul"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Jápeto"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatórios"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Estrela de Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Estrela de Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Liubliana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polaris"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Mostrar Fronteiras"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Estrela de Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ancara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Via Láctea"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "GNM"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "PNM"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plêiades"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Híades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Presépio"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compasso"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tucanae"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Erídano"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Bússola"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2008-12-28 13:17-0500\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Maşina Pneumatică"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Pasărea Paradisului"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vărsătorul"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Vulturul"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altarul"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Berbecul"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Vizitiul"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boarul"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Dalta"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Girafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Racul"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Câinii de Vânătoare"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Câinele Mare"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Câinele Mic"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricornul"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Carena"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeia"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centaurul"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeu"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Balena"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Cameleonul"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Compasul"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Porumbelul"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Părul Berenicei"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Coroana Australă"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Coroana Boreală"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corbul"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Cupa"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Crucea"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Lebăda"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfinul"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Peştele de Aur"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Dragonul"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Calul Mic"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanul"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Cuptorul"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Gemenii"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Cocorul"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hercule"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Orologiul"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hidra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hidra Australă"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indianul"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Şopârla"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leul"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Leul Mic"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Iepurele"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Balanţa"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lupul"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Linxul"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lira"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Platoul"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscopul"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Licornul"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Musca"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Echerul"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octantul"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ofiucus"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Păunul"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegas"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseu"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Phoenix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Pictorul"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Peştii"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Peştele Austral"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Pupa"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Busola"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Reticulul"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Săgeata"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Săgetătorul"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Scorpionul"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Sculptorul"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Scutul"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Capul şarpelui"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Coada şarpelui"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextantul"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Taurul"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescopul"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triunghiul"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triunghiul Austral"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucanul"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Ursa Mare"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Ursa Mică"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Velele"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Fecioara"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Peştele Zburător"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Vulpea"
 
@@ -527,3958 +616,4011 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hidra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
-msgid "Haumea"
+msgid "Orcus-Vanth"
 msgstr ""
 
 #: data.cpp:131
-msgid "Namaka"
+msgid "Orcus"
 msgstr ""
 
 #: data.cpp:132
-msgid "Hi'iaka"
+msgid "Vanth"
 msgstr ""
 
 #: data.cpp:133
-msgid "Makemake"
+msgid "Haumea"
 msgstr ""
 
 #: data.cpp:134
-msgid "S 2015 (136472) 1"
+msgid "Namaka"
 msgstr ""
 
 #: data.cpp:135
-msgid "Eris"
+msgid "Hi'iaka"
 msgstr ""
 
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triunghiul"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Concis"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Ian"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturn"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr ""
 
-#: data.cpp:285
+#: data.cpp:293
 #, fuzzy
 msgid "Fornjot"
 msgstr "Cuptorul"
 
-#: data.cpp:286
+#: data.cpp:294
 #, fuzzy
 msgid "Saturn LVIII"
 msgstr "Saturn"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr ""
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr ""
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr ""
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr ""
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr ""
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr ""
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr ""
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr ""
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr ""
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr ""
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr ""
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr ""
 
-#: data.cpp:299
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxi"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymede"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Soare"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "AMERICA DE NORD"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "AMERICA DE SUD"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRICA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARCTICA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "OCEANUL ATLANTIC DE NORD"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "OCEANUL ATLANTIC DE SUD"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "OCEANUL PACIFIC DE NORD"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "OCEANUL PACIFIC DE SUD"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "OCEANUL INDIAN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "OCEANUL ARCTIC"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr ""
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr ""
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr ""
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr ""
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr ""
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr ""
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr ""
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr ""
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr ""
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr ""
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr ""
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr ""
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr ""
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr ""
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr ""
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr ""
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr ""
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr ""
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr ""
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr ""
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr ""
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr ""
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr ""
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr ""
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr ""
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr ""
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr ""
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr ""
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr ""
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr ""
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr ""
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr ""
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr ""
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr ""
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr ""
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr ""
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr ""
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr ""
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr ""
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr ""
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr ""
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr ""
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr ""
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr ""
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr ""
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr ""
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr ""
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr ""
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr ""
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr ""
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr ""
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr ""
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr ""
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr ""
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr ""
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr ""
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr ""
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr ""
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr ""
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr ""
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr ""
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr ""
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr ""
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr ""
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr ""
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr ""
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr ""
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr ""
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr ""
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr ""
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr ""
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr ""
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr ""
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr ""
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr ""
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr ""
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr ""
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr ""
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr ""
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr ""
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr ""
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr ""
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr ""
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr ""
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr ""
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr ""
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr ""
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr ""
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr ""
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr ""
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr ""
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr ""
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr ""
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr ""
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr ""
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr ""
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr ""
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr ""
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr ""
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr ""
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr ""
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr ""
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr ""
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr ""
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr ""
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr ""
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr ""
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr ""
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr ""
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr ""
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr ""
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr ""
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr ""
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr ""
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr ""
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr ""
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr ""
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr ""
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr ""
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr ""
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr ""
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr ""
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr ""
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr ""
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr ""
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr ""
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr ""
 
-#: data.cpp:462
+#: data.cpp:470
 #, fuzzy
 msgid "Mexico City"
 msgstr "Randarizează locaţiile oraşelor"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr ""
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr ""
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr ""
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr ""
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr ""
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr ""
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr ""
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr ""
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr ""
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr ""
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr ""
 
-#: data.cpp:474
+#: data.cpp:482
 #, fuzzy
 msgid "New Delhi"
 msgstr "Adaugă dosar nou pentru marcaje"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr ""
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr ""
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr ""
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr ""
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr ""
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr ""
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr ""
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr ""
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr ""
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr ""
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr ""
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr ""
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr ""
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr ""
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr ""
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr ""
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr ""
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr ""
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr ""
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr ""
 
-#: data.cpp:495
+#: data.cpp:503
 #, fuzzy
 msgid "Port-au-Prince"
 msgstr " ua/s"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr ""
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr ""
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr ""
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr ""
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr ""
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr ""
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr ""
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr ""
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr ""
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr ""
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr ""
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr ""
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr ""
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr ""
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr ""
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr ""
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr ""
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr ""
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr ""
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr ""
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr ""
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr ""
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr ""
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr ""
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr ""
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr ""
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr ""
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr ""
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr ""
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr ""
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr ""
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr ""
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr ""
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr ""
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr ""
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr ""
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr ""
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr ""
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr ""
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr ""
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr ""
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr ""
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr ""
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr ""
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr ""
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr ""
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr ""
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr ""
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr ""
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr ""
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr ""
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr ""
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr ""
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr ""
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr ""
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr ""
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr ""
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr ""
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr ""
 
-#: data.cpp:555
-msgid "The Valley"
-msgstr ""
-
-#: data.cpp:556
-#, fuzzy
-msgid "Vatican City"
-msgstr "Randarizează locaţiile oraşelor"
-
-#: data.cpp:557
-msgid "Victoria"
-msgstr ""
-
-#: data.cpp:558
-msgid "Vienna"
-msgstr ""
-
-#: data.cpp:559
-msgid "Vientiane"
-msgstr ""
-
-#: data.cpp:560
-msgid "Vilnius"
-msgstr ""
-
-#: data.cpp:561
-msgid "Warsaw"
-msgstr ""
-
-#: data.cpp:562
-msgid "Washington D.C."
-msgstr ""
-
 #: data.cpp:563
-msgid "Wellington"
+msgid "The Valley"
 msgstr ""
 
 #: data.cpp:564
 #, fuzzy
-msgid "West Island"
-msgstr "Vest"
+msgid "Vatican City"
+msgstr "Randarizează locaţiile oraşelor"
 
 #: data.cpp:565
-msgid "Willemstad"
+msgid "Victoria"
 msgstr ""
 
 #: data.cpp:566
-msgid "Windhoek"
+msgid "Vienna"
 msgstr ""
 
 #: data.cpp:567
-msgid "Yamoussoukro"
+msgid "Vientiane"
 msgstr ""
 
 #: data.cpp:568
-msgid "Yaounde"
+msgid "Vilnius"
 msgstr ""
 
 #: data.cpp:569
-msgid "Yaren District"
+msgid "Warsaw"
 msgstr ""
 
 #: data.cpp:570
-msgid "Yerevan"
+msgid "Washington D.C."
 msgstr ""
 
 #: data.cpp:571
-msgid "Zagreb"
+msgid "Wellington"
 msgstr ""
 
 #: data.cpp:572
-msgid "Sol"
-msgstr "Soare"
+#, fuzzy
+msgid "West Island"
+msgstr "Vest"
 
 #: data.cpp:573
-msgid "Solar System Barycenter"
-msgstr "Baricentrul sistemului solar"
+msgid "Willemstad"
+msgstr ""
 
 #: data.cpp:574
-msgid "Sun"
-msgstr "Soare"
+msgid "Windhoek"
+msgstr ""
 
 #: data.cpp:575
-msgid "Alpheratz"
-msgstr "Alpheratz"
+msgid "Yamoussoukro"
+msgstr ""
 
 #: data.cpp:576
-msgid "Sirrah"
-msgstr "Sirrah"
+msgid "Yaounde"
+msgstr ""
 
 #: data.cpp:577
-msgid "Caph"
-msgstr "Caph"
+msgid "Yaren District"
+msgstr ""
 
 #: data.cpp:578
-msgid "Algenib"
-msgstr "Algenib"
+msgid "Yerevan"
+msgstr ""
 
 #: data.cpp:579
-msgid "Citadelle"
+msgid "Zagreb"
 msgstr ""
 
 #: data.cpp:580
+msgid "Sol"
+msgstr "Soare"
+
+#: data.cpp:581
+msgid "Solar System Barycenter"
+msgstr "Baricentrul sistemului solar"
+
+#: data.cpp:582
+msgid "Sun"
+msgstr "Soare"
+
+#: data.cpp:583
+msgid "Alpheratz"
+msgstr "Alpheratz"
+
+#: data.cpp:584
+msgid "Sirrah"
+msgstr "Sirrah"
+
+#: data.cpp:585
+msgid "Caph"
+msgstr "Caph"
+
+#: data.cpp:586
+msgid "Algenib"
+msgstr "Algenib"
+
+#: data.cpp:587
+msgid "Citadelle"
+msgstr ""
+
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Curent"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polaris"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Steaua purpurie a lui Hind"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxi"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn's Star"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triunghi"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Dreptunghiul roşu"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Randarizează stelele"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Steaua lui Luyten"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr ""
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr ""
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr ""
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Marte"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr ""
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr ""
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatoare"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Steaua lui Barnard"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr ""
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Steaua lui Campbell"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr ""
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr ""
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polaris"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Limite"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Steaua lui Babcock"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Formalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Alkaid"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Calea Lactee"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Marele nor al lui Magellan"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Micul nor al lui Magellan"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Pleiadele"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Roiul \"Stupul\""
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Compasul"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanul"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Busola"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,383 +1,474 @@
 # SPDX-FileCopyrightText: Celestia Development Team, Translators
 # SPDX-License-Identifier: GPL-2.0-or-later
-# 
+#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Celestia Development Team
 # This file is distributed under the same license as the celestia package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Hleb Valoshka <375gnu@gmail.com>, 2023
 # Askaniy Anpilogov, 2024
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.7.0\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2023-11-03 11:00+0000\n"
 "Last-Translator: Askaniy Anpilogov, 2024\n"
 "Language-Team: Russian (https://app.transifex.com/celestia/teams/93131/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Андромеда"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Насос"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Райская птица"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Водолей"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Орел"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Жертвенник"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Овен"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Возничий"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Волопас"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Резец"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Жираф"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Рак"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Гончие псы"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Большой пес"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Малый пес"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Козерог"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Киль"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Кассиопея"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Центавр"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Цефей"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Кит"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Хамелеон"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Циркуль"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Голубь"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Волосы Вероники"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Южная корона"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Северная корона"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Ворон"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Чаша"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Южный крест"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Лебедь"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Дельфин"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Золотая рыба"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Дракон"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Малый конь"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Эридан"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Печь"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Близнецы"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Журавль"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Геркулес"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Часы"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Гидра"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Южная гидра"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Индеец"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Ящерица"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Лев"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Малый лев"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Заяц"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Весы"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Волк"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Рысь"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Лира"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Столовая гора"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Микроскоп"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Единорог"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Муха"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Наугольник"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Октант"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Змееносец"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Орион"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Павлин"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Пегас"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Персей"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Феникс"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Живописец"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Рыбы"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Южная Рыба"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Корма"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Компас"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Сеть"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Стрела"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Стрелец"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Скорпион"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Скульптор"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Щит"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Голова змеи"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Хвост змеи"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Секстант"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Телец"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Телескоп"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Треугольник"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Южный треугольник"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Тукан"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Большая медведица"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Малая медведица"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Паруса"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Дева"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Летучая рыба"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Лисичка"
 
@@ -533,3878 +624,3932 @@ msgstr "Никта"
 msgid "Kerberos"
 msgstr "Кербер"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Гидра"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr "Церера"
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+#, fuzzy
+msgid "Vanth"
+msgstr "Эванте"
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "Хаумеа"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "Намака"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "Хииака"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "Макемаке"
 
-#: data.cpp:134
+#: data.cpp:139
 msgid "S 2015 (136472) 1"
 msgstr "S 2015 (136472) 1"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Треугольник"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "Эрида"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "Дисномия"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "Метида"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "Адрастея"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "Амальтея"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "Фива"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "Фемисто"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "Леда"
 
-#: data.cpp:143
+#: data.cpp:151
 msgid "Ersa"
 msgstr "Эрса"
 
-#: data.cpp:144
+#: data.cpp:152
 msgid "Pandia"
 msgstr "Пандия"
 
-#: data.cpp:145
+#: data.cpp:153
 msgid "Himalia"
 msgstr "Гималия"
 
-#: data.cpp:146
+#: data.cpp:154
 msgid "Lysithea"
 msgstr "Лиситея"
 
-#: data.cpp:147
+#: data.cpp:155
 msgid "Elara"
 msgstr "Элара"
 
-#: data.cpp:148
+#: data.cpp:156
 msgid "Dia"
 msgstr "Дия"
 
-#: data.cpp:149
+#: data.cpp:157
 msgid "Carpo"
 msgstr "Карпо"
 
-#: data.cpp:150
+#: data.cpp:158
 msgid "Valetudo"
 msgstr "Валетудо"
 
-#: data.cpp:151
+#: data.cpp:159
 msgid "Euporie"
 msgstr "Эвпорие"
 
-#: data.cpp:152
+#: data.cpp:160
 msgid "Jupiter LV"
 msgstr "Юпитер LV"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr "Евфеме"
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr "S 2003 J 16"
 
-#: data.cpp:155
+#: data.cpp:163
 msgid "Jupiter LXVIII"
 msgstr "Юпитер LXVIII"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "Ананке"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "Гарпалике"
 
-#: data.cpp:158
+#: data.cpp:166
 msgid "S 2003 J 12"
 msgstr "S 2003 J 12"
 
-#: data.cpp:159
+#: data.cpp:167
 msgid "Jupiter LII"
 msgstr "Юпитер LII"
 
-#: data.cpp:160
+#: data.cpp:168
 msgid "Praxidike"
 msgstr "Праксидике"
 
-#: data.cpp:161
+#: data.cpp:169
 msgid "S 2003 J 2"
 msgstr "S 2003 J 2"
 
-#: data.cpp:162
+#: data.cpp:170
 msgid "Euanthe"
 msgstr "Эванте"
 
-#: data.cpp:163
+#: data.cpp:171
 msgid "Orthosie"
 msgstr "Ортозие"
 
-#: data.cpp:164
+#: data.cpp:172
 msgid "Jupiter LXIV"
 msgstr "Юпитер LXIV"
 
-#: data.cpp:165
+#: data.cpp:173
 msgid "Iocaste"
 msgstr "Иокасте"
 
-#: data.cpp:166
+#: data.cpp:174
 msgid "Mneme"
 msgstr "Мнеме"
 
-#: data.cpp:167
+#: data.cpp:175
 msgid "Thyone"
 msgstr "Тионе"
 
-#: data.cpp:168
+#: data.cpp:176
 msgid "Jupiter LIV"
 msgstr "Юпитер LIV"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr "Тельксиное"
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr "Гелике"
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr "Гермиппе"
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr "Филофросине"
 
-#: data.cpp:173
+#: data.cpp:181
 msgid "Jupiter LVI"
 msgstr "Юпитер LVI"
 
-#: data.cpp:174
+#: data.cpp:182
 msgid "Kallichore"
 msgstr "Каллихоре"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "Халдене"
 
-#: data.cpp:176
+#: data.cpp:184
 msgid "Arche"
 msgstr "Архе"
 
-#: data.cpp:177
+#: data.cpp:185
 msgid "Jupiter LXIX"
 msgstr "Юпитер LXIX"
 
-#: data.cpp:178
+#: data.cpp:186
 msgid "Kale"
 msgstr "Кале"
 
-#: data.cpp:179
+#: data.cpp:187
 msgid "Jupiter LXXII"
 msgstr "Юпитер LXXII"
 
-#: data.cpp:180
+#: data.cpp:188
 msgid "Jupiter LXI"
 msgstr "Юпитер LXI"
 
-#: data.cpp:181
+#: data.cpp:189
 msgid "Cyllene"
 msgstr "Киллене"
 
-#: data.cpp:182
+#: data.cpp:190
 msgid "Taygete"
 msgstr "Тайгете"
 
-#: data.cpp:183
+#: data.cpp:191
 msgid "Jupiter LXX"
 msgstr "Юпитер LXX"
 
-#: data.cpp:184
+#: data.cpp:192
 msgid "Eurydome"
 msgstr "Эвридоме"
 
-#: data.cpp:185
+#: data.cpp:193
 msgid "Jupiter LI"
 msgstr "Юпитер LI"
 
-#: data.cpp:186
+#: data.cpp:194
 msgid "S 2003 J 9"
 msgstr "S 2003 J 9"
 
-#: data.cpp:187
+#: data.cpp:195
 msgid "Jupiter LXVII"
 msgstr "Jupiter LXVII"
 
-#: data.cpp:188
+#: data.cpp:196
 msgid "Aitne"
 msgstr "Этне"
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "Карме"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "Каллирое"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "Эриноме"
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr "Пазифее"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr "Эйрене"
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr "S 2003 J 24"
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "Синопе"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr "Эвкеладе"
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "Исоное"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr "S 2003 J 4"
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr "Автоное"
 
-#: data.cpp:200
+#: data.cpp:208
 msgid "Herse"
 msgstr "Герсе"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "Пасифе"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr "S 2003 J 10"
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr "Коре"
 
-#: data.cpp:204
+#: data.cpp:212
 msgid "Jupiter LXIII"
 msgstr "Юпитер LXIII"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr "Гегемоне"
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr "Спонде"
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "Калике"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr "Аойде"
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "Мегаклите"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr "S 2003 J 23"
 
-#: data.cpp:211
+#: data.cpp:219
 msgid "Jupiter LXVI"
 msgstr "Юпитер LXVI"
 
-#: data.cpp:212
+#: data.cpp:220
 msgid "Jupiter LIX"
 msgstr "Юпитер LIX"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr "S 2009 S 1"
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "Пан"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr "Дафнис"
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "Атлас"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Прометей"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Пандора"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Эпиметей"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Янус"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr "Эгеон"
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr "Мефона"
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr "Анфа"
 
-#: data.cpp:224
+#: data.cpp:232
 msgid "Pallene"
 msgstr "Паллена"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "Телесто"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "Калипсо"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr "Полидевк"
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "Елена"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr "S 2019 S 1"
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr "Кивиок"
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr "Иджирак"
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr "Палиак"
 
-#: data.cpp:233
+#: data.cpp:241
 msgid "Skathi"
 msgstr "Скади"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr "S 2004 S 37"
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr "S 2007 S 2"
 
-#: data.cpp:236
+#: data.cpp:244
 msgid "Albiorix"
 msgstr "Альбиорикс"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr "Бефинд"
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr "S 2004 S 31"
 
-#: data.cpp:239
+#: data.cpp:247
 msgid "Saturn LX"
 msgstr "Сатурн LX"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr "Сколл"
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr "Таркек"
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr "Тарвос"
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr "Эррипо"
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr "Сиарнак"
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr "Грейп"
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr "Гирроккин"
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr "Мундильфари"
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr "S 2006 S 1"
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr "S 2004 S 13"
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr "S 2007 S 3"
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr "Суттунг"
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr "Грид"
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr "Нарви"
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr "Ярнсакса"
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr "S 2004 S 12"
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr "Бергельмир"
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr "Эггтер"
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr "S 2004 S 17"
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr "Хати"
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr "Фарбаути"
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr "Трюм"
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr "S 2004 S 7"
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr "Бели"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr "Бестла"
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr "Герд"
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr "Ангрбода"
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr "Гуннлед"
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr "Эгир"
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr "S 2006 S 3"
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr "Альвальди"
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr "Кари"
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr "Скрюмир"
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr "S 2004 S 28"
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr "Фенрир"
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr "Логи"
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr "S 2004 S 21"
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr "Гейррёд"
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr "S 2004 S 24"
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr "S 2004 S 36"
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr "Имир"
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr "Сурт"
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr "S 2004 S 39"
 
-#: data.cpp:283
+#: data.cpp:291
 msgid "Saturn LXIV"
 msgstr "Сатурн LXIV"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr "Тьяцци"
 
-#: data.cpp:285
+#: data.cpp:293
 msgid "Fornjot"
 msgstr "Форньот"
 
-#: data.cpp:286
+#: data.cpp:294
 msgid "Saturn LVIII"
 msgstr "Сатурн LVIII"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "Корделия"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "Офелия"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "Бианка"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "Крессида"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "Дездемона"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "Джульетта"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "Порция"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "Розалинда"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr "Купидон"
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "Белинда"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr "Пердита"
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "Пак"
 
-#: data.cpp:299
+#: data.cpp:307
 msgid "Mab"
 msgstr "Маб"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr "Франциско"
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "Калибан"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "Стефано"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr "Тринкуло"
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "Сикоракса"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr "Маргарита"
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "Просперо"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "Сетебос"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr "Фердинанд"
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "Наяда"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "Таласса"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "Деспина"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "Галатея"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Ларисса"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr "Гиппокамп"
 
-#: data.cpp:315
+#: data.cpp:323
 msgid "Halimede"
 msgstr "Галимеда"
 
-#: data.cpp:316
+#: data.cpp:324
 msgid "Sao"
 msgstr "Сао"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr "Лаомедея"
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr "Псамафа"
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr "Несо"
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "СЕВЕРНАЯ АМЕРИКА"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ЮЖНАЯ АМЕРИКА"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ЕВРАЗИЯ"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "АФРИКА"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "АВСТРАЛИЯ"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "АНТАРКТИДА"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "АТЛАНТИЧЕСКИЙ ОКЕАН"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "АТЛАНТИЧЕСКИЙ ОКЕАН"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ТИХИЙ ОКЕАН"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ТИХИЙ ОКЕАН"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ИНДИЙСКИЙ ОКЕАН"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "СЕВЕРНЫЙ ЛЕДОВИТЫЙ ОКЕАН"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Абу-Даби"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Аккра"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Адамстаун"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Аддис-Абеба"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Алжир"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Алофи"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Амман"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Амстердам"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Андорра-ла-Велья"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Анкара"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Антананариву"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Апиа"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ашхабад"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Асмэра"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Астана"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Асунсьон"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Афины"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Баку"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Бамако"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Бандар-Сери-Бегаван"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Бангкок"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Банги"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Банжул"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Бас-Тер"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Бастер"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Пекин"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Бейрут"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Белград"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Бельмопан"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Берлин"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Берн"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Бишкек"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Бисау"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Блумфонтейн"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Богота"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Бразилия"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Братислава"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Браззавиль"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Бриджтаун"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Брюссель"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Бухарест"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Будапешт"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Буэнос-Айрес"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Каир"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Канберра"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Кейптаун"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Каракас"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Кастри"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Кайенна"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Шарлотта Амалия"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Кишинёв"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Коломбо"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Конакри"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Копенгаген"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Котону"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Дакар"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Дар-эс-Салам"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Дакка"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Дили"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Джибути"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Доха"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Дуглас"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Дублин"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Душанбе"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Фонгафале"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Фор-де-Франс"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Фритаун"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Габороне"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Джорджтаун"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Джорджтаун"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Гибралтар"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Гранд-Тёркс"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Гватемала"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Хагатна"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Гаага"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Гамильтон"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Хараре"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Гавана"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Хельсинки"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr "Гонконг"
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Хониара"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Исламабад"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Джеймстаун"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Иерусалим"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Кабул"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Кампала"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Киев"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Кигали"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Кингстон"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Кингстаун"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Киншаса"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Корор"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Куала-Лумпур"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Кувейт"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Эль-Аюн"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "Ла-Пас"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Либревиль"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Лилонгве"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Лима"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Лиссабон"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Лобамба"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Ломе"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Лондон"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Лонгйир"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Луанда"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Люксембург"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Мадрид"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Маджуро"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Малабо"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Мале"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Манагуа"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Манама"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Манила"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Мапуту"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Масеру"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Мбабане"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Мехико"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Минск"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Могадишо"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Монако"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Монровия"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Монтевидео"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Морони"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Москва"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Маскат"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Найроби"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Нассау"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Нджамена"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Нью-Дели"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Ниамей"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Никосия"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Нумеа"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Нук"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Ораньестад"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Осло"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Оттава"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Уагадугу"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Паго-Паго"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Паликир"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Панама"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Папеэте"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Парамарибо"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Париж"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Пномпень"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Плимут"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Порт-Луи"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Порт-Морсби"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Порт-ау-Принс"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спейн"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Порто-Ново"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Порт-Вила"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Прага"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Прая"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Претория"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Кито"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Рабат"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Янгон"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Рейкьявик"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Рига"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Эр-Рияд"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Род-Таун"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Рим"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Розо"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Сент-Джордж"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Сент-Хельер"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Сент-Джонс"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Сент-Питер-Порт"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Сен-Дени"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Сент-Пьер"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "Сан-Хосе"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "Сан-Хуан"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Сан-Марино"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Сан-Сальвадор"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Сана"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Сантьяго"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Санто-Доминго"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Сан-Томе"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Сараево"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Сеул"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Сетлмент"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Сингапур"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Скопье"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "София"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шри-Джаяварденепура-Котте"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Порт-Стэнли"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Стокгольм"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Сукре"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Сува"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Тайбэй"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Таллин"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Тбилиси"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Тегусигальпа"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Тегеран"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Тель-Авив"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Тхимпху"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Тирана"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Токио"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Торсхавн"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Триполи"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Тунис"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Улан-Батор"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Валлетта"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Валли"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Ватикан"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Виктория"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Вена"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Вьентьян"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Вильнюс"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Вашингтон, DC"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Веллингтон"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Вест Исланд"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Виллемстад"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Виндхук"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Ямусукро"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Яунде"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Район Ярен"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Ереван"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Загреб"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Солнце"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Центр Солнечной системы"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Солнце"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Альферац"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Зирра"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Каф"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Альгениб"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr "Цитадель"
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Шемали"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Анкаа"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr "Феликсварела"
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr "Фулу"
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Шедар"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Шедир"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Дифда"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Денеб Кайтос"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr "Кокиболка"
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Ахирд"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Звезда Ван Маанена 2"
 
-#: data.cpp:591
+#: data.cpp:599
 msgid "Castula"
 msgstr "Кастула"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Нави"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr "Ненке"
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr "Вуррен"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Мирах"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr "Эмив"
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr "Ревати"
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Адхил"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr "Беленос"
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Рукбах"
 
-#: data.cpp:601
+#: data.cpp:609
 msgid "Alpherg"
 msgstr "Альфарг"
 
-#: data.cpp:602
+#: data.cpp:610
 msgid "Titawin"
 msgstr "Титавин"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ахернар"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr "Нембус"
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr "Торкулар"
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr "Торкуларис Септентрионалис"
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Батен Кайтос"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr "Моталлах"
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Капут Триангули"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Месартим"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Сегин"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Шератан"
 
-#: data.cpp:613
+#: data.cpp:621
 msgid "Alrescha"
 msgstr "Альриша"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Аль Реша"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Альмах"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Альмаак"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Аламак"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Гамаль"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Мира"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Полярная"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr "Буна"
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr "Каффальджидхма"
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr "Коэйя"
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr "Северная Лилия"
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr "Нушагак"
 
-#: data.cpp:626
+#: data.cpp:634
 msgid "Bharani"
 msgstr "Бхарани"
 
-#: data.cpp:627
+#: data.cpp:635
 msgid "Miram"
 msgstr "Мирам"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Ангетенар"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Азха"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Акамар"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr "Иравади"
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Менкар"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Менкаб"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Алголь"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr "Мисам"
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Ботейн"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr "Далим"
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr "Зибаль"
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr "Интан"
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Мирфак"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Мирфак"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Марфак"
 
-#: data.cpp:643
+#: data.cpp:651
 msgid "Ran"
 msgstr "Ран"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr "Тупи"
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Рана"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Атик"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Целено"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Электра"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Тайгета"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Майя"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Астеропа"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Меропа"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Альциона"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Плейона"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Заурак"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Менкиб"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Бейд"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Кейд"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr "Прима Гиадум"
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr "Секунда Гиадум"
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr "Беемин"
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Аин"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr "Чамукуй"
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr "Хоггар"
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr "Тхеемин"
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Альдебаран"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr "Скептрум"
 
-#: data.cpp:668
+#: data.cpp:676
 msgid "Tabit"
 msgstr "Табит"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr "Моухун"
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr "Хассале"
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Багряная звезда Хинда"
 
-#: data.cpp:672
+#: data.cpp:680
 msgid "Almaaz"
 msgstr "Альмааз"
 
-#: data.cpp:673
+#: data.cpp:681
 msgid "Saclateni"
 msgstr "Сацлатени"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Садатони"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr "Гаедус"
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Курса"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr "Маго"
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Звезда Каптейна"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Ригель"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Капелла"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Беллатрикс"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Эльнатх"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Альнас"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Нихаль"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Табит"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Минтака"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Арнеб"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Меисса"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Хека"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr "Хатсия"
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Альнилам"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr "Бубуп"
 
-#: data.cpp:693
+#: data.cpp:701
 msgid "Tianguan"
 msgstr "Тяньгуань"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Факт"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Альнитак"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Сайф"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Вазн"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Бетельгейзе"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Приджипати"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Менкалинан"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr "Махасим"
 
-#: data.cpp:702
+#: data.cpp:710
 msgid "Elkurud"
 msgstr "Элькуруд"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr "Амадиоха"
 
-#: data.cpp:704
+#: data.cpp:712
 msgid "Propus"
 msgstr "Пропус"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Красный прямоугольник"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Фуруд"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Мирзам"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Мурзим"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Тейят"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Канопус"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Сухель"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr "Люсилинбург"
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr "Лузитания"
 
-#: data.cpp:714
+#: data.cpp:722
 msgid "Plaskett's Star"
 msgstr "Звезда Пласкетта"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Альхена"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Альмейсан"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr "Носакса"
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Мебсута"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Сириус"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr "Альзирр"
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr "Нервия"
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Адара"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Адара"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr "Цитала"
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr "Унургуните"
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Мулифейн"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Мекбуда"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Везен"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Бернес 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Васат"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Алудра"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Гомейса"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Звезда Лейтена"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Кастор"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr "Цзишуй"
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Процион"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Эльгомайса"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr "Сейбо"
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Поллукс"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr "Тапекуе"
 
-#: data.cpp:741
+#: data.cpp:749
 msgid "Azmidi"
 msgstr "Азмиди"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Азмидиск"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Наос"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr "Турейс"
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Регор"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Тегмин"
 
-#: data.cpp:747
+#: data.cpp:755
 msgid "Tarf"
 msgstr "Тарф"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Аль Тарф"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr "Насти"
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr "Пиаутос"
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Авиор"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr "Альциаукат"
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Мусцида"
 
-#: data.cpp:754
+#: data.cpp:762
 msgid "Minchir"
 msgstr "Минхир"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr "Гакйид"
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr "Мелеф"
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Азеллус Бореалис"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Азеллус Аустралис"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr "Альсефина"
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr "Ашлеша"
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr "Коперник"
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr "Стрибор"
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Акубенс"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr "Талитха"
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Дноцес"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr "Алькафра"
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Талита Аустралис"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Сухаиль"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr "Нан"
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Миаплацид"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Аспидиске"
 
-#: data.cpp:772
+#: data.cpp:780
 msgid "Markeb"
 msgstr "Маркеб"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Альфард"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Кор Гидра [Cердце Гидры]"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr "Интеркрус"
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Альтерф"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr "Иллириец"
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr "Калауси"
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Укдах"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Субра"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Рас Эласед Аустралис"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr "Наташа"
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr "Чжан"
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Расалас"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Рас Эласед Бореалис"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr "Фелис"
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr "Бибха"
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Регул"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Кабелецед"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Кор Леонис [Cердце Льва]"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Адхафера"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Альдафера"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Танийа Бореалис"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Альгиеба"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Танийа Аустралис"
 
-#: data.cpp:796
+#: data.cpp:804
 msgid "Macondo"
 msgstr "Макондо"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr "Проципа"
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr "Тчалаван"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Алькес"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Мерак"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Лаланд 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Дубхе"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Дубб"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr "Динголей"
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Зосма"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Духр"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Шератан"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Кокса"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Чёрт"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr "Звезда Иннеса"
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr "Хунаппу"
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Алула Аустралис"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Алула Бореалис"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Цзе Цеанг"
 
-#: data.cpp:815
+#: data.cpp:823
 msgid "Shama"
 msgstr "Шама"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Гиаусар"
 
-#: data.cpp:817
+#: data.cpp:825
 msgid "Formosa"
 msgstr "Формоза"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr "Сагарматха"
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr "Звезда Пшибыльского"
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr "Уклун"
 
-#: data.cpp:821
+#: data.cpp:829
 msgid "Flegetonte"
 msgstr "Флегетонте"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr "Тайяншоу"
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Денебола"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Завийява"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Алараф"
 
-#: data.cpp:826
+#: data.cpp:834
 msgid "Aniara"
 msgstr "Аниара"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Грумбридж 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Фекда"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Фад"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr "Тонатиу"
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Альхиба"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr "Имай"
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Мегрец"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Гиенах"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Заниах"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr "Гинан"
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr "Тупан"
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Акрукс"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Альгораб"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Гакрукс"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr "Фуни"
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Чара"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Крац"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Мухлифайн"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Поррима"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr "Ла Суперба"
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr "Тяньи"
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Мимоза"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Алиот"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr "Тайи"
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Минелаува"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Аува"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Кор Кароли [Сердце Карла]"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Виндемиатрикс"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Альмуредин"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr "Диадема"
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Мицар"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Спика"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Азимех"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Алькор"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr "Дофида"
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr "Лизма"
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Хеза"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Алькаид"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Бенетнаш"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Муфрид"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Хадар"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Агена"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Тубан"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Менкент"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr "Канг"
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Арктур"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Сырма"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr "Сюаньгэ"
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr "Эльгафар"
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Проксима"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Сегинус"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Цегинус"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr "Толиман"
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr "Ригиль Кентаврус"
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Изар"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Мирак"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Пульхеррима"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr "Мёнх"
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr "Мерга"
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Кохаб"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Кохаб"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Зубен Эльгенуби"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr "Аркалис"
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr "Бэкту"
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Зубен Элакриби"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Неккар"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr "Брахиум"
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Зубен эль Шемали"
 
-#: data.cpp:895
+#: data.cpp:903
 msgid "Pherkad Minor"
 msgstr "Феркад Минор"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr "Никави"
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Феркад"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Алькалуропс"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Эдасих"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Нусакан"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Альфекка"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Гемма"
 
-#: data.cpp:903
+#: data.cpp:911
 msgid "Zubenelhakrabi"
 msgstr "Зубенальхакраби"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Зубен Элакраб"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr "Карака"
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Унукалхаи"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Чоу"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr "Гуджэ"
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr "Иклиль"
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr "Фанг"
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Джубба"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr "Акраб"
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Граффиас"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Акраб"
 
-#: data.cpp:915
+#: data.cpp:923
 msgid "Marsic"
 msgstr "Марсик"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Джабба"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr "Шарджа"
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr "Йед Приор"
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr "Йед Постериор"
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr "Хунор"
 
-#: data.cpp:921
+#: data.cpp:929
 msgid "Alniyat"
 msgstr "Альният"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Аль Ният"
 
-#: data.cpp:923
+#: data.cpp:931
 msgid "Athebyne"
 msgstr "Афебын"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Кужам"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr "Тимир"
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Антарес"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Корнефорос"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr "Огма"
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Марфик"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr "Росалиядекастро"
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr "Пайкаухалэ"
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Атрия"
 
-#: data.cpp:933
+#: data.cpp:941
 msgid "Larawag"
 msgstr "Лараваг"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr "Ксамидимура"
 
-#: data.cpp:935
+#: data.cpp:943
 msgid "Pipirima"
 msgstr "Пипирима"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr "Махсати"
 
-#: data.cpp:937
+#: data.cpp:945
 msgid "Rapeto"
 msgstr "Рапето"
 
-#: data.cpp:938
+#: data.cpp:946
 msgid "Alrakis"
 msgstr "Альракис"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Арракис"
 
-#: data.cpp:940
+#: data.cpp:948
 msgid "Aldhibah"
 msgstr "Алдиба"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Сабик"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Рас Альгети"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Рас Альгети"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Сарин"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr "Гэнибу"
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr "Инквил"
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Растабан"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Маасым"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Лесат"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Лесут"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Кума"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Йилдун"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Шаула"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Рас Альхаг"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Рас Альхагу"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Саргас"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Дзибан"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr "Гиртаб"
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Кебалраи"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr "Альруба"
 
-#: data.cpp:961
+#: data.cpp:969
 msgid "Cervantes"
 msgstr "Сервантес"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr "Фуюэ"
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Грумиум"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Эльтанин"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Этамин"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Звезда Барнарда"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr "Пинкойя"
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Альнасл"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr "Полис"
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Каус Медиа"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr "Аласия"
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Каус Аустралис"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Аль Асфар"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr "Фафнир"
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Каус Бореалис"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Вега"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr "Сихэ"
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Шелиак"
 
-#: data.cpp:979
+#: data.cpp:987
 msgid "Ainalrami"
 msgstr "Аинальрами"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Нунки"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr "Каве"
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Алия"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Сулафат"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Асцелла"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr "Окаб"
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Денеб эль Окаб"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr "Меридиана"
 
-#: data.cpp:988
+#: data.cpp:996
 msgid "Albaldah"
 msgstr "Альбальдах"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Альтаис"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Аль Тайс"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Нодус Секундус"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Аладфар"
 
-#: data.cpp:993
+#: data.cpp:1001
 msgid "Gumala"
 msgstr "Гумала"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr "Белель"
 
-#: data.cpp:995
+#: data.cpp:1003
 msgid "Arkab Prior"
 msgstr "Аркаб Приор"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Аркаб"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr "Сика"
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr "Аркаб Постериор"
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Рукбат"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr "Ансер"
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Альбирео"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr "Урук"
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Альсафи"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Звезда Кэмпбелла"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Шам"
 
-#: data.cpp:1006
+#: data.cpp:1014
 msgid "Fawaris"
 msgstr "Фаварис"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Таразед"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Тыл"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Альтаир"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Атаир"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr "Либертас"
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Альшаин"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr "Теребеллум"
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr "Финикия"
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr "Чечия"
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Альгеди"
 
-#: data.cpp:1017
+#: data.cpp:1025
 msgid "Alshat"
 msgstr "Альшат"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Дабих"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Садр"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Павлин"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr "Алдульфин"
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Ротанев"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Суалоцин"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Денеб"
 
-#: data.cpp:1025
+#: data.cpp:1033
 msgid "Aljanah"
 msgstr "Альджанах"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Альбали"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr "Музыка"
 
-#: data.cpp:1028
+#: data.cpp:1036
 msgid "Polaris Australis"
 msgstr "Южнополярная"
 
-#: data.cpp:1029
+#: data.cpp:1037
 msgid "Solaris"
 msgstr "Солярис"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Китальфа"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Лакайль 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Альдерамин"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Альфирк"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Садалсууд"
 
-#: data.cpp:1035
+#: data.cpp:1043
 msgid "Bunda"
 msgstr "Бунда"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr "Самайя"
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Нашира"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Азельфафаге"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr "Босона"
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Гранатовая звезда Гершеля"
 
-#: data.cpp:1041
+#: data.cpp:1049
 msgid "Erakis"
 msgstr "Эракис"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Эниф"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Денеб Альгеди"
 
-#: data.cpp:1044
+#: data.cpp:1052
 msgid "Aldhanab"
 msgstr "Альданаб"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Аль-Данаб"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr "Итонда"
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Курхах"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Садалмелик"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Альнаир"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Аль Найр"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Бихам"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Анча"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Садахбиа"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Сит"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr "Лайонрок"
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Крюгер 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Ситула"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Хомам"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr "Тиаки"
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Матар"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Звезда Бабкока"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Садалбари"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr "Хидор"
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Скат"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr "Гельветиос"
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Фомальгаут"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Шеат"
 
-#: data.cpp:1068
+#: data.cpp:1076
 msgid "Fumalsamakah"
 msgstr "Фумальсамаках"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Фум аль Самаках"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Маркаб"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Марчаб"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr "Эбла"
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Брэдли 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr "Сальм"
 
-#: data.cpp:1075
+#: data.cpp:1083
 msgid "Alkarab"
 msgstr "Алькараб"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr "Веритат"
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr "Поэрава"
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Эррай"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr "Аксолотль"
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Млечный путь"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "БМО"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "ММО"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Плеяды"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Гиады"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Ясли"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Скопление Улей"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Маффей 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Маффей 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Лев A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Секстант B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Лев I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Секстант A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Циркуль"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr "Галактика Андромеды"
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr "Галактика Треугольника"
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Холмберг VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Фатх 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Тукана"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Эридан"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Компас"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Тонантзинтла 2"

--- a/po/sk.po
+++ b/po/sk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "Last-Translator: Lubos Balazovic <lubos.balazovic@gmail.com>\n"
 "Language-Team: Slovenský <kde-i18n-doc@kde.org>\n"
 "Language: \n"
@@ -20,358 +20,447 @@ msgstr ""
 "X-Language: sk_SK\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Výveva"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Rajka"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vodnár"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Orol"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Oltár"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Baran"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Povozník"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Pastier"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Rydlo"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Žirafa"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Rak"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Poľovné psy"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Veľký pes"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Malý pes"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Kozorožec"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kýl"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kasiopeja"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentaurus"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cefeus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Veľryba"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Chameleón"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Kružidlo"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Holubica"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Vlasy Bereniky"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Južná koruna"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Severná koruna"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Havran"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Pohár"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Južný kríž"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Labuť"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfín"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Mečiar"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Drak"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Koník"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanus"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Pec"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Blíženci"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Žeriav"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Hodiny"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hydra"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Vodný had"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indián"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Jašterica"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Lev"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Malý lev"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Zajac"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Váhy"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Vlk"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Rys"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lýra"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Stolový vrch"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskop"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Jednorožec"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Mucha"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Pravítko"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktant"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Hadonos"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orión"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Páv"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegas"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perzeus"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fénix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Maliar"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Ryby"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Južná ryba"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Korma"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompas"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Sieť"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Šíp"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Strelec"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Škorpión"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Sochár"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Štít"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Hlava hada"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Chvost hada"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextant"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Býk"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Ďalekohľad"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Trojuholník"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Južný trojuholník"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukan"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Veľká medvedica (Veľký voz)"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Malá medvedica (Malý voz)"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Plachty"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Panna"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Lietajúca ryba"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Líštička"
 
@@ -527,3964 +616,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hydra"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Nouméa"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Trojuholník"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Stručný"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturn"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Pec"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturn"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Pec"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturn"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxie"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymedes"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Slnko"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "SEVERNÁ AMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "JUŽNÁ AMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURÁZIA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRÁLIA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTÍDA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "SEVERNÝ ATLANTICKÝ OCEÁN"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "JUŽNÝ ATLANTICKÝ OCEÁN"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "SEVERNÝ TICHÝ OCEÁN"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "JUŽNÝ TICHÝ OCEÁN"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDICKÝ OCEÁN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "SEVERNÝ ĽADOVÝ OCEÁN"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abú Dabí"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alžír"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asuncion"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atény"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Bejrut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belehrad"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlín"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brusel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukurešť"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapešť"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Káhira"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Kapské Mesto"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kišinev"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Konakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kodaň"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damask"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Džibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dušanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltár"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Haag"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoj"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Džakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jeruzalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kábul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Kartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kijev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuvajt"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "La'youn"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lisabon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londýn"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadišo"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monako"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskva"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muškat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Nouméa"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paríž"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Pénh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Praha"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangún"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Rijad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rím"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Maríno"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Soul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapur"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Srí Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Tchaj-pej"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taškent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "T'bilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teherán"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripolis"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulanbátar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikán"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viedeň"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varšava"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Jerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Záhreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Slnko"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Barycentrum Slnečnej sústavy"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Slnko"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Súčasný"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Hlava trojuholníka"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polárka"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hindova karmínová hviezda"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxie"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteynova hviezda"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Trojuholník"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Červený obdĺžnik"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Hviezdy"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sírius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luytenova hviezda"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Akubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Srdce hydry"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Srdce leva"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londýn"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Formát:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Karolovo srdce"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alkor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arktúr"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atény"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatóriá"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnardova hviezda"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbellova hviezda"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paríž"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polárka"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Hranice súhvezdí"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschelova Granátova hviezda"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcockova hviezda"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Mliečna cesta"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "VMM"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "MMM"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejády"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyjády"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Jasličky"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Hviezdokopa Úľ"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Lev A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextant B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Lev I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextant A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Kružidlo"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanus"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompas"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: celestia 1.4.1\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-02-21 20:58+0100\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -20,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Luftpumpen"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Paradisfågeln"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Vattumannen"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Örnen"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Altaret"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Väduren"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Kusken"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Björnvaktaren"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Gravstickeln"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Giraffen"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Kräftan"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Jakthundarna"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Stora hunden"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Lilla hunden"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Stenbocken"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Kölen"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeja"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Kentauren"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cepheus"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Valfisken"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Kameleonten"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Cirkelpassaren"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Duvan"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenikes hår"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Södra kronan"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Norra kronan"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Korpen"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Bägaren"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Södra korset"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Svanen"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delfinen"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Svärdfisken"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Draken"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Lilla hästen"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Floden Eridanus"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Ugnen"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Tvillingarna"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Tranan"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkules"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Pendeluret"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Vattenormen"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Lilla vattenormen"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indianen"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Ödlan"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Lejonet"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Lilla lejonet"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Haren"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Vågen"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Vargen"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lodjuret"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lyran"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Taffelberget"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskopet"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Enhörningen"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Flugan"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Vinkelhaken"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Oktanten"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ormbäraren"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Påfågeln"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasus"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseus"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Fenix"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Målaren"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Fiskarna"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Södra fisken"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Akterskeppet"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kompassen"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Rombiska nätet"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Pilen"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Skytten"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Skorpionen"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Bildhuggaren"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Skölden"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Ormens svans"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Ormens huvud"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextanten"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Oxen"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Kikaren"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triangeln"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Södra triangeln"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukanen"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Stora björnen"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Lilla björnen"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Seglet"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Jungfrun"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Flygfisken"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Räven"
 
@@ -527,3964 +616,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Vattenormen"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Noumea"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Bamako"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Amalthea"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triangeln"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Amalthea"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Jupiter"
+msgid "Pandia"
+msgstr "Pandora"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Jupiter"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jupiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jupiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jupiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jupiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jupiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jupiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jupiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callisto"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jupiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jupiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jupiter"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jupiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jupiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jupiter"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jupiter"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jupiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jupiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jupiter"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Callisto"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Fåordig"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jupiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jupiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jupiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Jan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Skat"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Skat"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Saturnus"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Saturnus"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Ugnen"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Saturnus"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Port-Vila"
+msgid "Fornjot"
+msgstr "Ugnen"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Saturnus"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Port-Vila"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Mar"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Galaxer"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymede"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Solen"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "NORDAMERIKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "SYDAMERIKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "EURASIEN"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRIKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AUSTRALIEN"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARKTIS"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "NORDATLANTEN"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "SYDATLANTEN"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "NORRA STILLA HAVET"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "SÖDRA STILLA HAVET"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "INDISKA OCEANEN"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "NORRA ISHAVET"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dhabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Accra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Abeba"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Alger"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Asjchabad"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asunción"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Aten"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bagdad"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Baku"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begawan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Peking"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beirut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Bryssel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bukarest"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapest"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kairo"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Canberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Kapstaden"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Caracas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Chisinau"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Colombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Conakry"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Köpenhamn"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Damaskus"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dhaka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Djibouti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Dusjanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Haag"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havanna"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsingfors"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Islamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Jerusalem"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabul"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Kathmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Khartoum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinshasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuwait"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "El Aaiún"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lissabon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "London"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Luxemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Manlig"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Mexico City"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadishu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monaco"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskva"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muskat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "New Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Nicosia"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nouakchott"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nukualofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prag"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "P'yŏngyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Quito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Rangoon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyadh"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Rom"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sana"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Sarajevo"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Förlikningsavtalet"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapore"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Skopje"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofia"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Tasjkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tbilisi"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Teheran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv-Jaffa"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tirana"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Tripoli"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunis"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikanstaten"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Wien"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Warszawa"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Washington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Yerevan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Solen"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Stjärnsystemets masscentrum"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Solen"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Aktuell"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Polstjärnan"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hinds karmosinröda stjärna"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galaxer"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyns stjärna"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Triangel"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Röda rektangelnebulosan"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Visa stjärnor"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luytens stjärna"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Vattenormens hjärta"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Lejonets hjärta"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "London"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Format: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Segin"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Aten"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Observatorier"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnards stjärna"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbells stjärna"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Peacock"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Polstjärnan"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Gränser"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcocks stjärna"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Vintergatan"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Plejaderna"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyaderna"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Praesepe"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Bikupan"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Cirkelpassaren"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "Stjärnhopen 47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Floden Eridanus"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kompassen"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: en\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2011-01-08 22:08+0200\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <kde-i18n-doc@kde.org>\n"
@@ -15,362 +15,451 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 1.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Pompa takımyıldızı"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Cennetkuşu takımyıldızı"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Kova takımyıldızı"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Kartal takımyıldızı"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Sunak takımyıldızı"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Koç takımyıldızı"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Arabacı takımyıldızı"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Çoban takımyıldızı"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Çelikkalem takımyıldızı"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Zürafa takımyıldızı "
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Yengeç takımyıldızı"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Av köpekleri takımyıldızı "
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Büyük Köpek takımyıldızı"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Küçük Köpek takımyıldızı"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Oğlak takımyıldızı"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Karina takımyıldızı"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Kraliçe takımyıldızı"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Erboğa takımyıldızı"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Kral takımyıldızı"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Balina takımyıldızı"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Bukalemun takımyıldızı"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Pergel takımyıldızı"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Güvercin takımyıldızı"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Berenices'in Saçı takımyıldızı"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Güneytacı takımyıldızı"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Kuzeytacı takımyıldızı"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Karga takımyıldızı"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Kupa takımyıldızı"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Güneyhaçı takımyıldızı"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Kuğu Takımyıldızı"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Yunus takımyıldızı"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Kılıçbalığı takımyıldızı"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Ejderha takımyıldızı"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Tay takımyıldızı"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Irmak takımyıldızı"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Ocak takımyıldızı"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "İkizler takımyıldızı"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Turna takımyıldızı"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Herkül takımyıldızı"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Saat takımyıldızı"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Suyılanı takımyıldızı"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Küçüksuyılanı takımyıldızı"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Hintli takımyıldızı"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Kertenkele takımyıldızı"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Aslan takımyıldızı"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Küçük Aslan takımyıldızı"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Tavşan takımyıldızı"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Terazi takımyıldızı"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Kurt takımyıldızı"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Vaşak takımyıldızı"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Çalgı takımyıldızı"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Masa takımyıldızı"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Mikroskop takımyıldızı"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Tekboynuz takımyıldızı"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Sinek takımyıldızı"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Cetvel takımyıldızı"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Sekizlik takımyıldızı"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Yılancı takımyıldızı"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Avcı Takımyıldızı"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Tavus takımyıldızı"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Kanatlıat takımyıldızı"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Kahraman takımyıldızı"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Anka takımyıldızı"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Ressam takımyıldızı"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Balık takımyıldızı"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Güneybalığı takımyıldızı"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Pupa takımyıldızı"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Kumpas takımyıldızı"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Ağcık takımyıldızı"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Okçuk takımyıldızı"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Yay takımyıldızı"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Akrep takımyıldızı"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Heykeltraş takımyıldızı"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Kalkan takımyıldızı"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Yılanın başı takımyıldızı"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Yılanın kuyruğu takımyıldızı"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Altılık takımyıldızı"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Boğa takımyıldızı"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Dürbün takımyıldızı"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Üçgen takımyıldızı"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Güney Üçgeni takımyıldızı"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tukan takımyıldızı"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Büyük Ayı takımyıldızı"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Küçük Ayı takımyıldızı"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Yelken takımyıldızı"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Başak takımyıldızı"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Uçanbalık takımyıldızı"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Tilkicik takımyıldızı"
 
@@ -526,3963 +615,4016 @@ msgstr "Nix"
 msgid "Kerberos"
 msgstr "Kerberos"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Suyılanı takımyıldızı"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "Haumea"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "Namaka"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "Hi'iaka"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "Makemake"
 
-#: data.cpp:134
+#: data.cpp:139
 #, fuzzy
 msgid "S 2015 (136472) 1"
 msgstr "S-2015 136472 I"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Üçgen takımyıldızı"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "Eris"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "Dysnomia"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "Metis"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "Adrastea"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "Amalthea"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "Thebe"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "Themisto"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "Leda"
 
-#: data.cpp:143
-msgid "Ersa"
-msgstr ""
-
-#: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Pandora"
-
-#: data.cpp:145
-msgid "Himalia"
-msgstr "Himalia"
-
-#: data.cpp:146
-msgid "Lysithea"
-msgstr "Lysithea"
-
-#: data.cpp:147
-msgid "Elara"
-msgstr "Elara"
-
-#: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Diphda"
-
-#: data.cpp:149
-msgid "Carpo"
-msgstr ""
-
-#: data.cpp:150
-msgid "Valetudo"
-msgstr ""
-
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
+msgid "Pandia"
+msgstr "Pandora"
+
+#: data.cpp:153
+msgid "Himalia"
+msgstr "Himalia"
+
+#: data.cpp:154
+msgid "Lysithea"
+msgstr "Lysithea"
+
+#: data.cpp:155
+msgid "Elara"
+msgstr "Elara"
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
 msgid "Jupiter LV"
 msgstr "Jüpiter"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr ""
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr ""
 
-#: data.cpp:155
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Jüpiter"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "Ananke"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "Harpalyke"
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Jüpiter"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr "Praxidike"
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Jüpiter"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr "Iocaste"
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Jüpiter"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr "Praxidike"
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Jüpiter"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr "Iocaste"
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Jüpiter"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Jüpiter"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Callirrhoe"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "Chaldene"
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Jüpiter"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Jüpiter"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Jüpiter"
-
-#: data.cpp:181
-#, fuzzy
-msgid "Cyllene"
-msgstr "Helene"
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr "Taygete"
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Jüpiter"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Jüpiter"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Jüpiter"
 
 #: data.cpp:188
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Jüpiter"
+
+#: data.cpp:189
+#, fuzzy
+msgid "Cyllene"
+msgstr "Helene"
+
+#: data.cpp:190
+msgid "Taygete"
+msgstr "Taygete"
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Jüpiter"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Jüpiter"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Jüpiter"
+
+#: data.cpp:196
 msgid "Aitne"
 msgstr ""
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "Carme"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "Callirrhoe"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "Erinome"
 
-#: data.cpp:192
+#: data.cpp:200
 #, fuzzy
 msgid "Pasithee"
 msgstr "Pasiphae"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "Sinope"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "Isonoe"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 #, fuzzy
 msgid "Autonoe"
 msgstr "Oto"
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Özlü"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "Pasiphae"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Jüpiter"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "Kalyke"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "Megaclite"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Jüpiter"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Jüpiter"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "Pan"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "Atlas"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Prometheus"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Pandora"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Epimetheus"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Janus"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
+#: data.cpp:232
 #, fuzzy
 msgid "Pallene"
 msgstr "Helene"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "Telesto"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "Calypso"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr ""
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "Helene"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr ""
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr ""
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr ""
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr ""
 
-#: data.cpp:233
+#: data.cpp:241
 #, fuzzy
 msgid "Skathi"
 msgstr "Skat"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr ""
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr ""
 
-#: data.cpp:236
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Albireo"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Satürn"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 #, fuzzy
 msgid "Beli"
 msgstr "Belinda"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Satürn"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr ""
 
-#: data.cpp:285
+#: data.cpp:293
 #, fuzzy
 msgid "Fornjot"
 msgstr "Ocak takımyıldızı"
 
-#: data.cpp:286
+#: data.cpp:294
 #, fuzzy
 msgid "Saturn LVIII"
 msgstr "Satürn"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "Cordelia"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "Ophelia"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "Bianca"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "Cressida"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "Desdemona"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "Juliet"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "Portia"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "Rosalind"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr ""
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "Belinda"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr ""
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "Puck"
 
-#: data.cpp:299
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Sekme"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "Caliban"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "Stephano"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "Sycorax"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "Prospero"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "Setebos"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "Naiad"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "Thalassa"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "Despina"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "Galatea"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Larissa"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ganymede"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Güneş"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "KUZEY AMERİKA"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "GÜNEY AMERİKA"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "AVRASYA"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "AFRİKA"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "AVUSTRALYA"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "ANTARTİKA"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "KUZEY ATLANTİK OKYANUSU"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "GÜNEY ATLANTİK OKYANUSU"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "KUZEY PASİFİK OKYANUSU"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "GÜNEY PASİFİK OKYANUSU"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "HİNT OKYANUSU"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "KUZEY BUZ DENİZİ"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Abu Dabi"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Abuja"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Akra"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Adamstown"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Addis Ababa"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Cezayir"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Alofi"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Amman"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Amsterdam"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Andorra la Vella"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Ankara"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Apia"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Aşkabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Asmara"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Asuncion"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Atina"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Avarua"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Bağdat"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Bakü"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Bamako"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Bandar Seri Begavan"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Bangkok"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Bangui"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Banjul"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Basse-Terre"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Pekin"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Beyrut"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Belgrad"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Belmopan"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Berlin"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Bern"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bişkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Bissau"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Bloemfontein"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Bogota"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Brasilia"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Bratislava"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Brazzaville"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Bridgetown"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Brüksel"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Bükreş"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Budapeşte"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Buenos Aires"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Bujumbura"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Kahire"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Kanberra"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Cape Town"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Karakas"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Castries"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Cayenne"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Charlotte Amalie"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Kişinev"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Kolombo"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Konakri"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Kopenhag"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Cotonou"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Dakar"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Şam"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Darüsselam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Dakka"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Dili"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Cibuti"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Doha"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Douglas"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Dublin"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Duşanbe"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Fort-de-France"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Freetown"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Gaborone"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "George Town"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Georgetown"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Cebelitarık"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Grand Turk"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Guatemala"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Lahey"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Hamilton"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Hanoi"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Harare"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Havana"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Helsinki"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Honiara"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "İslamabad"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Jakarta"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Jamestown"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Kudüs"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Kabil"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Kampala"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Katmandu"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Hartum"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Kiev"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Kigali"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Kingston"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Kingstown"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Kinşasa"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Koror"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Kuala Lumpur"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Kuveyt"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Layun"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "La Paz"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Libreville"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Lilongwe"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Lima"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Lizbon"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Ljubljana"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Lome"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Londra"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Luanda"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Lusaka"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Lüksemburg"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Madrid"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Majuro"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Malabo"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Male"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Managua"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Manama"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Manila"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Maputo"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Maseru"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Mbabane"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Meksiko"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Minsk"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Mogadişu"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Monako"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Monrovia"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Montevideo"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Moroni"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Moskova"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Muscat"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Nairobi"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Nassau"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "N'Djamena"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Yeni Delhi"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Niamey"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Lefkoşa"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Nuakşot"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Noumea"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Oranjestad"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Oslo"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Ottawa"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Ouagadougou"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Panama"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Paramaribo"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Paris"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Phnom Penh"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Plymouth"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Port Louis"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Port Moresby"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Port-au-Prince"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Port-of-Spain"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Porto-Novo"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Port-Vila"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Prag"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Praia"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Pretoria"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Pyongyang"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Kito"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Rabat"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Yangon"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Reykjavik"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Riga"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Riyad"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Roma"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Roseau"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Saint George's"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Saint Helier"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Saint John's"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Saint Peter Port"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Saint-Denis"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Saint-Pierre"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Saipan"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "San Jose"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "San Juan"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "San Marino"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "San Salvador"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Sanaa"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Santiago"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Santo Domingo"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Sao Tome"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Saraybosna"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Seoul"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Singapur"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Üsküp"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Sofya"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Stanley"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Stockholm"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Sucre"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Suva"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Taipei"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Tallinn"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Tarawa"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Taşkent"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Tiflis"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Tegucigalpa"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Tahran"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Tel Aviv"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Thimphu"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Tiran"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Tokyo"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Torshavn"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Trablus"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Tunus"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulan Batur"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Valletta"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Vatikan"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Victoria"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Viyana"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "Vientiane"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Varşova"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Vaşington D.C."
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Wellington"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Adası"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Willemstad"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Windhoek"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Yamoussoukro"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Yaounde"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Erivan"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Zagreb"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Güneş"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Güneş Sistemi Kütle Merkezi"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Güneş"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Achird"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Van Maanen 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Kastor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr ""
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Miraç"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Titan"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ağız"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Hamel"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Tansık"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Kutup Yıldızı"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Tansık"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Umacı"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Eldeberan"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Galatea"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn'in Yıldızı"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Ayak"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Kapella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Bellatrik"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Üçgen"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "İkizlerevi"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Red Rectangle"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "En Yakın Yıldızlar"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Akyıldız"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten'in Yıldızı"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Kastor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Öncü"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Polluks"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Achird"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Londra"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 #, fuzzy
 msgid "Chalawan"
 msgstr "Chaldene"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Biçim:"
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Georgetown"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Honiara"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Muhlifain"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Mimoza"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Başakçı"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Arktürüs"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Mars"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Atina"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Akrep Yüreği"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Tarawa"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Iapetus"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Gözlemevleri"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Barnard'ın Yıldızı"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Sheliak"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Nunki"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Altais"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Aladfar"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Guatemala"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Albireo"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell'in Yıldızı"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Paris"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Uçucu"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Tavuskuşu"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Denep"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Ljubljana"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Kutup Yıldızı"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Sınırlar"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock'ın Yıldızı"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Kılıf"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Ankara"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Samanyolu"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "BMB"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "KMB"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Ülker"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Hyades"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Arıkovanı kümesi"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Beehive Cluster"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Leo A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Sextans B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Leo I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Sextans A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Pergel takımyıldızı"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Tuc"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Irmak takımyıldızı"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Kumpas takımyıldızı"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uk\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2008-02-06 13:37+0200\n"
 "Last-Translator: Serhij Dubyk <dubyk@library.lviv.ua>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -20,366 +20,455 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Poedit-Language: Ukrainian\n"
 "X-Poedit-Country: UKRAINE\n"
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: KBabel 1.11.4\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Андромеда"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Насос"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Райський Птах"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Водолій"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Орел"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Жертівник"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Овен"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Візничий"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Волопас"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Різець"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Жираф"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Рак"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Гончі Пси"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Великий Пес"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Малий Пес"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Козеріг"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Кіль"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Кассіопея"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Центавр"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Цефей"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Кит"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Хамелеон"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Циркуль"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Голуб"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Волосся Вероніки"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Південна Корона"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Північна Корона"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Ворон"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Чаша"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Хрест (Південний)"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Лебідь"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Дельфін"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Золота Риба"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Дракон"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Малий Кінь"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Ерідан"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Піч"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Близнюки"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Журавель"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Геркулес"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Годинник"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Гідра"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Південний Змій"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Індієць"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Ящірка"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Лев"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Малий Лев"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Заєць"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Ваги"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Вовк"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Рись"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Ліра"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Столова Гора"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Мікроскоп"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Одноріг"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Муха"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Косинець"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Октант"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Змієносець"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Оріон"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Павич"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Пегас"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Персей"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Фенікс"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Живописець"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Риби"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Південна Риба"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Корма"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Компас"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Сітка"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Стріла"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Стрілець"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Скорпіон"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Скульптор"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Щит"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Голова Змії"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Хвіст Змії"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Секстант"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Тілець"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Телескоп"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Трикутник"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Південний Трикутник"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Тукан"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Велика Ведмедиця"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Мала Ведмедиця"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Паруси"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Діва"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Летюча Риба"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Лисичка"
 
@@ -535,3964 +624,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Гідра"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "Нумеа"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "Бамако"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "Амальтея"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Трикутник"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "Пандора"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "Амальтея"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "Діфда"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "Юпітер"
+msgid "Pandia"
+msgstr "Пандора"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "Діфда"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "Юпітер"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "Юпітер"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "Юпітер"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "Юпітер"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "Юпітер"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "Юпітер"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "Алкіона"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "Юпітер"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "Юпітер"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "Каллісто"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "Юпітер"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "Юпітер"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "Юпітер"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "Юпітер"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "Юпітер"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "Юпітер"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "Юпітер"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "Юпітер"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "Юпітер"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "Юпітер"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "Каллісто"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "Коротко"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "Юпітер"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "Юпітер"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "Юпітер"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "Січ"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "Прометей"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "Пандора"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "Епіметей"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "Янус"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "Скат"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "Скат"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "Альбірео"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "Сатурн"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "Сатурн"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Піч"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "Сатурн"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "Порт-Віла"
+msgid "Fornjot"
+msgstr "Піч"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "Сатурн"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "Порт-Віла"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Бер"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "Галактики"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "Ларісса"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "Ганімед"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "Сонце"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "ПІВНІЧНА АМЕРИКА"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "ПІВДЕННА АМЕРИКА"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "ЄВРАЗІЯ"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "АФРИКА"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "АВСТРАЛІЯ"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "АНТАРКТИДА"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "ПІВНІЧНИЙ АТЛАНТИЧНИЙ ОКЕАН"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "ПІВДЕННИЙ АТЛАНТИЧНИЙ ОКЕАН"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "ПІВНІЧНИЙ ТИХИЙ ОКЕАН"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "ПІВДЕННИЙ ТИХИЙ ОКЕАН"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "ІНДІЙСЬКИЙ ОКЕАН"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "АРКТИЧНИЙ ОКЕАН"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "Абу-Дабі"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "Абуджа"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "Аккра"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "Адамстаун"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "Аддис-Абеба"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "Алжир"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "Алофі"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "Амман"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "Амстердам"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "Андорра-ла-Велья"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "Анкара"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Антананаріву"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "Апья"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ашгабат"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "Асмера"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr "Астана"
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "Асунсьйон"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "Афіни"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "Аваруа"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "Багдад"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "Баку"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "Бамако"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "Бандар-Сері-Бегаван"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "Бангкок"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "Бангі"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "Банджул"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "Бас-Тер"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Бастер"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "Пекін"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "Бейрут"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "Белград"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "Бельмопан"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "Берлін"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "Берн"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Бішкек"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "Бісау"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "Блумфонтейн"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "Богота"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "Бразиліа"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "Братислава"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "Браззавіль"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "Бриджтаун"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "Брюссель"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "Бухарест"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "Будапешт"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "Буенос-Айрес"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "Бужумбура"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "Каїр"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "Канберра"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "Кейптаун"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "Каракас"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "Кастрі"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "Каєнна"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "Шарлотта-Амалія"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "Кишинів"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "Коломбо"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "Конакрі"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "Копенгаген"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "Котону"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "Дакар"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "Дамаск"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Дар-ес-Салам"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "Дакка"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "Ділі"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "Джибуті"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "Доха"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "Дуглас"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "Дублін"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "Душанбе"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Фонгафале"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "Фор-де-Франс"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "Фрітаун"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "Габороне"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "Джорджтаун"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "Джорджтаун"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "Гібралтар"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "Гранд-Терк"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "Гватемала"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Аґанья"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "Гаага"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "Гамільтон"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "Ханой"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "Хараре"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "Гавана"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "Гельсінкі"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "Хоніара"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "Ісламабад"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "Джакарта"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "Джеймстаун"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "Єрусалим"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "Кабул"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "Кампала"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "Катманду"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "Хартум"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "Київ"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "Кігалі"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "Кінгстон"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "Кінгстаун"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "Кіншаса"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "Корор"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "Куала-Лумпур"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "Кувейт"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "Ель-Аюн"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "Ла-Пас"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "Лібревіль"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "Лілонгве"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "Ліма"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "Лісабон"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "Любляна"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Лобамба"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "Ломе"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "Лондон"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Лонг'єрб'єн"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "Луанда"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "Лусака"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "Люксембург"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "Мадрид"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "Маджуро"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "Малабо"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "Мале"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Мамудзу"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "Манагуа"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "Манама"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "Маніла"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "Мапуто"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "Масеру"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Мата-Уту"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "Мбабане"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "Мехіко"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "Мінськ"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "Могадішо"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "Монако"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "Монровія"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "Монтевідео"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "Мороні"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "Москва"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "Маскат"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "Найробі"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "Нассау"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "Нджамена"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "Нью-Делі"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "Ніамей"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "Нікосія"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "Нуакшот"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "Нумеа"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Нукуалофа"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Нуук"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "Ораньєстад"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "Осло"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "Оттава"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "Уагадугу"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Паго-Паго"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Палікір"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "Панама"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Папеете"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "Парамарибо"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "Париж"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "Пномпень"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "Плімут"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "Порт-Луї"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "Порт-Морсбі"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "Порт-о-Пренс"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "Порт-оф-Спейн"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "Порто-Ново"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "Порт-Віла"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "Прага"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "Прая"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "Преторія"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "Пхеньян"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "Кіто"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "Рабат"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "Рангун"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "Рейк'явік"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "Рига"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "Ер-Ріядд"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Род-Таун"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "Рим"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "Розо"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "Сент-Джорджес"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "Сент-Гелієр"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "Сент-Джонс"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "Сент-Пітер-Порт"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "Сен-Дені"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "Сент-П'єр"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "Сайпан"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "Сан-Хосе"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "Сан-Хуан"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "Сан-Марино"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "Сан-Сальвадор"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "Сана"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "Сантьяго"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "Санто-Домінго"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "Сан-Томе"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "Сараєво"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "Сеул"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "Сеттлмент"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "Сингапур"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "Скоп'є"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "Софія"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Шрі-Джаяварденепура-Котте"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "Стенлі"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "Стокгольм"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "Сукре"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "Сува"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "Тайбей"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "Таллінн"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "Тарава"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "Ташкент"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "Тбілісі"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "Тегусігальпа"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "Тегеран"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "Тель-Авівв"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "Тхімпху"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "Тирана"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "Токіо"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "Торсгавн"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "Тріполі"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "Туніс"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Улан-Батор"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Вадуц"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "Валетта"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "Веллі"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "Місто Ватикан"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "Вікторія"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "Відень"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "В'єнтьян"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Вільнюс"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "Варшава"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "Вашингтон, округ Колумбія"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "Веллінгтон"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "Західний острів"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "Віллемстад"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "Віндгук"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "Ямусукро"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "Яунде"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Округ Ярен"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "Єреван"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "Загреб"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "Сонце"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "Центр тяжіння зоряної системи"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "Сонце"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "Альферац"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Сіррах"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "Каф"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "Альгеніб"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Шемалі"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "Анкаа"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "Шедар"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Шедір"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "Діфда"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Денеб Кайтос"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "Ахірд"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "Ван Маанен 2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "Кастор"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "Наві"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Поточне"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "Мірах"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "Адхіл"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "Рухба"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "Альферац"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "Титан"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "Ахернар"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "Батен Кайтос"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Капут Тріангулі"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "Месартхім"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "Сегін"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "Шератан"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Аль Реща"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Аль Реща"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "Альмах"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Альмаак"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Аламак"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "Гамаль"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "Міра"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "Полярна"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "Хара"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "Міра"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "Ангетенар"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "Азха"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "Акамар"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "Менкар"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Менкаб"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "Алгол"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "Ботейн"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "Мірфак"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "Мірфак"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Марфак"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "Рана"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "Рана"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "Атік"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "Келено"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "Електра"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "Тайгета"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "Майя"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "Астеропа"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "Меропа"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "Алкіона"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "Плейона"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "Заурак"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "Менкіб"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "Бейд"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "Кеїд"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "Ен"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "Альдебаран"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "Тхабіт"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Пурпурова Зірка Гайнда"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Альмаак"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "Галактики"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Садатоні"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "Курса"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Зірка Каптейна"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "Рігель"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "Капелла"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "Беллатрікс"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "Ельнатх"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "Альнат"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "Нігаль"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "Тхабіт"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "Мінтака"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "Арнеб"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "Меїса"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Гека"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "Альнілам"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "Трикутник"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "Факт"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "Альнітак"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "Саїф"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "Вазн"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "Бетельгейзе"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Пріджипаті"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "Менкалінан"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "Фуруд"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "Канопус"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "Червоний прямокутник"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "Фуруд"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "Мірцам"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Мурзім"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "Тейят"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "Канопус"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Сухель"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "Зірки"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "Альгена"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Альмейсан"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "Мебсута"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "Сіріус"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "Адхара"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Адара"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "Муліфейн"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "Мекбуда"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "Везен"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Бернес 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "Васат"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "Алудра"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "Гомейса"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Зірка Люйтена"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "Кастор"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "Проціон"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Ельгомайса"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "Поллукс"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Асмідіска"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Асмідіска"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "Наос"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "Регор"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "Тегмен"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Аль Тарф"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Аль Тарф"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "Авіор"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "Мускіда"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "Ахірд"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "Аселлус Бореаліс"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "Аселлус Аустраліс"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "Акубенс"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Днокес"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Таліта Аустраліс"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "Сухайль"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "Міаплацидус"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "Аспідіска"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "Маркаб"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "Альфард"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Серце Змії"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "Альтерф"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "Укдах"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "Субра"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Расалас Аустраліс"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "Расалас"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Расалас Бореаліс"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "Регул"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Кабелесед"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Серце Лева"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "Адгафера"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Айдхафера"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "Танія Бореаліс"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "Альгієба"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "Танія Аустраліс"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "Лондон"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "Алькес"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "Мерак"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "Лаланд 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "Дубге"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Дубб"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "Зосма"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Духр"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "Шертан"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Кокса"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Хорт"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "Алула Аустраліс"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "Алула Бореаліс"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Сі Цичжань"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "Шам"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "Джансар"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "Формат: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "Джорджтаун"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "Денебола"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "Завіджава"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Алараф"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "Хоніара"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Ґрумбрідж 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "Фекда"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Фад"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "Альчіба"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "Мегрец"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "Гієна"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "Занія"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "Акрукс"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "Альгораб"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "Гакрукс"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "Хара"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "Крац"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "Мухліфейн"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "Порріма"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "Мімоза"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "Аліот"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "Мінелаува"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Аува"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "Кор Каролі"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "Віндеміатрікс"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Альмюредін"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "Міцар"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "Спіка"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Азімех"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "Алькор"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "Гезе"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "Алькаїд"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Бенетнащ"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "Мюфрід"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "Хадар"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Аґена"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "Тубан"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "Менкент"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "Арктур"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "Сирма"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "Проксіма"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "Сегін"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Цегінус"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "Ізар"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Мірак"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Пульхерріма"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "Кохаб"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "Кохаб"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Зубен Ельгенубі"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "Зубен Елакрібі"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "Неккар"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "Зубен Ельшемалі"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "Феркад"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "Феркад"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "Алькалуропс"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "Едасіх"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "Нусакан"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "Альфекка"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Гемма"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Зубен аль-Хакрабі"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Зубен аль-Хакрабі"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "Унук-аль-Хей"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Чжоу"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "Джубба"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Граффіас"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Акраб"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "Марс"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "Джабба"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Аль Нійятт"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Аль Нійятт"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "Афіни"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "Куям"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "Антарес"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "Корнефорос"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "Марфік"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "Атрія"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "Тарава"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "Порріма"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "Япет"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Арракіс"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Арракіс"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "Альчіба"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "Сабік"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "Расальгеті"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Рас Альгеті"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "Сарін"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "Растабан"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "Масім"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "Лесат"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Лесут"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "Кума"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "Їлдун"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "Шаула"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "Расалгаага"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Рас Ельхейг"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "Саргас"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Дзібан"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "Кебальраї"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "Обсерваторії"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "Груміум"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "Ельтанін"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Етамін"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "Зірка Барнарда"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "Альнасл"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "Каус Медіа"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "Каус Аустраліс"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "Аль Атфар"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "Каус Бореаліс"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "Вега"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "Шеліак"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "Альдерамін"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "Нункі"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "Алія"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "Суляфат"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "Аскела"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Денеб ель-Окаб"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "Альбалі"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "Альтаїс"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Аль Таїс"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Нодус Секундус"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "Аладфар"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "Гватемала"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Аркаб"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Аркаб"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "Рукбат"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "Альбірео"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "Альсафі"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Зірка Кемпбелла"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "Шам"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "Париж"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "Таразед"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "Тил"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "Альтаїр"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Атаїр"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "Альшаїн"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "Альгеді"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "Альшаїн"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "Дабіх"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "Садр"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "Пікок"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "Ротанев"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "Суалокін"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "Денеб"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "Любляна"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "Альбалі"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "Каус Аустраліс"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "Полярна"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "Кітальфа"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "Лакайль 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "Альдерамін"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "Альфірк"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "Садалсууд"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "Межі"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "Нашира"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "Азельфафаге"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "Гранатова Зірка Гершеля"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Арракіс"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "Еніф"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "Денеб Альгеді"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Аль Дханаб"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Аль Дханаб"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "Курхах"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "Садалмелік"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "Альнаїр"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Аль-Наїр"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "Біхам"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "Анка"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "Садахбія"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "Сеат"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Крюгер 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "Сітула"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "Хомам"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "Матар"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Зірка Баблока"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "Садалбарі"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "Скат"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "Фомальгаут"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "Шеат"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Фум аль-Самака"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Фум аль-Самака"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "Маркаб"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Мархаб"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "Бредлі 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "Анкара"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "Ерраї"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Молочний шлях"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "Велика Магелланова Хмара"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "Мала Магелланова Хмара"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "Плеяди"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "Гіади"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "Ясла"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "Скупчення «Вулик»"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Маффеї 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Маффеї 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "Лев A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "Секстант B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "Лев I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "Секстант A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Циркуль"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Гольмберґ VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Фатх 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "47 Тукана"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Ерідан"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Компас"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Тонанцинтла 2"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CELESTIA-Chinese\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2006-08-09 12:18+0900\n"
 "Last-Translator: Joe ZhaoZhengxu <zhaozhengxu@yahoo.com>\n"
 "Language-Team: Chinese <zhaozhengxu@yahoo.com>\n"
@@ -24,358 +24,447 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "仙女座"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "唧筒座"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "天燕座"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "宝瓶座"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "天鹰座"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "天坛座"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "白羊座"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "御夫座"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "牧夫座"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "雕具座"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "鹿豹座"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "巨蟹座"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "猎犬座"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "大犬座"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "小犬座"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "摩羯座"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "船底座"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "仙后座"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "半人马座"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "仙王座"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "鲸鱼座"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "堰蜒座"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "圆规座"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "天鸽座"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "后发座"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "南冕座"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "北冕座"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "乌鸦座"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "巨爵座"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "南十字座"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "天鹅座"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "海豚座"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "剑鱼座"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "天龙座"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "小马座"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "波江座"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "天炉座"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "双子座"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "天鹤座"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "武仙座"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "时钟座"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "长蛇座"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "水蛇座"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "印第安座"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "蝎虎座"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "狮子座"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "小狮座"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "天兔座"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "天秤座"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "天狼座"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "天猫座"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "天琴座"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "山案座"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "显微镜座"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "麒麟座"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "苍蝇座"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "矩尺座"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "南极座"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "蛇夫座"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "猎户座"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "孔雀座"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "飞马座"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "英仙座"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "凤凰座"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "绘架座"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "双鱼座"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "南鱼座"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "船尾座"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "罗盘座"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "网罟座"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "天箭座"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "人马座"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "天蝎座"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "玉夫座"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "盾牌座"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "巨蛇座 头"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "巨蛇座 尾"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "六分仪座"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "金牛座"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "望远镜座"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "三角座"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "南三角座"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "杜鹃座"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "大熊座"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "小熊座"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "船帆座"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "室女座"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "飞鱼座"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "狐狸座"
 
@@ -531,3963 +620,4016 @@ msgstr "冥卫二"
 msgid "Kerberos"
 msgstr "冥卫四"
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "长蛇座"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr "谷神星"
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 msgid "Haumea"
 msgstr "妊神星"
 
-#: data.cpp:131
+#: data.cpp:134
 msgid "Namaka"
 msgstr "妊卫二"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr "妊卫一"
 
-#: data.cpp:133
+#: data.cpp:136
+msgid "Quaoar"
+msgstr ""
+
+#: data.cpp:137
+msgid "Weywot"
+msgstr ""
+
+#: data.cpp:138
 msgid "Makemake"
 msgstr "鸟神星"
 
-#: data.cpp:134
+#: data.cpp:139
 #, fuzzy
 msgid "S 2015 (136472) 1"
 msgstr "S-2015 136472 I"
 
-#: data.cpp:135
+#: data.cpp:140
+msgid "Gonggong"
+msgstr ""
+
+#: data.cpp:141
+#, fuzzy
+msgid "Xiangliu"
+msgstr "三角座"
+
+#: data.cpp:142
 msgid "Eris"
 msgstr "阋神星"
 
-#: data.cpp:136
+#: data.cpp:143
 msgid "Dysnomia"
 msgstr "阋卫一"
 
-#: data.cpp:137
+#: data.cpp:144
+msgid "Sedna"
+msgstr ""
+
+#: data.cpp:145
 msgid "Metis"
 msgstr "木卫十六"
 
-#: data.cpp:138
+#: data.cpp:146
 msgid "Adrastea"
 msgstr "木卫十五"
 
-#: data.cpp:139
+#: data.cpp:147
 msgid "Amalthea"
 msgstr "木卫五"
 
-#: data.cpp:140
+#: data.cpp:148
 msgid "Thebe"
 msgstr "木卫十四"
 
-#: data.cpp:141
+#: data.cpp:149
 msgid "Themisto"
 msgstr "木卫十八"
 
-#: data.cpp:142
+#: data.cpp:150
 msgid "Leda"
 msgstr "木卫十八"
 
-#: data.cpp:143
-msgid "Ersa"
-msgstr ""
-
-#: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "土卫十七"
-
-#: data.cpp:145
-msgid "Himalia"
-msgstr "木卫六"
-
-#: data.cpp:146
-msgid "Lysithea"
-msgstr "木卫十"
-
-#: data.cpp:147
-msgid "Elara"
-msgstr "木卫七"
-
-#: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "土司空 Diphda"
-
-#: data.cpp:149
-msgid "Carpo"
-msgstr ""
-
-#: data.cpp:150
-msgid "Valetudo"
-msgstr ""
-
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
+msgid "Pandia"
+msgstr "土卫十七"
+
+#: data.cpp:153
+msgid "Himalia"
+msgstr "木卫六"
+
+#: data.cpp:154
+msgid "Lysithea"
+msgstr "木卫十"
+
+#: data.cpp:155
+msgid "Elara"
+msgstr "木卫七"
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "土司空 Diphda"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
 msgid "Jupiter LV"
 msgstr "木星"
 
-#: data.cpp:153
+#: data.cpp:161
 msgid "Eupheme"
 msgstr ""
 
-#: data.cpp:154
+#: data.cpp:162
 msgid "S 2003 J 16"
 msgstr ""
 
-#: data.cpp:155
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "木星"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr "木卫十二"
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr "木卫二十二"
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "木星"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr "木卫二十七"
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "木星"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr "木卫二十四"
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "木星"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr "木卫二十七"
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "木星"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr "木卫二十四"
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "昴宿六 Alcyone"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "木星"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "木星"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "木卫十七"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr "木卫二十一"
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "木星"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "木星"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "木星"
-
-#: data.cpp:181
-#, fuzzy
-msgid "Cyllene"
-msgstr "土卫十二"
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr "木卫二十"
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "木星"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "木星"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "木星"
 
 #: data.cpp:188
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "木星"
+
+#: data.cpp:189
+#, fuzzy
+msgid "Cyllene"
+msgstr "土卫十二"
+
+#: data.cpp:190
+msgid "Taygete"
+msgstr "木卫二十"
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "木星"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "木星"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "木星"
+
+#: data.cpp:196
 msgid "Aitne"
 msgstr ""
 
-#: data.cpp:189
+#: data.cpp:197
 msgid "Carme"
 msgstr "木卫十一"
 
-#: data.cpp:190
+#: data.cpp:198
 msgid "Callirrhoe"
 msgstr "木卫十七"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr "木卫二十五"
 
-#: data.cpp:192
+#: data.cpp:200
 #, fuzzy
 msgid "Pasithee"
 msgstr "木卫八"
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr "木卫九"
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr "木卫二十六"
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 #, fuzzy
 msgid "Autonoe"
 msgstr "自动"
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "简单"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr "木卫八"
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "木星"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr "木卫二十三"
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr "木卫十九"
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "木星"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "木星"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 msgid "Pan"
 msgstr "土卫十八"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr "土卫十五"
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "土卫十六"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "土卫十七"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "土卫十一"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "土卫十"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
+#: data.cpp:232
 #, fuzzy
 msgid "Pallene"
 msgstr "土卫十二"
 
-#: data.cpp:225
+#: data.cpp:233
 msgid "Telesto"
 msgstr "土卫十三"
 
-#: data.cpp:226
+#: data.cpp:234
 msgid "Calypso"
 msgstr "土卫十四"
 
-#: data.cpp:227
+#: data.cpp:235
 msgid "Polydeuces"
 msgstr ""
 
-#: data.cpp:228
+#: data.cpp:236
 msgid "Helene"
 msgstr "土卫十二"
 
-#: data.cpp:229
+#: data.cpp:237
 msgid "S 2019 S 1"
 msgstr ""
 
-#: data.cpp:230
+#: data.cpp:238
 msgid "Kiviuq"
 msgstr ""
 
-#: data.cpp:231
+#: data.cpp:239
 msgid "Ijiraq"
 msgstr ""
 
-#: data.cpp:232
+#: data.cpp:240
 msgid "Paaliaq"
 msgstr ""
 
-#: data.cpp:233
+#: data.cpp:241
 #, fuzzy
 msgid "Skathi"
 msgstr "羽林军二十六 Skat"
 
-#: data.cpp:234
+#: data.cpp:242
 msgid "S 2004 S 37"
 msgstr ""
 
-#: data.cpp:235
+#: data.cpp:243
 msgid "S 2007 S 2"
 msgstr ""
 
-#: data.cpp:236
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "辇道增七"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "土星"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 #, fuzzy
 msgid "Beli"
 msgstr "天卫十四"
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "土星"
 
-#: data.cpp:284
+#: data.cpp:292
 msgid "Thiazzi"
 msgstr ""
 
-#: data.cpp:285
+#: data.cpp:293
 #, fuzzy
 msgid "Fornjot"
 msgstr "天炉座"
 
-#: data.cpp:286
+#: data.cpp:294
 #, fuzzy
 msgid "Saturn LVIII"
 msgstr "土星"
 
-#: data.cpp:287
+#: data.cpp:295
 msgid "Cordelia"
 msgstr "天卫六"
 
-#: data.cpp:288
+#: data.cpp:296
 msgid "Ophelia"
 msgstr "天卫七"
 
-#: data.cpp:289
+#: data.cpp:297
 msgid "Bianca"
 msgstr "天卫八"
 
-#: data.cpp:290
+#: data.cpp:298
 msgid "Cressida"
 msgstr "天卫九"
 
-#: data.cpp:291
+#: data.cpp:299
 msgid "Desdemona"
 msgstr "天卫十"
 
-#: data.cpp:292
+#: data.cpp:300
 msgid "Juliet"
 msgstr "天卫十一"
 
-#: data.cpp:293
+#: data.cpp:301
 msgid "Portia"
 msgstr "天卫十二"
 
-#: data.cpp:294
+#: data.cpp:302
 msgid "Rosalind"
 msgstr "天卫十三"
 
-#: data.cpp:295
+#: data.cpp:303
 msgid "Cupid"
 msgstr ""
 
-#: data.cpp:296
+#: data.cpp:304
 msgid "Belinda"
 msgstr "天卫十四"
 
-#: data.cpp:297
+#: data.cpp:305
 msgid "Perdita"
 msgstr ""
 
-#: data.cpp:298
+#: data.cpp:306
 msgid "Puck"
 msgstr "天卫十五"
 
-#: data.cpp:299
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "Tab"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr "天卫十六"
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr "天卫二十"
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr "天卫十七"
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr "天卫十八"
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr "天卫十九"
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr "海卫三"
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr "海卫四"
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr "海卫五"
 
-#: data.cpp:312
+#: data.cpp:320
 msgid "Galatea"
 msgstr "海卫六"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "海卫七"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "木卫三"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "太阳"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "北美洲"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "南美洲"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "欧亚大陆"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "非洲"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "大洋洲"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "南极"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "北大西洋"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "南大西洋"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "北太平洋"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "南太平洋"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "印度洋"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "北冰洋"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "阿布扎比"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "阿布贾"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "阿克拉"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "亚当斯敦"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "亚的斯亚贝巴"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "阿尔及尔"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "阿洛菲"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "安曼"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "阿姆斯特丹"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "安道尔城"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "安卡拉"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "塔那那利佛"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "阿皮亚"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "阿什哈巴德"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "阿斯马拉"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "亚松森"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "雅典"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "阿瓦鲁阿"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "巴格达"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "巴库"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "巴马科"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "斯里巴加湾市"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "曼谷"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "班吉"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "班珠尔"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "巴斯特尔"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "巴斯特尔"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "北京"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "贝鲁特"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "贝尔格莱德"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "贝尔莫潘"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "柏林"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "伯尔尼"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "比什凯克"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "比绍"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "布隆方丹"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "波哥大"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "巴西利亚"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "布拉迪斯拉发"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "布拉柴维尔"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "布里奇敦"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "布鲁塞尔"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "布加勒斯特"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "布达佩斯"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "布宜诺斯艾利斯"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "布琼布拉"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "开罗"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "堪培拉"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "开普敦"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "加拉加斯"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "卡斯特里"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "卡宴"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "夏洛特·阿马里"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "基希讷乌"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "科伦坡"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "科纳克里"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "哥本哈根"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "科托努"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "达喀尔"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "大马士革"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "达累斯萨拉姆"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "达卡"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "帝力"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "吉布提"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "多哈"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "道格拉斯"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "都柏林"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "杜尚别"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "丰迦法利"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "法兰西堡"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "弗里敦"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "哈博罗内"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "乔治敦"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "乔治敦"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "直布罗陀"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "科克本城"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "危地马拉城"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "阿加尼亚"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "海牙"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "哈密尔顿"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "河内"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "哈拉雷"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "哈瓦那"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "赫尔辛基"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "霍尼亚拉"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "伊斯兰堡"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "雅加达"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "詹姆斯敦"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "耶路撒冷"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "喀布尔"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "坎帕拉"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "加德满都"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "喀士穆"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "基辅"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "基加利"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "金斯敦"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "金斯敦"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "金沙萨"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "科罗尔"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "吉隆坡"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "科威特城"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "阿尤恩"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "拉巴斯"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "利伯维尔"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "利隆圭"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "利马"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "里斯本"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "卢布尔雅那"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "洛班巴"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "洛美"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "伦敦"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "朗伊尔城"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "罗安达"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "卢萨卡"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "卢森堡"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "马德里"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "马朱罗"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "马拉博"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "马累"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "马穆楚"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "马那瓜"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "麦纳麦"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "马尼拉"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "马普托"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "马塞卢"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "马塔乌图"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "姆巴巴内"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "墨西哥城"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "明斯克"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "摩加迪沙"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "摩纳哥城"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "蒙罗维亚"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "蒙得维的亚"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "莫罗尼"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "莫斯科"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "马斯喀特"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "内罗毕"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "拿骚"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "恩贾梅纳"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "新德里"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "尼亚美"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "尼科西亚"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "努瓦克肖特"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "努美阿"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "努库阿洛法"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "努克"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "奥拉涅斯塔德"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "奥斯陆"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "渥太华"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "瓦加杜古"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "帕果帕果"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "帕利基尔"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "巴拿马城"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "帕皮提"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "帕拉马里博"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "巴黎"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "金边"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "普利茅斯"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "路易港"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "莫尔兹比港"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "太子港"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "西班牙港"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "波多诺伏"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "维拉港"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "布拉格"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "普拉亚"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "比勒陀利亚"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "平壤"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "基多"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "拉巴特"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "仰光"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "雷克雅未克"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "里加"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "利雅得"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "罗德城"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "罗马"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "罗索"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "圣乔治"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "圣赫利尔"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "圣约翰"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "圣彼得港"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "圣但尼"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "圣皮埃尔"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "塞班"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "圣何塞"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "圣胡安"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "圣马力诺"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "圣萨尔瓦多"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "萨那"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "圣地亚哥"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "圣多明各"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "圣多美"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "萨拉热窝"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "首尔"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "新村"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "新加坡"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "斯科普里"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "索菲亚"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "斯里贾亚瓦德纳普拉科特"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "斯坦利"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "斯德哥尔摩"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "苏克雷"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "苏瓦"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "台北"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "塔林"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "塔拉瓦"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "塔什干"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "第比利斯"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "特古西加尔巴"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "德黑兰"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "特拉维夫市"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "廷布"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "地拉那"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "东京"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "托尔斯港"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "的黎波里"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "突尼斯"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "乌兰巴托"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "瓦杜兹"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "瓦莱塔"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "瓦利"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "梵蒂冈"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "维多利亚"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "维也纳"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "万象"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "维尔纽斯"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "华沙"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "华盛顿"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "威灵顿"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "西岛"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "威廉斯塔德"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "温得和克"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "亚穆苏克罗"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "雅温得"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "亚伦区"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "埃里温"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "萨格勒布"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "太阳"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "太阳系质心"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "太阳"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "壁宿二 Alpheratz"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "Sirrah"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "王良一 Caph"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "壁宿一 Algenib"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "火鸟六 Ankaa"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "王良四 Mesartim"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "土司空 Diphda"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "王良三 Ksora"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "范马南2"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "北河二 Castor"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "策 Navi"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 msgid "Wurren"
 msgstr ""
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "奎宿九 Mirach"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "奎宿七 Adhil"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "阁道三 Ruchbah"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "壁宿二 Alpheratz"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "土卫六"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "水委一 Achernar"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "天仓四 Baten Kaitos"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "娄宿二 Mesarthim"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "阁道二 Segin"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "娄宿一 Sheratan"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "天大将军一 Almach"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "Almaak"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "娄宿三Hamal"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "刍藁增二 Mira"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "勾陈一  Polaris"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "常陈四 Chara"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "刍藁增二 Mira"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "天苑九 Angetenar"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "天苑六 Azha"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "天园六 Acamar"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "天囷一 Menkar"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "天囷三 Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "大陵五 Algol"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "天阴四 Botein"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "天船三 Mirfak"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "天船三 Mirphak"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "天苑三 Rana"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "天苑三 Rana"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "卷舌增七 Atik"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "昴宿增六 Celaeno"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "昴宿一 Electra"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "昴宿二 Taygeta"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "昴宿四 Maia"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "昴宿三 Asterope"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "昴宿五 Merope"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "昴宿六 Alcyone"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "昴宿增十二 Pleione"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "天苑一 Zaurak"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "卷舌三 Menkib"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "九洲殊口二 Beid"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "九洲殊口增七 Keid"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "毕宿一 Ain"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "毕宿五 Aldebaran"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "参宿增卅六 Thabit"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "欣德深红星 Hind's Crimson Star"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "Almaak"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "海卫六"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "玉井三 Cursa"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "卡普坦星 Kapteyn's Star"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "参宿七 Rigel"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "五车二 Capella"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "参宿五 Bellatrix"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "五车五 Elnath"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "五车五 Alnath"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "厕二 Nihal"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "参宿增卅六 Thabit"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "参宿三 Mintaka"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "厕一 Arneb"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "觜宿一 Meissa"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "Heka"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "参宿二 Alnilam"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "三角形"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "丈人一 Phact"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "参宿一 Alnitak"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "参宿六 Saiph"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "子二 Wazn"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "参宿四 Betelgeuse"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "五车三 Menkalinan"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "孙增一 Furud"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "老人 Canopus"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "红矩形星 Red Rectangle"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "孙增一 Furud"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "军市一 Mirzam"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "井宿一 Tejat"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "老人 Canopus"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "最近的恒星"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "井宿三 Alhena"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "井宿五 Mebsuta"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "天狼 Sirius"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "弧矢七 Adhara"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "天狼增四 Muliphein"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "井宿七 Mekbuda"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "弧矢一 Wezen"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "别尔涅斯135 Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "天樽二 Wasat"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "弧矢二 Aludra"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "南河二 Gomeisa"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "鲁坦星 Luyten's Star"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "北河二 Castor"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "南河三 Procyon"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "北河三 Pollux"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "弧矢增廿二 Naos"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "天社一 Regor"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "水位四 Tegmine"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "海石一 Avior"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "内阶一 Muscida"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "王良三 Ksora"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "鬼宿三  Asellus Borealis"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "鬼宿四 Asellus Australis"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "柳宿增三 Acubens"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "天纪 Suhail"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "南船五 Miaplacidus"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "海石二 Aspidiske"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "室宿一 Markab"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "星宿一 Alphard"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "轩辕八 Alterf"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "星宿四 Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "轩辕十五 Subra"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "轩辕十 Rasalas"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "轩辕十四 Regulus"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "轩辕十一 Adhafera"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "中台一 Tania Borealis"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "轩辕十二 Algieba"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "中台二 Tania Australis"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "伦敦"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 #, fuzzy
 msgid "Chalawan"
 msgstr "木卫二十一"
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "翼宿一 Alkes"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "天璇 Merak"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "拉兰德21185 Lalande 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "天枢 Dubhe"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "西上相 Zosma"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "西次相 Chertan"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "下台二 Alula Australis"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "下台一 Alula Borealis"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "左旗一 Sham"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "上辅 Giausar"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "格式："
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "乔治敦"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "五帝座一 Denebola"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "右执法 Zavijava"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "霍尼亚拉"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "葛罗姆布里吉1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "天玑 Phecda"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "右辖 Alchiba"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "天权 Megrez"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "轸宿一 Gienah"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "左执法 Zaniah"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "十字架二 Acrux"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "轸宿三 Algorab"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "十字架一 Gacrux"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "常陈四 Chara"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "轸宿四 Kraz"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "库楼七"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "太微左垣二 东上相 Porrima"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "十字架三 Mimosa"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "玉衡 Alioth"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "太微左垣三 东次相 Minelauva"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "常陈一 Cor Caroli"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "太微左垣四 东次将 Vindemiatrix"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "开阳 Mizar"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "角宿一 Spica"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "辅 Alcor"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "角宿二 Heze"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "摇光 Alkaid"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "右摄提一 Muphrid"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "马腹一 Hadar"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "右枢 Thuban"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "库楼三 Menkent"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "大角 Arcturus"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "亢宿二 Syrma"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "比邻星 Proxima"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "招搖 Seginus"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "Ceginus"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "梗河一 Izar"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "北极二 帝 Kochab"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "帝(北极二) Kocab"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "氐宿增一 Zuben Elakribi"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "七公增五 Nekkar"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "氐宿四 Zubeneschamali"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "太子Pherkad"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "太子Pherkad"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "七公六 Alkalurops"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "左枢 Edasich"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "贯索三 Nusakan"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "贯索四 Alphecca"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "Zuben Elakrab"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "天市右垣七 蜀 Unukalhai"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "房宿三 Dschubba"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "火星"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "建闭 Jabbah"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "雅典"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "斗一 Cujam"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "心宿二 Antares"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "天市右垣一 河中 Kornephoros"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "列肆二 Marfik"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "三角形三 Atria"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "塔拉瓦"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "太微左垣二 东上相 Porrima"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "土卫八"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "右辖 Alchiba"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "宋 Sabik"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "帝座 Rasalgethi"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "天市左垣一 魏 Sarin"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "天棓三 Rastaban"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "赵 Maasym"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "尾宿九 Lesath"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "天棓增一 Kuma"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "勾陈二 Yildun"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "尾宿八 Shaula"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "侯 Rasalhague"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "尾宿五 Sargas"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "宗正一 Cebalrai"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "观测站"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "天棓一 Grumium"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "天棓四 Eltanin"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "天培四 Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "巴纳德星 Barnard's Star"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "箕宿一 Alnasl"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "箕宿二 Kaus Media"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "箕宿三 Kaus Australis"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "织女增三 Al Athfar"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "斗宿二 Kaus Borealis"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "织女一 Vega"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "渐台二(Sheliak)"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "天钩五 Alderamin"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "斗宿四(Nunki)"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr " 天市左垣七 徐 Alya"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "渐台三 Sulafat"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "斗宿六 Ascella"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "女宿一 Albali"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "天厨一(Altais)"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "辇道二"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "危地马拉城"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "天渊三 Rukbat"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "辇道增七"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "天厨二 Alsafi"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "坎贝尔星 Campbell's Star"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "左旗一 Sham"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "巴黎"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "河鼓三 Tarazed"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "天厨三 Tyl"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "河鼓二 Altair"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "河鼓一 Alshain"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "牛宿二 Algedi"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "河鼓一 Alshain"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "牛宿一 Dabih"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "天津一 Sadr"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "孔雀十一"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "瓠瓜四 Rotanev"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "瓠瓜一 Sualocin"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "天津四 Deneb"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "卢布尔雅那"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "女宿一 Albali"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "箕宿三 Kaus Australis"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "勾陈一  Polaris"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "虚宿二 Kitalpha"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "拉开耶8760 Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "天钩五 Alderamin"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "上卫增一 Alfirk"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "虚宿一 Sadalsuud"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "星座边界"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "垒壁阵三 Nashira"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "螣蛇四 Azelfafage"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "赫歇尔的石榴石星 Herschel's Garnet Star"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "危宿三 Enif"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "垒壁阵四 Deneb Algedi"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "Al Dhanab"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "天钩六 Kurhah"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "危宿一 Sadalmelik"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "鹤一 Alnair"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "危宿二 Biham"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "泣二 Ancha"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "坟墓二 Sadachbia"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "坟墓四 Seat"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "克虑格60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "女宿四 Situla"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "雷电一 Homam"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "离宫四 Matar"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "巴布科克星 Campbell's Star"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "离宫二 Sadalbari"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "羽林军二十六 Skat"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "北落师门 Fomalhaut"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "室宿二 Scheat"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "室宿一 Markab"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "布拉德利3077 Bradley 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "安卡拉"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "少卫增八 Errai"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "银河系"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "大麦哲伦云"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "小麦哲伦云"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "昴星团"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "毕星团"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "鬼星团"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "蜂巢星团"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "马费伊1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "马费伊2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "狮子座A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "六分仪座B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "狮子座I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "六分仪座A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "圆规座"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "霍姆伯格VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "法思703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "杜鹃座47球状星团"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "波江座"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "罗盘座"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "托南钦特拉2球状星团"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: team@celestiaproject.space\n"
-"POT-Creation-Date: 2023-07-27 10:41+0300\n"
+"POT-Creation-Date: 2024-11-10 13:12+0100\n"
 "PO-Revision-Date: 2009-08-10 15:50+0800\n"
 "Last-Translator: A.-L. Chen <alchen@tam.gov.tw>\n"
 "Language-Team: zh_TW, Tryneeds in Taiwan <tryneeds@gmail.com>\n"
@@ -20,358 +20,447 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data.cpp:1
+msgctxt "asterism"
 msgid "Andromeda"
 msgstr "Andromeda 仙女座"
 
 #: data.cpp:2
+msgctxt "asterism"
 msgid "Antlia"
 msgstr "Antlia 唧筒座"
 
 #: data.cpp:3
+msgctxt "asterism"
 msgid "Apus"
 msgstr "Apus 天燕座"
 
 #: data.cpp:4
+msgctxt "asterism"
 msgid "Aquarius"
 msgstr "Aquarius 寶瓶座"
 
 #: data.cpp:5
+msgctxt "asterism"
 msgid "Aquila"
 msgstr "Aquila 天鷹座"
 
 #: data.cpp:6
+msgctxt "asterism"
 msgid "Ara"
 msgstr "Ara 天壇座"
 
 #: data.cpp:7
+msgctxt "asterism"
 msgid "Aries"
 msgstr "Aries 白羊座"
 
 #: data.cpp:8
+msgctxt "asterism"
 msgid "Auriga"
 msgstr "Auriga 御夫座"
 
 #: data.cpp:9
+msgctxt "asterism"
 msgid "Boötes"
 msgstr "Boötes 牧夫座"
 
 #: data.cpp:10
+msgctxt "asterism"
 msgid "Caelum"
 msgstr "Caelum 雕具座"
 
 #: data.cpp:11
+msgctxt "asterism"
 msgid "Camelopardalis"
 msgstr "Camelopardalis 鹿豹座"
 
 #: data.cpp:12
+msgctxt "asterism"
 msgid "Cancer"
 msgstr "Cancer 巨蟹座"
 
 #: data.cpp:13
+msgctxt "asterism"
 msgid "Canes Venatici"
 msgstr "Canes Venatici 獵犬座"
 
 #: data.cpp:14
+msgctxt "asterism"
 msgid "Canis Major"
 msgstr "Canis Major 大犬座"
 
 #: data.cpp:15
+msgctxt "asterism"
 msgid "Canis Minor"
 msgstr "Canis Minor 小犬座"
 
 #: data.cpp:16
+msgctxt "asterism"
 msgid "Capricornus"
 msgstr "Capricornus 摩羯座"
 
 #: data.cpp:17
+msgctxt "asterism"
 msgid "Carina"
 msgstr "Carina 船底座"
 
 #: data.cpp:18
+msgctxt "asterism"
 msgid "Cassiopeia"
 msgstr "Cassiopeia 仙后座"
 
 #: data.cpp:19
+msgctxt "asterism"
 msgid "Centaurus"
 msgstr "Centaurus 半人馬座"
 
 #: data.cpp:20
+msgctxt "asterism"
 msgid "Cepheus"
 msgstr "Cepheus 仙王座"
 
 #: data.cpp:21
+msgctxt "asterism"
 msgid "Cetus"
 msgstr "Cetus 鯨魚座"
 
 #: data.cpp:22
+msgctxt "asterism"
 msgid "Chamaeleon"
 msgstr "Chamaeleon 蝘蜓座"
 
-#: data.cpp:23 data.cpp:1093
+#: data.cpp:23
+msgctxt "asterism"
 msgid "Circinus"
 msgstr "Circinus 圓規座"
 
 #: data.cpp:24
+msgctxt "asterism"
 msgid "Columba"
 msgstr "Columba 天鴿座"
 
 #: data.cpp:25
+msgctxt "asterism"
 msgid "Coma Berenices"
 msgstr "Coma Berenices 后髮座"
 
 #: data.cpp:26
+msgctxt "asterism"
 msgid "Corona Australis"
 msgstr "Corona Australis 南冕座"
 
 #: data.cpp:27
+msgctxt "asterism"
 msgid "Corona Borealis"
 msgstr "Corona Borealis 北冕座"
 
 #: data.cpp:28
+msgctxt "asterism"
 msgid "Corvus"
 msgstr "Corvus 烏鴉座"
 
 #: data.cpp:29
+msgctxt "asterism"
 msgid "Crater"
 msgstr "Crater 隕坑"
 
 #: data.cpp:30
+msgctxt "asterism"
 msgid "Crux"
 msgstr "Crux 南十字座"
 
 #: data.cpp:31
+msgctxt "asterism"
 msgid "Cygnus"
 msgstr "Cygnus 天鵝座"
 
 #: data.cpp:32
+msgctxt "asterism"
 msgid "Delphinus"
 msgstr "Delphinus 海豚座"
 
 #: data.cpp:33
+msgctxt "asterism"
 msgid "Dorado"
 msgstr "Dorado 劍魚座"
 
 #: data.cpp:34
+msgctxt "asterism"
 msgid "Draco"
 msgstr "Draco 天龍座"
 
 #: data.cpp:35
+msgctxt "asterism"
 msgid "Equuleus"
 msgstr "Equuleus 小馬座"
 
-#: data.cpp:36 data.cpp:1099
+#: data.cpp:36
+msgctxt "asterism"
 msgid "Eridanus"
 msgstr "Eridanus 波江座"
 
 #: data.cpp:37
+msgctxt "asterism"
 msgid "Fornax"
 msgstr "Fornax 天爐座"
 
 #: data.cpp:38
+msgctxt "asterism"
 msgid "Gemini"
 msgstr "Gemini 雙子座"
 
 #: data.cpp:39
+msgctxt "asterism"
 msgid "Grus"
 msgstr "Grus 天鶴座"
 
 #: data.cpp:40
+msgctxt "asterism"
 msgid "Hercules"
 msgstr "Hercules 武仙座"
 
 #: data.cpp:41
+msgctxt "asterism"
 msgid "Horologium"
 msgstr "Horologium 時鐘座"
 
-#: data.cpp:42 data.cpp:128
+#: data.cpp:42
+msgctxt "asterism"
 msgid "Hydra"
 msgstr "Hydra 長蛇座"
 
 #: data.cpp:43
+msgctxt "asterism"
 msgid "Hydrus"
 msgstr "Hydrus 水蛇座"
 
 #: data.cpp:44
+msgctxt "asterism"
 msgid "Indus"
 msgstr "Indus 印地安座"
 
 #: data.cpp:45
+msgctxt "asterism"
 msgid "Lacerta"
 msgstr "Lacerta 蝎虎座"
 
 #: data.cpp:46
+msgctxt "asterism"
 msgid "Leo"
 msgstr "Leo 獅子座"
 
 #: data.cpp:47
+msgctxt "asterism"
 msgid "Leo Minor"
 msgstr "Leo Minor 小獅座"
 
 #: data.cpp:48
+msgctxt "asterism"
 msgid "Lepus"
 msgstr "Lepus 天兔座"
 
 #: data.cpp:49
+msgctxt "asterism"
 msgid "Libra"
 msgstr "Libra 天秤座"
 
 #: data.cpp:50
+msgctxt "asterism"
 msgid "Lupus"
 msgstr "Lupus 豺狼座"
 
 #: data.cpp:51
+msgctxt "asterism"
 msgid "Lynx"
 msgstr "Lynx 天貓座"
 
 #: data.cpp:52
+msgctxt "asterism"
 msgid "Lyra"
 msgstr "Lyra 天琴座"
 
 #: data.cpp:53
+msgctxt "asterism"
 msgid "Mensa"
 msgstr "Mensa 山案座"
 
 #: data.cpp:54
+msgctxt "asterism"
 msgid "Microscopium"
 msgstr "Microscopium 顯微鏡座"
 
 #: data.cpp:55
+msgctxt "asterism"
 msgid "Monoceros"
 msgstr "Monoceros 麒麟座"
 
 #: data.cpp:56
+msgctxt "asterism"
 msgid "Musca"
 msgstr "Musca 蒼蠅座"
 
 #: data.cpp:57
+msgctxt "asterism"
 msgid "Norma"
 msgstr "Norma 矩尺座"
 
 #: data.cpp:58
+msgctxt "asterism"
 msgid "Octans"
 msgstr "Octans 南極座"
 
 #: data.cpp:59
+msgctxt "asterism"
 msgid "Ophiuchus"
 msgstr "Ophiuchus 蛇夫座"
 
 #: data.cpp:60
+msgctxt "asterism"
 msgid "Orion"
 msgstr "Orion 獵戶座"
 
 #: data.cpp:61
+msgctxt "asterism"
 msgid "Pavo"
 msgstr "Pavo 孔雀座"
 
 #: data.cpp:62
+msgctxt "asterism"
 msgid "Pegasus"
 msgstr "Pegasus 飛馬座"
 
 #: data.cpp:63
+msgctxt "asterism"
 msgid "Perseus"
 msgstr "Perseus 英仙座"
 
 #: data.cpp:64
+msgctxt "asterism"
 msgid "Phoenix"
 msgstr "Phoenix 鳳凰座"
 
 #: data.cpp:65
+msgctxt "asterism"
 msgid "Pictor"
 msgstr "Pictor 繪架座"
 
 #: data.cpp:66
+msgctxt "asterism"
 msgid "Pisces"
 msgstr "Pisces 雙魚座"
 
 #: data.cpp:67
+msgctxt "asterism"
 msgid "Piscis Austrinus"
 msgstr "Piscis Austrinus 南魚座"
 
 #: data.cpp:68
+msgctxt "asterism"
 msgid "Puppis"
 msgstr "Puppis 船尾座"
 
-#: data.cpp:69 data.cpp:1100
+#: data.cpp:69
+msgctxt "asterism"
 msgid "Pyxis"
 msgstr "Pyxis 羅盤座"
 
 #: data.cpp:70
+msgctxt "asterism"
 msgid "Reticulum"
 msgstr "Reticulum 網罟座"
 
 #: data.cpp:71
+msgctxt "asterism"
 msgid "Sagitta"
 msgstr "Sagitta 天箭座"
 
 #: data.cpp:72
+msgctxt "asterism"
 msgid "Sagittarius"
 msgstr "Sagittarius 人馬座"
 
 #: data.cpp:73
+msgctxt "asterism"
 msgid "Scorpius"
 msgstr "Scorpius 天蝎座"
 
 #: data.cpp:74
+msgctxt "asterism"
 msgid "Sculptor"
 msgstr "Sculptor 玉夫座"
 
 #: data.cpp:75
+msgctxt "asterism"
 msgid "Scutum"
 msgstr "Scutum 盾牌座"
 
 #: data.cpp:76
+msgctxt "asterism"
 msgid "Serpens Caput"
 msgstr "Serpens Caput 巨蛇座(頭)"
 
 #: data.cpp:77
+msgctxt "asterism"
 msgid "Serpens Cauda"
 msgstr "Serpens Cauda 巨蛇座(尾)"
 
 #: data.cpp:78
+msgctxt "asterism"
 msgid "Sextans"
 msgstr "Sextans 六分儀座"
 
 #: data.cpp:79
+msgctxt "asterism"
 msgid "Taurus"
 msgstr "Taurus 金牛座"
 
 #: data.cpp:80
+msgctxt "asterism"
 msgid "Telescopium"
 msgstr "Telescopium 望遠鏡座"
 
 #: data.cpp:81
+msgctxt "asterism"
 msgid "Triangulum"
 msgstr "Triangulum 三角座"
 
 #: data.cpp:82
+msgctxt "asterism"
 msgid "Triangulum Australe"
 msgstr "Triangulum Australe 南三角座"
 
 #: data.cpp:83
+msgctxt "asterism"
 msgid "Tucana"
 msgstr "Tucana 杜鵑座"
 
 #: data.cpp:84
+msgctxt "asterism"
 msgid "Ursa Major"
 msgstr "Ursa Major 大熊座"
 
 #: data.cpp:85
+msgctxt "asterism"
 msgid "Ursa Minor"
 msgstr "Ursa Minor 小熊座"
 
 #: data.cpp:86
+msgctxt "asterism"
 msgid "Vela"
 msgstr "Vela  船帆座"
 
 #: data.cpp:87
+msgctxt "asterism"
 msgid "Virgo"
 msgstr "Virgo 室女座"
 
 #: data.cpp:88
+msgctxt "asterism"
 msgid "Volans"
 msgstr "Volans 飛魚座"
 
 #: data.cpp:89
+msgctxt "asterism"
 msgid "Vulpecula"
 msgstr "Vulpecula 狐狸座"
 
@@ -527,3964 +616,4017 @@ msgstr ""
 msgid "Kerberos"
 msgstr ""
 
+#: data.cpp:128
+#, fuzzy
+msgid "Hydra"
+msgstr "Hydra 長蛇座"
+
 #: data.cpp:129
 msgid "Ceres"
 msgstr ""
 
 #: data.cpp:130
+msgid "Orcus-Vanth"
+msgstr ""
+
+#: data.cpp:131
+msgid "Orcus"
+msgstr ""
+
+#: data.cpp:132
+msgid "Vanth"
+msgstr ""
+
+#: data.cpp:133
 #, fuzzy
 msgid "Haumea"
 msgstr "諾美亞"
 
-#: data.cpp:131
+#: data.cpp:134
 #, fuzzy
 msgid "Namaka"
 msgstr "巴馬科"
 
-#: data.cpp:132
+#: data.cpp:135
 msgid "Hi'iaka"
 msgstr ""
 
-#: data.cpp:133
-msgid "Makemake"
-msgstr ""
-
-#: data.cpp:134
-msgid "S 2015 (136472) 1"
-msgstr ""
-
-#: data.cpp:135
-msgid "Eris"
-msgstr ""
-
 #: data.cpp:136
-msgid "Dysnomia"
+msgid "Quaoar"
 msgstr ""
 
 #: data.cpp:137
-msgid "Metis"
+msgid "Weywot"
 msgstr ""
 
 #: data.cpp:138
-msgid "Adrastea"
+msgid "Makemake"
 msgstr ""
 
 #: data.cpp:139
-msgid "Amalthea"
-msgstr "木衛五(Amalthea)"
+msgid "S 2015 (136472) 1"
+msgstr ""
 
 #: data.cpp:140
-msgid "Thebe"
+msgid "Gonggong"
 msgstr ""
 
 #: data.cpp:141
-msgid "Themisto"
-msgstr ""
+#, fuzzy
+msgid "Xiangliu"
+msgstr "Triangulum 三角座"
 
 #: data.cpp:142
-msgid "Leda"
+msgid "Eris"
 msgstr ""
 
 #: data.cpp:143
-msgid "Ersa"
+msgid "Dysnomia"
 msgstr ""
 
 #: data.cpp:144
-#, fuzzy
-msgid "Pandia"
-msgstr "土衛十七(Pandora)"
+msgid "Sedna"
+msgstr ""
 
 #: data.cpp:145
-msgid "Himalia"
+msgid "Metis"
 msgstr ""
 
 #: data.cpp:146
-msgid "Lysithea"
+msgid "Adrastea"
 msgstr ""
 
 #: data.cpp:147
-msgid "Elara"
-msgstr ""
+msgid "Amalthea"
+msgstr "木衛五(Amalthea)"
 
 #: data.cpp:148
-#, fuzzy
-msgid "Dia"
-msgstr "土司空 (Diphda)"
+msgid "Thebe"
+msgstr ""
 
 #: data.cpp:149
-msgid "Carpo"
+msgid "Themisto"
 msgstr ""
 
 #: data.cpp:150
-msgid "Valetudo"
+msgid "Leda"
 msgstr ""
 
 #: data.cpp:151
-msgid "Euporie"
+msgid "Ersa"
 msgstr ""
 
 #: data.cpp:152
 #, fuzzy
-msgid "Jupiter LV"
-msgstr "木星"
+msgid "Pandia"
+msgstr "土衛十七(Pandora)"
 
 #: data.cpp:153
-msgid "Eupheme"
+msgid "Himalia"
 msgstr ""
 
 #: data.cpp:154
-msgid "S 2003 J 16"
+msgid "Lysithea"
 msgstr ""
 
 #: data.cpp:155
+msgid "Elara"
+msgstr ""
+
+#: data.cpp:156
+#, fuzzy
+msgid "Dia"
+msgstr "土司空 (Diphda)"
+
+#: data.cpp:157
+msgid "Carpo"
+msgstr ""
+
+#: data.cpp:158
+msgid "Valetudo"
+msgstr ""
+
+#: data.cpp:159
+msgid "Euporie"
+msgstr ""
+
+#: data.cpp:160
+#, fuzzy
+msgid "Jupiter LV"
+msgstr "木星"
+
+#: data.cpp:161
+msgid "Eupheme"
+msgstr ""
+
+#: data.cpp:162
+msgid "S 2003 J 16"
+msgstr ""
+
+#: data.cpp:163
 #, fuzzy
 msgid "Jupiter LXVIII"
 msgstr "木星"
 
-#: data.cpp:156
+#: data.cpp:164
 msgid "Ananke"
 msgstr ""
 
-#: data.cpp:157
+#: data.cpp:165
 msgid "Harpalyke"
 msgstr ""
 
-#: data.cpp:158
-msgid "S 2003 J 12"
-msgstr ""
-
-#: data.cpp:159
-#, fuzzy
-msgid "Jupiter LII"
-msgstr "木星"
-
-#: data.cpp:160
-msgid "Praxidike"
-msgstr ""
-
-#: data.cpp:161
-msgid "S 2003 J 2"
-msgstr ""
-
-#: data.cpp:162
-msgid "Euanthe"
-msgstr ""
-
-#: data.cpp:163
-msgid "Orthosie"
-msgstr ""
-
-#: data.cpp:164
-#, fuzzy
-msgid "Jupiter LXIV"
-msgstr "木星"
-
-#: data.cpp:165
-msgid "Iocaste"
-msgstr ""
-
 #: data.cpp:166
-msgid "Mneme"
+msgid "S 2003 J 12"
 msgstr ""
 
 #: data.cpp:167
 #, fuzzy
+msgid "Jupiter LII"
+msgstr "木星"
+
+#: data.cpp:168
+msgid "Praxidike"
+msgstr ""
+
+#: data.cpp:169
+msgid "S 2003 J 2"
+msgstr ""
+
+#: data.cpp:170
+msgid "Euanthe"
+msgstr ""
+
+#: data.cpp:171
+msgid "Orthosie"
+msgstr ""
+
+#: data.cpp:172
+#, fuzzy
+msgid "Jupiter LXIV"
+msgstr "木星"
+
+#: data.cpp:173
+msgid "Iocaste"
+msgstr ""
+
+#: data.cpp:174
+msgid "Mneme"
+msgstr ""
+
+#: data.cpp:175
+#, fuzzy
 msgid "Thyone"
 msgstr "昴宿六 (Alcyone)"
 
-#: data.cpp:168
+#: data.cpp:176
 #, fuzzy
 msgid "Jupiter LIV"
 msgstr "木星"
 
-#: data.cpp:169
+#: data.cpp:177
 msgid "Thelxinoe"
 msgstr ""
 
-#: data.cpp:170
+#: data.cpp:178
 msgid "Helike"
 msgstr ""
 
-#: data.cpp:171
+#: data.cpp:179
 msgid "Hermippe"
 msgstr ""
 
-#: data.cpp:172
+#: data.cpp:180
 msgid "Philophrosyne"
 msgstr ""
 
-#: data.cpp:173
+#: data.cpp:181
 #, fuzzy
 msgid "Jupiter LVI"
 msgstr "木星"
 
-#: data.cpp:174
+#: data.cpp:182
 #, fuzzy
 msgid "Kallichore"
 msgstr "木衛四(Callisto)"
 
-#: data.cpp:175
+#: data.cpp:183
 msgid "Chaldene"
 msgstr ""
 
-#: data.cpp:176
-msgid "Arche"
-msgstr ""
-
-#: data.cpp:177
-#, fuzzy
-msgid "Jupiter LXIX"
-msgstr "木星"
-
-#: data.cpp:178
-msgid "Kale"
-msgstr ""
-
-#: data.cpp:179
-#, fuzzy
-msgid "Jupiter LXXII"
-msgstr "木星"
-
-#: data.cpp:180
-#, fuzzy
-msgid "Jupiter LXI"
-msgstr "木星"
-
-#: data.cpp:181
-msgid "Cyllene"
-msgstr ""
-
-#: data.cpp:182
-msgid "Taygete"
-msgstr ""
-
-#: data.cpp:183
-#, fuzzy
-msgid "Jupiter LXX"
-msgstr "木星"
-
 #: data.cpp:184
-msgid "Eurydome"
+msgid "Arche"
 msgstr ""
 
 #: data.cpp:185
 #, fuzzy
-msgid "Jupiter LI"
+msgid "Jupiter LXIX"
 msgstr "木星"
 
 #: data.cpp:186
-msgid "S 2003 J 9"
+msgid "Kale"
 msgstr ""
 
 #: data.cpp:187
 #, fuzzy
-msgid "Jupiter LXVII"
+msgid "Jupiter LXXII"
 msgstr "木星"
 
 #: data.cpp:188
-msgid "Aitne"
-msgstr ""
+#, fuzzy
+msgid "Jupiter LXI"
+msgstr "木星"
 
 #: data.cpp:189
-msgid "Carme"
+msgid "Cyllene"
 msgstr ""
 
 #: data.cpp:190
+msgid "Taygete"
+msgstr ""
+
+#: data.cpp:191
+#, fuzzy
+msgid "Jupiter LXX"
+msgstr "木星"
+
+#: data.cpp:192
+msgid "Eurydome"
+msgstr ""
+
+#: data.cpp:193
+#, fuzzy
+msgid "Jupiter LI"
+msgstr "木星"
+
+#: data.cpp:194
+msgid "S 2003 J 9"
+msgstr ""
+
+#: data.cpp:195
+#, fuzzy
+msgid "Jupiter LXVII"
+msgstr "木星"
+
+#: data.cpp:196
+msgid "Aitne"
+msgstr ""
+
+#: data.cpp:197
+msgid "Carme"
+msgstr ""
+
+#: data.cpp:198
 #, fuzzy
 msgid "Callirrhoe"
 msgstr "木衛四(Callisto)"
 
-#: data.cpp:191
+#: data.cpp:199
 msgid "Erinome"
 msgstr ""
 
-#: data.cpp:192
+#: data.cpp:200
 msgid "Pasithee"
 msgstr ""
 
-#: data.cpp:193
+#: data.cpp:201
 msgid "Eirene"
 msgstr ""
 
-#: data.cpp:194
+#: data.cpp:202
 msgid "S 2003 J 24"
 msgstr ""
 
-#: data.cpp:195
+#: data.cpp:203
 msgid "Sinope"
 msgstr ""
 
-#: data.cpp:196
+#: data.cpp:204
 msgid "Eukelade"
 msgstr ""
 
-#: data.cpp:197
+#: data.cpp:205
 msgid "Isonoe"
 msgstr ""
 
-#: data.cpp:198
+#: data.cpp:206
 msgid "S 2003 J 4"
 msgstr ""
 
-#: data.cpp:199
+#: data.cpp:207
 msgid "Autonoe"
 msgstr ""
 
-#: data.cpp:200
+#: data.cpp:208
 #, fuzzy
 msgid "Herse"
 msgstr "精簡"
 
-#: data.cpp:201
+#: data.cpp:209
 msgid "Pasiphae"
 msgstr ""
 
-#: data.cpp:202
+#: data.cpp:210
 msgid "S 2003 J 10"
 msgstr ""
 
-#: data.cpp:203
+#: data.cpp:211
 msgid "Kore"
 msgstr ""
 
-#: data.cpp:204
+#: data.cpp:212
 #, fuzzy
 msgid "Jupiter LXIII"
 msgstr "木星"
 
-#: data.cpp:205
+#: data.cpp:213
 msgid "Hegemone"
 msgstr ""
 
-#: data.cpp:206
+#: data.cpp:214
 msgid "Sponde"
 msgstr ""
 
-#: data.cpp:207
+#: data.cpp:215
 msgid "Kalyke"
 msgstr ""
 
-#: data.cpp:208
+#: data.cpp:216
 msgid "Aoede"
 msgstr ""
 
-#: data.cpp:209
+#: data.cpp:217
 msgid "Megaclite"
 msgstr ""
 
-#: data.cpp:210
+#: data.cpp:218
 msgid "S 2003 J 23"
 msgstr ""
 
-#: data.cpp:211
+#: data.cpp:219
 #, fuzzy
 msgid "Jupiter LXVI"
 msgstr "木星"
 
-#: data.cpp:212
+#: data.cpp:220
 #, fuzzy
 msgid "Jupiter LIX"
 msgstr "木星"
 
-#: data.cpp:213
+#: data.cpp:221
 msgid "S 2009 S 1"
 msgstr ""
 
-#: data.cpp:214
+#: data.cpp:222
 #, fuzzy
 msgid "Pan"
 msgstr "1"
 
-#: data.cpp:215
+#: data.cpp:223
 msgid "Daphnis"
 msgstr ""
 
-#: data.cpp:216
+#: data.cpp:224
 msgid "Atlas"
 msgstr ""
 
-#: data.cpp:217
+#: data.cpp:225
 msgid "Prometheus"
 msgstr "土衛十六(Prometheus)"
 
-#: data.cpp:218
+#: data.cpp:226
 msgid "Pandora"
 msgstr "土衛十七(Pandora)"
 
-#: data.cpp:219
+#: data.cpp:227
 msgid "Epimetheus"
 msgstr "土衛十一(Epimetheus)"
 
-#: data.cpp:220
+#: data.cpp:228
 msgid "Janus"
 msgstr "土衛十(Janus)"
 
-#: data.cpp:221
+#: data.cpp:229
 msgid "Aegaeon"
 msgstr ""
 
-#: data.cpp:222
+#: data.cpp:230
 msgid "Methone"
 msgstr ""
 
-#: data.cpp:223
+#: data.cpp:231
 msgid "Anthe"
 msgstr ""
 
-#: data.cpp:224
-msgid "Pallene"
-msgstr ""
-
-#: data.cpp:225
-#, fuzzy
-msgid "Telesto"
-msgstr "Celestia"
-
-#: data.cpp:226
-msgid "Calypso"
-msgstr ""
-
-#: data.cpp:227
-msgid "Polydeuces"
-msgstr ""
-
-#: data.cpp:228
-msgid "Helene"
-msgstr ""
-
-#: data.cpp:229
-msgid "S 2019 S 1"
-msgstr ""
-
-#: data.cpp:230
-msgid "Kiviuq"
-msgstr ""
-
-#: data.cpp:231
-msgid "Ijiraq"
-msgstr ""
-
 #: data.cpp:232
-msgid "Paaliaq"
+msgid "Pallene"
 msgstr ""
 
 #: data.cpp:233
 #, fuzzy
-msgid "Skathi"
-msgstr "羽林軍二十六 (Skat)"
+msgid "Telesto"
+msgstr "Celestia"
 
 #: data.cpp:234
-msgid "S 2004 S 37"
+msgid "Calypso"
 msgstr ""
 
 #: data.cpp:235
-msgid "S 2007 S 2"
+msgid "Polydeuces"
 msgstr ""
 
 #: data.cpp:236
+msgid "Helene"
+msgstr ""
+
+#: data.cpp:237
+msgid "S 2019 S 1"
+msgstr ""
+
+#: data.cpp:238
+msgid "Kiviuq"
+msgstr ""
+
+#: data.cpp:239
+msgid "Ijiraq"
+msgstr ""
+
+#: data.cpp:240
+msgid "Paaliaq"
+msgstr ""
+
+#: data.cpp:241
+#, fuzzy
+msgid "Skathi"
+msgstr "羽林軍二十六 (Skat)"
+
+#: data.cpp:242
+msgid "S 2004 S 37"
+msgstr ""
+
+#: data.cpp:243
+msgid "S 2007 S 2"
+msgstr ""
+
+#: data.cpp:244
 #, fuzzy
 msgid "Albiorix"
 msgstr "輦道增七 (Albireo)"
 
-#: data.cpp:237
+#: data.cpp:245
 msgid "Bebhionn"
 msgstr ""
 
-#: data.cpp:238
+#: data.cpp:246
 msgid "S 2004 S 31"
 msgstr ""
 
-#: data.cpp:239
+#: data.cpp:247
 #, fuzzy
 msgid "Saturn LX"
 msgstr "土星"
 
-#: data.cpp:240
+#: data.cpp:248
 msgid "Skoll"
 msgstr ""
 
-#: data.cpp:241
+#: data.cpp:249
 msgid "Tarqeq"
 msgstr ""
 
-#: data.cpp:242
+#: data.cpp:250
 msgid "Tarvos"
 msgstr ""
 
-#: data.cpp:243
+#: data.cpp:251
 msgid "Erriapus"
 msgstr ""
 
-#: data.cpp:244
+#: data.cpp:252
 msgid "Siarnaq"
 msgstr ""
 
-#: data.cpp:245
+#: data.cpp:253
 msgid "Greip"
 msgstr ""
 
-#: data.cpp:246
+#: data.cpp:254
 msgid "Hyrrokkin"
 msgstr ""
 
-#: data.cpp:247
+#: data.cpp:255
 msgid "Mundilfari"
 msgstr ""
 
-#: data.cpp:248
+#: data.cpp:256
 msgid "S 2006 S 1"
 msgstr ""
 
-#: data.cpp:249
+#: data.cpp:257
 msgid "S 2004 S 13"
 msgstr ""
 
-#: data.cpp:250
+#: data.cpp:258
 msgid "S 2007 S 3"
 msgstr ""
 
-#: data.cpp:251
+#: data.cpp:259
 msgid "Suttungr"
 msgstr ""
 
-#: data.cpp:252
+#: data.cpp:260
 msgid "Gridr"
 msgstr ""
 
-#: data.cpp:253
+#: data.cpp:261
 msgid "Narvi"
 msgstr ""
 
-#: data.cpp:254
+#: data.cpp:262
 msgid "Jarnsaxa"
 msgstr ""
 
-#: data.cpp:255
+#: data.cpp:263
 msgid "S 2004 S 12"
 msgstr ""
 
-#: data.cpp:256
+#: data.cpp:264
 msgid "Bergelmir"
 msgstr ""
 
-#: data.cpp:257
+#: data.cpp:265
 msgid "Eggther"
 msgstr ""
 
-#: data.cpp:258
+#: data.cpp:266
 msgid "S 2004 S 17"
 msgstr ""
 
-#: data.cpp:259
+#: data.cpp:267
 msgid "Hati"
 msgstr ""
 
-#: data.cpp:260
+#: data.cpp:268
 msgid "Farbauti"
 msgstr ""
 
-#: data.cpp:261
+#: data.cpp:269
 msgid "Thrymr"
 msgstr ""
 
-#: data.cpp:262
+#: data.cpp:270
 msgid "S 2004 S 7"
 msgstr ""
 
-#: data.cpp:263
+#: data.cpp:271
 msgid "Beli"
 msgstr ""
 
-#: data.cpp:264
+#: data.cpp:272
 msgid "Bestla"
 msgstr ""
 
-#: data.cpp:265
+#: data.cpp:273
 msgid "Gerd"
 msgstr ""
 
-#: data.cpp:266
+#: data.cpp:274
 msgid "Angrboda"
 msgstr ""
 
-#: data.cpp:267
+#: data.cpp:275
 msgid "Gunnlod"
 msgstr ""
 
-#: data.cpp:268
+#: data.cpp:276
 msgid "Aegir"
 msgstr ""
 
-#: data.cpp:269
+#: data.cpp:277
 msgid "S 2006 S 3"
 msgstr ""
 
-#: data.cpp:270
+#: data.cpp:278
 msgid "Alvaldi"
 msgstr ""
 
-#: data.cpp:271
+#: data.cpp:279
 msgid "Kari"
 msgstr ""
 
-#: data.cpp:272
+#: data.cpp:280
 msgid "Skrymir"
 msgstr ""
 
-#: data.cpp:273
+#: data.cpp:281
 msgid "S 2004 S 28"
 msgstr ""
 
-#: data.cpp:274
+#: data.cpp:282
 msgid "Fenrir"
 msgstr ""
 
-#: data.cpp:275
+#: data.cpp:283
 msgid "Loge"
 msgstr ""
 
-#: data.cpp:276
+#: data.cpp:284
 msgid "S 2004 S 21"
 msgstr ""
 
-#: data.cpp:277
+#: data.cpp:285
 msgid "Geirrod"
 msgstr ""
 
-#: data.cpp:278
+#: data.cpp:286
 msgid "S 2004 S 24"
 msgstr ""
 
-#: data.cpp:279
+#: data.cpp:287
 msgid "S 2004 S 36"
 msgstr ""
 
-#: data.cpp:280
+#: data.cpp:288
 msgid "Ymir"
 msgstr ""
 
-#: data.cpp:281
+#: data.cpp:289
 msgid "Surtur"
 msgstr ""
 
-#: data.cpp:282
+#: data.cpp:290
 msgid "S 2004 S 39"
 msgstr ""
 
-#: data.cpp:283
+#: data.cpp:291
 #, fuzzy
 msgid "Saturn LXIV"
 msgstr "土星"
 
-#: data.cpp:284
-msgid "Thiazzi"
-msgstr ""
-
-#: data.cpp:285
-#, fuzzy
-msgid "Fornjot"
-msgstr "Fornax 天爐座"
-
-#: data.cpp:286
-#, fuzzy
-msgid "Saturn LVIII"
-msgstr "土星"
-
-#: data.cpp:287
-msgid "Cordelia"
-msgstr ""
-
-#: data.cpp:288
-msgid "Ophelia"
-msgstr ""
-
-#: data.cpp:289
-msgid "Bianca"
-msgstr ""
-
-#: data.cpp:290
-msgid "Cressida"
-msgstr ""
-
-#: data.cpp:291
-msgid "Desdemona"
-msgstr ""
-
 #: data.cpp:292
-msgid "Juliet"
+msgid "Thiazzi"
 msgstr ""
 
 #: data.cpp:293
 #, fuzzy
-msgid "Portia"
-msgstr "維拉港"
+msgid "Fornjot"
+msgstr "Fornax 天爐座"
 
 #: data.cpp:294
-msgid "Rosalind"
-msgstr ""
+#, fuzzy
+msgid "Saturn LVIII"
+msgstr "土星"
 
 #: data.cpp:295
-msgid "Cupid"
+msgid "Cordelia"
 msgstr ""
 
 #: data.cpp:296
-msgid "Belinda"
+msgid "Ophelia"
 msgstr ""
 
 #: data.cpp:297
-msgid "Perdita"
+msgid "Bianca"
 msgstr ""
 
 #: data.cpp:298
-msgid "Puck"
+msgid "Cressida"
 msgstr ""
 
 #: data.cpp:299
+msgid "Desdemona"
+msgstr ""
+
+#: data.cpp:300
+msgid "Juliet"
+msgstr ""
+
+#: data.cpp:301
+#, fuzzy
+msgid "Portia"
+msgstr "維拉港"
+
+#: data.cpp:302
+msgid "Rosalind"
+msgstr ""
+
+#: data.cpp:303
+msgid "Cupid"
+msgstr ""
+
+#: data.cpp:304
+msgid "Belinda"
+msgstr ""
+
+#: data.cpp:305
+msgid "Perdita"
+msgstr ""
+
+#: data.cpp:306
+msgid "Puck"
+msgstr ""
+
+#: data.cpp:307
 #, fuzzy
 msgid "Mab"
 msgstr "3"
 
-#: data.cpp:300
+#: data.cpp:308
 msgid "Francisco"
 msgstr ""
 
-#: data.cpp:301
+#: data.cpp:309
 msgid "Caliban"
 msgstr ""
 
-#: data.cpp:302
+#: data.cpp:310
 msgid "Stephano"
 msgstr ""
 
-#: data.cpp:303
+#: data.cpp:311
 msgid "Trinculo"
 msgstr ""
 
-#: data.cpp:304
+#: data.cpp:312
 msgid "Sycorax"
 msgstr ""
 
-#: data.cpp:305
+#: data.cpp:313
 msgid "Margaret"
 msgstr ""
 
-#: data.cpp:306
+#: data.cpp:314
 msgid "Prospero"
 msgstr ""
 
-#: data.cpp:307
+#: data.cpp:315
 msgid "Setebos"
 msgstr ""
 
-#: data.cpp:308
+#: data.cpp:316
 msgid "Ferdinand"
 msgstr ""
 
-#: data.cpp:309
+#: data.cpp:317
 msgid "Naiad"
 msgstr ""
 
-#: data.cpp:310
+#: data.cpp:318
 msgid "Thalassa"
 msgstr ""
 
-#: data.cpp:311
+#: data.cpp:319
 msgid "Despina"
 msgstr ""
 
-#: data.cpp:312
+#: data.cpp:320
 #, fuzzy
 msgid "Galatea"
 msgstr "星系"
 
-#: data.cpp:313
+#: data.cpp:321
 msgid "Larissa"
 msgstr "海衛七(Larissa)"
 
-#: data.cpp:314
+#: data.cpp:322
 msgid "Hippocamp"
 msgstr ""
 
-#: data.cpp:315
+#: data.cpp:323
 #, fuzzy
 msgid "Halimede"
 msgstr "木衛三(Ganymede)"
 
-#: data.cpp:316
+#: data.cpp:324
 #, fuzzy
 msgid "Sao"
 msgstr "太陽"
 
-#: data.cpp:317
+#: data.cpp:325
 msgid "Laomedeia"
 msgstr ""
 
-#: data.cpp:318
+#: data.cpp:326
 msgid "Psamathe"
 msgstr ""
 
-#: data.cpp:319
+#: data.cpp:327
 msgid "Neso"
 msgstr ""
 
-#: data.cpp:320
+#: data.cpp:328
 msgid "NORTH AMERICA"
 msgstr "北美洲"
 
-#: data.cpp:321
+#: data.cpp:329
 msgid "SOUTH AMERICA"
 msgstr "南美洲"
 
-#: data.cpp:322
+#: data.cpp:330
 msgid "EURASIA"
 msgstr "歐亞大陸"
 
-#: data.cpp:323
+#: data.cpp:331
 msgid "AFRICA"
 msgstr "非洲"
 
-#: data.cpp:324
+#: data.cpp:332
 msgid "AUSTRALIA"
 msgstr "澳大利亞"
 
-#: data.cpp:325
+#: data.cpp:333
 msgid "ANTARCTICA"
 msgstr "南極洲"
 
-#: data.cpp:326
+#: data.cpp:334
 msgid "NORTH ATLANTIC OCEAN"
 msgstr "北大西洋"
 
-#: data.cpp:327
+#: data.cpp:335
 msgid "SOUTH ATLANTIC OCEAN"
 msgstr "南大西洋"
 
-#: data.cpp:328
+#: data.cpp:336
 msgid "NORTH PACIFIC OCEAN"
 msgstr "北太平洋"
 
-#: data.cpp:329
+#: data.cpp:337
 msgid "SOUTH PACIFIC OCEAN"
 msgstr "南太平洋"
 
-#: data.cpp:330
+#: data.cpp:338
 msgid "INDIAN OCEAN"
 msgstr "印度洋"
 
-#: data.cpp:331
+#: data.cpp:339
 msgid "ARCTIC OCEAN"
 msgstr "北極海"
 
-#: data.cpp:332
+#: data.cpp:340
 msgid "Abu Dhabi"
 msgstr "阿布達比"
 
-#: data.cpp:333
+#: data.cpp:341
 msgid "Abuja"
 msgstr "阿布札"
 
-#: data.cpp:334
+#: data.cpp:342
 msgid "Accra"
 msgstr "阿克拉"
 
-#: data.cpp:335
+#: data.cpp:343
 msgid "Adamstown"
 msgstr "亞當斯鎮"
 
-#: data.cpp:336
+#: data.cpp:344
 msgid "Addis Ababa"
 msgstr "阿迪斯阿貝巴"
 
-#: data.cpp:337
+#: data.cpp:345
 msgid "Algiers"
 msgstr "阿爾及爾"
 
-#: data.cpp:338
+#: data.cpp:346
 msgid "Alofi"
 msgstr "亞羅菲"
 
-#: data.cpp:339
+#: data.cpp:347
 msgid "Amman"
 msgstr "安曼"
 
-#: data.cpp:340
+#: data.cpp:348
 msgid "Amsterdam"
 msgstr "阿姆斯特丹"
 
-#: data.cpp:341
+#: data.cpp:349
 msgid "Andorra la Vella"
 msgstr "安道爾"
 
-#: data.cpp:342
+#: data.cpp:350
 msgid "Ankara"
 msgstr "安哥拉"
 
-#: data.cpp:343
+#: data.cpp:351
 msgid "Antananarivo"
 msgstr "Antananarivo"
 
-#: data.cpp:344
+#: data.cpp:352
 msgid "Apia"
 msgstr "亞庇"
 
-#: data.cpp:345
+#: data.cpp:353
 msgid "Ashgabat"
 msgstr "Ashgabat"
 
-#: data.cpp:346
+#: data.cpp:354
 msgid "Asmara"
 msgstr "阿斯馬拉"
 
-#: data.cpp:347
+#: data.cpp:355
 msgid "Astana"
 msgstr ""
 
-#: data.cpp:348
+#: data.cpp:356
 msgid "Asuncion"
 msgstr "亞松森"
 
-#: data.cpp:349
+#: data.cpp:357
 msgid "Athens"
 msgstr "雅典"
 
-#: data.cpp:350
+#: data.cpp:358
 msgid "Avarua"
 msgstr "阿瓦路亞"
 
-#: data.cpp:351
+#: data.cpp:359
 msgid "Baghdad"
 msgstr "巴格達"
 
-#: data.cpp:352
+#: data.cpp:360
 msgid "Baku"
 msgstr "巴庫"
 
-#: data.cpp:353
+#: data.cpp:361
 msgid "Bamako"
 msgstr "巴馬科"
 
-#: data.cpp:354
+#: data.cpp:362
 msgid "Bandar Seri Begawan"
 msgstr "斯里巴卡旺"
 
-#: data.cpp:355
+#: data.cpp:363
 msgid "Bangkok"
 msgstr "曼谷"
 
-#: data.cpp:356
+#: data.cpp:364
 msgid "Bangui"
 msgstr "班基"
 
-#: data.cpp:357
+#: data.cpp:365
 msgid "Banjul"
 msgstr "斑竹"
 
-#: data.cpp:358
+#: data.cpp:366
 msgid "Basse-Terre"
 msgstr "巴士地"
 
-#: data.cpp:359
+#: data.cpp:367
 msgid "Basseterre"
 msgstr "Basseterre"
 
-#: data.cpp:360
+#: data.cpp:368
 msgid "Beijing"
 msgstr "北京"
 
-#: data.cpp:361
+#: data.cpp:369
 msgid "Beirut"
 msgstr "貝魯特"
 
-#: data.cpp:362
+#: data.cpp:370
 msgid "Belgrade"
 msgstr "貝爾格萊德"
 
-#: data.cpp:363
+#: data.cpp:371
 msgid "Belmopan"
 msgstr "貝爾墨邦"
 
-#: data.cpp:364
+#: data.cpp:372
 msgid "Berlin"
 msgstr "柏林"
 
-#: data.cpp:365
+#: data.cpp:373
 msgid "Bern"
 msgstr "伯恩"
 
-#: data.cpp:366
+#: data.cpp:374
 msgid "Bishkek"
 msgstr "Bishkek"
 
-#: data.cpp:367
+#: data.cpp:375
 msgid "Bissau"
 msgstr "比索"
 
-#: data.cpp:368
+#: data.cpp:376
 msgid "Bloemfontein"
 msgstr "布隆泉"
 
-#: data.cpp:369
+#: data.cpp:377
 msgid "Bogota"
 msgstr "波哥大"
 
-#: data.cpp:370
+#: data.cpp:378
 msgid "Brasilia"
 msgstr "巴西利亞"
 
-#: data.cpp:371
+#: data.cpp:379
 msgid "Bratislava"
 msgstr "布拉提拉瓦"
 
-#: data.cpp:372
+#: data.cpp:380
 msgid "Brazzaville"
 msgstr "布拉薩市"
 
-#: data.cpp:373
+#: data.cpp:381
 msgid "Bridgetown"
 msgstr "橋鎮"
 
-#: data.cpp:374
+#: data.cpp:382
 msgid "Brussels"
 msgstr "布魯塞爾"
 
-#: data.cpp:375
+#: data.cpp:383
 msgid "Bucharest"
 msgstr "布加勒斯"
 
-#: data.cpp:376
+#: data.cpp:384
 msgid "Budapest"
 msgstr "布達佩斯"
 
-#: data.cpp:377
+#: data.cpp:385
 msgid "Buenos Aires"
 msgstr "布宜諾賽利斯"
 
-#: data.cpp:378
+#: data.cpp:386
 msgid "Bujumbura"
 msgstr "布松布拉"
 
-#: data.cpp:379
+#: data.cpp:387
 msgid "Cairo"
 msgstr "開羅"
 
-#: data.cpp:380
+#: data.cpp:388
 msgid "Canberra"
 msgstr "坎培拉"
 
-#: data.cpp:381
+#: data.cpp:389
 msgid "Cape Town"
 msgstr "開普頓"
 
-#: data.cpp:382
+#: data.cpp:390
 msgid "Caracas"
 msgstr "卡拉卡斯"
 
-#: data.cpp:383
+#: data.cpp:391
 msgid "Castries"
 msgstr "卡斯翠"
 
-#: data.cpp:384
+#: data.cpp:392
 msgid "Cayenne"
 msgstr "開雲"
 
-#: data.cpp:385
+#: data.cpp:393
 msgid "Charlotte Amalie"
 msgstr "沙洛特阿馬略"
 
-#: data.cpp:386
+#: data.cpp:394
 msgid "Chisinau"
 msgstr "奇西瑙"
 
-#: data.cpp:387
+#: data.cpp:395
 msgid "Colombo"
 msgstr "可倫坡"
 
-#: data.cpp:388
+#: data.cpp:396
 msgid "Conakry"
 msgstr "柯那克里"
 
-#: data.cpp:389
+#: data.cpp:397
 msgid "Copenhagen"
 msgstr "哥本哈根"
 
-#: data.cpp:390
+#: data.cpp:398
 msgid "Cotonou"
 msgstr "柯都努"
 
-#: data.cpp:391
+#: data.cpp:399
 msgid "Dakar"
 msgstr "達卡"
 
-#: data.cpp:392
+#: data.cpp:400
 msgid "Damascus"
 msgstr "大馬士革"
 
-#: data.cpp:393
+#: data.cpp:401
 msgid "Dar es Salaam"
 msgstr "Dar es Salaam"
 
-#: data.cpp:394
+#: data.cpp:402
 msgid "Dhaka"
 msgstr "達卡"
 
-#: data.cpp:395
+#: data.cpp:403
 msgid "Dili"
 msgstr "狄力"
 
-#: data.cpp:396
+#: data.cpp:404
 msgid "Djibouti"
 msgstr "吉布地"
 
-#: data.cpp:397
+#: data.cpp:405
 msgid "Doha"
 msgstr "杜哈"
 
-#: data.cpp:398
+#: data.cpp:406
 msgid "Douglas"
 msgstr "道格拉斯"
 
-#: data.cpp:399
+#: data.cpp:407
 msgid "Dublin"
 msgstr "都柏林"
 
-#: data.cpp:400
+#: data.cpp:408
 msgid "Dushanbe"
 msgstr "杜尚貝"
 
-#: data.cpp:401
+#: data.cpp:409
 msgid "Fongafale"
 msgstr "Fongafale"
 
-#: data.cpp:402
+#: data.cpp:410
 msgid "Fort-de-France"
 msgstr "法蘭西堡"
 
-#: data.cpp:403
+#: data.cpp:411
 msgid "Freetown"
 msgstr "自由城"
 
-#: data.cpp:404
+#: data.cpp:412
 msgid "Gaborone"
 msgstr "嘉柏隆里"
 
-#: data.cpp:405
+#: data.cpp:413
 msgid "George Town"
 msgstr "喬治鎮"
 
-#: data.cpp:406
+#: data.cpp:414
 msgid "Georgetown"
 msgstr "喬治市"
 
-#: data.cpp:407
+#: data.cpp:415
 msgid "Gibraltar"
 msgstr "直布羅陀"
 
-#: data.cpp:408
+#: data.cpp:416
 msgid "Grand Turk"
 msgstr "大特克"
 
-#: data.cpp:409
+#: data.cpp:417
 msgid "Guatemala"
 msgstr "瓜地馬拉"
 
-#: data.cpp:410
+#: data.cpp:418
 msgid "Hagatna"
 msgstr "Hagatna"
 
-#: data.cpp:411
+#: data.cpp:419
 msgid "The Hague"
 msgstr "海牙"
 
-#: data.cpp:412
+#: data.cpp:420
 msgid "Hamilton"
 msgstr "漢米頓"
 
-#: data.cpp:413
+#: data.cpp:421
 msgid "Hanoi"
 msgstr "河內"
 
-#: data.cpp:414
+#: data.cpp:422
 msgid "Harare"
 msgstr "哈拉雷"
 
-#: data.cpp:415
+#: data.cpp:423
 msgid "Havana"
 msgstr "哈瓦那"
 
-#: data.cpp:416
+#: data.cpp:424
 msgid "Helsinki"
 msgstr "赫爾辛基"
 
-#: data.cpp:417
+#: data.cpp:425
 msgid "Hong Kong"
 msgstr ""
 
-#: data.cpp:418
+#: data.cpp:426
 msgid "Honiara"
 msgstr "荷尼阿拉"
 
-#: data.cpp:419
+#: data.cpp:427
 msgid "Islamabad"
 msgstr "伊斯蘭馬巴德"
 
-#: data.cpp:420
+#: data.cpp:428
 msgid "Jakarta"
 msgstr "雅加達"
 
-#: data.cpp:421
+#: data.cpp:429
 msgid "Jamestown"
 msgstr "詹姆斯鎮"
 
-#: data.cpp:422
+#: data.cpp:430
 msgid "Jerusalem"
 msgstr "耶路撒冷"
 
-#: data.cpp:423
+#: data.cpp:431
 msgid "Kabul"
 msgstr "喀布爾"
 
-#: data.cpp:424
+#: data.cpp:432
 msgid "Kampala"
 msgstr "坎帕拉"
 
-#: data.cpp:425
+#: data.cpp:433
 msgid "Kathmandu"
 msgstr "加德滿都"
 
-#: data.cpp:426
+#: data.cpp:434
 msgid "Khartoum"
 msgstr "卡土穆"
 
-#: data.cpp:427
+#: data.cpp:435
 msgid "Kiev"
 msgstr "基輔"
 
-#: data.cpp:428
+#: data.cpp:436
 msgid "Kigali"
 msgstr "吉佳利"
 
-#: data.cpp:429 data.cpp:430
+#: data.cpp:437 data.cpp:438
 msgid "Kingston"
 msgstr "京斯頓"
 
-#: data.cpp:431
+#: data.cpp:439
 msgid "Kingstown"
 msgstr "金斯頓"
 
-#: data.cpp:432
+#: data.cpp:440
 msgid "Kinshasa"
 msgstr "金夏沙"
 
-#: data.cpp:433
+#: data.cpp:441
 msgid "Koror"
 msgstr "科羅爾"
 
-#: data.cpp:434
+#: data.cpp:442
 msgid "Kuala Lumpur"
 msgstr "吉隆坡"
 
-#: data.cpp:435
+#: data.cpp:443
 msgid "Kuwait"
 msgstr "科威特"
 
-#: data.cpp:436
+#: data.cpp:444
 msgid "La'youn"
 msgstr "La'youn"
 
-#: data.cpp:437
+#: data.cpp:445
 msgid "La Paz"
 msgstr "拉巴斯"
 
-#: data.cpp:438
+#: data.cpp:446
 msgid "Libreville"
 msgstr "自由市"
 
-#: data.cpp:439
+#: data.cpp:447
 msgid "Lilongwe"
 msgstr "里朗威"
 
-#: data.cpp:440
+#: data.cpp:448
 msgid "Lima"
 msgstr "來瑪"
 
-#: data.cpp:441
+#: data.cpp:449
 msgid "Lisbon"
 msgstr "里斯本"
 
-#: data.cpp:442
+#: data.cpp:450
 msgid "Ljubljana"
 msgstr "留布利安納"
 
-#: data.cpp:443
+#: data.cpp:451
 msgid "Lobamba"
 msgstr "Lobamba"
 
-#: data.cpp:444
+#: data.cpp:452
 msgid "Lome"
 msgstr "洛梅"
 
-#: data.cpp:445
+#: data.cpp:453
 msgid "London"
 msgstr "倫敦"
 
-#: data.cpp:446
+#: data.cpp:454
 msgid "Longyearbyen"
 msgstr "Longyearbyen"
 
-#: data.cpp:447
+#: data.cpp:455
 msgid "Luanda"
 msgstr "羅安達"
 
-#: data.cpp:448
+#: data.cpp:456
 msgid "Lusaka"
 msgstr "路沙卡"
 
-#: data.cpp:449
+#: data.cpp:457
 msgid "Luxembourg"
 msgstr "盧森堡"
 
-#: data.cpp:450
+#: data.cpp:458
 msgid "Madrid"
 msgstr "馬德里"
 
-#: data.cpp:451
+#: data.cpp:459
 msgid "Majuro"
 msgstr "馬久羅"
 
-#: data.cpp:452
+#: data.cpp:460
 msgid "Malabo"
 msgstr "馬拉繃"
 
-#: data.cpp:453
+#: data.cpp:461
 msgid "Male"
 msgstr "瑪律"
 
-#: data.cpp:454
+#: data.cpp:462
 msgid "Mamoutzou"
 msgstr "Mamoutzou"
 
-#: data.cpp:455
+#: data.cpp:463
 msgid "Managua"
 msgstr "馬拿瓜"
 
-#: data.cpp:456
+#: data.cpp:464
 msgid "Manama"
 msgstr "麥納瑪"
 
-#: data.cpp:457
+#: data.cpp:465
 msgid "Manila"
 msgstr "馬尼拉"
 
-#: data.cpp:458
+#: data.cpp:466
 msgid "Maputo"
 msgstr "馬布多"
 
-#: data.cpp:459
+#: data.cpp:467
 msgid "Maseru"
 msgstr "馬塞魯"
 
-#: data.cpp:460
+#: data.cpp:468
 msgid "Mata-Utu"
 msgstr "Mata-Utu"
 
-#: data.cpp:461
+#: data.cpp:469
 msgid "Mbabane"
 msgstr "墨巴本"
 
-#: data.cpp:462
+#: data.cpp:470
 msgid "Mexico City"
 msgstr "墨西哥城"
 
-#: data.cpp:463
+#: data.cpp:471
 msgid "Minsk"
 msgstr "明斯克"
 
-#: data.cpp:464
+#: data.cpp:472
 msgid "Mogadishu"
 msgstr "摩加迪休"
 
-#: data.cpp:465
+#: data.cpp:473
 msgid "Monaco"
 msgstr "摩納哥"
 
-#: data.cpp:466
+#: data.cpp:474
 msgid "Monrovia"
 msgstr "蒙羅維亞"
 
-#: data.cpp:467
+#: data.cpp:475
 msgid "Montevideo"
 msgstr "蒙特維多"
 
-#: data.cpp:468
+#: data.cpp:476
 msgid "Moroni"
 msgstr "莫洛尼"
 
-#: data.cpp:469
+#: data.cpp:477
 msgid "Moscow"
 msgstr "莫斯科"
 
-#: data.cpp:470
+#: data.cpp:478
 msgid "Muscat"
 msgstr "馬斯喀特"
 
-#: data.cpp:471
+#: data.cpp:479
 msgid "Nairobi"
 msgstr "奈洛比"
 
-#: data.cpp:472
+#: data.cpp:480
 msgid "Nassau"
 msgstr "納索"
 
-#: data.cpp:473
+#: data.cpp:481
 msgid "N'Djamena"
 msgstr "恩將納"
 
-#: data.cpp:474
+#: data.cpp:482
 msgid "New Delhi"
 msgstr "新德里"
 
-#: data.cpp:475
+#: data.cpp:483
 msgid "Niamey"
 msgstr "尼阿美"
 
-#: data.cpp:476
+#: data.cpp:484
 msgid "Nicosia"
 msgstr "尼古西亞"
 
-#: data.cpp:477
+#: data.cpp:485
 msgid "Nouakchott"
 msgstr "諾克少"
 
-#: data.cpp:478
+#: data.cpp:486
 msgid "Noumea"
 msgstr "諾美亞"
 
-#: data.cpp:479
+#: data.cpp:487
 msgid "Nuku'alofa"
 msgstr "Nuku'alofa"
 
-#: data.cpp:480
+#: data.cpp:488
 msgid "Nuuk"
 msgstr "Nuuk"
 
-#: data.cpp:481
+#: data.cpp:489
 msgid "Oranjestad"
 msgstr "奧蘭葉斯塔"
 
-#: data.cpp:482
+#: data.cpp:490
 msgid "Oslo"
 msgstr "奧斯陸"
 
-#: data.cpp:483
+#: data.cpp:491
 msgid "Ottawa"
 msgstr "渥太華"
 
-#: data.cpp:484
+#: data.cpp:492
 msgid "Ouagadougou"
 msgstr "瓦加杜古"
 
-#: data.cpp:485
+#: data.cpp:493
 msgid "Pago Pago"
 msgstr "Pago Pago"
 
-#: data.cpp:486
+#: data.cpp:494
 msgid "Palikir"
 msgstr "Palikir"
 
-#: data.cpp:487
+#: data.cpp:495
 msgid "Panama"
 msgstr "巴拿馬"
 
-#: data.cpp:488
+#: data.cpp:496
 msgid "Papeete"
 msgstr "Papeete"
 
-#: data.cpp:489
+#: data.cpp:497
 msgid "Paramaribo"
 msgstr "巴拉馬利波"
 
-#: data.cpp:490
+#: data.cpp:498
 msgid "Paris"
 msgstr "巴黎"
 
-#: data.cpp:491
+#: data.cpp:499
 msgid "Phnom Penh"
 msgstr "金邊"
 
-#: data.cpp:492
+#: data.cpp:500
 msgid "Plymouth"
 msgstr "普利茅斯"
 
-#: data.cpp:493
+#: data.cpp:501
 msgid "Port Louis"
 msgstr "路易士港"
 
-#: data.cpp:494
+#: data.cpp:502
 msgid "Port Moresby"
 msgstr "摩爾斯貝港"
 
-#: data.cpp:495
+#: data.cpp:503
 msgid "Port-au-Prince"
 msgstr "太子港"
 
-#: data.cpp:496
+#: data.cpp:504
 msgid "Port-of-Spain"
 msgstr "西班牙港"
 
-#: data.cpp:497
+#: data.cpp:505
 msgid "Porto-Novo"
 msgstr "新港/諾弗港"
 
-#: data.cpp:498
+#: data.cpp:506
 msgid "Port-Vila"
 msgstr "維拉港"
 
-#: data.cpp:499
+#: data.cpp:507
 msgid "Prague"
 msgstr "布拉格"
 
-#: data.cpp:500
+#: data.cpp:508
 msgid "Praia"
 msgstr "培亞"
 
-#: data.cpp:501
+#: data.cpp:509
 msgid "Pretoria"
 msgstr "普利托里亞"
 
-#: data.cpp:502
+#: data.cpp:510
 msgid "P'yongyang"
 msgstr "平壤"
 
-#: data.cpp:503
+#: data.cpp:511
 msgid "Quito"
 msgstr "基多"
 
-#: data.cpp:504
+#: data.cpp:512
 msgid "Rabat"
 msgstr "拉巴特"
 
-#: data.cpp:505
+#: data.cpp:513
 msgid "Rangoon"
 msgstr "仰光"
 
-#: data.cpp:506
+#: data.cpp:514
 msgid "Reykjavik"
 msgstr "雷克雅維克"
 
-#: data.cpp:507
+#: data.cpp:515
 msgid "Riga"
 msgstr "里加"
 
-#: data.cpp:508
+#: data.cpp:516
 msgid "Riyadh"
 msgstr "利雅德"
 
-#: data.cpp:509
+#: data.cpp:517
 msgid "Road Town"
 msgstr "Road Town"
 
-#: data.cpp:510
+#: data.cpp:518
 msgid "Rome"
 msgstr "羅姆"
 
-#: data.cpp:511
+#: data.cpp:519
 msgid "Roseau"
 msgstr "羅梭"
 
-#: data.cpp:512
+#: data.cpp:520
 msgid "Saint George's"
 msgstr "聖喬治"
 
-#: data.cpp:513
+#: data.cpp:521
 msgid "Saint Helier"
 msgstr "聖赫列"
 
-#: data.cpp:514
+#: data.cpp:522
 msgid "Saint John's"
 msgstr "聖約翰"
 
-#: data.cpp:515
+#: data.cpp:523
 msgid "Saint Peter Port"
 msgstr "聖彼得港"
 
-#: data.cpp:516
+#: data.cpp:524
 msgid "Saint-Denis"
 msgstr "聖丹尼"
 
-#: data.cpp:517
+#: data.cpp:525
 msgid "Saint-Pierre"
 msgstr "聖匹"
 
-#: data.cpp:518
+#: data.cpp:526
 msgid "Saipan"
 msgstr "塞班"
 
-#: data.cpp:519
+#: data.cpp:527
 msgid "San Jose"
 msgstr "聖約瑟"
 
-#: data.cpp:520
+#: data.cpp:528
 msgid "San Juan"
 msgstr "聖胡安"
 
-#: data.cpp:521
+#: data.cpp:529
 msgid "San Marino"
 msgstr "聖馬力諾"
 
-#: data.cpp:522
+#: data.cpp:530
 msgid "San Salvador"
 msgstr "聖薩爾瓦多"
 
-#: data.cpp:523
+#: data.cpp:531
 msgid "Sanaa"
 msgstr "沙那"
 
-#: data.cpp:524
+#: data.cpp:532
 msgid "Santiago"
 msgstr "聖地牙哥"
 
-#: data.cpp:525
+#: data.cpp:533
 msgid "Santo Domingo"
 msgstr "聖多明哥"
 
-#: data.cpp:526
+#: data.cpp:534
 msgid "Sao Tome"
 msgstr "聖多美"
 
-#: data.cpp:527
+#: data.cpp:535
 msgid "Sarajevo"
 msgstr "沙拉耶佛"
 
-#: data.cpp:528
+#: data.cpp:536
 msgid "Seoul"
 msgstr "首爾"
 
-#: data.cpp:529
+#: data.cpp:537
 msgid "The Settlement"
 msgstr "The Settlement"
 
-#: data.cpp:530
+#: data.cpp:538
 msgid "Singapore"
 msgstr "新加坡"
 
-#: data.cpp:531
+#: data.cpp:539
 msgid "Skopje"
 msgstr "斯科普耶"
 
-#: data.cpp:532
+#: data.cpp:540
 msgid "Sofia"
 msgstr "索非亞"
 
-#: data.cpp:533
+#: data.cpp:541
 msgid "Sri Jayewardenepura Kotte"
 msgstr "Sri Jayewardenepura Kotte"
 
-#: data.cpp:534
+#: data.cpp:542
 msgid "Stanley"
 msgstr "史坦萊"
 
-#: data.cpp:535
+#: data.cpp:543
 msgid "Stockholm"
 msgstr "斯德哥爾摩"
 
-#: data.cpp:536
+#: data.cpp:544
 msgid "Sucre"
 msgstr "蘇克雷"
 
-#: data.cpp:537
+#: data.cpp:545
 msgid "Suva"
 msgstr "蘇瓦"
 
-#: data.cpp:538
+#: data.cpp:546
 msgid "Taipei"
 msgstr "台北"
 
-#: data.cpp:539
+#: data.cpp:547
 msgid "Tallinn"
 msgstr "塔林"
 
-#: data.cpp:540
+#: data.cpp:548
 msgid "Tarawa"
 msgstr "塔拉瓦"
 
-#: data.cpp:541
+#: data.cpp:549
 msgid "Tashkent"
 msgstr "塔什干"
 
-#: data.cpp:542
+#: data.cpp:550
 msgid "T'bilisi"
 msgstr "提弗利司"
 
-#: data.cpp:543
+#: data.cpp:551
 msgid "Tegucigalpa"
 msgstr "德古斯加巴"
 
-#: data.cpp:544
+#: data.cpp:552
 msgid "Tehran"
 msgstr "德黑蘭"
 
-#: data.cpp:545
+#: data.cpp:553
 msgid "Tel Aviv"
 msgstr "特拉維夫"
 
-#: data.cpp:546
+#: data.cpp:554
 msgid "Thimphu"
 msgstr "辛布"
 
-#: data.cpp:547
+#: data.cpp:555
 msgid "Tirana"
 msgstr "地拉那"
 
-#: data.cpp:548
+#: data.cpp:556
 msgid "Tokyo"
 msgstr "東京"
 
-#: data.cpp:549
+#: data.cpp:557
 msgid "Torshavn"
 msgstr "托沙文"
 
-#: data.cpp:550
+#: data.cpp:558
 msgid "Tripoli"
 msgstr "的黎波里"
 
-#: data.cpp:551
+#: data.cpp:559
 msgid "Tunis"
 msgstr "突尼斯"
 
-#: data.cpp:552
+#: data.cpp:560
 msgid "Ulaanbaatar"
 msgstr "Ulaanbaatar"
 
-#: data.cpp:553
+#: data.cpp:561
 msgid "Vaduz"
 msgstr "Vaduz"
 
-#: data.cpp:554
+#: data.cpp:562
 msgid "Valletta"
 msgstr "法勒他"
 
-#: data.cpp:555
+#: data.cpp:563
 msgid "The Valley"
 msgstr "The Valley"
 
-#: data.cpp:556
+#: data.cpp:564
 msgid "Vatican City"
 msgstr "梵蒂岡"
 
-#: data.cpp:557
+#: data.cpp:565
 msgid "Victoria"
 msgstr "維多利亞"
 
-#: data.cpp:558
+#: data.cpp:566
 msgid "Vienna"
 msgstr "維也納"
 
-#: data.cpp:559
+#: data.cpp:567
 msgid "Vientiane"
 msgstr "永珍"
 
-#: data.cpp:560
+#: data.cpp:568
 msgid "Vilnius"
 msgstr "Vilnius"
 
-#: data.cpp:561
+#: data.cpp:569
 msgid "Warsaw"
 msgstr "華沙"
 
-#: data.cpp:562
+#: data.cpp:570
 msgid "Washington D.C."
 msgstr "華盛頓特區"
 
-#: data.cpp:563
+#: data.cpp:571
 msgid "Wellington"
 msgstr "威靈頓"
 
-#: data.cpp:564
+#: data.cpp:572
 msgid "West Island"
 msgstr "West Island"
 
-#: data.cpp:565
+#: data.cpp:573
 msgid "Willemstad"
 msgstr "維倫斯塔"
 
-#: data.cpp:566
+#: data.cpp:574
 msgid "Windhoek"
 msgstr "文胡克"
 
-#: data.cpp:567
+#: data.cpp:575
 msgid "Yamoussoukro"
 msgstr "雅穆索戈"
 
-#: data.cpp:568
+#: data.cpp:576
 msgid "Yaounde"
 msgstr "雅溫德"
 
-#: data.cpp:569
+#: data.cpp:577
 msgid "Yaren District"
 msgstr "Yaren District"
 
-#: data.cpp:570
+#: data.cpp:578
 msgid "Yerevan"
 msgstr "葉勒凡"
 
-#: data.cpp:571
+#: data.cpp:579
 msgid "Zagreb"
 msgstr "札格拉布"
 
-#: data.cpp:572
+#: data.cpp:580
 msgid "Sol"
 msgstr "太陽"
 
-#: data.cpp:573
+#: data.cpp:581
 msgid "Solar System Barycenter"
 msgstr "太陽系質量中心"
 
-#: data.cpp:574
+#: data.cpp:582
 msgid "Sun"
 msgstr "太陽"
 
-#: data.cpp:575
+#: data.cpp:583
 msgid "Alpheratz"
 msgstr "壁宿二 (Alpheratz)"
 
-#: data.cpp:576
+#: data.cpp:584
 msgid "Sirrah"
 msgstr "壁宿二 (Sirrah)"
 
-#: data.cpp:577
+#: data.cpp:585
 msgid "Caph"
 msgstr "王良一 (Caph)"
 
-#: data.cpp:578
+#: data.cpp:586
 msgid "Algenib"
 msgstr "壁宿一 (Algenib)"
 
-#: data.cpp:579
+#: data.cpp:587
 msgid "Citadelle"
 msgstr ""
 
-#: data.cpp:580
+#: data.cpp:588
 msgid "Schemali"
 msgstr "Schemali"
 
-#: data.cpp:581
+#: data.cpp:589
 msgid "Ankaa"
 msgstr "火鳥六 (Ankaa)"
 
-#: data.cpp:582
+#: data.cpp:590
 msgid "Felixvarela"
 msgstr ""
 
-#: data.cpp:583
+#: data.cpp:591
 msgid "Fulu"
 msgstr ""
 
-#: data.cpp:584
+#: data.cpp:592
 msgid "Schedar"
 msgstr "王良四 Schedar"
 
-#: data.cpp:585
+#: data.cpp:593
 msgid "Shedir"
 msgstr "Shedir"
 
-#: data.cpp:586
+#: data.cpp:594
 msgid "Diphda"
 msgstr "土司空 (Diphda)"
 
-#: data.cpp:587
+#: data.cpp:595
 msgid "Deneb Kaitos"
 msgstr "Deneb Kaitos"
 
-#: data.cpp:588
+#: data.cpp:596
 msgid "Cocibolca"
 msgstr ""
 
-#: data.cpp:589
+#: data.cpp:597
 msgid "Achird"
 msgstr "王良三 (Achird)"
 
-#: data.cpp:590
+#: data.cpp:598
 msgid "Van Maanen 2"
 msgstr "范馬南星"
 
-#: data.cpp:591
+#: data.cpp:599
 #, fuzzy
 msgid "Castula"
 msgstr "北河二 (Castor)"
 
-#: data.cpp:592
+#: data.cpp:600
 msgid "Navi"
 msgstr "策 (Navi)"
 
-#: data.cpp:593
+#: data.cpp:601
 msgid "Nenque"
 msgstr ""
 
-#: data.cpp:594
+#: data.cpp:602
 #, fuzzy
 msgid "Wurren"
 msgstr "Current 目前的"
 
-#: data.cpp:595
+#: data.cpp:603
 msgid "Mirach"
 msgstr "奎宿九 (Mirach)"
 
-#: data.cpp:596
+#: data.cpp:604
 msgid "Emiw"
 msgstr ""
 
-#: data.cpp:597
+#: data.cpp:605
 msgid "Revati"
 msgstr ""
 
-#: data.cpp:598
+#: data.cpp:606
 msgid "Adhil"
 msgstr "天大將軍增一 (Adhil)"
 
-#: data.cpp:599
+#: data.cpp:607
 msgid "Bélénos"
 msgstr ""
 
-#: data.cpp:600
+#: data.cpp:608
 msgid "Ruchbah"
 msgstr "閣道三 (Ruchbah)"
 
-#: data.cpp:601
+#: data.cpp:609
 #, fuzzy
 msgid "Alpherg"
 msgstr "壁宿二 (Alpheratz)"
 
-#: data.cpp:602
+#: data.cpp:610
 #, fuzzy
 msgid "Titawin"
 msgstr "土衛六(Titan)"
 
-#: data.cpp:603
+#: data.cpp:611
 msgid "Achernar"
 msgstr "水委一 (Achernar)"
 
-#: data.cpp:604
+#: data.cpp:612
 msgid "Nembus"
 msgstr ""
 
-#: data.cpp:605
+#: data.cpp:613
 msgid "Torcular"
 msgstr ""
 
-#: data.cpp:606
+#: data.cpp:614
 msgid "Torcularis Septentrionalis"
 msgstr ""
 
-#: data.cpp:607
+#: data.cpp:615
 msgid "Baten Kaitos"
 msgstr "天倉四 (Baten Kaitos)"
 
-#: data.cpp:608
+#: data.cpp:616
 msgid "Mothallah"
 msgstr ""
 
-#: data.cpp:609
+#: data.cpp:617
 msgid "Caput Trianguli"
 msgstr "Caput Trianguli"
 
-#: data.cpp:610
+#: data.cpp:618
 msgid "Mesarthim"
 msgstr "婁宿二 (Mesarthim)"
 
-#: data.cpp:611
+#: data.cpp:619
 msgid "Segin"
 msgstr "閣道二 (Segin)"
 
-#: data.cpp:612
+#: data.cpp:620
 msgid "Sheratan"
 msgstr "婁宿一 (Sheratan)"
 
-#: data.cpp:613
+#: data.cpp:621
 #, fuzzy
 msgid "Alrescha"
 msgstr "Al Rescha"
 
-#: data.cpp:614
+#: data.cpp:622
 msgid "Al Rescha"
 msgstr "Al Rescha"
 
-#: data.cpp:615
+#: data.cpp:623
 msgid "Almach"
 msgstr "天大將軍一 (Almach)"
 
-#: data.cpp:616
+#: data.cpp:624
 msgid "Almaak"
 msgstr "天大將軍一 (Almaak)"
 
-#: data.cpp:617
+#: data.cpp:625
 msgid "Alamak"
 msgstr "Alamak"
 
-#: data.cpp:618
+#: data.cpp:626
 msgid "Hamal"
 msgstr "婁宿三 (Hamal)"
 
-#: data.cpp:619
+#: data.cpp:627
 msgid "Mira"
 msgstr "蒭藁增二 (Mira)"
 
-#: data.cpp:620
+#: data.cpp:628
 msgid "Polaris"
 msgstr "勾陳一[北極星] (Polaris)"
 
-#: data.cpp:621
+#: data.cpp:629
 msgid "Buna"
 msgstr ""
 
-#: data.cpp:622
+#: data.cpp:630
 msgid "Kaffaljidhma"
 msgstr ""
 
-#: data.cpp:623
+#: data.cpp:631
 msgid "Koeia"
 msgstr ""
 
-#: data.cpp:624
+#: data.cpp:632
 msgid "Lilii Borea"
 msgstr ""
 
-#: data.cpp:625
+#: data.cpp:633
 msgid "Nushagak"
 msgstr ""
 
-#: data.cpp:626
+#: data.cpp:634
 #, fuzzy
 msgid "Bharani"
 msgstr "常陳四 (Chara)"
 
-#: data.cpp:627
+#: data.cpp:635
 #, fuzzy
 msgid "Miram"
 msgstr "蒭藁增二 (Mira)"
 
-#: data.cpp:628
+#: data.cpp:636
 msgid "Angetenar"
 msgstr "天苑九 (Angetenar)"
 
-#: data.cpp:629
+#: data.cpp:637
 msgid "Azha"
 msgstr "天苑六 (Azha)"
 
-#: data.cpp:630
+#: data.cpp:638
 msgid "Acamar"
 msgstr "天園六 (Acamar)"
 
-#: data.cpp:631
+#: data.cpp:639
 msgid "Ayeyarwady"
 msgstr ""
 
-#: data.cpp:632
+#: data.cpp:640
 msgid "Menkar"
 msgstr "天囷一 (Menkar)"
 
-#: data.cpp:633
+#: data.cpp:641
 msgid "Menkab"
 msgstr "Menkab"
 
-#: data.cpp:634
+#: data.cpp:642
 msgid "Algol"
 msgstr "大陵五 (Algol)"
 
-#: data.cpp:635
+#: data.cpp:643
 msgid "Misam"
 msgstr ""
 
-#: data.cpp:636
+#: data.cpp:644
 msgid "Botein"
 msgstr "天陰四 (Botein)"
 
-#: data.cpp:637
+#: data.cpp:645
 msgid "Dalim"
 msgstr ""
 
-#: data.cpp:638
+#: data.cpp:646
 msgid "Zibal"
 msgstr ""
 
-#: data.cpp:639
+#: data.cpp:647
 msgid "Intan"
 msgstr ""
 
-#: data.cpp:640
+#: data.cpp:648
 msgid "Mirfak"
 msgstr "天船三 (Mirfak)"
 
-#: data.cpp:641
+#: data.cpp:649
 msgid "Mirphak"
 msgstr "天船三 (Mirphak)"
 
-#: data.cpp:642
+#: data.cpp:650
 msgid "Marfak"
 msgstr "Marfak"
 
-#: data.cpp:643
+#: data.cpp:651
 #, fuzzy
 msgid "Ran"
 msgstr "天苑三 (Rana)"
 
-#: data.cpp:644
+#: data.cpp:652
 msgid "Tupi"
 msgstr ""
 
-#: data.cpp:645
+#: data.cpp:653
 msgid "Rana"
 msgstr "天苑三 (Rana)"
 
-#: data.cpp:646
+#: data.cpp:654
 msgid "Atik"
 msgstr "卷舌四 (Atik)"
 
-#: data.cpp:647
+#: data.cpp:655
 msgid "Celaeno"
 msgstr "昴宿增六 (Celaeno)"
 
-#: data.cpp:648
+#: data.cpp:656
 msgid "Electra"
 msgstr "昴宿一 (Electra)"
 
-#: data.cpp:649
+#: data.cpp:657
 msgid "Taygeta"
 msgstr "昴宿二 (Taygeta)"
 
-#: data.cpp:650
+#: data.cpp:658
 msgid "Maia"
 msgstr "昴宿四 (Maia)"
 
-#: data.cpp:651
+#: data.cpp:659
 msgid "Asterope"
 msgstr "昴宿三 (Asterope)"
 
-#: data.cpp:652
+#: data.cpp:660
 msgid "Merope"
 msgstr "昴宿五 (Merope)"
 
-#: data.cpp:653
+#: data.cpp:661
 msgid "Alcyone"
 msgstr "昴宿六 (Alcyone)"
 
-#: data.cpp:654
+#: data.cpp:662
 msgid "Pleione"
 msgstr "昴宿增十二 (Pleione)"
 
-#: data.cpp:655
+#: data.cpp:663
 msgid "Zaurak"
 msgstr "天苑一 (Zaurak)"
 
-#: data.cpp:656
+#: data.cpp:664
 msgid "Menkib"
 msgstr "卷舌三 (Menkib)"
 
-#: data.cpp:657
+#: data.cpp:665
 msgid "Beid"
 msgstr "九州殊口二 (Beid)"
 
-#: data.cpp:658
+#: data.cpp:666
 msgid "Keid"
 msgstr "九州殊口增七 (keid)"
 
-#: data.cpp:659
+#: data.cpp:667
 msgid "Prima Hyadum"
 msgstr ""
 
-#: data.cpp:660
+#: data.cpp:668
 msgid "Secunda Hyadum"
 msgstr ""
 
-#: data.cpp:661
+#: data.cpp:669
 msgid "Beemim"
 msgstr ""
 
-#: data.cpp:662
+#: data.cpp:670
 msgid "Ain"
 msgstr "畢宿一 (Ain)"
 
-#: data.cpp:663
+#: data.cpp:671
 msgid "Chamukuy"
 msgstr ""
 
-#: data.cpp:664
+#: data.cpp:672
 msgid "Hoggar"
 msgstr ""
 
-#: data.cpp:665
+#: data.cpp:673
 msgid "Theemin"
 msgstr ""
 
-#: data.cpp:666
+#: data.cpp:674
 msgid "Aldebaran"
 msgstr "畢宿五 (Aldebaran)"
 
-#: data.cpp:667
+#: data.cpp:675
 msgid "Sceptrum"
 msgstr ""
 
-#: data.cpp:668
+#: data.cpp:676
 #, fuzzy
 msgid "Tabit"
 msgstr "參宿增三十六 (Thabit)"
 
-#: data.cpp:669
+#: data.cpp:677
 msgid "Mouhoun"
 msgstr ""
 
-#: data.cpp:670
+#: data.cpp:678
 msgid "Hassaleh"
 msgstr ""
 
-#: data.cpp:671
+#: data.cpp:679
 msgid "Hind's Crimson Star"
 msgstr "Hind 深紅星"
 
-#: data.cpp:672
+#: data.cpp:680
 #, fuzzy
 msgid "Almaaz"
 msgstr "天大將軍一 (Almaak)"
 
-#: data.cpp:673
+#: data.cpp:681
 #, fuzzy
 msgid "Saclateni"
 msgstr "星系"
 
-#: data.cpp:674
+#: data.cpp:682
 msgid "Sadatoni"
 msgstr "Sadatoni"
 
-#: data.cpp:675
+#: data.cpp:683
 msgid "Haedus"
 msgstr ""
 
-#: data.cpp:676
+#: data.cpp:684
 msgid "Cursa"
 msgstr "玉井三 (Cursa)"
 
-#: data.cpp:677
+#: data.cpp:685
 msgid "Mago"
 msgstr ""
 
-#: data.cpp:678
+#: data.cpp:686
 msgid "Kapteyn's Star"
 msgstr "Kapteyn 星"
 
-#: data.cpp:679
+#: data.cpp:687
 msgid "Rigel"
 msgstr "參宿七 (Rigel)"
 
-#: data.cpp:680
+#: data.cpp:688
 msgid "Capella"
 msgstr "五車二 (Capella)"
 
-#: data.cpp:681
+#: data.cpp:689
 msgid "Bellatrix"
 msgstr "參宿五 (Bellatrix)"
 
-#: data.cpp:682
+#: data.cpp:690
 msgid "Elnath"
 msgstr "五車五 (Elnath)"
 
-#: data.cpp:683
+#: data.cpp:691
 msgid "Alnath"
 msgstr "五車五 (Alnath)"
 
-#: data.cpp:684
+#: data.cpp:692
 msgid "Nihal"
 msgstr "廁二 (Nihal)"
 
-#: data.cpp:685
+#: data.cpp:693
 msgid "Thabit"
 msgstr "參宿增三十六 (Thabit)"
 
-#: data.cpp:686
+#: data.cpp:694
 msgid "Mintaka"
 msgstr "參宿三 (Mintaka)"
 
-#: data.cpp:687
+#: data.cpp:695
 msgid "Arneb"
 msgstr "廁一 (Arneb)"
 
-#: data.cpp:688
+#: data.cpp:696
 msgid "Meissa"
 msgstr "觜宿一 (Meissa)"
 
-#: data.cpp:689
+#: data.cpp:697
 msgid "Heka"
 msgstr "觜宿二 (Heka)"
 
-#: data.cpp:690
+#: data.cpp:698
 msgid "Hatysa"
 msgstr ""
 
-#: data.cpp:691
+#: data.cpp:699
 msgid "Alnilam"
 msgstr "參宿二 (Alnilam)"
 
-#: data.cpp:692
+#: data.cpp:700
 msgid "Bubup"
 msgstr ""
 
-#: data.cpp:693
+#: data.cpp:701
 #, fuzzy
 msgid "Tianguan"
 msgstr "三角形"
 
-#: data.cpp:694
+#: data.cpp:702
 msgid "Phact"
 msgstr "丈人一 (Phact)"
 
-#: data.cpp:695
+#: data.cpp:703
 msgid "Alnitak"
 msgstr "參宿一 (Alnitak)"
 
-#: data.cpp:696
+#: data.cpp:704
 msgid "Saiph"
 msgstr "參宿六 (Saiph)"
 
-#: data.cpp:697
+#: data.cpp:705
 msgid "Wazn"
 msgstr "子二 (Wazn)"
 
-#: data.cpp:698
+#: data.cpp:706
 msgid "Betelgeuse"
 msgstr "參宿四 (Betelgeuse)"
 
-#: data.cpp:699
+#: data.cpp:707
 msgid "Prijipati"
 msgstr "Prijipati"
 
-#: data.cpp:700
+#: data.cpp:708
 msgid "Menkalinan"
 msgstr "五車三 (Menkalinan)"
 
-#: data.cpp:701
+#: data.cpp:709
 msgid "Mahasim"
 msgstr ""
 
-#: data.cpp:702
+#: data.cpp:710
 #, fuzzy
 msgid "Elkurud"
 msgstr "孫增一 (Furud)"
 
-#: data.cpp:703
+#: data.cpp:711
 msgid "Amadioha"
 msgstr ""
 
-#: data.cpp:704
+#: data.cpp:712
 #, fuzzy
 msgid "Propus"
 msgstr "老人 (Canopus)"
 
-#: data.cpp:705
+#: data.cpp:713
 msgid "Red Rectangle"
 msgstr "紅矩形"
 
-#: data.cpp:706
+#: data.cpp:714
 msgid "Furud"
 msgstr "孫增一 (Furud)"
 
-#: data.cpp:707
+#: data.cpp:715
 msgid "Mirzam"
 msgstr "軍市一 (Mirzam)"
 
-#: data.cpp:708
+#: data.cpp:716
 msgid "Murzim"
 msgstr "Murzim"
 
-#: data.cpp:709
+#: data.cpp:717
 msgid "Tejat"
 msgstr "井宿一 (Tejat)"
 
-#: data.cpp:710
+#: data.cpp:718
 msgid "Canopus"
 msgstr "老人 (Canopus)"
 
-#: data.cpp:711
+#: data.cpp:719
 msgid "Suhel"
 msgstr "Suhel"
 
-#: data.cpp:712
+#: data.cpp:720
 msgid "Lucilinburhuc"
 msgstr ""
 
-#: data.cpp:713
+#: data.cpp:721
 msgid "Lusitânia"
 msgstr ""
 
-#: data.cpp:714
+#: data.cpp:722
 #, fuzzy
 msgid "Plaskett's Star"
 msgstr "顯示恆星"
 
-#: data.cpp:715
+#: data.cpp:723
 msgid "Alhena"
 msgstr "井宿三 (Alhena)"
 
-#: data.cpp:716
+#: data.cpp:724
 msgid "Almeisan"
 msgstr "Almeisan"
 
-#: data.cpp:717
+#: data.cpp:725
 msgid "Nosaxa"
 msgstr ""
 
-#: data.cpp:718
+#: data.cpp:726
 msgid "Mebsuta"
 msgstr "井宿五 (Mebsuta)"
 
-#: data.cpp:719
+#: data.cpp:727
 msgid "Sirius"
 msgstr "天狼 (Sirius)"
 
-#: data.cpp:720
+#: data.cpp:728
 msgid "Alzirr"
 msgstr ""
 
-#: data.cpp:721
+#: data.cpp:729
 msgid "Nervia"
 msgstr ""
 
-#: data.cpp:722
+#: data.cpp:730
 msgid "Adhara"
 msgstr "弧矢七 (Adhara)"
 
-#: data.cpp:723
+#: data.cpp:731
 msgid "Adara"
 msgstr "Adara"
 
-#: data.cpp:724
+#: data.cpp:732
 msgid "Citalá"
 msgstr ""
 
-#: data.cpp:725
+#: data.cpp:733
 msgid "Unurgunite"
 msgstr ""
 
-#: data.cpp:726
+#: data.cpp:734
 msgid "Muliphein"
 msgstr "天狼增四 (Muliphein)"
 
-#: data.cpp:727
+#: data.cpp:735
 msgid "Mekbuda"
 msgstr "井宿七 (Mekbuda)"
 
-#: data.cpp:728
+#: data.cpp:736
 msgid "Wezen"
 msgstr "弧矢一 (Wezen)"
 
-#: data.cpp:729
+#: data.cpp:737
 msgid "Bernes 135"
 msgstr "Bernes 135"
 
-#: data.cpp:730
+#: data.cpp:738
 msgid "Wasat"
 msgstr "天罇二 (Wasat)"
 
-#: data.cpp:731
+#: data.cpp:739
 msgid "Aludra"
 msgstr "弧矢二 (Aludra)"
 
-#: data.cpp:732
+#: data.cpp:740
 msgid "Gomeisa"
 msgstr "南河二 (Gomeisa)"
 
-#: data.cpp:733
+#: data.cpp:741
 msgid "Luyten's Star"
 msgstr "Luyten 星"
 
-#: data.cpp:734
+#: data.cpp:742
 msgid "Castor"
 msgstr "北河二 (Castor)"
 
-#: data.cpp:735
+#: data.cpp:743
 msgid "Jishui"
 msgstr ""
 
-#: data.cpp:736
+#: data.cpp:744
 msgid "Procyon"
 msgstr "南河三 (Procyon)"
 
-#: data.cpp:737
+#: data.cpp:745
 msgid "Elgomaisa"
 msgstr "Elgomaisa"
 
-#: data.cpp:738
+#: data.cpp:746
 msgid "Ceibo"
 msgstr ""
 
-#: data.cpp:739
+#: data.cpp:747
 msgid "Pollux"
 msgstr "北河三 (Pollux)"
 
-#: data.cpp:740
+#: data.cpp:748
 msgid "Tapecue"
 msgstr ""
 
-#: data.cpp:741
+#: data.cpp:749
 #, fuzzy
 msgid "Azmidi"
 msgstr "Asmidiske"
 
-#: data.cpp:742
+#: data.cpp:750
 msgid "Asmidiske"
 msgstr "Asmidiske"
 
-#: data.cpp:743
+#: data.cpp:751
 msgid "Naos"
 msgstr "弧矢增二十二 (Naos)"
 
-#: data.cpp:744
+#: data.cpp:752
 msgid "Tureis"
 msgstr ""
 
-#: data.cpp:745
+#: data.cpp:753
 msgid "Regor"
 msgstr "天社一 (Regor)"
 
-#: data.cpp:746
+#: data.cpp:754
 msgid "Tegmine"
 msgstr "水位四 (Tegmine)"
 
-#: data.cpp:747
+#: data.cpp:755
 #, fuzzy
 msgid "Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:748
+#: data.cpp:756
 msgid "Al Tarf"
 msgstr "Al Tarf"
 
-#: data.cpp:749
+#: data.cpp:757
 msgid "Násti"
 msgstr ""
 
-#: data.cpp:750
+#: data.cpp:758
 msgid "Piautos"
 msgstr ""
 
-#: data.cpp:751
+#: data.cpp:759
 msgid "Avior"
 msgstr "海石一 (Avior)"
 
-#: data.cpp:752
+#: data.cpp:760
 msgid "Alsciaukat"
 msgstr ""
 
-#: data.cpp:753
+#: data.cpp:761
 msgid "Muscida"
 msgstr "內階一 (Muscida)"
 
-#: data.cpp:754
+#: data.cpp:762
 #, fuzzy
 msgid "Minchir"
 msgstr "王良三 (Achird)"
 
-#: data.cpp:755
+#: data.cpp:763
 msgid "Gakyid"
 msgstr ""
 
-#: data.cpp:756
+#: data.cpp:764
 msgid "Meleph"
 msgstr ""
 
-#: data.cpp:757
+#: data.cpp:765
 msgid "Asellus Borealis"
 msgstr "鬼宿三 (Asellus Borealis)"
 
-#: data.cpp:758
+#: data.cpp:766
 msgid "Asellus Australis"
 msgstr "鬼宿四 (Asellus Australis)"
 
-#: data.cpp:759
+#: data.cpp:767
 msgid "Alsephina"
 msgstr ""
 
-#: data.cpp:760
+#: data.cpp:768
 msgid "Ashlesha"
 msgstr ""
 
-#: data.cpp:761
+#: data.cpp:769
 msgid "Copernicus"
 msgstr ""
 
-#: data.cpp:762
+#: data.cpp:770
 msgid "Stribor"
 msgstr ""
 
-#: data.cpp:763
+#: data.cpp:771
 msgid "Acubens"
 msgstr "柳宿增三 (Acubens)"
 
-#: data.cpp:764
+#: data.cpp:772
 msgid "Talitha"
 msgstr ""
 
-#: data.cpp:765
+#: data.cpp:773
 msgid "Dnoces"
 msgstr "Dnoces"
 
-#: data.cpp:766
+#: data.cpp:774
 msgid "Alkaphrah"
 msgstr ""
 
-#: data.cpp:767
+#: data.cpp:775
 msgid "Talitha Australis"
 msgstr "Talitha Australis"
 
-#: data.cpp:768
+#: data.cpp:776
 msgid "Suhail"
 msgstr "天記 (Suhail)"
 
-#: data.cpp:769
+#: data.cpp:777
 msgid "Nahn"
 msgstr ""
 
-#: data.cpp:770
+#: data.cpp:778
 msgid "Miaplacidus"
 msgstr "南船五 (Miaplacidus)"
 
-#: data.cpp:771
+#: data.cpp:779
 msgid "Aspidiske"
 msgstr "海石二 (Aspidiske)"
 
-#: data.cpp:772
+#: data.cpp:780
 #, fuzzy
 msgid "Markeb"
 msgstr "室宿一 (Markab)"
 
-#: data.cpp:773
+#: data.cpp:781
 msgid "Alphard"
 msgstr "星宿一 (Alphard)"
 
-#: data.cpp:774
+#: data.cpp:782
 msgid "Cor Hydrae"
 msgstr "Cor Hydrae"
 
-#: data.cpp:775
+#: data.cpp:783
 msgid "Intercrus"
 msgstr ""
 
-#: data.cpp:776
+#: data.cpp:784
 msgid "Alterf"
 msgstr "軒轅八 (Alterf)"
 
-#: data.cpp:777
+#: data.cpp:785
 msgid "Illyrian"
 msgstr ""
 
-#: data.cpp:778
+#: data.cpp:786
 msgid "Kalausi"
 msgstr ""
 
-#: data.cpp:779
+#: data.cpp:787
 msgid "Ukdah"
 msgstr "星宿四 Ukdah"
 
-#: data.cpp:780
+#: data.cpp:788
 msgid "Subra"
 msgstr "軒轅十五 (Subra)"
 
-#: data.cpp:781
+#: data.cpp:789
 msgid "Ras Elased Australis"
 msgstr "Ras Elased Australis"
 
-#: data.cpp:782
+#: data.cpp:790
 msgid "Natasha"
 msgstr ""
 
-#: data.cpp:783
+#: data.cpp:791
 msgid "Zhang"
 msgstr ""
 
-#: data.cpp:784
+#: data.cpp:792
 msgid "Rasalas"
 msgstr "軒轅十 (Rasalas)"
 
-#: data.cpp:785
+#: data.cpp:793
 msgid "Ras Elased Borealis"
 msgstr "Ras Elased Borealis"
 
-#: data.cpp:786
+#: data.cpp:794
 msgid "Felis"
 msgstr ""
 
-#: data.cpp:787
+#: data.cpp:795
 msgid "Bibhā"
 msgstr ""
 
-#: data.cpp:788
+#: data.cpp:796
 msgid "Regulus"
 msgstr "軒轅十四 (Regulus)"
 
-#: data.cpp:789
+#: data.cpp:797
 msgid "Kabeleced"
 msgstr "Kabeleced"
 
-#: data.cpp:790
+#: data.cpp:798
 msgid "Cor Leonis"
 msgstr "Cor Leonis"
 
-#: data.cpp:791
+#: data.cpp:799
 msgid "Adhafera"
 msgstr "軒轅十一 (Adhafera)"
 
-#: data.cpp:792
+#: data.cpp:800
 msgid "Aldhafera"
 msgstr "Aldhafera"
 
-#: data.cpp:793
+#: data.cpp:801
 msgid "Tania Borealis"
 msgstr "中台一[三台三] (Tania Borealis)"
 
-#: data.cpp:794
+#: data.cpp:802
 msgid "Algieba"
 msgstr "軒轅十二 (Algieba)"
 
-#: data.cpp:795
+#: data.cpp:803
 msgid "Tania Australis"
 msgstr "中台二[三台四] (Tania Australis)"
 
-#: data.cpp:796
+#: data.cpp:804
 #, fuzzy
 msgid "Macondo"
 msgstr "倫敦"
 
-#: data.cpp:797
+#: data.cpp:805
 msgid "Praecipua"
 msgstr ""
 
-#: data.cpp:798
+#: data.cpp:806
 msgid "Chalawan"
 msgstr ""
 
-#: data.cpp:799
+#: data.cpp:807
 msgid "Alkes"
 msgstr "翼宿一 (Alkes)"
 
-#: data.cpp:800
+#: data.cpp:808
 msgid "Merak"
 msgstr "天璇[北斗二] (Merak)"
 
-#: data.cpp:801
+#: data.cpp:809
 msgid "Lalande 21185"
 msgstr "拉蘭德 (Lalande) 21185"
 
-#: data.cpp:802
+#: data.cpp:810
 msgid "Dubhe"
 msgstr "天樞[北斗一] (Dubhe)"
 
-#: data.cpp:803
+#: data.cpp:811
 msgid "Dubb"
 msgstr "Dubb"
 
-#: data.cpp:804
+#: data.cpp:812
 msgid "Dingolay"
 msgstr ""
 
-#: data.cpp:805
+#: data.cpp:813
 msgid "Zosma"
 msgstr "西上相[太微右垣五] (Zosma)"
 
-#: data.cpp:806
+#: data.cpp:814
 msgid "Duhr"
 msgstr "Duhr"
 
-#: data.cpp:807
+#: data.cpp:815
 msgid "Chertan"
 msgstr "西次相[太微右垣四] (Chertan)"
 
-#: data.cpp:808
+#: data.cpp:816
 msgid "Coxa"
 msgstr "Coxa"
 
-#: data.cpp:809
+#: data.cpp:817
 msgid "Chort"
 msgstr "Chort"
 
-#: data.cpp:810
+#: data.cpp:818
 msgid "Innes' Star"
 msgstr ""
 
-#: data.cpp:811
+#: data.cpp:819
 msgid "Hunahpú"
 msgstr ""
 
-#: data.cpp:812
+#: data.cpp:820
 msgid "Alula Australis"
 msgstr "下台二[三台六] (Alula Australis)"
 
-#: data.cpp:813
+#: data.cpp:821
 msgid "Alula Borealis"
 msgstr "下台一[三台五] (Alula Borealis)"
 
-#: data.cpp:814
+#: data.cpp:822
 msgid "Tsze Tseang"
 msgstr "Tsze Tseang"
 
-#: data.cpp:815
+#: data.cpp:823
 #, fuzzy
 msgid "Shama"
 msgstr "左旗一 (Sham)"
 
-#: data.cpp:816
+#: data.cpp:824
 msgid "Giausar"
 msgstr "上輔 (Giausar)"
 
-#: data.cpp:817
+#: data.cpp:825
 #, fuzzy
 msgid "Formosa"
 msgstr "格式: "
 
-#: data.cpp:818
+#: data.cpp:826
 msgid "Sagarmatha"
 msgstr ""
 
-#: data.cpp:819
+#: data.cpp:827
 msgid "Przybylski's Star"
 msgstr ""
 
-#: data.cpp:820
+#: data.cpp:828
 msgid "Uklun"
 msgstr ""
 
-#: data.cpp:821
+#: data.cpp:829
 #, fuzzy
 msgid "Flegetonte"
 msgstr "喬治市"
 
-#: data.cpp:822
+#: data.cpp:830
 msgid "Taiyangshou"
 msgstr ""
 
-#: data.cpp:823
+#: data.cpp:831
 msgid "Denebola"
 msgstr "五帝座一 (Denebola)"
 
-#: data.cpp:824
+#: data.cpp:832
 msgid "Zavijava"
 msgstr "右執法 (Zavijava)"
 
-#: data.cpp:825
+#: data.cpp:833
 msgid "Alaraph"
 msgstr "Alaraph"
 
-#: data.cpp:826
+#: data.cpp:834
 #, fuzzy
 msgid "Aniara"
 msgstr "荷尼阿拉"
 
-#: data.cpp:827
+#: data.cpp:835
 msgid "Groombridge 1830"
 msgstr "Groombridge 1830"
 
-#: data.cpp:828
+#: data.cpp:836
 msgid "Phecda"
 msgstr "天璣[北斗三] (Phecda)"
 
-#: data.cpp:829
+#: data.cpp:837
 msgid "Phad"
 msgstr "Phad"
 
-#: data.cpp:830
+#: data.cpp:838
 msgid "Tonatiuh"
 msgstr ""
 
-#: data.cpp:831
+#: data.cpp:839
 msgid "Alchiba"
 msgstr "右轄 (Alchiba)"
 
-#: data.cpp:832
+#: data.cpp:840
 msgid "Imai"
 msgstr ""
 
-#: data.cpp:833
+#: data.cpp:841
 msgid "Megrez"
 msgstr "天權[北斗四] (Megrez)"
 
-#: data.cpp:834
+#: data.cpp:842
 msgid "Gienah"
 msgstr "軫宿一 (Gienah)"
 
-#: data.cpp:835
+#: data.cpp:843
 msgid "Zaniah"
 msgstr "左執法[太微左垣一] (Zaniah)"
 
-#: data.cpp:836
+#: data.cpp:844
 msgid "Ginan"
 msgstr ""
 
-#: data.cpp:837
+#: data.cpp:845
 msgid "Tupã"
 msgstr ""
 
-#: data.cpp:838
+#: data.cpp:846
 msgid "Acrux"
 msgstr "十字架二 (Acrux)"
 
-#: data.cpp:839
+#: data.cpp:847
 msgid "Algorab"
 msgstr "軫宿三 (Algorab)"
 
-#: data.cpp:840
+#: data.cpp:848
 msgid "Gacrux"
 msgstr "十字架一 (Gacrux)"
 
-#: data.cpp:841
+#: data.cpp:849
 msgid "Funi"
 msgstr ""
 
-#: data.cpp:842
+#: data.cpp:850
 msgid "Chara"
 msgstr "常陳四 (Chara)"
 
-#: data.cpp:843
+#: data.cpp:851
 msgid "Kraz"
 msgstr "軫宿四 (Kraz)"
 
-#: data.cpp:844
+#: data.cpp:852
 msgid "Muhlifain"
 msgstr "庫樓七 (Muhlifain)"
 
-#: data.cpp:845
+#: data.cpp:853
 msgid "Porrima"
 msgstr "東上相[太微左垣二] (Porrima)"
 
-#: data.cpp:846
+#: data.cpp:854
 msgid "La Superba"
 msgstr ""
 
-#: data.cpp:847
+#: data.cpp:855
 msgid "Tianyi"
 msgstr ""
 
-#: data.cpp:848
+#: data.cpp:856
 msgid "Mimosa"
 msgstr "十字架三 (Mimosa)"
 
-#: data.cpp:849
+#: data.cpp:857
 msgid "Alioth"
 msgstr "玉衡[北斗五] (Alioth)"
 
-#: data.cpp:850
+#: data.cpp:858
 msgid "Taiyi"
 msgstr ""
 
-#: data.cpp:851
+#: data.cpp:859
 msgid "Minelauva"
 msgstr "東次相[太微左垣三] (Minelauva)"
 
-#: data.cpp:852
+#: data.cpp:860
 msgid "Auva"
 msgstr "Auva"
 
-#: data.cpp:853
+#: data.cpp:861
 msgid "Cor Caroli"
 msgstr "常陳一 (Cor Caroli)"
 
-#: data.cpp:854
+#: data.cpp:862
 msgid "Vindemiatrix"
 msgstr "東次將[太微左垣四] (Vindemiatrix)"
 
-#: data.cpp:855
+#: data.cpp:863
 msgid "Almuredin"
 msgstr "Almuredin"
 
-#: data.cpp:856
+#: data.cpp:864
 msgid "Diadem"
 msgstr ""
 
-#: data.cpp:857
+#: data.cpp:865
 msgid "Mizar"
 msgstr "開陽[北斗六] (Mizar)"
 
-#: data.cpp:858
+#: data.cpp:866
 msgid "Spica"
 msgstr "角宿一 (Spica)"
 
-#: data.cpp:859
+#: data.cpp:867
 msgid "Azimech"
 msgstr "Azimech"
 
-#: data.cpp:860
+#: data.cpp:868
 msgid "Alcor"
 msgstr "輔 (Alcor)"
 
-#: data.cpp:861
+#: data.cpp:869
 msgid "Dofida"
 msgstr ""
 
-#: data.cpp:862
+#: data.cpp:870
 msgid "Liesma"
 msgstr ""
 
-#: data.cpp:863
+#: data.cpp:871
 msgid "Heze"
 msgstr "角宿二 (Heze)"
 
-#: data.cpp:864
+#: data.cpp:872
 msgid "Alkaid"
 msgstr "搖光[北斗七] (Alkaid)"
 
-#: data.cpp:865
+#: data.cpp:873
 msgid "Benetnasch"
 msgstr "Benetnasch"
 
-#: data.cpp:866
+#: data.cpp:874
 msgid "Muphrid"
 msgstr "右攝提一 (Muphrid)"
 
-#: data.cpp:867
+#: data.cpp:875
 msgid "Hadar"
 msgstr "馬腹一 (Hadar)"
 
-#: data.cpp:868
+#: data.cpp:876
 msgid "Agena"
 msgstr "Agena"
 
-#: data.cpp:869
+#: data.cpp:877
 msgid "Thuban"
 msgstr "右樞[紫微右垣一] (Thuban)"
 
-#: data.cpp:870
+#: data.cpp:878
 msgid "Menkent"
 msgstr "庫樓三 (Menkent)"
 
-#: data.cpp:871
+#: data.cpp:879
 msgid "Kang"
 msgstr ""
 
-#: data.cpp:872
+#: data.cpp:880
 msgid "Arcturus"
 msgstr "大角 (Arcturus)"
 
-#: data.cpp:873
+#: data.cpp:881
 msgid "Syrma"
 msgstr "亢宿二 (Syrma)"
 
-#: data.cpp:874
+#: data.cpp:882
 msgid "Xuange"
 msgstr ""
 
-#: data.cpp:875
+#: data.cpp:883
 msgid "Elgafar"
 msgstr ""
 
-#: data.cpp:876
+#: data.cpp:884
 msgid "Proxima"
 msgstr "比鄰星 (Proxima)"
 
-#: data.cpp:877
+#: data.cpp:885
 msgid "Seginus"
 msgstr "招搖 (Seginus)"
 
-#: data.cpp:878
+#: data.cpp:886
 msgid "Ceginus"
 msgstr "七公增十 (Ceginus)"
 
-#: data.cpp:879
+#: data.cpp:887
 msgid "Toliman"
 msgstr ""
 
-#: data.cpp:880
+#: data.cpp:888
 msgid "Rigil Kentaurus"
 msgstr ""
 
-#: data.cpp:881
+#: data.cpp:889
 msgid "Izar"
 msgstr "梗河一 (Izar)"
 
-#: data.cpp:882
+#: data.cpp:890
 msgid "Mirak"
 msgstr "Mirak"
 
-#: data.cpp:883
+#: data.cpp:891
 msgid "Pulcherrima"
 msgstr "Pulcherrima"
 
-#: data.cpp:884
+#: data.cpp:892
 msgid "Mönch"
 msgstr ""
 
-#: data.cpp:885
+#: data.cpp:893
 msgid "Merga"
 msgstr ""
 
-#: data.cpp:886
+#: data.cpp:894
 msgid "Kochab"
 msgstr "帝[北極二] (Kochab)"
 
-#: data.cpp:887
+#: data.cpp:895
 msgid "Kocab"
 msgstr "帝[北極二] (Kocab)"
 
-#: data.cpp:888
+#: data.cpp:896
 msgid "Zubenelgenubi"
 msgstr "Zubenelgenubi"
 
-#: data.cpp:889
+#: data.cpp:897
 msgid "Arcalís"
 msgstr ""
 
-#: data.cpp:890
+#: data.cpp:898
 msgid "Baekdu"
 msgstr ""
 
-#: data.cpp:891
+#: data.cpp:899
 msgid "Zuben Elakribi"
 msgstr "氐宿增一 (Zuben Elakribi)"
 
-#: data.cpp:892
+#: data.cpp:900
 msgid "Nekkar"
 msgstr "七公增五 (Nekkar)"
 
-#: data.cpp:893
+#: data.cpp:901
 msgid "Brachium"
 msgstr ""
 
-#: data.cpp:894
+#: data.cpp:902
 msgid "Zubeneschamali"
 msgstr "氐宿四 (Zubeneschamali)"
 
-#: data.cpp:895
+#: data.cpp:903
 #, fuzzy
 msgid "Pherkad Minor"
 msgstr "太子[北極一] (Pherkad)"
 
-#: data.cpp:896
+#: data.cpp:904
 msgid "Nikawiy"
 msgstr ""
 
-#: data.cpp:897
+#: data.cpp:905
 msgid "Pherkad"
 msgstr "太子[北極一] (Pherkad)"
 
-#: data.cpp:898
+#: data.cpp:906
 msgid "Alkalurops"
 msgstr "七公六 (Alkalurops)"
 
-#: data.cpp:899
+#: data.cpp:907
 msgid "Edasich"
 msgstr "左樞[紫微左垣一] (Edasich)"
 
-#: data.cpp:900
+#: data.cpp:908
 msgid "Nusakan"
 msgstr "貫索三 (Nusakan)"
 
-#: data.cpp:901
+#: data.cpp:909
 msgid "Alphecca"
 msgstr "貫索四 (Alphecca)"
 
-#: data.cpp:902
+#: data.cpp:910
 msgid "Gemma"
 msgstr "Gemma"
 
-#: data.cpp:903
+#: data.cpp:911
 #, fuzzy
 msgid "Zubenelhakrabi"
 msgstr "氐宿三 (Zuben Elakrab)"
 
-#: data.cpp:904
+#: data.cpp:912
 msgid "Zuben Elakrab"
 msgstr "氐宿三 (Zuben Elakrab)"
 
-#: data.cpp:905
+#: data.cpp:913
 msgid "Karaka"
 msgstr ""
 
-#: data.cpp:906
+#: data.cpp:914
 msgid "Unukalhai"
 msgstr "蜀[天市右垣七] (Unukalhai)"
 
-#: data.cpp:907
+#: data.cpp:915
 msgid "Chow"
 msgstr "Chow"
 
-#: data.cpp:908
+#: data.cpp:916
 msgid "Gudja"
 msgstr ""
 
-#: data.cpp:909
+#: data.cpp:917
 msgid "Iklil"
 msgstr ""
 
-#: data.cpp:910
+#: data.cpp:918
 msgid "Fang"
 msgstr ""
 
-#: data.cpp:911
+#: data.cpp:919
 msgid "Dschubba"
 msgstr "房宿三 (Dschubba)"
 
-#: data.cpp:912
+#: data.cpp:920
 msgid "Acrab"
 msgstr ""
 
-#: data.cpp:913
+#: data.cpp:921
 msgid "Graffias"
 msgstr "Graffias"
 
-#: data.cpp:914
+#: data.cpp:922
 msgid "Akrab"
 msgstr "Akrab"
 
-#: data.cpp:915
+#: data.cpp:923
 #, fuzzy
 msgid "Marsic"
 msgstr "火星"
 
-#: data.cpp:916
+#: data.cpp:924
 msgid "Jabbah"
 msgstr "鍵閉 (Jabbah)"
 
-#: data.cpp:917
+#: data.cpp:925
 msgid "Sharjah"
 msgstr ""
 
-#: data.cpp:918
+#: data.cpp:926
 msgid "Yed Prior"
 msgstr ""
 
-#: data.cpp:919
+#: data.cpp:927
 msgid "Yed Posterior"
 msgstr ""
 
-#: data.cpp:920
+#: data.cpp:928
 msgid "Hunor"
 msgstr ""
 
-#: data.cpp:921
+#: data.cpp:929
 #, fuzzy
 msgid "Alniyat"
 msgstr "Al Niyat"
 
-#: data.cpp:922
+#: data.cpp:930
 msgid "Al Niyat"
 msgstr "Al Niyat"
 
-#: data.cpp:923
+#: data.cpp:931
 #, fuzzy
 msgid "Athebyne"
 msgstr "雅典"
 
-#: data.cpp:924
+#: data.cpp:932
 msgid "Cujam"
 msgstr "斗一 (Cujam)"
 
-#: data.cpp:925
+#: data.cpp:933
 msgid "Timir"
 msgstr ""
 
-#: data.cpp:926
+#: data.cpp:934
 msgid "Antares"
 msgstr "心宿二 (Antares)"
 
-#: data.cpp:927
+#: data.cpp:935
 msgid "Kornephoros"
 msgstr "河中[天市右垣一] (Kornephoros)"
 
-#: data.cpp:928
+#: data.cpp:936
 msgid "Ogma"
 msgstr ""
 
-#: data.cpp:929
+#: data.cpp:937
 msgid "Marfik"
 msgstr "列肆二 (Marfik)"
 
-#: data.cpp:930
+#: data.cpp:938
 msgid "Rosalíadecastro"
 msgstr ""
 
-#: data.cpp:931
+#: data.cpp:939
 msgid "Paikauhale"
 msgstr ""
 
-#: data.cpp:932
+#: data.cpp:940
 msgid "Atria"
 msgstr "三角形三 (Atria)"
 
-#: data.cpp:933
+#: data.cpp:941
 #, fuzzy
 msgid "Larawag"
 msgstr "塔拉瓦"
 
-#: data.cpp:934
+#: data.cpp:942
 msgid "Xamidimura"
 msgstr ""
 
-#: data.cpp:935
+#: data.cpp:943
 #, fuzzy
 msgid "Pipirima"
 msgstr "東上相[太微左垣二] (Porrima)"
 
-#: data.cpp:936
+#: data.cpp:944
 msgid "Mahsati"
 msgstr ""
 
-#: data.cpp:937
+#: data.cpp:945
 #, fuzzy
 msgid "Rapeto"
 msgstr "土衛八(Iapetus)"
 
-#: data.cpp:938
+#: data.cpp:946
 #, fuzzy
 msgid "Alrakis"
 msgstr "Arrakis"
 
-#: data.cpp:939
+#: data.cpp:947
 msgid "Arrakis"
 msgstr "Arrakis"
 
-#: data.cpp:940
+#: data.cpp:948
 #, fuzzy
 msgid "Aldhibah"
 msgstr "右轄 (Alchiba)"
 
-#: data.cpp:941
+#: data.cpp:949
 msgid "Sabik"
 msgstr "宋[天市左垣十一] (Sabik)"
 
-#: data.cpp:942
+#: data.cpp:950
 msgid "Rasalgethi"
 msgstr "帝座 (Rasalgethi)"
 
-#: data.cpp:943
+#: data.cpp:951
 msgid "Ras Algethi"
 msgstr "Ras Algethi"
 
-#: data.cpp:944
+#: data.cpp:952
 msgid "Sarin"
 msgstr "魏[天市左垣一] (Sarin)"
 
-#: data.cpp:945
+#: data.cpp:953
 msgid "Guniibuu"
 msgstr ""
 
-#: data.cpp:946
+#: data.cpp:954
 msgid "Inquill"
 msgstr ""
 
-#: data.cpp:947
+#: data.cpp:955
 msgid "Rastaban"
 msgstr "天棓三 (Rastaban)"
 
-#: data.cpp:948
+#: data.cpp:956
 msgid "Maasym"
 msgstr "趙[天市左垣二] (Maasym)"
 
-#: data.cpp:949
+#: data.cpp:957
 msgid "Lesath"
 msgstr "尾宿九 (Lesath)"
 
-#: data.cpp:950
+#: data.cpp:958
 msgid "Lesuth"
 msgstr "Lesuth"
 
-#: data.cpp:951
+#: data.cpp:959
 msgid "Kuma"
 msgstr "天棓增一 (Kuma)"
 
-#: data.cpp:952
+#: data.cpp:960
 msgid "Yildun"
 msgstr "勾陳二 (Yildun)"
 
-#: data.cpp:953
+#: data.cpp:961
 msgid "Shaula"
 msgstr "尾宿八 (Shaula)"
 
-#: data.cpp:954
+#: data.cpp:962
 msgid "Rasalhague"
 msgstr "候 (Rasalhague)"
 
-#: data.cpp:955
+#: data.cpp:963
 msgid "Ras Alhague"
 msgstr "Ras Alhague"
 
-#: data.cpp:956
+#: data.cpp:964
 msgid "Sargas"
 msgstr "尾宿五 (Sargas)"
 
-#: data.cpp:957
+#: data.cpp:965
 msgid "Dziban"
 msgstr "Dziban"
 
-#: data.cpp:958
+#: data.cpp:966
 msgid "Girtab"
 msgstr ""
 
-#: data.cpp:959
+#: data.cpp:967
 msgid "Cebalrai"
 msgstr "宗正一 (Cebalrai)"
 
-#: data.cpp:960
+#: data.cpp:968
 msgid "Alruba"
 msgstr ""
 
-#: data.cpp:961
+#: data.cpp:969
 #, fuzzy
 msgid "Cervantes"
 msgstr "天文臺"
 
-#: data.cpp:962
+#: data.cpp:970
 msgid "Fuyue"
 msgstr ""
 
-#: data.cpp:963
+#: data.cpp:971
 msgid "Grumium"
 msgstr "天棓一 (Grumium)"
 
-#: data.cpp:964
+#: data.cpp:972
 msgid "Eltanin"
 msgstr "天棓四 (Eltanin)"
 
-#: data.cpp:965
+#: data.cpp:973
 msgid "Etamin"
 msgstr "Etamin"
 
-#: data.cpp:966
+#: data.cpp:974
 msgid "Barnard's Star"
 msgstr "巴納德 (Barnard) 星"
 
-#: data.cpp:967
+#: data.cpp:975
 msgid "Pincoya"
 msgstr ""
 
-#: data.cpp:968
+#: data.cpp:976
 msgid "Alnasl"
 msgstr "箕宿一 (Alnasl)"
 
-#: data.cpp:969
+#: data.cpp:977
 msgid "Polis"
 msgstr ""
 
-#: data.cpp:970
+#: data.cpp:978
 msgid "Kaus Media"
 msgstr "箕宿二 (Kaus Media)"
 
-#: data.cpp:971
+#: data.cpp:979
 msgid "Alasia"
 msgstr ""
 
-#: data.cpp:972
+#: data.cpp:980
 msgid "Kaus Australis"
 msgstr "箕宿三 (Kaus Australis)"
 
-#: data.cpp:973
+#: data.cpp:981
 msgid "Al Athfar"
 msgstr "織女增三 (Al Athfar)"
 
-#: data.cpp:974
+#: data.cpp:982
 msgid "Fafnir"
 msgstr ""
 
-#: data.cpp:975
+#: data.cpp:983
 msgid "Kaus Borealis"
 msgstr "斗宿二 (Kaus Borealis)"
 
-#: data.cpp:976
+#: data.cpp:984
 msgid "Vega"
 msgstr "織女一 (Vega)"
 
-#: data.cpp:977
+#: data.cpp:985
 msgid "Xihe"
 msgstr ""
 
-#: data.cpp:978
+#: data.cpp:986
 msgid "Sheliak"
 msgstr "漸台二 (Sheliak)"
 
-#: data.cpp:979
+#: data.cpp:987
 #, fuzzy
 msgid "Ainalrami"
 msgstr "天鉤五 (Alderamin)"
 
-#: data.cpp:980
+#: data.cpp:988
 msgid "Nunki"
 msgstr "斗宿四 (Nunki)"
 
-#: data.cpp:981
+#: data.cpp:989
 msgid "Kaveh"
 msgstr ""
 
-#: data.cpp:982
+#: data.cpp:990
 msgid "Alya"
 msgstr "徐[天市左垣七] (Alya)"
 
-#: data.cpp:983
+#: data.cpp:991
 msgid "Sulafat"
 msgstr "漸台三 (Sulafat)"
 
-#: data.cpp:984
+#: data.cpp:992
 msgid "Ascella"
 msgstr "斗宿六 (Ascella)"
 
-#: data.cpp:985
+#: data.cpp:993
 msgid "Okab"
 msgstr ""
 
-#: data.cpp:986
+#: data.cpp:994
 msgid "Deneb el Okab"
 msgstr "Deneb el Okab"
 
-#: data.cpp:987
+#: data.cpp:995
 msgid "Meridiana"
 msgstr ""
 
-#: data.cpp:988
+#: data.cpp:996
 #, fuzzy
 msgid "Albaldah"
 msgstr "女宿一 (Albali)"
 
-#: data.cpp:989
+#: data.cpp:997
 msgid "Altais"
 msgstr "天廚一 (Altais)"
 
-#: data.cpp:990
+#: data.cpp:998
 msgid "Al Tais"
 msgstr "Al Tais"
 
-#: data.cpp:991
+#: data.cpp:999
 msgid "Nodus Secundus"
 msgstr "Nodus Secundus"
 
-#: data.cpp:992
+#: data.cpp:1000
 msgid "Aladfar"
 msgstr "輦道二 (Aladfar)"
 
-#: data.cpp:993
+#: data.cpp:1001
 #, fuzzy
 msgid "Gumala"
 msgstr "瓜地馬拉"
 
-#: data.cpp:994
+#: data.cpp:1002
 msgid "Belel"
 msgstr ""
 
-#: data.cpp:995
+#: data.cpp:1003
 #, fuzzy
 msgid "Arkab Prior"
 msgstr "Arkab"
 
-#: data.cpp:996
+#: data.cpp:1004
 msgid "Arkab"
 msgstr "Arkab"
 
-#: data.cpp:997
+#: data.cpp:1005
 msgid "Sika"
 msgstr ""
 
-#: data.cpp:998
+#: data.cpp:1006
 msgid "Arkab Posterior"
 msgstr ""
 
-#: data.cpp:999
+#: data.cpp:1007
 msgid "Rukbat"
 msgstr "天淵三 (Rukbat)"
 
-#: data.cpp:1000
+#: data.cpp:1008
 msgid "Anser"
 msgstr ""
 
-#: data.cpp:1001
+#: data.cpp:1009
 msgid "Albireo"
 msgstr "輦道增七 (Albireo)"
 
-#: data.cpp:1002
+#: data.cpp:1010
 msgid "Uruk"
 msgstr ""
 
-#: data.cpp:1003
+#: data.cpp:1011
 msgid "Alsafi"
 msgstr "天廚二 (Alsafi)"
 
-#: data.cpp:1004
+#: data.cpp:1012
 msgid "Campbell's Star"
 msgstr "Campbell 星"
 
-#: data.cpp:1005
+#: data.cpp:1013
 msgid "Sham"
 msgstr "左旗一 (Sham)"
 
-#: data.cpp:1006
+#: data.cpp:1014
 #, fuzzy
 msgid "Fawaris"
 msgstr "巴黎"
 
-#: data.cpp:1007
+#: data.cpp:1015
 msgid "Tarazed"
 msgstr "河鼓三 (Tarazed)"
 
-#: data.cpp:1008
+#: data.cpp:1016
 msgid "Tyl"
 msgstr "天廚三 (Tyl)"
 
-#: data.cpp:1009
+#: data.cpp:1017
 msgid "Altair"
 msgstr "河鼓二 (Altair)"
 
-#: data.cpp:1010
+#: data.cpp:1018
 msgid "Atair"
 msgstr "Atair"
 
-#: data.cpp:1011
+#: data.cpp:1019
 msgid "Libertas"
 msgstr ""
 
-#: data.cpp:1012
+#: data.cpp:1020
 msgid "Alshain"
 msgstr "河鼓一 (Alshain)"
 
-#: data.cpp:1013
+#: data.cpp:1021
 msgid "Terebellum"
 msgstr ""
 
-#: data.cpp:1014
+#: data.cpp:1022
 msgid "Phoenicia"
 msgstr ""
 
-#: data.cpp:1015
+#: data.cpp:1023
 msgid "Chechia"
 msgstr ""
 
-#: data.cpp:1016
+#: data.cpp:1024
 msgid "Algedi"
 msgstr "牛宿二 (Algedi)"
 
-#: data.cpp:1017
+#: data.cpp:1025
 #, fuzzy
 msgid "Alshat"
 msgstr "河鼓一 (Alshain)"
 
-#: data.cpp:1018
+#: data.cpp:1026
 msgid "Dabih"
 msgstr "牛宿一 (Dabih)"
 
-#: data.cpp:1019
+#: data.cpp:1027
 msgid "Sadr"
 msgstr "天津一 (Sadr)"
 
-#: data.cpp:1020
+#: data.cpp:1028
 msgid "Peacock"
 msgstr "孔雀十一 (Peacock)"
 
-#: data.cpp:1021
+#: data.cpp:1029
 msgid "Aldulfin"
 msgstr ""
 
-#: data.cpp:1022
+#: data.cpp:1030
 msgid "Rotanev"
 msgstr "瓠瓜四 (Rotanev)"
 
-#: data.cpp:1023
+#: data.cpp:1031
 msgid "Sualocin"
 msgstr "瓠瓜一 (Sualocin)"
 
-#: data.cpp:1024
+#: data.cpp:1032
 msgid "Deneb"
 msgstr "天津四 (Deneb)"
 
-#: data.cpp:1025
+#: data.cpp:1033
 #, fuzzy
 msgid "Aljanah"
 msgstr "留布利安納"
 
-#: data.cpp:1026
+#: data.cpp:1034
 msgid "Albali"
 msgstr "女宿一 (Albali)"
 
-#: data.cpp:1027
+#: data.cpp:1035
 msgid "Musica"
 msgstr ""
 
-#: data.cpp:1028
+#: data.cpp:1036
 #, fuzzy
 msgid "Polaris Australis"
 msgstr "箕宿三 (Kaus Australis)"
 
-#: data.cpp:1029
+#: data.cpp:1037
 #, fuzzy
 msgid "Solaris"
 msgstr "勾陳一[北極星] (Polaris)"
 
-#: data.cpp:1030
+#: data.cpp:1038
 msgid "Kitalpha"
 msgstr "虛宿二 (Kitalpha)"
 
-#: data.cpp:1031
+#: data.cpp:1039
 msgid "Lacaille 8760"
 msgstr "拉卡伊 Lacaille 8760"
 
-#: data.cpp:1032
+#: data.cpp:1040
 msgid "Alderamin"
 msgstr "天鉤五 (Alderamin)"
 
-#: data.cpp:1033
+#: data.cpp:1041
 msgid "Alfirk"
 msgstr "上衛增一 (Alfirk)"
 
-#: data.cpp:1034
+#: data.cpp:1042
 msgid "Sadalsuud"
 msgstr "虛宿一 (Sadalsuud)"
 
-#: data.cpp:1035
+#: data.cpp:1043
 #, fuzzy
 msgid "Bunda"
 msgstr "邊界"
 
-#: data.cpp:1036
+#: data.cpp:1044
 msgid "Sāmaya"
 msgstr ""
 
-#: data.cpp:1037
+#: data.cpp:1045
 msgid "Nashira"
 msgstr "壘壁陣三 (Nashira)"
 
-#: data.cpp:1038
+#: data.cpp:1046
 msgid "Azelfafage"
 msgstr "螣蛇四 (Azelfafage)"
 
-#: data.cpp:1039
+#: data.cpp:1047
 msgid "Bosona"
 msgstr ""
 
-#: data.cpp:1040
+#: data.cpp:1048
 msgid "Herschel's Garnet Star"
 msgstr "赫歇爾的石榴石星"
 
-#: data.cpp:1041
+#: data.cpp:1049
 #, fuzzy
 msgid "Erakis"
 msgstr "Arrakis"
 
-#: data.cpp:1042
+#: data.cpp:1050
 msgid "Enif"
 msgstr "危宿三 (Enif)"
 
-#: data.cpp:1043
+#: data.cpp:1051
 msgid "Deneb Algedi"
 msgstr "壘壁陣四 (Deneb Algedi)"
 
-#: data.cpp:1044
+#: data.cpp:1052
 #, fuzzy
 msgid "Aldhanab"
 msgstr "敗臼一 (Al Dhanab)"
 
-#: data.cpp:1045
+#: data.cpp:1053
 msgid "Al Dhanab"
 msgstr "敗臼一 (Al Dhanab)"
 
-#: data.cpp:1046
+#: data.cpp:1054
 msgid "Itonda"
 msgstr ""
 
-#: data.cpp:1047
+#: data.cpp:1055
 msgid "Kurhah"
 msgstr "天鉤六 (Kurhah)"
 
-#: data.cpp:1048
+#: data.cpp:1056
 msgid "Sadalmelik"
 msgstr "危宿一 (Sadalmelik)"
 
-#: data.cpp:1049
+#: data.cpp:1057
 msgid "Alnair"
 msgstr "鶴一 (Alnair)"
 
-#: data.cpp:1050
+#: data.cpp:1058
 msgid "Al Nair"
 msgstr "Al Nair"
 
-#: data.cpp:1051
+#: data.cpp:1059
 msgid "Biham"
 msgstr "危宿二 (Biham)"
 
-#: data.cpp:1052
+#: data.cpp:1060
 msgid "Ancha"
 msgstr "泣二 (Ancha)"
 
-#: data.cpp:1053
+#: data.cpp:1061
 msgid "Sadachbia"
 msgstr "墳墓二 (Sadachbia)"
 
-#: data.cpp:1054
+#: data.cpp:1062
 msgid "Seat"
 msgstr "墳墓四 (Seat)"
 
-#: data.cpp:1055
+#: data.cpp:1063
 msgid "Lionrock"
 msgstr ""
 
-#: data.cpp:1056
+#: data.cpp:1064
 msgid "Kruger 60"
 msgstr "Kruger 60"
 
-#: data.cpp:1057
+#: data.cpp:1065
 msgid "Situla"
 msgstr "虛梁三 (Situla)"
 
-#: data.cpp:1058
+#: data.cpp:1066
 msgid "Homam"
 msgstr "雷電一 (Homam)"
 
-#: data.cpp:1059
+#: data.cpp:1067
 msgid "Tiaki"
 msgstr ""
 
-#: data.cpp:1060
+#: data.cpp:1068
 msgid "Matar"
 msgstr "離宮四 (Matar)"
 
-#: data.cpp:1061
+#: data.cpp:1069
 msgid "Babcock's Star"
 msgstr "Babcock 星"
 
-#: data.cpp:1062
+#: data.cpp:1070
 msgid "Sadalbari"
 msgstr "離宮二 (Sadalbari)"
 
-#: data.cpp:1063
+#: data.cpp:1071
 msgid "Hydor"
 msgstr ""
 
-#: data.cpp:1064
+#: data.cpp:1072
 msgid "Skat"
 msgstr "羽林軍二十六 (Skat)"
 
-#: data.cpp:1065
+#: data.cpp:1073
 msgid "Helvetios"
 msgstr ""
 
-#: data.cpp:1066
+#: data.cpp:1074
 msgid "Fomalhaut"
 msgstr "北落師門 (Fomalhaut)"
 
-#: data.cpp:1067
+#: data.cpp:1075
 msgid "Scheat"
 msgstr "室宿二 (Scheat)"
 
-#: data.cpp:1068
+#: data.cpp:1076
 #, fuzzy
 msgid "Fumalsamakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1069
+#: data.cpp:1077
 msgid "Fum al Samakah"
 msgstr "Fum al Samakah"
 
-#: data.cpp:1070
+#: data.cpp:1078
 msgid "Markab"
 msgstr "室宿一 (Markab)"
 
-#: data.cpp:1071
+#: data.cpp:1079
 msgid "Marchab"
 msgstr "Marchab"
 
-#: data.cpp:1072
+#: data.cpp:1080
 msgid "Ebla"
 msgstr ""
 
-#: data.cpp:1073
+#: data.cpp:1081
 msgid "Bradley 3077"
 msgstr "布萊得雷 3077"
 
-#: data.cpp:1074
+#: data.cpp:1082
 msgid "Salm"
 msgstr ""
 
-#: data.cpp:1075
+#: data.cpp:1083
 #, fuzzy
 msgid "Alkarab"
 msgstr "安哥拉"
 
-#: data.cpp:1076
+#: data.cpp:1084
 msgid "Veritate"
 msgstr ""
 
-#: data.cpp:1077
+#: data.cpp:1085
 msgid "Poerava"
 msgstr ""
 
-#: data.cpp:1078
+#: data.cpp:1086
 msgid "Errai"
 msgstr "少衛增八 (Errai)"
 
-#: data.cpp:1079
+#: data.cpp:1087
 msgid "Axólotl"
 msgstr ""
 
-#: data.cpp:1080
+#: data.cpp:1088
 msgid "Milky Way"
 msgstr "Milky Way 銀河"
 
-#: data.cpp:1081
+#: data.cpp:1089
 msgid "LMC"
 msgstr "LMC"
 
-#: data.cpp:1082
+#: data.cpp:1090
 msgid "SMC"
 msgstr "SMC"
 
-#: data.cpp:1083
+#: data.cpp:1091
 msgid "Pleiades"
 msgstr "昴宿星團"
 
-#: data.cpp:1084
+#: data.cpp:1092
 msgid "Hyades"
 msgstr "畢宿星團"
 
-#: data.cpp:1085
+#: data.cpp:1093
 msgid "Praesepe"
 msgstr "鬼宿星團"
 
-#: data.cpp:1086
+#: data.cpp:1094
 msgid "Beehive Cluster"
 msgstr "蜂巢星團"
 
-#: data.cpp:1087
+#: data.cpp:1095
 msgid "Maffei 1"
 msgstr "Maffei 1"
 
-#: data.cpp:1088
+#: data.cpp:1096
 msgid "Maffei 2"
 msgstr "Maffei 2"
 
-#: data.cpp:1089
+#: data.cpp:1097
 msgid "Leo A"
 msgstr "獅子座 A"
 
-#: data.cpp:1090
+#: data.cpp:1098
 msgid "Sextans B"
 msgstr "六分儀座 B"
 
-#: data.cpp:1091
+#: data.cpp:1099
 msgid "Leo I"
 msgstr "獅子座 I"
 
-#: data.cpp:1092
+#: data.cpp:1100
 msgid "Sextans A"
 msgstr "六分儀座 A"
 
-#: data.cpp:1094
+#: data.cpp:1101
+#, fuzzy
+msgid "Circinus"
+msgstr "Circinus 圓規座"
+
+#: data.cpp:1102
 msgid "Andromeda Galaxy"
 msgstr ""
 
-#: data.cpp:1095
+#: data.cpp:1103
 msgid "Triangulum Galaxy"
 msgstr ""
 
-#: data.cpp:1096
+#: data.cpp:1104
 msgid "Holmberg VI"
 msgstr "Holmberg VI"
 
-#: data.cpp:1097
+#: data.cpp:1105
 msgid "Fath 703"
 msgstr "Fath 703"
 
-#: data.cpp:1098
+#: data.cpp:1106
 msgid "47 Tuc"
 msgstr "杜鵑座 47"
 
-#: data.cpp:1101
+#: data.cpp:1107
+#, fuzzy
+msgid "Eridanus"
+msgstr "Eridanus 波江座"
+
+#: data.cpp:1108
+#, fuzzy
+msgid "Pyxis"
+msgstr "Pyxis 羅盤座"
+
+#: data.cpp:1109
 msgid "Tonantzintla 2"
 msgstr "Tonantzintla 2"
 


### PR DESCRIPTION
This change is backwards-incompatible with 1.6.x. Fixes #189

Related Celestia PR: CelestiaProject/Celestia#2260