### PR TITLE
nearstars.stc update (2025-02-09)

### DIFF
--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -38,7 +38,19 @@
 # Barycenter positions are based on mass estimates from the papers themselves. The 
 # values used are listed below.
 
+
+
 # Common papers:
+
+# Baliunas et al. (1983), AJ 275, p. 752-772
+#   "Stellar rotation in lower main-sequence stars measured from time variations in H and K emission-line fluxes. II.
+#    Detailed analysis of the 1980 observing season data."
+#   https://ui.adsabs.harvard.edu/abs/1983ApJ...275..752B/abstract
+
+# Baliunas et al. (1996), AJ Letters 457, p.L99
+#   "Magnetic Field and Rotation in Lower Main-Sequence Stars:
+#    an Empirical Time-dependent Magnetic Bode's Relation?"
+#   https://ui.adsabs.harvard.edu/abs/1996ApJ...457L..99B/abstract
 
 # Boyajian et al. (2012), AJ 746 (1), id. 101
 #   "Stellar Diameters and Temperatures. I. Main-sequence A, F, and G Stars"
@@ -49,17 +61,28 @@
 #   https://ui.adsabs.harvard.edu/abs/2012ApJ...757..112B/abstract
 
 # Boyajian et al. (2013), AJ 771 (1), id. 40
-#   "Stellar Diameters and Temperatures. III. Main-sequence A, F, G, and K Stars:
-#    Additional High-precision Measurements and Empirical Relations"
+#   "Stellar Diameters and Temperatures. III. Main-sequence A, F, G, and K Stars: Additional High-precision Measurements and Empirical Relations"
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...771...40B/abstract
+
+# Cincunegui et al. (2007), A&A 469 (1), pp.309-317
+#   "Hα and the Ca II H and K lines as activity proxies for late-type stars"
+#   https://ui.adsabs.harvard.edu/abs/2007A%26A...469..309C/abstract
+
+# Demory et al. (2009), A&A 505 (1), 205
+#   "Mass-radius relation of low and very low-mass stars revisited with the VLTI"
+#   https://www.aanda.org/articles/aa/full_html/2009/37/aa11976-09/aa11976-09.html
 
 # Díez Alonso et al. (2019), A&A 621, id.A126
 #   "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
 
 # Engle et al. (2023), AJ Letters 954 (2), id.L50
-# "Living with a Red Dwarf: The Rotation-Age Relationships of M Dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2023ApJ...954L..50E/abstract
+#   "Living with a Red Dwarf: The Rotation-Age Relationships of M Dwarfs"
+#   https://ui.adsabs.harvard.edu/abs/2023ApJ...954L..50E/abstract
+
+# Hojjatpanah et al. (2020), A&A 639, id.A35
+#   "The correlation between photometric variability and radial velocity jitter. Based on TESS and HARPS observations"
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...639A..35H/abstract
 
 # Houdebine et al. (2019), AJ 158 (2), id. 56
 #   "The Mass-Activity Relationships in M and K Dwarfs. I.
@@ -105,6 +128,12 @@
 # Segransan et al. (2000), A&A 364, 665
 #   "Accurate masses of very low mass stars. III. 16 new or improved masses"
 #   http://adsabs.harvard.edu/abs/2000A%26A...364..665S
+
+# Zhang et al. (2020), AJ 891 (2), id.171
+#   "COol Companions ON Ultrawide orbiTS (COCONUTS). I.
+#    A High-gravity T4 Benchmark around an Old White Dwarf and a Re-examination of
+#    the Surface-gravity Dependence of the L/T Transition"
+#   https://ui.adsabs.harvard.edu/abs/2020ApJ...891..171Z/abstract
 
 
 
@@ -921,6 +950,7 @@ Barycenter "EPS Ind:Gliese 845" # orbit of A & B components unknown
 # V-magnitudes from King et al. (2010), A&A 510, id.A99
 #   "ɛ Indi Ba, Bb: a detailed study of the nearest known brown dwarfs
 #   https://ui.adsabs.harvard.edu/abs/2010A%26A...510A..99K/abstract
+# Temperatures and radii (calculated) from Zhang et al. (2020), AJ 891 (2), id.171
 Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 {
 	RA 331.07645260
@@ -930,10 +960,10 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 "EPS Ind Ba:CI Ind A:Gliese 845 Ba:GJ 13185 A"
 {
-	Radius 59000
-	SpectralType "T1.5V"
-	AppMag 24.12
-	Temperature 1320
+	Radius<rS>	0.08762
+	SpectralType	"T1.5V"
+	AppMag	24.12
+	Temperature	1304
 
 	OrbitBarycenter "EPS Ind B"
 	EllipticalOrbit {
@@ -950,10 +980,10 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 "EPS Ind Bb:CI Ind B:Gliese 845 Bb:GJ 13185 B"
 {
-	Radius 61000
-	SpectralType "T6V"
-	AbsMag 40 # extremely low
-	Temperature 910
+	Radius<rS>	0.08698
+	SpectralType	"T6V"
+	AbsMag	40 # extremely low
+	Temperature	963
 
 	OrbitBarycenter "EPS Ind B"
 	EllipticalOrbit {
@@ -2146,10 +2176,8 @@ Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 }
 
 # Used Gaia EDR3 parallax for A
-# mass and radius of A from Demory et al. (2009), A&A 505 (1), 205
-# "Mass-radius relation of low and very low-mass stars revisited with the VLTI"
-# https://www.aanda.org/articles/aa/full_html/2009/37/aa11976-09/aa11976-09.html
-# masses of B, C from same sources as orbit
+# Mass and radius of A from Demory et al. (2009), A&A 505 (1), 205
+# Masses of B, C from same sources as orbit
 Barycenter "Gliese 570:ADS 9446"
 {
 	RA 224.36820687 # mass ratio 0.802:(0.586:0.390)
@@ -2157,14 +2185,16 @@ Barycenter "Gliese 570:ADS 9446"
 	Distance 19.1987 # 169.8843 +/- 0.0653 mas
 }
 
+# Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# Rotation period from Cincunegui et al. (2007), A&A 469 (1), pp.309-317
 73184 "KX Lib:Gliese 570 A:ADS 9446 A"
 {
-	OrbitBarycenter "Gliese 570"
-	SpectralType "K4V"
-	AppMag 5.64
-	Radius 514100
-	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
+	Radius<rS>	0.715
+	SpectralType	"K4V"
+	AppMag	5.64
+	Temperature	4505
 
+	OrbitBarycenter "Gliese 570"
 	EllipticalOrbit {             # fully specified orientation
 		Period           2130
 		SemiMajorAxis   104.5 # mass ratio 0.802:(0.586:0.390)
@@ -2174,12 +2204,19 @@ Barycenter "Gliese 570:ADS 9446"
 		ArgOfPericenter 129.2
 		MeanAnomaly      52.6
 	}
+	UniformRotation
+	{
+	    Period<d>	44.6
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
 }
 
+# Temperatures and radii (non-empirical) from Torres et al. (2010), A&A Review 18 (1-2), pp. 67-126
+#   "Accurate masses and radii of normal stars: modern results and applications"
+#   https://ui.adsabs.harvard.edu/abs/2010A%26ARv..18...67T/abstract
 Barycenter 73182 "Gliese 570 BC"
 {
 	OrbitBarycenter "Gliese 570"
-
 	EllipticalOrbit {             # fully specified orientation
 		Period           2130
 		SemiMajorAxis    85.9 # mass ratio 0.802:(0.586:0.390)
@@ -2193,11 +2230,12 @@ Barycenter 73182 "Gliese 570 BC"
 
 "Gliese 570 B:ADS 9446 B"
 {
-	OrbitBarycenter "Gliese 570 BC"
-	SpectralType "M1.5V"
-	Radius 324000 # approx. for class
-	AppMag 8.33
+	Radius<rS>	0.67
+	SpectralType	"M1.5V"
+	AppMag	8.33
+	Temperature	3500
 
+	OrbitBarycenter "Gliese 570 BC"
 	EllipticalOrbit {              # fully specified orientation
 		Period            0.846
 		SemiMajorAxis     0.35 # mass ratio 0.586:0.390
@@ -2207,15 +2245,17 @@ Barycenter 73182 "Gliese 570 BC"
 		ArgOfPericenter 221.92
 		MeanAnomaly      45.19
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
 }
 
 "Gliese 570 C:ADS 9446 C"
 {
-	OrbitBarycenter "Gliese 570 BC"
-	SpectralType "M3V"
-	Radius 270000 # approx. for class
-	AppMag 9.94
+	Radius<rS>	0.43
+	SpectralType	"M3V"
+	AppMag	9.94
+	Temperature	3270
 
+	OrbitBarycenter "Gliese 570 BC"
 	EllipticalOrbit {             # fully specified orientation
 		Period           0.846
 		SemiMajorAxis    0.53 # mass ratio 0.586:0.390
@@ -2225,21 +2265,24 @@ Barycenter 73182 "Gliese 570 BC"
 		ArgOfPericenter 41.92
 		MeanAnomaly     45.19
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
 }
 
-# radius and temperature from Zhang et al. (2021), ApJ 911 (1), 7
-# "The Hawaii Infrared Parallax Program. V. New T-dwarf Members and Candidate
-# Members of Nearby Young Moving Groups"
-# https://iopscience.iop.org/article/10.3847/1538-4357/abe3fa
+# Radius and temperature from Zhang et al. (2021), ApJ 911 (1), 7
+#   "The Hawaii Infrared Parallax Program. V. New T-dwarf Members and Candidate
+#    Members of Nearby Young Moving Groups"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/abe3fa
 "Gliese 570 D:ADS 9446 D"
 {
 	RA 224.31233
 	Dec -21.36328
 	Distance 19.1987
-	SpectralType "T7.5V"
-	Temperature 786
-	Radius 64000
-	AbsMag 40 # extremely low
+
+	Radius<rJ>	0.89
+	SpectralType	"T7.5V"
+	AbsMag	40 # extremely low
+	Temperature	786
+
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
 }
 
@@ -2332,12 +2375,15 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 }
 
 # Mass ratio from theoretical values from same source as orbit
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
 "Achird A:ETA Cas A:24 Cas A:Gliese 34 A:ADS 671 A"
 {
-	OrbitBarycenter "ETA Cas"
-	SpectralType "G0V"
-	AppMag 3.44
+	Radius<rS>	1.0386
+	SpectralType	"G0V"
+	AppMag	3.44
+	Temperature	5973
 
+	OrbitBarycenter "ETA Cas"
 	EllipticalOrbit {
 		Period          479.27
 		SemiMajorAxis    24.23 # mass ratio 1.07:0.55
@@ -2347,14 +2393,15 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 		ArgOfPericenter 182.11
 		MeanAnomaly      82.68
 	}
+	InfoURL	"https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
 }
 
 2026693663 "Achird B:ETA Cas B:24 Cas B:Gliese 34 B:ADS 671 B"
 {
-	OrbitBarycenter "ETA Cas"
 	SpectralType "K7V"
 	AppMag 7.51
 
+	OrbitBarycenter "ETA Cas"
 	EllipticalOrbit {
 		Period        479.27
 		SemiMajorAxis  47.13 # mass ratio 1.07:0.55
@@ -2364,6 +2411,7 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 		ArgOfPericenter 2.11
 		MeanAnomaly    82.68
 	}
+	InfoURL	"https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
 }
 
 Barycenter "Guniibuu:36 Oph:Gliese 663:ADS 10417" # orbit of (AB) & C unknown
@@ -2373,6 +2421,7 @@ Barycenter "Guniibuu:36 Oph:Gliese 663:ADS 10417" # orbit of (AB) & C unknown
 	Distance 19.4092
 }
 
+# Rotation periods from Baliunas et al. (1983), AJ 275, p. 752-772
 Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 {
 	RA 258.83461527 # mass ratio 0.75:0.76
@@ -2381,14 +2430,17 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 }
 
 # Average masses from Luck, R. E. (2017), AJ 153 (1), 21
-# "Abundances in the Local Region II: F, G, and K Dwarfs and Subgiants"
-# http://iopscience.iop.org/article/10.3847/1538-3881/153/1/21/meta
+#   "Abundances in the Local Region II: F, G, and K Dwarfs and Subgiants"
+#   http://iopscience.iop.org/article/10.3847/1538-3881/153/1/21/meta
+# Radius and temperature from Demory et al. (2009), A&A 505 (1), 205
 1003266820 "Guniibuu A:36 Oph A:Gliese 663 A:ADS 10417 A"
 {
-	OrbitBarycenter "36 Oph AB"
-	SpectralType "K2V"
-	AppMag 5.08
+	Radius<rS>	0.817
+	SpectralType	"K2V"
+	AppMag	5.08
+	Temperature	4843
 
+	OrbitBarycenter "36 Oph AB"
 	EllipticalOrbit {
 		Period          470.9
 		SemiMajorAxis    38.93 # mass ratio 0.75:0.76
@@ -2398,14 +2450,19 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 		ArgOfPericenter 270.97
 		MeanAnomaly     246.27
 	}
+	UniformRotation
+	{
+	    Period<d>	20.3
+	}
+	InfoURL	"https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
 2003266820 "Guniibuu B:36 Oph B:Gliese 663 B:ADS 10417 B"
 {
-	OrbitBarycenter "36 Oph AB"
 	SpectralType "K1V"
 	AppMag 5.08
 
+	OrbitBarycenter "36 Oph AB"
 	EllipticalOrbit {
 		Period         470.9
 		SemiMajorAxis   38.42 # mass ratio 0.75:0.76
@@ -2415,15 +2472,27 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 		ArgOfPericenter 90.97
 		MeanAnomaly    246.27
 	}
+	UniformRotation
+	{
+	    Period<d>	22.9
+	}
+	InfoURL	"https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
+# Rotation period from Baliunas et al. (1996), AJ Letters 457, p.L99
 84478 "Guniibuu C:36 Oph C:V2215 Oph:Gliese 664:Gliese 663 C:ADS 10417 C"
 {
 	RA 259.05329410
 	Dec -26.55114609
 	Distance 19.4185 # 167.9617 +/- 0.0311 mas
+
 	SpectralType "K5V"
 	AppMag 6.34
+
+	UniformRotation
+	{
+	    Period<d>	21
+	}
 	InfoURL "https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
@@ -2453,10 +2522,9 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 	InfoURL "https://en.wikipedia.org/wiki/WISE_1541%E2%88%922250"
 }
 
-# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
-# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
-# M Dwarfs"
-# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
+# Masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
+#   "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence M Dwarfs"
+#   http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
 Barycenter 1242 "GJ 1005:Luyten 722-22"
 {
 	RA 3.86988027
@@ -2524,13 +2592,25 @@ Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A &
 	AppMag 11.50
 }
 
-15510 # 82 Eri
+# Physical properties from Nari et al. (2025), A&A 693, id.A297
+#   "Revisiting the multi-planetary system of the nearby star HD 20794:
+#    Confirmation of a low-mass planet in the habitable zone of a nearby G-dwarf"
+#   https://ui.adsabs.harvard.edu/abs/2025A%26A...693A.297N/abstract
+15510 # e Eri / 82 G. Eri / HD 20794
 {
 	RA 50.00034362
 	Dec -43.06655253
 	Distance 19.7045 # 165.5242 +/- 0.0784 mas
-	SpectralType "G6V"
-	AppMag 4.27
+
+	Radius<rS>	0.93    # not directly measured
+	SpectralType	"G6V"
+	AppMag	4.336
+	Temperature	5368
+	
+	UniformRotation
+	{
+	    Period<d>	38.8
+	}
 	InfoURL "https://en.wikipedia.org/wiki/82_G._Eridani"
 }
 
@@ -2579,13 +2659,24 @@ Barycenter 34603 "Gliese 268:Ross 986"
 	}
 }
 
+# Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# Rotation period from Hojjatpanah et al. (2020), A&A 639, id.A35
 99240 # Del Pav
 {
 	RA 302.19503989
 	Dec -66.18709128
 	Distance 19.8931 # 163.9544 +/- 0.1222 mas
+
+	Radius<rS>	1.197
 	SpectralType "G8IV"
 	AppMag 3.56
+	Temperature	5571
+
+	UniformRotation
+	{
+	    Period<d>	21.4
+	}
+	InfoURL	"https://en.wikipedia.org/wiki/Delta_Pavonis"
 }
 
 "2MASS 0136+0933:2MASS J01365662+0933473:SIMP J013656.5+093347:GJ 10218"
@@ -2598,9 +2689,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 	InfoURL "https://en.wikipedia.org/wiki/SIMP_J013656.5%2B093347"
 }
 
-# coordinates, parallax from Schilbach, Röser & Scholz (2009), A&A 493 (2), L27-L30
-# "Trigonometric parallaxes of ten ultracool subdwarfs"
-# https://www.aanda.org/articles/aa/abs/2009/02/aa11281-08/aa11281-08.html
+# Coordinates, parallax from Schilbach, Röser & Scholz (2009), A&A 493 (2), L27-L30
+#   "Trigonometric parallaxes of ten ultracool subdwarfs"
+#   https://www.aanda.org/articles/aa/abs/2009/02/aa11281-08/aa11281-08.html
 "2MASS 0937+2931:2MASS J09373487+2931409:GJ 11388"
 {
 	RA 144.395250
@@ -2716,7 +2807,7 @@ Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_581"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 1405+5534:WISE J140518.39+553421.3:GJ 12023"
 {
 	RA 211.320620
@@ -2730,9 +2821,9 @@ Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 }
 
 # Parameters from Gonzalez-Alvarez et al. (2020), A&A 637, A93
-# "The CARMENES search for exoplanets around M dwarfs. A super-Earth planet orbiting 
-# HD 79211 (GJ 338 B)"
-# https://arxiv.org/abs/2003.13052
+#   "The CARMENES search for exoplanets around M dwarfs. A super-Earth planet orbiting 
+#    HD 79211 (GJ 338 B)"
+#   https://arxiv.org/abs/2003.13052
 Barycenter "Gliese 338:Struve 1321:ADS 7251"
 {
 	RA 138.58729103 # mass ratio 0.69:0.64
@@ -3012,17 +3103,33 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 	InfoURL "https://en.wikipedia.org/wiki/GJ_1128"
 }
 
-114622 # Gliese 892
+# Radius and temperature from Li et al. (2025), preprint
+#   "K-dwarf Radius Inflation and a 10-Gyr Spin-down Clock Unveiled through
+#    Asteroseismology of HD~219134 from the Keck Planet Finder"
+#   https://arxiv.org/abs/2502.00971
+# Rotation period from Motalebi et al. (2015), A&A 584, id.A72
+#   "The HARPS-N Rocky Planet Search. I. HD 219134 b:
+#    A transiting rocky planet in a multi-planet system at 6.5 pc from the Sun"
+#   https://ui.adsabs.harvard.edu/abs/2015A%26A...584A..72M/abstract
+114622 # Gliese 892 / HD 219134
 {
 	RA 348.33773395
 	Dec 57.16966644
 	Distance 21.3364 # 152.8640 +/- 0.0494 mas
-	SpectralType "K3V"
-	AppMag 5.570
+
+	Radius<rS>	0.783
+	SpectralType	"K3V"
+	AppMag	5.674
+	Temperature	4678
+
+	UniformRotation
+	{
+	    Period<d>	42.3
+	}
 	InfoURL "https://en.wikipedia.org/wiki/HD_219134"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 0825+2805:WISE J082507.35+280548.5:GJ 11222"
 {
 	RA 126.280525

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -47,124 +47,205 @@
 #   "Stellar rotation in lower main-sequence stars measured from time variations in H and K emission-line fluxes. II. Detailed analysis of the 1980 observing season data."
 #   https://ui.adsabs.harvard.edu/abs/1983ApJ...275..752B/abstract
 
-# Baliunas et al. (1996), AJ Letters 457, p.L99
+# Baliunas et al. (1996), AJL 457, p.L99
 #   "Magnetic Field and Rotation in Lower Main-Sequence Stars: an Empirical Time-dependent Magnetic Bode's Relation?"
+#   https://iopscience.iop.org/article/10.1086/309891
 #   https://ui.adsabs.harvard.edu/abs/1996ApJ...457L..99B/abstract
+
+# Beichman et al. (2014), ApJ 783 (2), 68
+#   "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+
+# Benedict et al. (2016), AJ 152 (5), 141
+#   "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence M Dwarfs"
+#   http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
 
 # Boyajian et al. (2012), AJ 746 (1), id. 101
 #   "Stellar Diameters and Temperatures. I. Main-sequence A, F, and G Stars"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/746/1/101
 #   https://ui.adsabs.harvard.edu/abs/2012ApJ...746..101B/abstract
 
 # Boyajian et al. (2012), AJ 757 (2), id. 112
 #   "Stellar Diameters and Temperatures. II. Main-sequence K- and M-stars"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/757/2/112
 #   https://ui.adsabs.harvard.edu/abs/2012ApJ...757..112B/abstract
 
 # Boyajian et al. (2013), AJ 771 (1), id. 40
 #   "Stellar Diameters and Temperatures. III. Main-sequence A, F, G, and K Stars: Additional High-precision Measurements and Empirical Relations"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/771/1/40
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...771...40B/abstract
+
+# von Braun et al. (2014), MNRAS 438 (3), p.2413–2425
+#   "Stellar diameters and temperatures – V. 11 newly characterized exoplanet host stars"
+#   https://academic.oup.com/mnras/article/438/3/2413/972333
+#   https://ui.adsabs.harvard.edu/abs/2014MNRAS.438.2413V/abstract
 
 # Brandenburg et al. (2017), AJ 845 (1), id. 79
 #   "Evolution of Co-existing Long and Short Period Stellar Activity Cycles"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/aa7cfa
 #   https://ui.adsabs.harvard.edu/abs/2017ApJ...845...79B/abstract
 
 # Chevalier et al. (2023), A&A 678, id.A19
 #   "Binary masses and luminosities with Gaia DR3"
+#   https://www.aanda.org/articles/aa/full_html/2023/10/aa47111-23/aa47111-23.html
 #   https://ui.adsabs.harvard.edu/abs/2023A%26A...678A..19C/abstract
 
 # Cincunegui et al. (2007), A&A 469 (1), pp.309-317
 #   "Hα and the Ca II H and K lines as activity proxies for late-type stars"
+#   https://www.aanda.org/articles/aa/abs/2007/25/aa6503-06/aa6503-06.html
 #   https://ui.adsabs.harvard.edu/abs/2007A%26A...469..309C/abstract
+
+# Delfosse et al. (1999), A&A 344, 897
+#   "New neighbours. I. 13 new companions to nearby M dwarfs"
+#   http://adsabs.harvard.edu/abs/1999A&A...344..897D
+#   https://arxiv.org/abs/astro-ph/9812008
 
 # Demory et al. (2009), A&A 505 (1), 205
 #   "Mass-radius relation of low and very low-mass stars revisited with the VLTI"
 #   https://www.aanda.org/articles/aa/full_html/2009/37/aa11976-09/aa11976-09.html
+#   https://ui.adsabs.harvard.edu/abs/2009A%26A...505..205D/abstract
 
 # Díez Alonso et al. (2019), A&A 621, id.A126
 #   "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
+#   https://www.aanda.org/articles/aa/full_html/2019/01/aa33316-18/aa33316-18.html
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
 
 # Donahue et al. (1996), AJ 466, p.384
 #   "A Relationship between Mean Rotation Period in Lower Main-Sequence Stars and Its Observed Range"
 #   https://ui.adsabs.harvard.edu/abs/1996ApJ...466..384D/abstract
 
-# Engle et al. (2023), AJ Letters 954 (2), id.L50
+# Engle et al. (2023), AJL 954 (2), id.L50
 #   "Living with a Red Dwarf: The Rotation-Age Relationships of M Dwarfs"
+#   https://iopscience.iop.org/article/10.3847/2041-8213/acf472
 #   https://ui.adsabs.harvard.edu/abs/2023ApJ...954L..50E/abstract
+
+# Hekker and Aerts (2010), A&A 515, id.A43
+#   "Line-profile variations of stochastically excited oscillations in four evolved stars"
+#   https://ui.adsabs.harvard.edu/abs/2010A%26A...515A..43H/abstract
 
 # Hojjatpanah et al. (2020), A&A 639, id.A35
 #   "The correlation between photometric variability and radial velocity jitter. Based on TESS and HARPS observations"
+#   https://www.aanda.org/articles/aa/full_html/2020/07/aa38035-20/aa38035-20.html
 #   https://ui.adsabs.harvard.edu/abs/2020A%26A...639A..35H/abstract
 
 # Houdebine et al. (2019), AJ 158 (2), id. 56
-#   "The Mass-Activity Relationships in M and K Dwarfs. I. Stellar Parameters of Our Sample of M and K Dwarfs"
+#   "The Mass–Activity Relationships in M and K Dwarfs. I. Stellar Parameters of Our Sample of M and K Dwarfs"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ab23fe
 #   https://ui.adsabs.harvard.edu/abs/2019AJ....158...56H/abstract
+
+# Justesen and Albrecht (2020), A&A 642, id.A212
+#   "The spin-orbit alignment of visual binaries"
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...642A.212J/abstract
+
+# Kirkpatrick et al. (2019), ApJS 240 (2), 19
+#   "Preliminary Trigonometric Parallaxes of 184 Late-T and Y Dwarfs and an Analysis of the Field Substellar Mass Function into the "Planetary" Mass Regime"
+#   https://iopscience.iop.org/article/10.3847/1538-4365/aaf6af
 
 # Laliotis et al. (2023), AJ 165 (4), id.176
 #   "Doppler Constraints on Planetary Companions to Nearby Sun-like Stars: An Archival Radial Velocity Survey of Southern Targets for Proposed NASA Direct Imaging Missions"
-# https://ui.adsabs.harvard.edu/abs/2023AJ....165..176L/abstract
+#   https://iopscience.iop.org/article/10.3847/1538-3881/acc067
+#   https://ui.adsabs.harvard.edu/abs/2023AJ....165..176L/abstract
 
 # Mann et al. (2013), AJ 779 (2), id. 188
 #   "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/779/2/188
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
 
 # Mann et al. (2015), ApJ 804 (1), 64
 #   "How to Constrain Your M Dwarf: Measuring Effective Temperature, Bolometric Luminosity, Mass, and Radius"
-#   http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
+#   https://iopscience.iop.org/article/10.1088/0004-637X/804/1/64
+#   https://ui.adsabs.harvard.edu/abs/2015ApJ...804...64M/abstract
+
+# Montesinos et al. (2016), A&A 593, id.A51
+#   "Incidence of debris discs around FGK stars in the solar neighbourhood"
+#   https://www.aanda.org/articles/aa/full_html/2016/09/aa28329-16/aa28329-16.html
+#   https://ui.adsabs.harvard.edu/abs/2016A%26A...593A..51M/abstract
 
 # Olspert et al. (2018), A&A 619, id.A6
 #   "Estimating activity cycles with probabilistic methods. II. The Mount Wilson Ca H&K data"
+#   https://www.aanda.org/articles/aa/full_html/2018/11/aa32525-17/aa32525-17.html
 #   https://ui.adsabs.harvard.edu/abs/2018A%26A...619A...6O/abstract
 
 # Pass et al. (2023), AJ 166 (1), id.16
 #   "Active Stars in the Spectroscopic Survey of Mid-to-late M Dwarfs within 15 pc"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/acd6a2
 #   https://ui.adsabs.harvard.edu/abs/2023AJ....166...16P/abstract
 
 # Pizzolato et al. (2003), A&A 397, p.147-157
 #   "The stellar activity-rotation relationship revisited: Dependence of saturated and non-saturated X-ray emission regimes on stellar mass for late-type dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2003A%26A...397..147P/abstract
+#   https://www.aanda.org/articles/aa/abs/2003/01/aa2680/aa2680.html
+#   https://ui.adsabs.harvard.edu/abs/2003A%26A...397..147P/abstract
 
 # Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-#   "A discontinuity in the Teff-radius relation of M-dwarfs"
+#   "A discontinuity in the Teff–radius relation of M-dwarfs"
+#   https://academic.oup.com/mnras/article/484/2/2674/5289886
 #   https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 
 # Rains et al. (2020), MNRAS 493 (2), p.2377-2394
 #   "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
+#   https://academic.oup.com/mnras/article/493/2/2377/5771406
 #   https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
 
 # Reinhold et al. (2019), A&A 621, id.A21
 #   "Transition from spot to faculae domination. An alternate explanation for the dearth of intermediate Kepler rotation periods"
+#   https://www.aanda.org/articles/aa/full_html/2019/01/aa33754-18/aa33754-18.html
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A..21R/abstract
 
 # Segransan et al. (2000), A&A 364, 665
 #   "Accurate masses of very low mass stars. III. 16 new or improved masses"
+#   https://arxiv.org/abs/astro-ph/0010585
 #   http://adsabs.harvard.edu/abs/2000A%26A...364..665S
 
 # Suárez Mascareño et al. (2015), MNRAS 452 (3), p.2745-2756
 #   "Rotation periods of late-type dwarf stars from time series high-resolution spectroscopy of chromospheric indicators"
+#   https://academic.oup.com/mnras/article/452/3/2745/1079718
 #   https://ui.adsabs.harvard.edu/abs/2015MNRAS.452.2745S/abstract
+
+# Tokovinin et al. (2015), AJ 150 (2), 50
+#   "Speckle Interferometry at SOAR in 2014"
+#   http://iopscience.iop.org/article/10.1088/0004-6256/150/2/50/meta
+
+# Tokovinin et al. (2020), AJ 160 (1), 7
+#   "Speckle Interferometry at SOAR in 2019"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ab91c1
+#   https://ui.adsabs.harvard.edu/abs/2020AJ....160....7T/abstract
+
+# van Belle et al. (2009), AJ 694 (2), pp. 1085-1098
+#   "Directly Determined Linear Radii and Effective Temperatures of Exoplanet Host Stars"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/694/2/1085
+#   https://ui.adsabs.harvard.edu/abs/2009ApJ...694.1085V/abstract
+
+# Wright et al. (2004), AJ Supplement Series 152 (2), pp. 261-295
+#   "Chromospheric Ca II Emission in Nearby F, G, K, and M Stars"
+#   https://iopscience.iop.org/article/10.1086/386283
+#   https://ui.adsabs.harvard.edu/abs/2004ApJS..152..261W/abstract
 
 # Wright et al. (2011), AJ 743 (1), id. 48
 #   "The Stellar-activity-Rotation Relationship and the Evolution of Stellar Dynamos"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/743/1/48
 #   https://ui.adsabs.harvard.edu/abs/2011ApJ...743...48W/abstract
 
 # Zhang et al. (2020), AJ 891 (2), id.171
 #   "COol Companions ON Ultrawide orbiTS (COCONUTS). I. A High-gravity T4 Benchmark around an Old White Dwarf and a Re-examination of the Surface-gravity Dependence of the L/T Transition"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ab765c
 #   https://ui.adsabs.harvard.edu/abs/2020ApJ...891..171Z/abstract
 
 
 
 Barycenter "Solar System Barycenter:SSB"
 {
-	RA 0
-	Dec 0
-	Distance 0
+	RA	0
+	Dec	0
+	Distance	0
 }
 
 # Radius from Emilio et al. (2012), AJ 750 (2), id. 135
 #   "Measuring the Solar Radius from Space during the 2003 and 2006 Mercury Transits"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/750/2/135
 #   https://ui.adsabs.harvard.edu/abs/2012ApJ...750..135E/abstract
 # AbsMag (V-band) from Willmer (2018), AJ 236 (2), id. 47
 #   "The Absolute Magnitude of the Sun in Several Filters"
+#   https://iopscience.iop.org/article/10.3847/1538-4365/aabfdf
 #   https://ui.adsabs.harvard.edu/abs/2018ApJS..236...47W/abstract
 0 "Sol:Sun"
 {
@@ -174,8 +255,9 @@ Barycenter "Solar System Barycenter:SSB"
 	Radius	696342
 	SpectralType	"G2V"
 	AbsMag	4.81
-	Temperature	5772
 	BoloCorrection	-0.08
+	Temperature	5772
+	
 	UniformRotation
 	{
 	    Period<d>	25.38
@@ -189,15 +271,17 @@ Barycenter "Solar System Barycenter:SSB"
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
 # V-magnitude from Ribas et al. (2017), A&A 603, id.A58
 #   "The full spectral radiative properties of Proxima Centauri"
+#   https://www.aanda.org/articles/aa/full_html/2017/07/aa30582-17/aa30582-17.html
 #   https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..58R/abstract
 # Rotation period from Collins et al. (2017), A&A 602, id.A48
 #   "Calculations of periodicity from Hα profiles of Proxima Centauri"
+#   https://www.aanda.org/articles/aa/full_html/2017/06/aa28827-16/aa28827-16.html
 #   https://ui.adsabs.harvard.edu/abs/2017A%26A...602A..48C/abstract
 70890 # Proxima Cen
 {
-	RA  217.39232147
-	Dec -62.67607512
-	Distance 4.2465 # 768.0665 +/- 0.0499 mas
+	RA	 217.39232147
+	Dec	-62.67607512
+	Distance	4.2465 # 768.0665 +/- 0.0499 mas
 
 	Radius<rS>	0.154
 	SpectralType	"M5.5Ve"
@@ -216,14 +300,16 @@ Barycenter "Solar System Barycenter:SSB"
 # Akeson et al. (2021), AJ 162 (1), 14
 #   "Precision Millimeter Astrometry of the α Centauri AB System"
 #   https://iopscience.iop.org/article/10.3847/1538-3881/abfaff
+#   https://iopscience.iop.org/article/10.3847/1538-3881/abfaff
 # Temperatures of A and B from Kervella et al. (2017), A&A 597, id.A137
 #   "The radii and limb darkenings of α Centauri A and B . Interferometric measurements with VLTI/PIONIER"
+#   https://www.aanda.org/articles/aa/full_html/2017/01/aa29505-16/aa29505-16.html
 #   https://ui.adsabs.harvard.edu/abs/2017A%26A...597A.137K/abstract
 Barycenter "ALF Cen:Gliese 559"
 {
-	RA  219.85892215
-	Dec -60.83163195
-	Distance 4.3441 # 750.81 +/- 0.38 mas
+	RA	 219.85892215
+	Dec	-60.83163195
+	Distance	4.3441 # 750.81 +/- 0.38 mas
 }
 
 71683 # ALF Cen A
@@ -278,12 +364,13 @@ Barycenter "ALF Cen:Gliese 559"
 # Temperature from Mann et al. (2013), AJ 779 (2), id. 188
 # Rotation period from Toledo-Padrón et al. (2019), MNRAS 488 (4), p.5145-5161
 #   "Stellar activity analysis of Barnard's Star: very slow rotation and evidence for long-term activity cycle"
+#   https://academic.oup.com/mnras/article/488/4/5145/5539724
 #   https://ui.adsabs.harvard.edu/abs/2019MNRAS.488.5145T/abstract
 87937 # Barnard's Star
 {
-	RA 269.44850253
-	Dec 4.73942005
-	Distance 5.9629 # 546.9759 +/- 0.0401 mas
+	RA	269.44850253
+	Dec	4.73942005
+	Distance	5.9629 # 546.9759 +/- 0.0401 mas
 
 	Radius<rS>	0.185
 	SpectralType	"M4V"
@@ -299,23 +386,25 @@ Barycenter "ALF Cen:Gliese 559"
 
 # Bedin et al. (2024), AN 345 (1), e20230158
 #   "HST astrometry of the closest brown dwarfs-II. Improved parameters and constraints on a third body"
+#   https://onlinelibrary.wiley.com/doi/full/10.1002/asna.20230158
 #   https://ui.adsabs.harvard.edu/abs/2024AN....34530158B/abstract
 # Magnitudes from Boffin et al. (2014), A&A 561, L4
-#   "Possible astrometric discovery of a substellar companion to the closest
-#    binary brown dwarf system WISE J104915.57-531906.1"
+#   "Possible astrometric discovery of a substellar companion to the closest binary brown dwarf system WISE J104915.57-531906.1"
 #   https://www.aanda.org/articles/aa/full_html/2014/01/aa22975-13/aa22975-13.html
+#   https://ui.adsabs.harvard.edu/abs/2014A%26A...561L...4B/abstract
 # Temperatures from Kniazev et al. (2013), AJ 770 (2), id. 124
 #   "Characterization of the nearby L/T Binary Brown Dwarf WISE J104915.57-531906.1 at 2 pc from the Sun"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/770/2/124
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...770..124K/abstract
 # Rotation periods from Apai, Nardiello & Bedin (2021), ApJ 906 (1), 64
-#   "TESS Observations of the Luhman 16 AB Brown Dwarf System: Rotational Periods,
-#    Lightcurve Evolution, and Zonal Circulation"
+#   "TESS Observations of the Luhman 16 AB Brown Dwarf System: Rotational Periods, Lightcurve Evolution, and Zonal Circulation"
 #   https://iopscience.iop.org/article/10.3847/1538-4357/abcb97
+#   https://ui.adsabs.harvard.edu/abs/2021ApJ...906...64A/abstract
 Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 {
-	RA 162.32821578
-	Dec -53.31941054
-	Distance 6.51019 # 500.993 +/- 0.050 mas
+	RA	162.32821578
+	Dec	-53.31941054
+	Distance	6.51019 # 500.993 +/- 0.050 mas
 }
 
 "Luhman 16 A:WISE 1049-5319 A:WISE J104915.57-531906.1 A:GJ 11551 A"
@@ -363,12 +452,13 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 # Parameters from Kirkpatrick et al. (2021)
 # Temperature from Luhman et al. (2024), AJ 167 (1), id.5
 #   "JWST/NIRSpec Observations of the Coldest Known Brown Dwarf"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ad0b72
 #   https://ui.adsabs.harvard.edu/abs/2024AJ....167....5L/abstract
 "WISE 0855-0714:WISE J085510.83-071442.5:GJ 11286"
 {
-	RA 133.780984
-	Dec -7.243932
-	Distance 7.430 # 439.0 +/- 2.4 mas
+	RA	133.780984
+	Dec	-7.243932
+	Distance	7.430 # 439.0 +/- 2.4 mas
 
 	Radius 60000 # approx.
 	SpectralType "Y4"
@@ -382,9 +472,9 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 # Rotation period from Díez Alonso et al. (2019), A&A 621, id.A126
 "CN Leo:Gliese 406:Wolf 359"
 {
-	RA 164.10319031
-	Dec 7.00272694
-	Distance 7.8558 # 415.1794 +/- 0.0684 mas
+	RA	164.10319031
+	Dec	7.00272694
+	Distance	7.8558 # 415.1794 +/- 0.0684 mas
 
 	Radius<rS>	0.159
 	SpectralType	"M6V"
@@ -403,12 +493,13 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 # Rotation period from Díaz et al. (2019), A&A 625, id.A17
 #   "The SOPHIE search for northern extrasolar planets. XIV.
 #    A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
+#   https://www.aanda.org/articles/aa/full_html/2019/05/aa35019-19/aa35019-19.html
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...625A..17D/abstract
 54035 # Gliese 411 / Lalande 21185
 {
-	RA 165.83095968
-	Dec 35.94865303
-	Distance 8.3044 # 392.7529 +/- 0.0321 mas
+	RA	165.83095968
+	Dec	35.94865303
+	Distance	8.3044 # 392.7529 +/- 0.0321 mas
 
 	Radius<rS>	0.387
 	SpectralType	"M2V"
@@ -426,11 +517,12 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 #   "The Sirius System and Its Astrophysical Puzzles: Hubble Space Telescope and 
 #    Ground-based Astrometry"
 #   https://iopscience.iop.org/article/10.3847/1538-4357/aa6af8
+#   https://ui.adsabs.harvard.edu/abs/2017ApJ...840...70B/abstract
 Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 {
-	RA 101.28715533
-	Dec -16.71611586
-	Distance 8.608 # 378.9 +/- 1.4 mas
+	RA	101.28715533
+	Dec	-16.71611586
+	Distance	8.608 # 378.9 +/- 1.4 mas
 }
 
 "Sirius A:Dog Star A:ALF CMa A:9 CMa A:Gliese 244 A:ADS 5423 A"
@@ -477,23 +569,27 @@ Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 # Orbit from Gravity Collaboration (2024), A&A 685, id.L9
 #   "Astrometric detection of a Neptune-mass candidate planet in
 #    the nearest M-dwarf binary system GJ65 with VLTI/GRAVITY"
+#   https://www.aanda.org/articles/aa/full_html/2024/05/aa49547-24/aa49547-24.html
 #   https://ui.adsabs.harvard.edu/abs/2024A%26A...685L...9G/abstract
 # Radii from Kervella et al. (2016), A&A 593, id.A127
 #   "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
 #    Fundamental parameters from PIONIER, NACO, and UVES observations"
+#   https://www.aanda.org/articles/aa/full_html/2016/09/aa28631-16/aa28631-16.html
 #   https://ui.adsabs.harvard.edu/abs/2016A%26A...593A.127K/abstract
 # Temperatures from MacDonald et al. (2018), AJ 860 (1), id. 15
 #   "The Magnetic Binary GJ 65: A Test of Magnetic Diffusivity Effects"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/aac2c0
 #   https://ui.adsabs.harvard.edu/abs/2018ApJ...860...15M/abstract
 # Rotation periods and inclinations from Barnes et al. (2017), MNRAS 471 (1), 811
 #   "Surprisingly different star-spot distributions on the near equal-mass 
 #    equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
+#   https://academic.oup.com/mnras/article/471/1/811/3871365
 #   https://ui.adsabs.harvard.edu/abs/2017MNRAS.471..811B/abstract
 Barycenter "Gliese 65:Luyten 726-8"
 {
-	RA 24.77161345
-	Dec -17.94799509
-	Distance 8.78190              # 371.396 ± 0.453 mas
+	RA	24.77161345
+	Dec	-17.94799509
+	Distance	8.78190              # 371.396 ± 0.453 mas
 }
 
 "BL Cet:Gliese 65 A:Luyten 726-8 A"
@@ -553,12 +649,13 @@ Barycenter "Gliese 65:Luyten 726-8"
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
 # Rotation period and inclination from Ibañez Bustos et al. (2020), A&A 644, id.A2
 #   "Activity-rotation in the dM4 star Gl 729. A possible chromospheric cycle"
+#   https://www.aanda.org/articles/aa/full_html/2020/12/aa39164-20/aa39164-20.html
 #   https://ui.adsabs.harvard.edu/abs/2020A%26A...644A...2I/abstract
 92403 # Gliese 729 / Ross 154
 {
-	RA 282.45878902
-	Dec -23.83709745
-	Distance 9.7063 # 336.0266 +/- 0.0317 mas
+	RA	282.45878902
+	Dec	-23.83709745
+	Distance	9.7063 # 336.0266 +/- 0.0317 mas
 
 	Radius<rS>	0.205
 	SpectralType "M3.5Ve"
@@ -576,9 +673,9 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 "HH And:Gliese 905:Ross 248"
 {
-	RA 355.48001526
-	Dec 44.17037570
-	Distance 10.3057 # 316.4812 +/- 0.0444 mas
+	RA	355.48001526
+	Dec	44.17037570
+	Distance	10.3057 # 316.4812 +/- 0.0444 mas
 	SpectralType "M5.0V"
 	AppMag 12.28
 	InfoURL "https://en.wikipedia.org/wiki/Ross_248"
@@ -586,17 +683,19 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 # Parallax from Benedict (2022), Research Notes of the AAS 6 (3), id.45
 #   "Revisiting HST/FGS Astrometry of ϵ Eridani
+#   https://iopscience.iop.org/article/10.3847/2515-5172/ac5b6b
 #   https://ui.adsabs.harvard.edu/abs/2022RNAAS...6...45B/abstract
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
 # Rotational elements from Roettenbacher et al. (2022), AJ 163 (1), id.19
 #   "EXPRES. III. Revealing the Stellar Activity Radial Velocity Signature of
 #    ϵ Eridani with Photometry and Interferometry"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ac3235
 #   https://ui.adsabs.harvard.edu/abs/2022AJ....163...19R/abstract
 16537 # Ran / Eps Eri
 {
-	RA 53.22829342
-	Dec -9.45816822
-	Distance 10.501 # 310.60 +/- 0.04 mas
+	RA	53.22829342
+	Dec	-9.45816822
+	Distance	10.501 # 310.60 +/- 0.04 mas
 
 	Radius<rS>	0.738
 	SpectralType	"K2V"
@@ -606,17 +705,17 @@ Barycenter "Gliese 65:Luyten 726-8"
 	UniformRotation
 	{
 	    Period<d>	11.4
-	    Inclination	12            # inclination = 70 degrees
-	    AscendingNode	88        # position angle of rotation axis = 335 degrees
+	    Inclination	12            # Inclination = 70 degrees
+	    AscendingNode	88        # Rotation axis position angle = 335 degrees
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Epsilon_Eridani"
 }
 
 114046 # Lacaille 9352
 {
-	RA 346.50391668
-	Dec -35.84716421
-	Distance 10.7241 # 304.1354 +/- 0.0200 mas
+	RA	346.50391668
+	Dec	-35.84716421
+	Distance	10.7241 # 304.1354 +/- 0.0200 mas
 	SpectralType "M2V"
 	AppMag 7.34
 	InfoURL "https://en.wikipedia.org/wiki/Lacaille_9352"
@@ -624,9 +723,9 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 57548 # Ross 128
 {
-	RA 176.93768799
-	Dec 0.79911997
-	Distance 11.0074 # 296.3053 +/- 0.0302 mas
+	RA	176.93768799
+	Dec	0.79911997
+	Distance	11.0074 # 296.3053 +/- 0.0302 mas
 	SpectralType "M4V"
 	AppMag 11.153
 	InfoURL "https://en.wikipedia.org/wiki/Ross_128"
@@ -635,9 +734,9 @@ Barycenter "Gliese 65:Luyten 726-8"
 # Segransan et al. (2000), A&A 364, 665
 Barycenter "Gliese 866:Luyten 789-6"
 {
-	RA 339.650693945
-	Dec -15.28964705
-	Distance 11.109 # 293.6 +/- 0.9 mas
+	RA	339.650693945
+	Dec	-15.28964705
+	Distance	11.109 # 293.6 +/- 0.9 mas
 }
 
 Barycenter "Gliese 866 A:Luyten 789-6 A"
@@ -708,13 +807,14 @@ Barycenter "Gliese 866 A:Luyten 789-6 A"
 # Rotation periods from Olspert et al. (2018), A&A 619, id.A6
 Barycenter "61 Cyg:Gliese 820:ADS 14636"
 {
-	RA 316.75090091 # mass ratio 0.690:0.605
-	Dec 38.76022325 # A: 285.9949 +/- 0.0599 mas
-	Distance 11.404 # B: 286.0054 +/- 0.0289 mas
+	RA	316.75090091 # mass ratio 0.690:0.605
+	Dec	38.76022325 # A: 285.9949 +/- 0.0599 mas
+	Distance	11.404 # B: 286.0054 +/- 0.0289 mas
 }
 
-# Rotational inclination from Boro Saikia et al. (2016), A&A 594, id.A29
+# Rotation inclination from Boro Saikia et al. (2016), A&A 594, id.A29
 #   "A solar-like magnetic cycle on the mature K-dwarf 61 Cygni A (HD 201091)"
+#   https://www.aanda.org/articles/aa/full_html/2016/10/aa28262-16/aa28262-16.html
 #   https://ui.adsabs.harvard.edu/abs/2016A%26A...594A..29B/abstract
 104214 "61 Cyg A:HD 201091:V1803 Cyg:Gliese 820 A:ADS 14636 A"
 {
@@ -769,19 +869,22 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 # Orbit from Bond et al. (2018), Res. Notes AAS 2 (3), 147
 #   "Final Hubble Space Telescope Astrometry of the Procyon Binary System"
 #   https://iopscience.iop.org/article/10.3847/2515-5172/aad9a4
+#   https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..147B/abstract
 # Parameters from Bond et al. (2015), ApJ 813 (2), 106
 #   "Hubble Space Telescope Astrometry of the Procyon System"
 #   https://iopscience.iop.org/article/10.1088/0004-637X/813/2/106
+#   https://ui.adsabs.harvard.edu/abs/2015ApJ...813..106B/abstract
 Barycenter 37279 "Procyon:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 {
-	RA 114.82549791
-	Dec 5.22498756
-	Distance 11.444 # 285.0 +/- 0.7 mas
+	RA	114.82549791
+	Dec	5.22498756
+	Distance	11.444 # 285.0 +/- 0.7 mas
 }
 
 # Radius (lit. weighted mean) and temperature (lit. weighted mean) from Boyajian et al. (2013), AJ 771 (1), id. 40
 # Rotation period from Koncewicz and Jordan (2007), MNRAS 374 (1), pp. 220-231
 #   "OI line emission in cool stars: calculations using partial redistribution"
+#   https://academic.oup.com/mnras/article/374/1/220/961071
 #   https://ui.adsabs.harvard.edu/abs/2007MNRAS.374..220K/abstract
 "Procyon A:ALF CMi A:10 CMi A:Gliese 280 A:ADS 6251 A"
 {
@@ -809,6 +912,7 @@ Barycenter 37279 "Procyon:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 
 # Temperature from Provencal et al. (2002), AJ 568 (1), pp. 324-334
 #   "Procyon B: Outside the Iron Box"
+#   https://iopscience.iop.org/article/10.1086/338769
 #   https://ui.adsabs.harvard.edu/abs/2002ApJ...568..324P/abstract
 "Procyon B:ALF CMi B:10 CMi B:Gliese 280 B:ADS 6251 B"
 {
@@ -833,9 +937,9 @@ Barycenter 37279 "Procyon:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 # Masses from Mann et al. (2015), ApJ 804 (1), 64
 Barycenter "Gliese 725:Struve 2398:ADS 11632"
 {
-	RA 280.68307740 # mass ratio 0.334:0.248
-	Dec 59.63698903 # A: 283.8401 +/- 0.0220 mas
-	Distance 11.491 # B: 283.8378 +/- 0.0287 mas
+	RA	280.68307740 # mass ratio 0.334:0.248
+	Dec	59.63698903 # A: 283.8401 +/- 0.0220 mas
+	Distance	11.491 # B: 283.8378 +/- 0.0287 mas
 }
 
 91768 "Gliese 725 A:Struve 2398 A:ADS 11632 A"
@@ -877,12 +981,13 @@ Barycenter "Gliese 725:Struve 2398:ADS 11632"
 # Pinamonti et al. (2018), A&A 617, A104
 #   "The HADES RV Programme with HARPS-N at TNG. VIII. GJ15A: a multiple
 #    wide planetary system sculpted by binary interaction"
-#   https://arxiv.org/abs/1804.03476
+#   https://www.aanda.org/articles/aa/full_html/2018/09/aa32535-17/aa32535-17.html
+#   https://ui.adsabs.harvard.edu/abs/2018A%26A...617A.104P/abstract
 Barycenter 1475 "Gliese 15:Groombridge 34:ADS 246"
 {
-	RA 4.61664355 # mass ratio 0.38:0.15
-	Dec 44.02590687 # A: 280.7068 +/- 0.0203 mas
-	Distance 11.619 # B: 280.6947 +/- 0.0278 mas
+	RA	4.61664355 # mass ratio 0.38:0.15
+	Dec	44.02590687 # A: 280.7068 +/- 0.0203 mas
+	Distance	11.619 # B: 280.6947 +/- 0.0278 mas
 }
 
 "GX And:Gliese 15 A:Groombridge 34 A:ADS 246 A"
@@ -924,9 +1029,9 @@ Barycenter 1475 "Gliese 15:Groombridge 34:ADS 246"
 
 "DX Cnc:GJ 1111:Giclas 51-15"
 {
-	RA 127.45009240
-	Dec 26.77328597
-	Distance 11.6797 # 279.2496 +/- 0.0637 mas
+	RA	127.45009240
+	Dec	26.77328597
+	Distance	11.6797 # 279.2496 +/- 0.0637 mas
 	SpectralType "M6.5V"
 	AppMag 14.81
 	InfoURL "https://en.wikipedia.org/wiki/DX_Cancri"
@@ -934,23 +1039,26 @@ Barycenter 1475 "Gliese 15:Groombridge 34:ADS 246"
 
 Barycenter "EPS Ind:Gliese 845" # orbit of A & B components unknown
 {
-	RA 330.90487220 # mass ratio 0.732:(0.0716:0.0669)
-	Dec -56.79670693
-	Distance 11.853
+	RA	330.90487220 # mass ratio 0.732:(0.0716:0.0669)
+	Dec	-56.79670693
+	Distance	11.853
 }
 
+# RA, Dec, and Distance from Gaia DR3, corrected for barycentre using https://arxiv.org/abs/2412.14542
 # Radius from Lundkvist et al. (2024), AJ 964 (2), id.110
 #   "Low-amplitude Solar-like Oscillations in the K5 V Star ϵ Indi A"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ad25f2
 #   https://ui.adsabs.harvard.edu/abs/2024ApJ...964..110L/abstract
 # Temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
 # Rotation period from Feng et al. (2019), MNRAS 490 (4), p.5002-5016
 #   "Detection of the nearest Jupiter analogue in radial velocity and astrometry data"
+#   https://academic.oup.com/mnras/article/490/4/5002/5601391
 #   https://ui.adsabs.harvard.edu/abs/2019MNRAS.490.5002F/abstract
 108870 "EPS Ind A:Gliese 845 A"
 {
-	RA 330.87240788
-	Dec -56.79725466
-	Distance 11.8670 # 274.8431 +/- 0.0956 mas
+	RA	330.87270093
+	Dec	-56.79711407
+	Distance	11.8623 # 274.9531 +/- 0.1457 mas
 
 	Radius<rS>	0.713
 	SpectralType	"K5V"
@@ -968,16 +1076,18 @@ Barycenter "EPS Ind:Gliese 845" # orbit of A & B components unknown
 # Dieterich et al. (2018)
 #   "Dynamical Masses of ε Indi B and C: Two Massive
 #    Brown Dwarfs at the Edge of the Stellar–substellar Boundary"
-#   https://arxiv.org/abs/1807.09880
+#   https://iopscience.iop.org/article/10.3847/1538-4357/aadadc
+#   https://ui.adsabs.harvard.edu/abs/2018ApJ...865...28D/abstract
 # V-magnitudes from King et al. (2010), A&A 510, id.A99
 #   "ɛ Indi Ba, Bb: a detailed study of the nearest known brown dwarfs
+#   https://www.aanda.org/articles/aa/full_html/2010/02/aa12981-09/aa12981-09.html
 #   https://ui.adsabs.harvard.edu/abs/2010A%26A...510A..99K/abstract
 # Temperatures and radii (calculated) from Zhang et al. (2020), AJ 891 (2), id.171
 Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 {
-	RA 331.07645260
-	Dec -56.79381207
-	Distance 11.780 # 276.88 +/- 0.81 mas
+	RA	331.07645260
+	Dec	-56.79381207
+	Distance	11.780 # 276.88 +/- 0.81 mas
 }
 
 "EPS Ind Ba:CI Ind A:Gliese 845 Ba:GJ 13185 A"
@@ -1022,30 +1132,37 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 # Physical parameters from Korolik et al. (2023), AJ 166 (3), id.123
 #   "Refining the Stellar Parameters of τ Ceti: a Pole-on Solar Analog"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ace906
 #   https://ui.adsabs.harvard.edu/abs/2023AJ....166..123K/abstract
+# Debris disk orientation from Lawler et al. (2014), MNRAS 444 (3), p.2665-2675
+#   "The debris disc of solar analogue τ Ceti: Herschel observations and dynamical simulations of the proposed multiplanet system"
+#   https://academic.oup.com/mnras/article/444/3/2665/1067501
+#   https://ui.adsabs.harvard.edu/abs/2014MNRAS.444.2665L/abstract
 8102 # Tau Cet
 {
-	RA 26.00905506
-	Dec -15.93368020
-	Distance 11.9118 # 273.8097 +/- 0.1701 mas
+	RA	26.00905506
+	Dec	-15.93368020
+	Distance	11.9118 # 273.8097 +/- 0.1701 mas
 
 	Radius<rS>	0.793
 	SpectralType "G8V"
 	AppMag 3.50
 	Temperature	5320
 
-	UniformRotation
+	UniformRotation                   # Assume closest alignment with orbital plane
 	{
-	    Period<d>	32
+	    Period<d>	46
+		Inclination	59.773929         # Inclination: 7 +/- 7 degrees (Korolik et al. (2023), AJ 166 (3), id.123)
+		AscendingNode	282.809320    # Major axis position angle: 105 degrees (Lawler et al. (2014), MNRAS 444 (3), p.2665-2675)
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Tau_Ceti"
 }
 
 "GJ 1061:Luyten 372-58"
 {
-	RA 54.00339388
-	Dec -44.51436232
-	Distance 11.9839 # 272.1615 +/- 0.0316 mas
+	RA	54.00339388
+	Dec	-44.51436232
+	Distance	11.9839 # 272.1615 +/- 0.0316 mas
 	SpectralType "M5.5V"
 	AppMag 13.03
 	InfoURL "https://en.wikipedia.org/wiki/GJ_1061"
@@ -1053,9 +1170,9 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 5643 # YZ Cet
 {
-	RA 18.13325425
-	Dec -16.99615487
-	Distance 12.1222 # 269.0573 +/- 0.0337 mas
+	RA	18.13325425
+	Dec	-16.99615487
+	Distance	12.1222 # 269.0573 +/- 0.0337 mas
 	SpectralType "M4.0Ve"
 	AppMag 12.074
 	InfoURL "https://en.wikipedia.org/wiki/YZ_Ceti"
@@ -1063,9 +1180,9 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 36208 # Luyten's Star
 {
-	RA 111.85462844
-	Dec 5.20938270
-	Distance 12.3485 # 264.1269 +/- 0.0413 mas
+	RA	111.85462844
+	Dec	5.20938270
+	Distance	12.3485 # 264.1269 +/- 0.0413 mas
 	SpectralType "M3.5V"
 	AppMag 9.872
 	InfoURL "https://en.wikipedia.org/wiki/Luyten%27s_Star"
@@ -1073,9 +1190,9 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 "Teegarden's Star:SO0253+1652:SO025300.5+165258:GJ 10393"
 {
-	RA 43.26964248
-	Dec 16.86437382
-	Distance 12.4970 # 260.9884 +/- 0.0934 mas
+	RA	43.26964248
+	Dec	16.86437382
+	Distance	12.4970 # 260.9884 +/- 0.0934 mas
 	SpectralType "M7.0V"
 	AppMag 15.40
 	InfoURL "https://en.wikipedia.org/wiki/Teegarden%27s_Star"
@@ -1083,9 +1200,9 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 24186 # Kapteyn's Star
 {
-	RA 77.95993735
-	Dec -45.04381270
-	Distance 12.8308 # 254.1986 +/- 0.0168 mas
+	RA	77.95993735
+	Dec	-45.04381270
+	Distance	12.8308 # 254.1986 +/- 0.0168 mas
 	SpectralType "M1VI"
 	AppMag 8.853
 	InfoURL "https://en.wikipedia.org/wiki/Kapteyn%27s_Star"
@@ -1093,23 +1210,23 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 105090 # Lacaille 8760
 {
-	RA 319.29501814
-	Dec -38.87245640
-	Distance 12.9472 # 251.9124 +/- 0.0352 mas
+	RA	319.29501814
+	Dec	-38.87245640
+	Distance	12.9472 # 251.9124 +/- 0.0352 mas
 	SpectralType "M1V"
 	AppMag 6.68
 	InfoURL "https://en.wikipedia.org/wiki/Lacaille_8760"
 }
 
 # Used Gaia EDR3 parallax for A
-# parameters from Vigan et al. (2012), A&A 540, A131
-# "High-contrast spectroscopy of SCR J1845-6357 B"
-# https://www.aanda.org/articles/aa/abs/2012/04/aa18426-11/aa18426-11.html
+# Parameters from Vigan et al. (2012), A&A 540, A131
+#   "High-contrast spectroscopy of SCR J1845-6357 B"
+#   https://www.aanda.org/articles/aa/abs/2012/04/aa18426-11/aa18426-11.html
 Barycenter "SCR 1845-6357:GJ 12724"
 {
-	RA 281.29804386
-	Dec -63.96056737
-	Distance 13.0638 # 249.6651 +/- 0.1330 mas
+	RA	281.29804386
+	Dec	-63.96056737
+	Distance	13.0638 # 249.6651 +/- 0.1330 mas
 }
 
 "SCR 1845-6357 A:GJ 12724 A"
@@ -1141,9 +1258,9 @@ Barycenter "SCR 1845-6357:GJ 12724"
 
 Barycenter 110893 "Gliese 860:Kruger 60:ADS 15972"
 {
-	RA 336.99185002 # mass ratio 0.30:0.17
-	Dec 57.69405691 # only used DR2 parallax of A
-	Distance 13.0780 # 249.3926 +/- 0.1653 mas
+	RA	336.99185002 # mass ratio 0.30:0.17
+	Dec	57.69405691 # only used DR2 parallax of A
+	Distance	13.0780 # 249.3926 +/- 0.1653 mas
 }
 
 1000923991 "Gliese 860 A:Kruger 60 A:ADS 15972 A"
@@ -1184,23 +1301,23 @@ Barycenter 110893 "Gliese 860:Kruger 60:ADS 15972"
 
 "DENIS 1048-3956:DENIS J104814.6-395606:RECONS 2:GJ 11547"
 {
-	RA 162.05388772
-	Dec -39.93962595
-	Distance 13.1932 # 247.2156 +/- 0.0512 mas
+	RA	162.05388772
+	Dec	-39.93962595
+	Distance	13.1932 # 247.2156 +/- 0.0512 mas
 	SpectralType "M9V"
 	AppMag 17.532
 	InfoURL "https://en.wikipedia.org/wiki/DENIS_J1048%E2%88%923956"
 }
 
-# parallax from Leggett et al. (2012), ApJ 748 (2), 74
-# "The Properties of the 500 K Dwarf UGPS J072227.51-054031.2 and a Study
-# of the Far-red Flux of Cold Brown Dwarfs"
-# https://iopscience.iop.org/article/10.1088/0004-637X/748/2/74
+# Parallax from Leggett et al. (2012), ApJ 748 (2), 74
+#   "The Properties of the 500 K Dwarf UGPS J072227.51-054031.2 and a Study
+#    of the Far-red Flux of Cold Brown Dwarfs"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/748/2/74
 "UGPS 0722-0540:UGPS J072227.51-054031.2:GJ 11075"
 {
-	RA 110.6161250
-	Dec -5.6753056
-	Distance 13.433 # 242.8 +/- 2.40 mas
+	RA	110.6161250
+	Dec	-5.6753056
+	Distance	13.433 # 242.8 +/- 2.40 mas
 	SpectralType "T9V"
 	Temperature 505
 	Radius 60000 # approx.
@@ -1208,15 +1325,12 @@ Barycenter 110893 "Gliese 860:Kruger 60:ADS 15972"
 	InfoURL "https://en.wikipedia.org/wiki/UGPS_J072227.51%E2%88%92054031.2"
 }
 
-# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
-# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
-# M Dwarfs"
-# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
+# Masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
 Barycenter 30920 "Gliese 234:Ross 614"
 {
-	RA 97.35079477
-	Dec -2.81713072
-	Distance 13.533 # 241.0 +/- 0.4 mas
+	RA	97.35079477
+	Dec	-2.81713072
+	Distance	13.533 # 241.0 +/- 0.4 mas
 }
 
 "V577 Mon:Gliese 234 A:Ross 614 A"
@@ -1254,15 +1368,12 @@ Barycenter 30920 "Gliese 234:Ross 614"
 	}
 }
 
-# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
-# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
-# M Dwarfs"
-# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
+# Masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
 Barycenter "Gliese 473:Wolf 424"
 {
-	RA 188.31458052 # mass ratio 0.124:0.113
-	Dec 9.02196651
-	Distance 13.850 # 235.5 +/- 2.9 mas
+	RA	188.31458052 # mass ratio 0.124:0.113
+	Dec	9.02196651
+	Distance	13.850 # 235.5 +/- 2.9 mas
 }
 
 "Gliese 473 A:Wolf 424 A"
@@ -1303,9 +1414,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 80824 # Wolf 1061
 {
-	RA 247.57481416
-	Dec -12.66785108
-	Distance 14.0500 # 232.1390 +/- 0.0268 mas
+	RA	247.57481416
+	Dec	-12.66785108
+	Distance	14.0500 # 232.1390 +/- 0.0268 mas
 	SpectralType "M3V"
 	AppMag 10.072
 	InfoURL "https://en.wikipedia.org/wiki/Wolf_1061"
@@ -1313,9 +1424,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 3829 # van Maanen's Star
 {
-	RA 12.29674025
-	Dec 5.37655661
-	Distance 14.0718 # 231.7800 +/- 0.0183 mas
+	RA	12.29674025
+	Dec	5.37655661
+	Distance	14.0718 # 231.7800 +/- 0.0183 mas
 	SpectralType "DZ7.5"
 	AppMag 12.374
 	InfoURL "https://en.wikipedia.org/wiki/Van_Maanen_2"
@@ -1323,9 +1434,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 439 # Gliese 1
 {
-	RA 1.38328415
-	Dec -37.36774403
-	Distance 14.1747 # 230.0970 +/- 0.0362 mas
+	RA	1.38328415
+	Dec	-37.36774403
+	Distance	14.1747 # 230.0970 +/- 0.0362 mas
 	SpectralType "M2V"
 	AppMag 8.562
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_1"
@@ -1333,9 +1444,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 "TZ Ari:Gliese 83.1:GJ 9066:Luyten 1159-16"
 {
-	RA 30.05898705
-	Dec 13.04407120
-	Distance 14.5780 # 223.7321 +/- 0.0699 mas
+	RA	30.05898705
+	Dec	13.04407120
+	Distance	14.5780 # 223.7321 +/- 0.0699 mas
 	SpectralType "M4.5V"
 	AppMag 12.298
 	InfoURL "https://en.wikipedia.org/wiki/TZ_Arietis"
@@ -1343,9 +1454,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 86162 # Gliese 687
 {
-	RA 264.10405257
-	Dec 68.33349764
-	Distance 14.8395 # 219.7898 +/- 0.0210 mas
+	RA	264.10405257
+	Dec	68.33349764
+	Distance	14.8395 # 219.7898 +/- 0.0210 mas
 	SpectralType "M3.0V"
 	AppMag 9.15
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_687"
@@ -1353,20 +1464,20 @@ Barycenter "Gliese 473:Wolf 424"
 
 85523 # Gliese 674
 {
-	RA 262.17016392
-	Dec -46.89910490
-	Distance 14.8492 # 219.6463 +/- 0.0262 mas
+	RA	262.17016392
+	Dec	-46.89910490
+	Distance	14.8492 # 219.6463 +/- 0.0262 mas
 	SpectralType "M3V"
 	AppMag 9.407
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_674"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 1639-6847:WISE J163940.83-684738.6:GJ 12393"
 {
-	RA 249.922582
-	Dec -68.798903
-	Distance 14.852 # 219.6 +/- 2.3 mas
+	RA	249.922582
+	Dec	-68.798903
+	Distance	14.852 # 219.6 +/- 2.3 mas
 	SpectralType "Y0Vpec"
 	Temperature 412
 	Radius 60000 # approx.
@@ -1376,9 +1487,9 @@ Barycenter "Gliese 473:Wolf 424"
 
 "GJ 3622:LP 731-58"
 {
-	RA 162.05518400
-	Dec -11.34280332
-	Distance 14.8706 # 219.3302 +/- 0.0602 mas
+	RA	162.05518400
+	Dec	-11.34280332
+	Distance	14.8706 # 219.3302 +/- 0.0602 mas
 	SpectralType "M6.5V"
 	AppMag 15.784
 	InfoURL "https://en.wikipedia.org/wiki/LHS_292"
@@ -1386,31 +1497,28 @@ Barycenter "Gliese 473:Wolf 424"
 
 57367 # Luyten 145-141
 {
-	RA 176.45664662
-	Dec -64.84305285
-	Distance 15.1226 # 215.6753 +/- 0.0181 mas
+	RA	176.45664662
+	Dec	-64.84305285
+	Distance	15.1226 # 215.6753 +/- 0.0181 mas
 	SpectralType "DQ6"
 	AppMag 11.513
 }
 
 # Used Gaia EDR3 parallax for B
-# masses from Benedict et al. (2016), AJ 152 (5), 141
-# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
-# M Dwarfs"
-# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
-# orbit listed for A-B in Sixth Catalog yields unrealistically high mass sum
+# Masses from Benedict et al. (2016), AJ 152 (5), 141
+# Orbit listed for A-B in Sixth Catalog yields unrealistically high mass sum
 Barycenter "GJ 1245"
 {
-	RA 298.48051408 # mass ratio (0.111:0.076):0.10
-	Dec 44.41253085
-	Distance 15.2001 # 214.5745 +/- 0.0476 mas
+	RA	298.48051408 # mass ratio (0.111:0.076):0.10
+	Dec	44.41253085
+	Distance	15.2001 # 214.5745 +/- 0.0476 mas
 }
 
 Barycenter "GJ 1245 A"
 {
-	RA 298.47975909
-	Dec 44.41233014
-	Distance 15.2001
+	RA	298.47975909
+	Dec	44.41233014
+	Distance	15.2001
 }
 
 "V1581 Cyg:GJ 1245 Aa"
@@ -1449,25 +1557,22 @@ Barycenter "GJ 1245 A"
 
 "GJ 1245 B"
 {
-	RA 298.48192590
-	Dec 44.41290616
-	Distance 15.2001
+	RA	298.48192590
+	Dec	44.41290616
+	Distance	15.2001
 	SpectralType "M6V"
 	AppMag 13.99
 }
 
-# parallax from Kirkpatrick et al. (2019), ApJS 240 (2), 19
-# "Preliminary Trigonometric Parallaxes of 184 Late-T and Y Dwarfs and an
-# Analysis of the Field Substellar Mass Function into the 'Planetary' Mass Regime"
-# https://iopscience.iop.org/article/10.3847/1538-4365/aaf6af
-# rotation period, radius from Burningham et al. (2016), MNRAS 463, 2
-# "A LOFAR mini-survey for low-frequency radio emission from the nearest brown dwarfs"
-# https://academic.oup.com/mnras/article/463/2/2202/2892466
+# Parallax from Kirkpatrick et al. (2019), ApJS 240 (2), 19
+# Rotation period, radius from Burningham et al. (2016), MNRAS 463, 2
+#   "A LOFAR mini-survey for low-frequency radio emission from the nearest brown dwarfs"
+#   https://academic.oup.com/mnras/article/463/2/2202/2892466
 "WISE 1741+2553:WISE J174124.25+255319.6:GJ 12549"
 {
-	RA 265.352586
-	Dec 25.892878
-	Distance 15.220 # 214.3 +/- 2.8 mas
+	RA	265.352586
+	Dec	25.892878
+	Distance	15.220 # 214.3 +/- 2.8 mas
 	SpectralType "T9V"
 	Temperature 620
 	Radius 60000 # approx.
@@ -1478,9 +1583,9 @@ Barycenter "GJ 1245 A"
 
 113020 # Gliese 876
 {
-	RA 343.32411100
-	Dec -14.26668939
-	Distance 15.2382 # 214.0380 +/- 0.0356 mas
+	RA	343.32411100
+	Dec	-14.26668939
+	Distance	15.2382 # 214.0380 +/- 0.0356 mas
 	SpectralType "M3.5V"
 	AppMag 10.192
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_876"
@@ -1488,9 +1593,9 @@ Barycenter "GJ 1245 A"
 
 "GJ 3618:Luyten 143-23"
 {
-	RA 161.08527551
-	Dec -61.20263830
-	Distance 15.7586 # 206.9698 +/- 0.0448 mas 
+	RA	161.08527551
+	Dec	-61.20263830
+	Distance	15.7586 # 206.9698 +/- 0.0448 mas 
 	SpectralType "M5.0V"
 	AppMag 13.920
 	InfoURL "https://en.wikipedia.org/wiki/LHS_288"
@@ -1498,9 +1603,9 @@ Barycenter "GJ 1245 A"
 
 "GJ 1002"
 {
-	RA 1.67635043
-	Dec -7.54647533
-	Distance 15.8060 # 206.3500 +/- 0.0474 mas
+	RA	1.67635043
+	Dec	-7.54647533
+	Distance	15.8060 # 206.3500 +/- 0.0474 mas
 	SpectralType "M5.5V"
 	Radius 122000 # approx. for class
 	AppMag 13.837
@@ -1509,9 +1614,9 @@ Barycenter "GJ 1245 A"
 
 "DENIS 0255-4700:DENIS-P J025503.5-470050:2MASS 0255-4700:2MASS J02550357-4700509:GJ 10402"
 {
-	RA 43.77198593
-	Dec -47.01672836
-	Distance 15.8771 # 205.4251 +/- 0.1857 mas
+	RA	43.77198593
+	Dec	-47.01672836
+	Distance	15.8771 # 205.4251 +/- 0.1857 mas
 	SpectralType "L9V"
 	Radius 60000 # approx.
 	AppMag 22.921
@@ -1522,9 +1627,9 @@ Barycenter "GJ 1245 A"
 # Rotation period from Pizzolato et al. (2003), A&A 397, p.147-157
 49908 # Gliese 380 / Groombridge 1618 / HD 88230
 {
-	RA 152.83292896
-	Dec 49.45198890
-	Distance 15.8857 # 205.3148 +/- 0.0224 mas
+	RA	152.83292896
+	Dec	49.45198890
+	Distance	15.8857 # 205.3148 +/- 0.0224 mas
 
 	Radius<rS>	0.6398
 	SpectralType	"K6Ve"
@@ -1541,34 +1646,34 @@ Barycenter "GJ 1245 A"
 # Masses from Mann et al. (2015), ApJ 804 (1), 64
 Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 {
-	RA 166.34402770 # mass ratio 0.39:0.0952
-	Dec 43.52995949
-	Distance 15.9977
+	RA	166.34402770 # mass ratio 0.39:0.0952
+	Dec	43.52995949
+	Distance	15.9977
 }
 
 "Gliese 412 A:Lalande 21258 A"
 {
-	RA 166.34205974
-	Dec 43.53094856
-	Distance 15.9969 # 203.8876 +/- 0.0332 mas
+	RA	166.34205974
+	Dec	43.53094856
+	Distance	15.9969 # 203.8876 +/- 0.0332 mas
 	SpectralType "M1.0Ve"
 	AppMag 8.780
 }
 
 "WX UMa:Gliese 412 B:Lalande 21258 B"
 {
-	RA 166.35208968
-	Dec 43.52590762
-	Distance 16.0012 # 203.8323 +/- 0.0500 mas
+	RA	166.35208968
+	Dec	43.52590762
+	Distance	16.0012 # 203.8323 +/- 0.0500 mas
 	SpectralType "M6.0V"
 	AppMag 14.45
 }
 
 1001741423 "AD Leo:Gliese 388"
 {
-	RA 154.89881370
-	Dec 19.86980991
-	Distance 16.1939 # 201.4064 +/- 0.0296 mas
+	RA	154.89881370
+	Dec	19.86980991
+	Distance	16.1939 # 201.4064 +/- 0.0296 mas
 	SpectralType "M4Vae"
 	Radius 180000 # approx. for class
 	AppMag 9.52
@@ -1577,9 +1682,9 @@ Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 
 106440 # Gliese 832
 {
-	RA 323.39125188
-	Dec -49.01263040
-	Distance 16.2005 # 201.3252 +/- 0.0237 mas
+	RA	323.39125188
+	Dec	-49.01263040
+	Distance	16.2005 # 201.3252 +/- 0.0237 mas
 	SpectralType "M2V"
 	Radius 306000 # approx. for class
 	AppMag 8.672
@@ -1588,9 +1693,9 @@ Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 
 86214 # Gliese 682
 {
-	RA 264.26088739
-	Dec -44.32338224
-	Distance 16.3328 # 199.6944 +/- 0.0312 mas
+	RA	264.26088739
+	Dec	-44.32338224
+	Distance	16.3328 # 199.6944 +/- 0.0312 mas
 	SpectralType "M3.5V"
 	Radius 180000 # approx. for class
 	AppMag 10.946
@@ -1598,28 +1703,29 @@ Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 }
 
 # Mass of component A from Ma et al. (2018), MNRAS 480 (2), 2411
-#   "The first super-Earth detection from the high cadence and high radial velocity 
-#    precision Dharma Planet Survey"
-#   https://arxiv.org/abs/1807.07098
+#   "The first super-Earth detection from the high cadence and high radial velocity precision Dharma Planet Survey"
+#   https://academic.oup.com/mnras/article/480/2/2411/5056228
+#   https://ui.adsabs.harvard.edu/abs/2018MNRAS.480.2411M/abstract
 Barycenter 19849 "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC) unknown
 {
-	RA 63.81919733 # mass ratio 0.78:(0.573:0.2036)
-	Dec -7.67024168
-	Distance 16.3399
+	RA	63.81919733 # mass ratio 0.78:(0.573:0.2036)
+	Dec	-7.67024168
+	Distance	16.3399
 }
 
 # Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112
 # Rotation period from Laliotis et al. (2023), AJ 165 (4), id.176
 "Keid A:OMI2 Eri A:40 Eri A:Gliese 166 A:ADS 3093 A"
 {
-	RA 63.80795301
-	Dec -7.66807782
-	Distance 16.3398 # 199.6080 +/- 0.1208 mas
+	RA	63.80795301
+	Dec	-7.66807782
+	Distance	16.3398 # 199.6080 +/- 0.1208 mas
 
 	Radius<rS>	0.8051
 	SpectralType	"K0V"
 	AppMag	4.43
 	Temperature	5147
+
 	UniformRotation
 	{
 	    Period<d>	43.504
@@ -1629,15 +1735,14 @@ Barycenter 19849 "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC)
 
 Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 {
-	RA 63.83049088 # mass ratio 0.573:0.2036
-	Dec -7.67241502 # B: 199.6911 +/- 0.0512 mas
-	Distance 16.340 # C: 199.4516 +/- 0.0692 mas
+	RA	63.83049088 # mass ratio 0.573:0.2036
+	Dec	-7.67241502 # B: 199.6911 +/- 0.0512 mas
+	Distance	16.340 # C: 199.4516 +/- 0.0692 mas
 }
 
 # Radius and temperature from Bond et al. (2017), ApJ 848 (1), 16
-# "Astrophysical Implications of a New Dynamical Mass for the 
-#  Nearby White Dwarf 40 Eridani B"
-# http://iopscience.iop.org/article/10.3847/1538-4357/aa8a63/meta
+#   "Astrophysical Implications of a New Dynamical Mass for the Nearby White Dwarf 40 Eridani B"
+#   http://iopscience.iop.org/article/10.3847/1538-4357/aa8a63/meta
 "Keid B:OMI2 Eri B:40 Eri B:Gliese 166 B:ADS 3093 B"
 {
 	Radius<rS>	0.01308
@@ -1659,7 +1764,7 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 }
 
 # Temperature from Houdebine et al. (2019), AJ 158 (2), id. 56
-# Rotation period from Engle et al. (2023), AJ Letters 954 (2), id.L50
+# Rotation period from Engle et al. (2023), AJL 954 (2), id.L50
 "Keid C:OMI2 Eri C:40 Eri C:DY Eri:Gliese 166 C:ADS 3093 C"
 {
 	Radius	180000                # approx. for class
@@ -1686,9 +1791,9 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 
 112460 # EV Lac
 {
-	RA 341.70282545
-	Dec 44.33195332
-	Distance 16.4761 # 197.9573 +/- 0.0220 mas
+	RA	341.70282545
+	Dec	44.33195332
+	Distance	16.4761 # 197.9573 +/- 0.0220 mas
 	SpectralType "M4.0V"
 	Radius 225000 # approx. for class
 	AppMag 10.26
@@ -1696,21 +1801,21 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 }
 
 # Eggenberger et al. (2008), A&A 482 (2), 631
-# "Analysis of 70 Ophiuchi AB including seismic constraints"
-# https://www.aanda.org/articles/aa/abs/2008/17/aa8624-07/aa8624-07.html
+#   "Analysis of 70 Ophiuchi AB including seismic constraints"
+#   https://www.aanda.org/articles/aa/abs/2008/17/aa8624-07/aa8624-07.html
 # Radii and temperatures from Boyajian et al. (2012), AJ 757 (2), id. 112
 Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 {
-	RA 271.36511072 # mass ratio 0.89:0.73
-	Dec 2.49476206 # A: 195.5674 +/- 0.1964 mas
-	Distance 16.668 # B: 195.8563 +/- 0.2535 mas
+	RA	271.36511072 # mass ratio 0.89:0.73
+	Dec	2.49476206 # A: 195.5674 +/- 0.1964 mas
+	Distance	16.668 # B: 195.8563 +/- 0.2535 mas
 }
 
 1052130434 "70 Oph A:Gliese 702 A:Struve 2272 A:ADS 11046 A"
 {
 	Radius<rS>	0.8310
 	SpectralType	"K0V"
-	AppMag	4.13
+	AppMag	4.191
 	Temperature	5407
 
 	OrbitBarycenter "70 Oph"
@@ -1735,7 +1840,7 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 {
 	Radius<rS>	0.6697
 	SpectralType	"K4V"
-	AppMag	6.07
+	AppMag	6.061
 	Temperature	4475
 
 	OrbitBarycenter "70 Oph"
@@ -1753,12 +1858,13 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 
 # Physical parameters from Bouchaud et al. (2020), A&A 633, A78
 #   "A realistic two-dimensional model of Altair"
-#   https://arxiv.org/abs/1912.03138
+#   https://www.aanda.org/articles/aa/full_html/2020/01/aa36830-19/aa36830-19.html
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...633A..78B/abstract
 97649 # Altair
 {
-	RA 297.69582730
-	Dec 8.86832120
-	Distance 16.730 # 194.95 +/- 0.57 mas
+	RA	297.69582730
+	Dec	8.86832120
+	Distance	16.730 # 194.95 +/- 0.57 mas
 
 	Radius<rS>	2.008           # Equatorial radius: 2.008 ± 0.006 / Polar radius: 1.565 ± 0.014
 	SemiAxes	[ 1 0.779 1 ]   # Flattening: 0.220 ± 0.003
@@ -1776,13 +1882,11 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 }
 
 # Orbit from Tokovinin et al. (2020), AJ 160 (1), 7
-# "Speckle Interferometry at SOAR in 2019"
-# https://arxiv.org/abs/2005.05305
 Barycenter "GJ 1116"
 {
-	RA 134.55895246 # mass ratio 0.11:0.10
-	Dec 19.76277843 # A: 194.1443 +/- 0.1228 mas
-	Distance 16.749 # B: 196.2619 +/- 0.1976 mas
+	RA	134.55895246 # mass ratio 0.11:0.10
+	Dec	19.76277843 # A: 194.1443 +/- 0.1228 mas
+	Distance	16.749 # B: 196.2619 +/- 0.1976 mas
 }
 
 "EI Cnc:GJ 1116 A"
@@ -1826,9 +1930,9 @@ Barycenter "GJ 1116"
 #   https://academic.oup.com/mnras/article/463/2/2202/2892466
 "WISE 1506+7027:WISE J150649.97+702736.1:GJ 12169"
 {
-	RA 226.70263615
-	Dec 70.46161913
-	Distance 16.8173 # 193.9412 +/- 0.6277 mas
+	RA	226.70263615
+	Dec	70.46161913
+	Distance	16.8173 # 193.9412 +/- 0.6277 mas
 	AppMag 17.48 # calculated from J, H, and Ks bands
 	SpectralType "T6"
 	Radius 60000 # approx.
@@ -1839,9 +1943,9 @@ Barycenter "GJ 1116"
 
 1006050134 "GJ 3379:Giclas 99-49"
 {
-	RA 90.01597644
-	Dec 2.70637408
-	Distance 16.9861 # 192.0135 +/- 0.0310 mas
+	RA	90.01597644
+	Dec	2.70637408
+	Distance	16.9861 # 192.0135 +/- 0.0310 mas
 	SpectralType "M3.5Ve"
 	Radius 225000 # approx. for class
 	AppMag 11.31
@@ -1850,18 +1954,18 @@ Barycenter "GJ 1116"
 
 "WISE 0817-6155:WISEP J081729.74-615504.1:GJ 11204"
 {
-	RA 124.37351806
-	Dec -61.91613022
-	Distance 17.0018 # 191.8362 +/- 0.4186 mas
+	RA	124.37351806
+	Dec	-61.91613022
+	Distance	17.0018 # 191.8362 +/- 0.4186 mas
 	SpectralType "T6V"
 	AbsMag 34 # for approximate radius in Celestia
 }
 
 57544 # Gliese 445
 {
-	RA 176.93940798
-	Dec 78.69329745
-	Distance 17.1368 # 190.3251 +/- 0.0194 mas
+	RA	176.93940798
+	Dec	78.69329745
+	Distance	17.1368 # 190.3251 +/- 0.0194 mas
 	SpectralType "M4.0Ve"
 	Radius 181000 # approx. for class
 	AppMag 10.84
@@ -1871,12 +1975,12 @@ Barycenter "GJ 1116"
 # Magnitude from Perez Garrido et al. (2014), A&A 567, A6
 #   "2MASS J154043.42-510135.7: a new addition to the 5 pc population"
 #   https://www.aanda.org/articles/aa/abs/2014/07/aa23615-14/aa23615-14.html
-# Appears to be duplicated in CNS5 GJ 12258=GJ 12259
-"WISE 1540-5101:WISE J154045.65-510139.2:GJ 12258:GJ 12259"
+# Appears to be duplicated in CNS5 GJ 12258 = GJ 12259
+"WISE 1540-5101:WISE J154045.65-510139.2:2MASS J154043.42−510135.7:GJ 12258:GJ 12259"
 {
-	RA 235.19517746
-	Dec -51.02810131
-	Distance 17.3738 # 187.7290 +/- 0.0496 mas
+	RA	235.19517746
+	Dec	-51.02810131
+	Distance	17.3738 # 187.7290 +/- 0.0496 mas
 	SpectralType "M6.5"
 	Radius 83500 # approx. for class
 	AppMag 15.26 # measured w/ ESO Faint Object Spectrograph and Camera
@@ -1888,9 +1992,9 @@ Barycenter "GJ 1116"
 # Unresolved binary; separation and orbit unknown
 "2MASS 0939-2448 A:2MASS J09393548-2448279 A:GJ 11394 A"
 {
-	RA 144.897865
-	Dec -24.807761
-	Distance 17.414 # 187.30 +/- 4.60 mas
+	RA	144.897865
+	Dec	-24.807761
+	Distance	17.414 # 187.30 +/- 4.60 mas
 	SpectralType "T8V"
 	Temperature 600
 	Radius 60000 # approx.
@@ -1899,9 +2003,9 @@ Barycenter "GJ 1116"
 
 "2MASS 0939-2448 B:2MASS J09393548-2448279 B:GJ 11394 B"
 {
-	RA 144.897885
-	Dec -24.807761
-	Distance 17.414 # 187.30 +/- 4.60 mas
+	RA	144.897885
+	Dec	-24.807761
+	Distance	17.414 # 187.30 +/- 4.60 mas
 	SpectralType "T8V"
 	Temperature 600
 	Radius 60000 # approx.
@@ -1910,9 +2014,9 @@ Barycenter "GJ 1116"
 
 "GJ 3323:LP 656-38:RECONS 3"
 {
-	RA 75.48680521
-	Dec -6.94858741
-	Distance 17.5309 # 186.0466 +/- 0.0277 mas
+	RA	75.48680521
+	Dec	-6.94858741
+	Distance	17.5309 # 186.0466 +/- 0.0277 mas
 	SpectralType "M4.0Ve"
 	Radius 180000 # approx. for class
 	AppMag 12.196
@@ -1921,9 +2025,9 @@ Barycenter "GJ 1116"
 
 67155 # Lalande 25372
 {
-	RA 206.44056584
-	Dec 14.88505270
-	Distance 17.7263 # 183.9962 +/- 0.0253 mas
+	RA	206.44056584
+	Dec	14.88505270
+	Distance	17.7263 # 183.9962 +/- 0.0253 mas
 	SpectralType "M2V"
 	Radius 306000 # approx. for class
 	AppMag 8.50
@@ -1934,19 +2038,20 @@ Barycenter "GJ 1116"
 #   "Relativistic deflection of background starlight measures the mass of 
 #    a nearby white dwarf star"
 #   https://arxiv.org/abs/1706.02037
+#   https://ui.adsabs.harvard.edu/abs/2017Sci...356.1046S/abstract
 # Orbit listed in Sixth Orbit Catalogue is of poor quality, so unused
 Barycenter 21088 "Gliese 169.1:Stein 2051"
 {
-	RA 67.81236059 # mass ratio MB/MA 2.07
-	Dec 58.96899220
-	Distance 17.9935
+	RA	67.81236059 # mass ratio MB/MA 2.07
+	Dec	58.96899220
+	Distance	17.9935
 }
 
 1004123744 "Gliese 169.1 A:Stein 2051 A"
 {
-	RA 67.80919063
-	Dec 58.96797997
-	Distance 17.9954 # 181.2438 +/- 0.0499 mas
+	RA	67.80919063
+	Dec	58.96797997
+	Distance	17.9954 # 181.2438 +/- 0.0499 mas
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
 	AppMag 10.977
@@ -1955,9 +2060,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 
 1020623744 "Gliese 169.1 B:Stein 2051 B"
 {
-	RA 67.81389197
-	Dec 58.96948121
-	Distance 17.9926 # 181.2730 +/- 0.0203 mas
+	RA	67.81389197
+	Dec	58.96948121
+	Distance	17.9926 # 181.2730 +/- 0.0203 mas
 	SpectralType "DC5"
 	Temperature 7122
 	Radius 7900
@@ -1974,9 +2079,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 #   http://iopscience.iop.org/0004-637X/848/2/83/
 "2MASS 1114-2618:2MASS J11145133-2618235:GJ 11600"
 {
-	RA 168.7032979
-	Dec -26.3074976
-	Distance 18.201 # 179.2 +/- 1.4 mas
+	RA	168.7032979
+	Dec	-26.3074976
+	Distance	18.201 # 179.2 +/- 1.4 mas
 	SpectralType "T7.5V"
 	Temperature 680
 	Radius 64000
@@ -1986,9 +2091,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 
 33226 # Wolf 294
 {
-	RA 103.70012923
-	Dec 33.26640802
-	Distance 18.2146 # 179.0629 +/- 0.0280 mas
+	RA	103.70012923
+	Dec	33.26640802
+	Distance	18.2146 # 179.0629 +/- 0.0280 mas
 	SpectralType "M3V"
 	Radius 270000 # approx. for class
 	AppMag 10.11
@@ -1997,9 +2102,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 
 103039 # LP 816-60
 {
-	RA 313.13613276
-	Dec -16.97455847
-	Distance 18.3305 # 177.9312 +/- 0.0365 mas
+	RA	313.13613276
+	Dec	-16.97455847
+	Distance	18.3305 # 177.9312 +/- 0.0365 mas
 	SpectralType "M4V"
 	Radius 181000 # approx. for class
 	AppMag 11.458
@@ -2009,9 +2114,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 # Parameters from Kirkpatrick et al. (2021)
 "WISE 0350-5658:WISE J035000.32-565830.2:GJ 10528"
 {
-	RA 57.500868
-	Dec -56.975831
-	Distance 18.490 # 176.4 +/- 2.3 mas
+	RA	57.500868
+	Dec	-56.975831
+	Distance	18.490 # 176.4 +/- 2.3 mas
 	SpectralType "Y1V"
 	Temperature 388
 	Radius 60000 # approx.
@@ -2021,9 +2126,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 
 "2MASS 1835+3259:2MASS J18353790+3259545:GJ 12692"
 {
-	RA 278.90744885
-	Dec 32.99478716
-	Distance 18.5534 # 175.7930 +/- 0.0468 mas
+	RA	278.90744885
+	Dec	32.99478716
+	Distance	18.5534 # 175.7930 +/- 0.0468 mas
 	SpectralType "M8.5V"
 	Radius 66000 # approx. for class
 	AppMag 18.27
@@ -2032,9 +2137,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 
 25878 # Wolf 1453
 {
-	RA 82.86754111
-	Dec -3.68652760
-	Distance 18.6042 # 175.3131 +/- 0.0204 mas
+	RA	82.86754111
+	Dec	-3.68652760
+	Distance	18.6042 # 175.3131 +/- 0.0204 mas
 	SpectralType "M1.5Ve"
 	Radius 324000 # approx. for class
 	AppMag 7.968
@@ -2046,9 +2151,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 #   http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
 "2MASS 0415-0935:2MASS J04151954-0935066:GJ 10582"
 {
-	RA 63.8381022
-	Dec -9.5835266
-	Distance 18.616 # 175.2 +/- 1.7 mas
+	RA	63.8381022
+	Dec	-9.5835266
+	Distance	18.616 # 175.2 +/- 1.7 mas
 	SpectralType "T8.0V"
 	Temperature 750
 	Radius 60000 # approx.
@@ -2061,9 +2166,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 #   https://iopscience.iop.org/article/10.3847/1538-3881/ac273e
 Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230"
 {
-	RA 92.64357908
-	Dec -21.86782311
-	Distance 18.7906 # 173.574 +/- 0.013 mas
+	RA	92.64357908
+	Dec	-21.86782311
+	Distance	18.7906 # 173.574 +/- 0.013 mas
 }
 
 # Radius and rotational parameters from Bowler et al. (2023), AJ 165 (4), 164
@@ -2099,6 +2204,7 @@ Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230"
 # Xuan et al. (2024), Nature
 #   "The cool brown dwarf Gliese 229 B is a close binary"
 #   https://arxiv.org/abs/2410.11953
+#   https://ui.adsabs.harvard.edu/abs/2024Natur.634.1070X/abstract
 Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 {
 	OrbitBarycenter "Gliese 229"
@@ -2166,14 +2272,15 @@ Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 
 # Radius from Hon et al. (2024), AJ 975 (1), id.147
 #   "Asteroseismology of the Nearby K Dwarf σ Draconis Using the Keck Planet Finder and TESS"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ad76a9
 #   https://ui.adsabs.harvard.edu/abs/2024ApJ...975..147H/abstract
 # Temperature from Boyajian et al. (2012), AJ 746 (1), id. 101
 # Rotation period from Reinhold et al. (2019), A&A 621, id.A21
 96100 # Alsafi / Sig Dra / HD 185144
 {
-	RA 293.09759805
-	Dec 69.65345106
-	Distance 18.7993 # 173.4939 +/- 0.0748 mas
+	RA	293.09759805
+	Dec	69.65345106
+	Distance	18.7993 # 173.4939 +/- 0.0748 mas
 	
 	Radius<rS>	0.772
 	SpectralType	"K0V"
@@ -2189,9 +2296,9 @@ Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 
 26857 # Ross 47
 {
-	RA 85.54770759
-	Dec 12.48235992
-	Distance 18.8883 # 172.6762 +/- 0.0286 mas
+	RA	85.54770759
+	Dec	12.48235992
+	Distance	18.8883 # 172.6762 +/- 0.0286 mas
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
 	AppMag 11.509
@@ -2203,9 +2310,9 @@ Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 # Masses of B, C from same sources as orbit
 Barycenter "Gliese 570:ADS 9446"
 {
-	RA 224.36820687 # mass ratio 0.802:(0.586:0.390)
-	Dec -21.42079800
-	Distance 19.1987 # 169.8843 +/- 0.0653 mas
+	RA	224.36820687 # mass ratio 0.802:(0.586:0.390)
+	Dec	-21.42079800
+	Distance	19.1987 # 169.8843 +/- 0.0653 mas
 }
 
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
@@ -2230,12 +2337,15 @@ Barycenter "Gliese 570:ADS 9446"
 	UniformRotation
 	{
 	    Period<d>	44.6
+		Inclination      0
+		AscendingNode    0
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_570"
 }
 
 # Temperatures and radii (non-empirical) from Torres et al. (2010), A&A Review 18 (1-2), pp. 67-126
 #   "Accurate masses and radii of normal stars: modern results and applications"
+#   https://arxiv.org/abs/0908.2624
 #   https://ui.adsabs.harvard.edu/abs/2010A%26ARv..18...67T/abstract
 Barycenter 73182 "Gliese 570 BC"
 {
@@ -2297,9 +2407,9 @@ Barycenter 73182 "Gliese 570 BC"
 #   https://iopscience.iop.org/article/10.3847/1538-4357/abe3fa
 "Gliese 570 D:ADS 9446 D"
 {
-	RA 224.31233
-	Dec -21.36328
-	Distance 19.1987
+	RA	224.31233
+	Dec	-21.36328
+	Distance	19.1987
 
 	Radius<rJ>	0.89
 	SpectralType	"T7.5V"
@@ -2311,9 +2421,9 @@ Barycenter 73182 "Gliese 570 BC"
 
 86990 # Luyten 205-128
 {
-	RA 266.63344447
-	Dec -57.32506180
-	Distance 19.2078 # 169.8042 +/- 0.0465 mas
+	RA	266.63344447
+	Dec	-57.32506180
+	Distance	19.2078 # 169.8042 +/- 0.0465 mas
 	SpectralType "M3.5V"
 	Radius 225000 # approx. for class
 	AppMag 10.783
@@ -2321,9 +2431,9 @@ Barycenter 73182 "Gliese 570 BC"
 
 "Gliese 754:Luyten 347-14"
 {
-	RA 290.20411627
-	Dec -45.57110617
-	Distance 19.2724 # 169.2351 +/- 0.0588 mas
+	RA	290.20411627
+	Dec	-45.57110617
+	Distance	19.2724 # 169.2351 +/- 0.0588 mas
 	SpectralType "M4.5V"
 	Radius 180000 # approx. for class
 	AppMag 12.23
@@ -2332,9 +2442,9 @@ Barycenter 73182 "Gliese 570 BC"
 
 117473 # Gliese 908
 {
-	RA 357.30660382
-	Dec 2.39691794
-	Distance 19.2745 # 169.2163 +/- 0.0281 mas
+	RA	357.30660382
+	Dec	2.39691794
+	Distance	19.2745 # 169.2163 +/- 0.0281 mas
 	SpectralType "M1V"
 	Radius 341000 # approx. for class
 	AppMag 8.993
@@ -2342,25 +2452,27 @@ Barycenter 73182 "Gliese 570 BC"
 }
 
 # Parameters of A from Karminski et al. (2018), A&A 618, A115
-# "The CARMENES search for exoplanets around M dwarfs. A Neptune-mass
-# planet traversing the habitable zone around HD 180617"
-# https://arxiv.org/abs/1808.01183
+#   "The CARMENES search for exoplanets around M dwarfs. A Neptune-mass
+#    planet traversing the habitable zone around HD 180617"
+#   https://www.aanda.org/articles/aa/full_html/2018/10/aa33354-18/aa33354-18.html
+#   https://ui.adsabs.harvard.edu/abs/2018A%26A...618A.115K/abstract
 # Parameters of B from Tsuji et al. (2016), PASJ 68 (1), 1331
-# "Near-infrared spectroscopy of M dwarfs. III. Carbon and oxygen abundances
-# in late M dwarfs, including the dusty rapid rotator 2MASSI J1835379+325954"
-# https://arxiv.org/abs/1511.04682
+#   "Near-infrared spectroscopy of M dwarfs. III. Carbon and oxygen abundances
+#    in late M dwarfs, including the dusty rapid rotator 2MASSI J1835379+325954"
+#   https://academic.oup.com/pasj/article/68/1/13/2469987
+#   https://ui.adsabs.harvard.edu/abs/2016PASJ...68...13T/abstract
 Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
 {
-	RA 289.22927187 # mass ratio 0.45:0.09
-	Dec 5.15987580
-	Distance 19.2942
+	RA	289.22927187 # mass ratio 0.45:0.09
+	Dec	5.15987580
+	Distance	19.2942
 }
 
 "V1428 Aql:Gliese 752 A:Ross 652 A:Wolf 1055 A:HD 180617 A"
 {
-	RA 289.22765150
-	Dec 5.16297630
-	Distance 19.2922 # 169.0615 +/- 0.0239 mas
+	RA	289.22765150
+	Dec	5.16297630
+	Distance	19.2922 # 169.0615 +/- 0.0239 mas
 	SpectralType "M2.5V"
 	Radius 315000
 	AppMag 9.115
@@ -2370,9 +2482,9 @@ Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
 
 "Van Biesbroeck's Star:V1298 Aql:Gliese 752 B:Ross 652 B:Wolf 1055 B:VB 10:HD 180617 B"
 {
-	RA 289.23737370
-	Dec 5.14437332
-	Distance 19.3045 # 168.9537 +/- 0.0668 mas
+	RA	289.23737370
+	Dec	5.14437332
+	Distance	19.3045 # 168.9537 +/- 0.0668 mas
 	SpectralType "M8.0V"
 	Radius 86000
 	AppMag 17.30
@@ -2381,9 +2493,9 @@ Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
 
 76074 # Gliese 588
 {
-	RA 233.04692742
-	Dec -41.28017409
-	Distance 19.2996 # 168.9965 +/- 0.0270 mas
+	RA	233.04692742
+	Dec	-41.28017409
+	Distance	19.2996 # 168.9965 +/- 0.0270 mas
 	SpectralType "M2.5V"
 	Radius 290000 # approx. for class
 	AppMag 9.311
@@ -2392,13 +2504,14 @@ Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
 
 Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 {
-	RA 12.28385489 # mass ratio 1.07:0.55
-	Dec 57.81375040 # A: 168.8322 +/- 0.1663 mas
-	Distance 19.331 # B: 168.7186 +/- 0.0216 mas
+	RA	12.28385489 # mass ratio 1.07:0.55
+	Dec	57.81375040 # A: 168.8322 +/- 0.1663 mas
+	Distance	19.331 # B: 168.7186 +/- 0.0216 mas
 }
 
 # Mass ratio from theoretical values from same source as orbit
 # Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Justesen and Albrecht (2020), A&A 642, id.A212
 "Achird A:ETA Cas A:24 Cas A:Gliese 34 A:ADS 671 A"
 {
 	Radius<rS>	1.0386
@@ -2415,6 +2528,12 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 		AscendingNode     8.78
 		ArgOfPericenter 182.11
 		MeanAnomaly      82.68
+	}
+	UniformRotation
+	{
+	    Period<d>	16.5
+		Inclination	0
+		AscendingNode	0
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
 }
@@ -2439,17 +2558,17 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 
 Barycenter "Guniibuu:36 Oph:Gliese 663:ADS 10417" # orbit of (AB) & C unknown
 {
-	RA 258.90522009 # mass ratio (0.75:0.76):0.72
-	Dec -26.58920251
-	Distance 19.4092
+	RA	258.90522009 # mass ratio (0.75:0.76):0.72
+	Dec	-26.58920251
+	Distance	19.4092
 }
 
 # Rotation periods from Baliunas et al. (1983), AJ 275, p. 752-772
 Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 {
-	RA 258.83461527 # mass ratio 0.75:0.76
-	Dec -26.60734861 # A: 168.1303 +/- 0.1081 mas
-	Distance 19.405 # B: 168.0031 +/- 0.1343 mas
+	RA	258.83461527 # mass ratio 0.75:0.76
+	Dec	-26.60734861 # A: 168.1303 +/- 0.1081 mas
+	Distance	19.405 # B: 168.0031 +/- 0.1343 mas
 }
 
 # Average masses from Luck, R. E. (2017), AJ 153 (1), 21
@@ -2498,16 +2617,18 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 	UniformRotation
 	{
 	    Period<d>	22.9
+		Inclination      0
+		AscendingNode    0
 	}
 	InfoURL "https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
-# Rotation period from Baliunas et al. (1996), AJ Letters 457, p.L99
+# Rotation period from Baliunas et al. (1996), AJL 457, p.L99
 84478 "Guniibuu C:36 Oph C:V2215 Oph:Gliese 664:Gliese 663 C:ADS 10417 C"
 {
-	RA 259.05329410
-	Dec -26.55114609
-	Distance 19.4185 # 167.9617 +/- 0.0311 mas
+	RA	259.05329410
+	Dec	-26.55114609
+	Distance	19.4185 # 167.9617 +/- 0.0311 mas
 
 	SpectralType "K5V"
 	AppMag 6.34
@@ -2521,23 +2642,21 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 
 37766 # Ross 882
 {
-	RA 116.16583593
-	Dec 3.55048445
-	Distance 19.5330 # 166.9769 +/- 0.0343 mas
+	RA	116.16583593
+	Dec	3.55048445
+	Distance	19.5330 # 166.9769 +/- 0.0343 mas
 	SpectralType "M4.0V"
 	Radius 180000 # approx. for class
 	AppMag 11.225
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
-# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
-# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
 "WISE 1541-2250:WISE J1541-2250:WISEPA J154151.66-225025.2:GJ 12260"
 {
-	RA 235.463692
-	Dec -22.840586
-	Distance 19.542 # 166.9 +/- 2.0 mas
+	RA	235.463692
+	Dec	-22.840586
+	Distance	19.542 # 166.9 +/- 2.0 mas
 	SpectralType "Y1"
 	Temperature 350
 	Radius 69900
@@ -2546,13 +2665,11 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 }
 
 # Masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
-#   "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence M Dwarfs"
-#   http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
 Barycenter 1242 "GJ 1005:Luyten 722-22"
 {
-	RA 3.86988027
-	Dec -16.13657165
-	Distance 19.577 # 166.6 +/- 0.3 mas
+	RA	3.86988027
+	Dec	-16.13657165
+	Distance	19.577 # 166.6 +/- 0.3 mas
 }
 
 "GJ 1005 A:Luyten 722-22 A"
@@ -2591,27 +2708,34 @@ Barycenter 1242 "GJ 1005:Luyten 722-22"
 
 Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A & B unknown
 {
-	RA 302.80247598 # mass ratio 0.82:0.20
-	Dec -36.10846971
-	Distance 19.6093
+	RA	302.80247598 # mass ratio 0.82:0.20
+	Dec	-36.10846971
+	Distance	19.6093
 }
 
 "Gliese 783 A:CD-36 13940 A:J Herschel 5173 A:HJ 5173 A"
 {
-	RA 302.80226904
-	Dec -36.10821654
-	Distance 19.6093 # 166.3272 +/- 0.1065 mas
+	RA	302.80226904
+	Dec	-36.10821654
+	Distance	19.6093 # 166.3272 +/- 0.1065 mas
+
 	SpectralType "K2.5V"
 	AppMag 5.32
+
+	UniformRotation
+	{
+	    Period<d>	3.44
+	}
 }
 
 "Gliese 783 B:CD-36 13940 B:J Herschel 5173 B:HJ 5173 B"
 {
-	RA 302.8033 # matched to the same epoch as primary's coordinates
-	Dec -36.1095 # using the latter's proper motions
-	Distance 19.6093
-	SpectralType "M3.5V"
+	RA	302.8033 # matched to the same epoch as primary's coordinates
+	Dec	-36.1095 # using the latter's proper motions
+	Distance	19.6093
+	
 	Radius 180000 # approx. for class
+	SpectralType "M3.5V"
 	AppMag 11.50
 }
 
@@ -2621,9 +2745,9 @@ Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A &
 #   https://ui.adsabs.harvard.edu/abs/2025A%26A...693A.297N/abstract
 15510 # e Eri / 82 G. Eri / HD 20794
 {
-	RA 50.00034362
-	Dec -43.06655253
-	Distance 19.7045 # 165.5242 +/- 0.0784 mas
+	RA	50.00034362
+	Dec	-43.06655253
+	Distance	19.7045 # 165.5242 +/- 0.0784 mas
 
 	Radius<rS>	0.93    # not directly measured
 	SpectralType	"G6V"
@@ -2638,13 +2762,13 @@ Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A &
 }
 
 # Barry et al. (2012), ApJ 760 (1), 55
-# "A Precise Physical Orbit for the M-dwarf Binary Gliese 268"
-# http://iopscience.iop.org/article/10.1088/0004-637X/760/1/55/meta
+#   "A Precise Physical Orbit for the M-dwarf Binary Gliese 268"
+#   http://iopscience.iop.org/article/10.1088/0004-637X/760/1/55/meta
 Barycenter 34603 "Gliese 268:Ross 986"
 {
-	RA 107.50514340
-	Dec 38.52526942
-	Distance 19.7414 # 165.2147 +/- 0.0636 mas
+	RA	107.50514340
+	Dec	38.52526942
+	Distance	19.7414 # 165.2147 +/- 0.0636 mas
 }
 
 "QY Aur:Gliese 268 A:Ross 986 A"
@@ -2686,9 +2810,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 # Rotation period from Hojjatpanah et al. (2020), A&A 639, id.A35
 99240 # Del Pav
 {
-	RA 302.19503989
-	Dec -66.18709128
-	Distance 19.8931 # 163.9544 +/- 0.1222 mas
+	RA	302.19503989
+	Dec	-66.18709128
+	Distance	19.8931 # 163.9544 +/- 0.1222 mas
 
 	Radius<rS>	1.197
 	SpectralType "G8IV"
@@ -2704,9 +2828,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 
 "2MASS 0136+0933:2MASS J01365662+0933473:SIMP J013656.5+093347:GJ 10218"
 {
-	RA 24.24124979
-	Dec 9.56307045
-	Distance 19.9548 # 163.4478 +/- 0.4629 mas
+	RA	24.24124979
+	Dec	9.56307045
+	Distance	19.9548 # 163.4478 +/- 0.4629 mas
 	SpectralType "T2.5V"
 	AbsMag 27.5 # for approximate radius in Celestia
 	InfoURL "https://en.wikipedia.org/wiki/SIMP_J013656.5%2B093347"
@@ -2717,9 +2841,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 #   https://www.aanda.org/articles/aa/abs/2009/02/aa11281-08/aa11281-08.html
 "2MASS 0937+2931:2MASS J09373487+2931409:GJ 11388"
 {
-	RA 144.395250
-	Dec 29.528189
-	Distance 19.961 # 163.39 +/- 1.76 mas
+	RA	144.395250
+	Dec	29.528189
+	Distance	19.961 # 163.39 +/- 1.76 mas
 	SpectralType "T6.0V"
 	AbsMag 33.5 # for approximate radius in Celestia
 	InfoURL "https://en.wikipedia.org/wiki/2MASS_J09373487%2B2931409"
@@ -2727,24 +2851,22 @@ Barycenter 34603 "Gliese 268:Ross 986"
 
 99701 # Gliese 784
 {
-	RA 303.47739056
-	Dec -45.16473054
-	Distance 20.1062 # 162.2171 +/- 0.0225 mas
+	RA	303.47739056
+	Dec	-45.16473054
+	Distance	20.1062 # 162.2171 +/- 0.0225 mas
 	SpectralType "M0V"
 	Radius 432000 # approx. for class
 	AppMag 7.966
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_784"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
-# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
-# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
 "WISE 2209+2711:WISE J220905.73+271143.9:GJ 13202"
 {
-	RA 332.275805
-	Dec 27.193641
-	Distance 20.170 # 161.7 +/- 2.0 mas
+	RA	332.275805
+	Dec	27.193641
+	Distance	20.170 # 161.7 +/- 2.0 mas
 	SpectralType "Y0V"
 	Temperature 350
 	Radius 69900
@@ -2754,9 +2876,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 
 "GJ 1221:LP 44-113"
 {
-	RA 267.01612291
-	Dec 70.88157381
-	Distance 20.2588 # 160.9952 +/- 0.0119 mas
+	RA	267.01612291
+	Dec	70.88157381
+	Distance	20.2588 # 160.9952 +/- 0.0119 mas
 	SpectralType "DQ9P"
 	AppMag 14.15
 	InfoURL "https://en.wikipedia.org/wiki/G_240-72"
@@ -2764,9 +2886,9 @@ Barycenter 34603 "Gliese 268:Ross 986"
 
 71253 # Gliese 555
 {
-	RA 218.56843176
-	Dec -12.51692385
-	Distance 20.3946 # 159.9225 +/- 0.0546 mas
+	RA	218.56843176
+	Dec	-12.51692385
+	Distance	20.3946 # 159.9225 +/- 0.0546 mas
 	SpectralType "M3.5V"
 	Radius 225000 # approx. for class
 	AppMag 11.317
@@ -2774,13 +2896,13 @@ Barycenter 34603 "Gliese 268:Ross 986"
 }
 
 # Curiel et al. (2022), AJ 164 (3), 93
-# "3D orbital architecture of a dwarf binary system and its planetary companion"
-# https://ui.adsabs.harvard.edu/abs/2022AJ....164...93C/abstract
+#   "3D orbital architecture of a dwarf binary system and its planetary companion"
+#   https://ui.adsabs.harvard.edu/abs/2022AJ....164...93C/abstract
 Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 {
-	RA 352.97054871 # mass ratio 0.43814:0.16527
-	Dec 19.93708072
-	Distance 20.400 # 159.88 +/- 0.17 mas
+	RA	352.97054871 # mass ratio 0.43814:0.16527
+	Dec	19.93708072
+	Distance	20.400 # 159.88 +/- 0.17 mas
 }
 
 1000231723 "EQ Peg A:Gliese 896 A:BD+19 5116 A"
@@ -2821,9 +2943,9 @@ Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 
 74995 # Gliese 581
 {
-	RA 229.85630133
-	Dec -7.72270702
-	Distance 20.5494 # 158.7183 +/- 0.0301 mas
+	RA	229.85630133
+	Dec	-7.72270702
+	Distance	20.5494 # 158.7183 +/- 0.0301 mas
 	SpectralType "M3V"
 	Radius 270000 # approx. for class
 	AppMag 10.560
@@ -2833,9 +2955,9 @@ Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 # Parameters from Kirkpatrick et al. (2021)
 "WISE 1405+5534:WISE J140518.39+553421.3:GJ 12023"
 {
-	RA 211.320620
-	Dec 55.572896
-	Distance 20.617 # 158.2 +/- 2.6 mas
+	RA	211.320620
+	Dec	55.572896
+	Distance	20.617 # 158.2 +/- 2.6 mas
 	SpectralType "Y0V"
 	Temperature 411
 	Radius 60000 # approx.
@@ -2849,9 +2971,9 @@ Barycenter 116132 "EQ Peg:Gliese 896:BD+19 5116"
 #   https://arxiv.org/abs/2003.13052
 Barycenter "Gliese 338:Struve 1321:ADS 7251"
 {
-	RA 138.58729103 # mass ratio 0.69:0.64
-	Dec 52.68376704 # A: 157.8879 +/- 0.0197 mas
-	Distance 20.658 # B: 157.8825 +/- 0.0211 mas
+	RA	138.58729103 # mass ratio 0.69:0.64
+	Dec	52.68376704 # A: 157.8879 +/- 0.0197 mas
+	Distance	20.658 # B: 157.8825 +/- 0.0211 mas
 }
 
 45343 "Gliese 338 A:Struve 1321 A:ADS 7251 A"
@@ -2896,9 +3018,9 @@ Barycenter "Gliese 338:Struve 1321:ADS 7251"
 
 "LHS 2090:LP 368-128:GJ 11309"
 {
-	RA 135.09564332
-	Dec 21.83206260
-	Distance 20.7388 # 157.2686 +/- 0.0535 mas
+	RA	135.09564332
+	Dec	21.83206260
+	Distance	20.7388 # 157.2686 +/- 0.0535 mas
 	SpectralType "M6.5V"
 	Radius 105000 # approx. for class
 	AppMag 16.100
@@ -2906,18 +3028,17 @@ Barycenter "Gliese 338:Struve 1321:ADS 7251"
 }
 
 # Orbit from Agati et al. (2015), A&A 574 (A6), 32
-# "Are the orbital poles of binary stars in the solar neighbourhood anisotropically 
-# distributed?"
-# https://www.aanda.org/articles/aa/abs/2015/02/aa23056-13/aa23056-13.html
+#   "Are the orbital poles of binary stars in the solar neighbourhood anisotropically distributed?"
+#   https://www.aanda.org/articles/aa/abs/2015/02/aa23056-13/aa23056-13.html
 # Masses from Söderhjelm, S. (1999), A&A 341, 121
-# "Visual binary orbits and masses post Hipparcos"
-# http://adsabs.harvard.edu/abs/1999A%26A...341..121S
+#   "Visual binary orbits and masses post Hipparcos"
+#   http://adsabs.harvard.edu/abs/1999A%26A...341..121S
 # Distance from RECONS' weighted parallax
 Barycenter 84140 "Gliese 661:BD+45 2505"
 {
-	RA 258.03421598
-	Dec 45.65905974
-	Distance 20.865 # 156.32 +/- 1.28 mas
+	RA	258.03421598
+	Dec	45.65905974
+	Distance	20.865 # 156.32 +/- 1.28 mas
 }
 
 "Gliese 661 A:BD+45 2505 A"
@@ -2958,9 +3079,9 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 
 "2MASS 1503+2525:2MASS J15031961+2525196:GJ 12162"
 {
-	RA 225.83214226
-	Dec 25.42464449
-	Distance 20.9375 # 155.7758 +/- 0.7557 mas
+	RA	225.83214226
+	Dec	25.42464449
+	Distance	20.9375 # 155.7758 +/- 0.7557 mas
 	SpectralType "T5.5V"
 	AbsMag 32 # for approximate radius in Celestia
 	InfoURL "https://en.wikipedia.org/wiki/2MASS_J15031961%2B2525196"
@@ -2968,9 +3089,9 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 
 "LP 944-20:GJ 10513"
 {
-	RA 54.89857021
-	Dec -35.42759364
-	Distance 20.9614 # 155.5982 +/- 0.0522 mas
+	RA	54.89857021
+	Dec	-35.42759364
+	Distance	20.9614 # 155.5982 +/- 0.0522 mas
 	SpectralType "M9.5Ve"
 	Radius 56000 # approx. for class
 	AppMag 18.69
@@ -2979,9 +3100,9 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 
 "Gliese 223.2:GJ 9193:LP 658-2:HL 4"
 {
-	RA 88.79209556
-	Dec -4.17892709
-	Distance 21.0102 # 155.2373 +/- 0.0175 mas
+	RA	88.79209556
+	Dec	-4.17892709
+	Distance	21.0102 # 155.2373 +/- 0.0175 mas
 	SpectralType "DZ9" # DZ11
 	AppMag 14.45
 	InfoURL "https://en.wikipedia.org/wiki/LP_658-2"
@@ -2989,9 +3110,9 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 
 "GL Vir:GJ 1156:Luyten 1190-34"
 {
-	RA 184.74174734
-	Dec 11.12695237
-	Distance 21.0832 # 154.6999 +/- 0.0445 mas
+	RA	184.74174734
+	Dec	11.12695237
+	Distance	21.0832 # 154.6999 +/- 0.0445 mas
 	SpectralType "M4.5V"
 	Radius 160000 # approx. for class
 	AppMag 13.898
@@ -3000,9 +3121,9 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 
 80459 # Gliese 625
 {
-	RA 246.35588833
-	Dec 54.30333867
-	Distance 21.1309 # 154.3503 +/- 0.0161 mas
+	RA	246.35588833
+	Dec	54.30333867
+	Distance	21.1309 # 154.3503 +/- 0.0161 mas
 	SpectralType "M1.5V"
 	Radius 324000 # approx. for class
 	AppMag 10.17
@@ -3012,17 +3133,17 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 # Used Gaia EDR3 parallax for C
 Barycenter "Gliese 644:Wolf 630" # orbit of (AB) & C unknown
 {
-	RA 253.86817134 # mass ratio (0.4155:(0.3466:0.3143)):0.0841
-	Dec -8.34454331
-	Distance 21.1837 # 153.9659 +/- 0.0570 mas
+	RA	253.86817134 # mass ratio (0.4155:(0.3466:0.3143)):0.0841
+	Dec	-8.34454331
+	Distance	21.1837 # 153.9659 +/- 0.0570 mas
 }
 
 # Masses from Segransan et al. (2000), A&A 364, 665
 Barycenter 82817 "Gliese 644 AB:Wolf 630 AB"
 {
-	RA 253.86621222
-	Dec -8.34032583
-	Distance 21.1837
+	RA	253.86621222
+	Dec	-8.34032583
+	Distance	21.1837
 }
 
 "V1054 Oph:Gliese 644 A:Wolf 630 A"
@@ -3095,9 +3216,9 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 # Physical parameters from Mann et al. (2015), ApJ 804 (1), 64
 "Gliese 644 C:Wolf 630 C:VB 8"
 {
-	RA 253.89324627
-	Dec -8.39852302
-	Distance 21.1837
+	RA	253.89324627
+	Dec	-8.39852302
+	Distance	21.1837
 	SpectralType "M7V"
 	AppMag 16.916
 	Radius 78680
@@ -3106,9 +3227,9 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 
 82809 "Gliese 643:Wolf 629"
 {
-	RA 253.85142033
-	Dec -8.32657626
-	Distance 21.1961 # 153.8754 +/- 0.0474 mas
+	RA	253.85142033
+	Dec	-8.32657626
+	Distance	21.1961 # 153.8754 +/- 0.0474 mas
 	SpectralType "M3.5V"
 	Radius 225000 # approx. for class
 	AppMag 11.759
@@ -3117,9 +3238,9 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 
 "GJ 1128:LHS 271:Luyten 100-115"
 {
-	RA 145.69216012
-	Dec -68.87998538
-	Distance 21.2121 # 153.7593 +/- 0.0249 mas
+	RA	145.69216012
+	Dec	-68.87998538
+	Distance	21.2121 # 153.7593 +/- 0.0249 mas
 	SpectralType "M4.0V"
 	Radius 180000 # approx. for class
 	AppMag 12.78
@@ -3133,12 +3254,13 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 # Rotation period from Motalebi et al. (2015), A&A 584, id.A72
 #   "The HARPS-N Rocky Planet Search. I. HD 219134 b:
 #    A transiting rocky planet in a multi-planet system at 6.5 pc from the Sun"
+#   https://www.aanda.org/articles/aa/full_html/2015/12/aa26822-15/aa26822-15.html
 #   https://ui.adsabs.harvard.edu/abs/2015A%26A...584A..72M/abstract
 114622 # Gliese 892 / HD 219134
 {
-	RA 348.33773395
-	Dec 57.16966644
-	Distance 21.3364 # 152.8640 +/- 0.0494 mas
+	RA	348.33773395
+	Dec	57.16966644
+	Distance	21.3364 # 152.8640 +/- 0.0494 mas
 
 	Radius<rS>	0.783
 	SpectralType	"K3V"
@@ -3155,21 +3277,21 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 # Parameters from Kirkpatrick et al. (2021)
 "WISE 0825+2805:WISE J082507.35+280548.5:GJ 11222"
 {
-	RA 126.280525
-	Dec 28.096445
-	Distance 21.373 # 152.6 +/- 2.0 mas
+	RA	126.280525
+	Dec	28.096445
+	Distance	21.373 # 152.6 +/- 2.0 mas
 	SpectralType "Y0.5V"
 	Temperature 376
 	Radius 60000 # approx.
 	AbsMag 40 # extremely low
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 0410+1502:WISE J041022.71+150248.4:GJ 10571"
 {
-	RA 62.596159
-	Dec 15.043733
-	Distance 21.557 # 151.3 +/- 2.0 mas
+	RA	62.596159
+	Dec	15.043733
+	Distance	21.557 # 151.3 +/- 2.0 mas
 	SpectralType "Y0V"
 	Temperature 451
 	Radius 60000 # approx.
@@ -3177,12 +3299,12 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 	InfoURL "https://en.wikipedia.org/wiki/WISEPA_J041022.71%2B150248.5"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "2MASS 0521+1025:2MASS J05212615+1025328:WISE J052126.29+102528.4:GJ 10757"
 {
-	RA 80.359997
-	Dec 10.423818
-	Distance 21.715 # 150.2 +/- 3.0 mas
+	RA	80.359997
+	Dec	10.423818
+	Distance	21.715 # 150.2 +/- 3.0 mas
 	SpectralType "T7.5"
 	Temperature 727
 	Radius 60000 # approx.
@@ -3192,9 +3314,9 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 
 "LHS 337:Luyten 471-42:GJ 3737"
 {
-	RA 189.70080544
-	Dec -38.38740912
-	Distance 21.7324 # 150.0781 +/- 0.0322 mas
+	RA	189.70080544
+	Dec	-38.38740912
+	Distance	21.7324 # 150.0781 +/- 0.0322 mas
 	SpectralType "M4.0V"
 	Radius 180000 # approx. for class
 	AppMag 12.74
@@ -3203,9 +3325,9 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 
 53767 # Ross 104
 {
-	RA 165.01567860
-	Dec 22.83170230
-	Distance 22.0081 # 148.1986 +/- 0.0253 mas
+	RA	165.01567860
+	Dec	22.83170230
+	Distance	22.0081 # 148.1986 +/- 0.0253 mas
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
 	AppMag 10.020
@@ -3217,16 +3339,18 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 #   http://adsabs.harvard.edu/abs/1999A%26A...341..121S
 # Rotational elements and B's temperature from Strassmeier et al. (2023), A&A 674, id.A118
 #   "Zeeman Doppler imaging of ξ Boo A and B"
+#   https://www.aanda.org/articles/aa/full_html/2023/06/aa45664-22/aa45664-22.html
 #   https://ui.adsabs.harvard.edu/abs/2023A%26A...674A.118S/abstract
 Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 {
-	RA 222.84746520 # mass ratio 0.94:0.67
-	Dec 19.10061690 # A: 148.0695 +/- 0.1317 mas
-	Distance 22.013 # B: 148.1793 +/- 0.0546 mas
+	RA	222.84746520 # mass ratio 0.94:0.67
+	Dec	19.10061690 # A: 148.0695 +/- 0.1317 mas
+	Distance	22.013 # B: 148.1793 +/- 0.0546 mas
 }
 
 # Radius and temperature from Karovicova et al. (2022), A&A 658, id.A47
 #   "Fundamental stellar parameters of benchmark stars from CHARA interferometry. II. Dwarf stars"
+#   https://www.aanda.org/articles/aa/full_html/2022/02/aa41833-21/aa41833-21.html
 #   https://ui.adsabs.harvard.edu/abs/2022A%26A...658A..47K/abstract
 1007221481 "XI Boo A:37 Boo A:Gliese 566 A:ADS 9413 A"
 {
@@ -3281,9 +3405,9 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 
 "Gliese 299:Ross 619"
 {
-	RA 122.99468256
-	Dec 8.75040152
-	Distance 22.0791 # 147.7218 +/- 0.0950 mas
+	RA	122.99468256
+	Dec	8.75040152
+	Distance	22.0791 # 147.7218 +/- 0.0950 mas
 	SpectralType "M4.5V"
 	Radius 160000 # approx. for class
 	AppMag 12.834
@@ -3291,16 +3415,12 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 }
 
 # Tokovinin et al. (2015), AJ 150 (2), 50
-#   "Speckle Interferometry at SOAR in 2014"
-#   http://iopscience.iop.org/article/10.1088/0004-6256/150/2/50/meta
 # Delfosse et al. (1999), A&A 344, 897
-#   "New neighbours. I. 13 new companions to nearby M dwarfs"
-#   http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter "GJ 3522:Giclas 41-14"
 {
-	RA 134.73639684 # mass ratio (0.19:0.17):0.17
-	Dec 8.47245694
-	Distance 22.088 # 147.66 +/- 1.98 mas
+	RA	134.73639684 # mass ratio (0.19:0.17):0.17
+	Dec	8.47245694
+	Distance	22.088 # 147.66 +/- 1.98 mas
 }
 
 Barycenter "GJ 3522 A:Giclas 41-14 A"
@@ -3373,13 +3493,11 @@ Barycenter "GJ 3522 A:Giclas 41-14 A"
 }
 
 # Delfosse et al. (1999), A&A 344, 897
-# "New neighbours. I. 13 new companions to nearby M dwarfs"
-# http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter 106106 "Gliese 829:Ross 775"
 {
-	RA 322.40807988
-	Dec 17.64497780
-	Distance 22.1129 # 147.4958 +/- 0.0257 mas
+	RA	322.40807988
+	Dec	17.64497780
+	Distance	22.1129 # 147.4958 +/- 0.0257 mas
 }
 
 "Gliese 829 A:Ross 775 A"
@@ -3415,25 +3533,26 @@ Barycenter 106106 "Gliese 829:Ross 775"
 }
 
 # Dupuy et al. (2019), AJ 158 (5), 174
-# "WISE J072003.20-084651.2B is a Massive T Dwarf"
-# https://arxiv.org/abs/1908.06994
+#   "WISE J072003.20-084651.2B is a Massive T Dwarf"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ab3cd1
+#   https://ui.adsabs.harvard.edu/abs/2019AJ....158..174D/abstract
 Barycenter "Scholz's Star:WISE 0720-0846:WISE J072003.20-084651.2:GJ 11068"
 {
-	RA 110.01336164
-	Dec -8.78107327
-	Distance 22.172 # 147.1 +1.1 -1.2 mas
+	RA	110.01336164
+	Dec	-8.78107327
+	Distance	22.172 # 147.1 +1.1 -1.2 mas
 }
 
 # Apparent magnitude of A from Ivanov et al. (2015), A&A 574, A64
-# "Properties of the solar neighbor WISE J072003.20-084651.2"
-# https://www.aanda.org/articles/aa/abs/2015/02/aa24883-14/aa24883-14.html
+#   "Properties of the solar neighbor WISE J072003.20-084651.2"
+#   https://www.aanda.org/articles/aa/abs/2015/02/aa24883-14/aa24883-14.html
 "Scholz's Star A:WISE 0720-0846 A:WISE J072003.20-084651.2 A:GJ 11068 A"
 {
-	OrbitBarycenter "WISE 0720-0846"
+	Radius 70900
 	SpectralType "M9.5V"
 	AppMag 18.266
-	Radius 70900
 
+	OrbitBarycenter "WISE 0720-0846"
 	EllipticalOrbit {              # fully specified orbit
 		Period            8.06
 		SemiMajorAxis     0.87 # mass ratio 99J:66J
@@ -3443,15 +3562,16 @@ Barycenter "Scholz's Star:WISE 0720-0846:WISE J072003.20-084651.2:GJ 11068"
 		ArgOfPericenter  39.7
 		MeanAnomaly      18.4
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Scholz's_Star"
 }
 
 "Scholz's Star B:WISE 0720-0846 B:WISE J072003.20-084651.2 B:GJ 11068 B"
 {
-	OrbitBarycenter "WISE 0720-0846"
+	Radius 58800
 	SpectralType "T5.5V"
 	AbsMag 32 # for approximate radius in Celestia
-	Radius 58800
 
+	OrbitBarycenter "WISE 0720-0846"
 	EllipticalOrbit {              # fully specified orbit
 		Period            8.06
 		SemiMajorAxis     1.31 # mass ratio 99J:66J
@@ -3461,26 +3581,24 @@ Barycenter "Scholz's Star:WISE 0720-0846:WISE J072003.20-084651.2:GJ 11068"
 		ArgOfPericenter 219.7
 		MeanAnomaly      18.4
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Scholz's_Star"
 }
 
 "2MASS 1928+2356:2MASS J19284155+2356016:GJ 12834"
 {
-	RA 292.17175326
-	Dec 23.93500480
-	Distance 22.2774 # 146.4067 +/- 1.2001 mas
+	RA	292.17175326
+	Dec	23.93500480
+	Distance	22.2774 # 146.4067 +/- 1.2001 mas
 	SpectralType "T6"
 	AbsMag 33.5 # for approximate radius in Celestia
 }
 
-# parallax from Kirkpatrick et al. (2019), ApJS 240 (2), 19
-# "Preliminary Trigonometric Parallaxes of 184 Late-T and Y Dwarfs and an
-# Analysis of the Field Substellar Mass Function into the 'Planetary' Mass Regime"
-# https://iopscience.iop.org/article/10.3847/1538-4365/aaf6af
+# Parallax from Kirkpatrick et al. (2019), ApJS 240 (2), 19
 "WISE 0254+0223:WISE J025409.51+022358.6:GJ 10400"
 {
-	RA 43.5328583
-	Dec 2.3989861
-	Distance 22.324 # 146.1 +/- 1.5 mas
+	RA	43.5328583
+	Dec	2.3989861
+	Distance	22.324 # 146.1 +/- 1.5 mas
 	SpectralType "T8V"
 	Temperature 656
 	Radius 60000 # approx.
@@ -3490,45 +3608,46 @@ Barycenter "Scholz's Star:WISE 0720-0846:WISE J072003.20-084651.2:GJ 11068"
 
 # Used parallax of component A, from Gaia EDR3
 # Winters et al. (2019), AJ 158 (4), 152
-# "Three Red Suns in the Sky: A Transiting, Terrestrial Planet in a Triple 
-# M Dwarf System at 6.9 Parsecs"
-# https://arxiv.org/abs/1906.10147
-# CNS5 lists the entire system as GJ 3193 ABC, and does not contain an entry
-# for GJ 3192
+#   "Three Red Suns in the Sky: A Transiting, Terrestrial Planet in a Triple M-dwarf System at 6.9 pc"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ab364d
+#   https://ui.adsabs.harvard.edu/abs/2019AJ....158..152W/abstract
+# CNS5 lists the entire system as GJ 3193 ABC, and does not contain an entry for GJ 3192
 Barycenter 14101 "LTT 1445:GJ 3193"
 {
-	RA 45.46154733 # mass ratio 0.257:(0.215:0.161)
-	Dec -16.59369072
-	Distance 22.3867 # 145.6922 +/- 0.0244 mas
+	RA	45.46154733 # mass ratio 0.257:(0.215:0.161)
+	Dec	-16.59369072
+	Distance	22.3867 # 145.6922 +/- 0.0244 mas
 }
 
 1006945865 "LTT 1445 A:GJ 3193 A:LP 771-96:Luyten 730-18:RECONS 4:TOI-455"
 {
-	RA 45.46242451
-	Dec -16.59453281
-	Distance 22.3867
-	AppMag 11.22
-	SpectralType "M3V"
+	RA	45.46242451
+	Dec	-16.59453281
+	Distance	22.3867
+
 	Radius 186400
-	InfoURL "https://en.wikipedia.org/wiki/LTT_1445#Stellar_system"
+	SpectralType "M3V"
+	AppMag 11.22
+
+	InfoURL "https://en.wikipedia.org/wiki/LTT_1445"
 }
 
 # CNS5 does not list the GJ 3192 designation
 Barycenter "LTT 1445 BC:GJ 3193 BC:GJ 3192:LP 771-95"
 {
-	RA 45.46094777
-	Dec -16.59311514
-	Distance 22.3867
+	RA	45.46094777
+	Dec	-16.59311514
+	Distance	22.3867
 }
 
 # CNS5 does not list the GJ 3192 designation
 "LTT 1445 B:GJ 3193 B:GJ 3192 A:LP 771-95 A"
 {
-	OrbitBarycenter "LTT 1445 BC"
+	Radius 164200
 	SpectralType "M4V" # estimate from mass and radius
 	AppMag 11.78
-	Radius 164200
 
+	OrbitBarycenter "LTT 1445 BC"
 	EllipticalOrbit {
 		Period          36.2
 		SemiMajorAxis   3.41 # mass ratio 0.215:0.161
@@ -3538,16 +3657,17 @@ Barycenter "LTT 1445 BC:GJ 3193 BC:GJ 3192:LP 771-95"
 		ArgOfPericenter 333.35
 		MeanAnomaly     169.06
 	}
+	InfoURL "https://en.wikipedia.org/wiki/LTT_1445"
 }
 
 # CNS5 does not list the GJ 3192 designation
 "LTT 1445 C:GJ 3193 C:GJ 3192 B:LP 771-95 B"
 {
-	OrbitBarycenter "LTT 1445 BC"
+	Radius 137100
 	SpectralType "M4V" # estimate from mass and radius
 	AppMag 12.64
-	Radius 137100
 
+	OrbitBarycenter "LTT 1445 BC"
 	EllipticalOrbit {
 		Period          36.2
 		SemiMajorAxis   4.55 # mass ratio 0.215:0.161
@@ -3557,25 +3677,26 @@ Barycenter "LTT 1445 BC:GJ 3193 BC:GJ 3192:LP 771-95"
 		ArgOfPericenter 153.35
 		MeanAnomaly     169.06
 	}
+	InfoURL "https://en.wikipedia.org/wiki/LTT_1445"
 }
 
 113296 # Ross 671
 {
-	RA 344.14022173
-	Dec 16.55216937
-	Distance 22.3972 # 145.6234 +/- 0.0255 mas
+	RA	344.14022173
+	Dec	16.55216937
+	Distance	22.3972 # 145.6234 +/- 0.0255 mas
 	SpectralType "M1.5Ve"
 	Radius 324000 # approx. for class
 	AppMag 8.638
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # Not in CNS5
 "CWISE 1055+5443:CWISE J105512.11+544328.3"
 {
-	RA 163.799544
-	Dec 54.724527
-	Distance 22.494 # 145.0 +/- 14.7 mas
+	RA	163.799544
+	Dec	54.724527
+	Distance	22.494 # 145.0 +/- 14.7 mas
 	SpectralType "sdT8"
 	Temperature 686
 	Radius 60000 # approx.
@@ -3584,9 +3705,9 @@ Barycenter "LTT 1445 BC:GJ 3193 BC:GJ 3192:LP 771-95"
 
 53020 # Wolf 358
 {
-	RA 162.71296407
-	Dec 6.80448954
-	Distance 22.7225 # 143.5391 +/- 0.0286 mas
+	RA	162.71296407
+	Dec	6.80448954
+	Distance	22.7225 # 143.5391 +/- 0.0286 mas
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
 	AppMag 11.675
@@ -3605,9 +3726,9 @@ Modify 103096 # Gliese 809
 
 "2MASS 2146+3813:2MASS J21462206+3813047:GJ 13136"
 {
-	RA 326.59288194
-	Dec 38.21751708
-	Distance 22.9858 # 141.8946 +/- 0.0212 mas
+	RA	326.59288194
+	Dec	38.21751708
+	Distance	22.9858 # 141.8946 +/- 0.0212 mas
 	SpectralType "M5V"
 	Radius 140000 # approx. for class
 	AppMag 12.210
@@ -3615,24 +3736,22 @@ Modify 103096 # Gliese 809
 
 "GJ 3877:LP 914-54"
 {
-	RA 224.15695945
-	Dec -28.16725415
-	Distance 23.0029 # 141.7891 +/- 0.0617 mas
+	RA	224.15695945
+	Dec	-28.16725415
+	Distance	23.0029 # 141.7891 +/- 0.0617 mas
 	SpectralType "M7.0V"
 	Radius 84000 # approx. for class
 	AppMag 17.141
 	InfoURL "https://en.wikipedia.org/wiki/LHS_3003"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
-# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
-# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
 "WISE 2056+1459:WISE J205628.91+145953.2:GJ 13033"
 {
-	RA 314.121593
-	Dec 14.998858
-	Distance 23.165 # 140.8 +/- 2.0 mas
+	RA	314.121593
+	Dec	14.998858
+	Distance	23.165 # 140.8 +/- 2.0 mas
 	SpectralType "Y0V"
 	Temperature 407
 	Radius 65000
@@ -3642,20 +3761,20 @@ Modify 103096 # Gliese 809
 
 "GJ 1068:Luyten 230-188"
 {
-	RA 62.61100026
-	Dec -53.61299677
-	Distance 23.1816 # 140.6961 +/- 0.0214 mas
+	RA	62.61100026
+	Dec	-53.61299677
+	Distance	23.1816 # 140.6961 +/- 0.0214 mas
 	SpectralType "M4.5V"
 	Radius 160000 # approx. for class
 	AppMag 13.58
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 0049+2151:WISE J004945.61+215120.0:GJ 10131"
 {
-	RA 12.439534
-	Dec 21.855377
-	Distance 23.231 # 140.4 +/- 2.1 mas
+	RA	12.439534
+	Dec	21.855377
+	Distance	23.231 # 140.4 +/- 2.1 mas
 	SpectralType "T8.5"
 	Temperature 640
 	Radius 60000 # approx.
@@ -3665,9 +3784,9 @@ Modify 103096 # Gliese 809
 
 "GJ 1286"
 {
-	RA 353.79706944
-	Dec -2.39279939
-	Distance 23.4074 # 139.3389 +/- 0.0441 mas
+	RA	353.79706944
+	Dec	-2.39279939
+	Distance	23.4074 # 139.3389 +/- 0.0441 mas
 	SpectralType "M5.0V"
 	Radius 140000 # approx. for class
 	AppMag 14.69
@@ -3676,20 +3795,20 @@ Modify 103096 # Gliese 809
 # Used Gaia EDR3 parallax for B
 Barycenter "Gliese 105" # orbit of (AC) and B unknown
 {
-	RA 39.03674095 # mass ratio (0.78:102.6J):0.21
-	Dec 6.89039568
-	Distance 23.5599 # 138.4371 +/- 0.0420 mas
+	RA	39.03674095 # mass ratio (0.78:102.6J):0.21
+	Dec	6.89039568
+	Distance	23.5599 # 138.4371 +/- 0.0420 mas
 }
 
 # Feng et al. (2021), MNRAS 507 (2), 2856
-# "Optimized modelling of Gaia-Hipparcos astrometry for the detection of the
-# smallest cold Jupiter and confirmation of seven low-mass companions"
-# https://arxiv.org/abs/2107.14056
+#   "Optimized modelling of Gaia–Hipparcos astrometry for the detection of the smallest cold Jupiter and confirmation of seven low-mass companions"
+#   https://academic.oup.com/mnras/article/507/2/2856/6338119
+#   https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.2856F/abstract
 Barycenter 12114 "Gliese 105 AC"
 {
-	RA 39.02838451
-	Dec 6.89333911
-	Distance 23.5599
+	RA	39.02838451
+	Dec	6.89333911
+	Distance	23.5599
 }
 
 # Radius and temperature from Mann et al. (2013), AJ 779 (2), id. 188
@@ -3715,14 +3834,15 @@ Barycenter 12114 "Gliese 105 AC"
 	{
 	    Period<d>	48.0
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_105"
 }
 
 "Gliese 105 C"
 {
-	OrbitBarycenter "Gliese 105 AC"
 	SpectralType "M7V"
 	AppMag 16.77
 
+	OrbitBarycenter "Gliese 105 AC"
 	EllipticalOrbit {              # fully specified orientation
 		Period         76.107
 		SemiMajorAxis    15.1 # mass ratio 0.78:102.6J
@@ -3732,51 +3852,55 @@ Barycenter 12114 "Gliese 105 AC"
 		ArgOfPericenter 188.3
 		MeanAnomaly     273.7
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_105"
 }
 
 "BX Cet:Gliese 105 B"
 {
-	RA 39.07167733
-	Dec 6.87808990
-	Distance 23.5599
-	AppMag 11.664
-	SpectralType "M3.5V"
+	RA	39.07167733
+	Dec	6.87808990
+	Distance	23.5599
+
 	Radius 225000 # approx. for class
+	SpectralType "M3.5V"
+	AppMag 11.664
+
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_105"
 }
 
 "V488 Hya:2MASS J08354256-0819237:GJ 11250"
 {
-	RA 128.92481210
-	Dec -8.32181827
-	Distance 23.5807 # 138.3147 +/- 0.2145 mas
+	RA	128.92481210
+	Dec	-8.32181827
+	Distance	23.5807 # 138.3147 +/- 0.2145 mas
 	SpectralType "L6.5V"
 	AbsMag 21.5 # for approximate radius in Celestia
 }
 
 "GJ 4274:Luyten 788-34"
 {
-	RA 335.78059284
-	Dec -17.61050757
-	Distance 23.5955 # 138.2280 +/- 0.0482 mas
+	RA	335.78059284
+	Dec	-17.61050757
+	Distance	23.5955 # 138.2280 +/- 0.0482 mas
 	SpectralType "M4.5Ve"
 	Radius 160000 # approx. for class
 	AppMag 13.30
 }
 
 # Used parallax of component C from Gaia EDR3
-# orbit listed for AB-C in Sixth Catalog yields unrealistically high mass sum
+# Orbit listed for AB-C in Sixth Catalog yields unrealistically high mass sum
 Barycenter "Gliese 667:CD-34 11626"
 {
-	RA 259.74581449 # mass ratio (0.68:0.59):0.35
-	Dec -34.99176542
-	Distance 23.6232 # 138.0663 +/- 0.0283 mas
+	RA	259.74581449 # mass ratio (0.68:0.59):0.35
+	Dec	-34.99176542
+	Distance	23.6232 # 138.0663 +/- 0.0283 mas
 }
 
 Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 {
-	RA  259.74431576
-	Dec -34.99010370
-	Distance 23.6232
+	RA	 259.74431576
+	Dec	-34.99010370
+	Distance	23.6232
 }
 
 1008507370 "Gliese 667 A:CD-34 11626 A"
@@ -3794,6 +3918,7 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 		ArgOfPericenter 183.60
 		MeanAnomaly     205.84
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_667#Gliese_667_A"
 }
 
 2008507370 "Gliese 667 B:CD-34 11626 B"
@@ -3811,14 +3936,15 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 		ArgOfPericenter   3.60
 		MeanAnomaly     205.84
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_667#Gliese_667_B"
 }
 
 # Rotation period from Suárez Mascareño et al. (2015), MNRAS 452 (3), p.2745-2756
 "Gliese 667 C:CD-34 11626 C"
 {
-	RA 259.75125274
-	Dec -34.99779509
-	Distance 23.6232
+	RA	259.75125274
+	Dec	-34.99779509
+	Distance	23.6232
 
 	Radius 324000 # approx. for class
 	SpectralType "M1.5V"
@@ -3833,23 +3959,21 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 
 "WISE 0607+2429:WISEP J060738.65+242953.4:GJ 10869"
 {
-	RA 91.91027347
-	Dec 24.49769409
-	Distance 23.6240 # 138.0616 +/- 0.5185 mas
+	RA	91.91027347
+	Dec	24.49769409
+	Distance	23.6240 # 138.0616 +/- 0.5185 mas
 	SpectralType "L9V"
 	AbsMag 23 # approx. for radius in Celestia
 	InfoURL "https://en.wikipedia.org/wiki/WISE_0607%2B2429"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
-# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
-# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
 "WISE 0313+7807:WISE J031325.94+780744.3:GJ 10442"
 {
-	RA 48.359149
-	Dec 78.129087
-	Distance 24.053 # 135.6 +/- 2.8 mas
+	RA	48.359149
+	Dec	78.129087
+	Distance	24.053 # 135.6 +/- 2.8 mas
 	SpectralType "T8.5V"
 	Temperature 651
 	Radius 61500
@@ -3859,9 +3983,9 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 
 "2MASS 1507-1627:2MASS J15074769-1627386:GJ 12172"
 {
-	RA 226.94794580
-	Dec -16.46512505
-	Distance 24.1691 # 134.9474 +/- 0.2611 mas
+	RA	226.94794580
+	Dec	-16.46512505
+	Distance	24.1691 # 134.9474 +/- 0.2611 mas
 	SpectralType "L5V"
 	Radius 60000 # approx.
 	AppMag 22.136
@@ -3872,9 +3996,9 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 # Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
 3765 # Gliese 33 / HD 4628
 {
-	RA 12.09910708
-	Dec 5.27553945
-	Distance 24.2505 # 134.4948 +/- 0.0578 mas
+	RA	12.09910708
+	Dec	5.27553945
+	Distance	24.2505 # 134.4948 +/- 0.0578 mas
 
 	Radius<rS>	0.6954
 	SpectralType "K2.5V"
@@ -3889,20 +4013,24 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 }
 
 # Used Hipparcos parallax instead
-# Radius from Kjeldsen et al. (2008), AJ Letters 683 (2), pp. L175
+# Radius from Kjeldsen et al. (2008), AJL 683 (2), pp. L175
 #   "Correcting Stellar Oscillation Frequencies for Near-Surface Effects"
+#   https://iopscience.iop.org/article/10.1086/591667
 #   https://ui.adsabs.harvard.edu/abs/2008ApJ...683L.175K/abstract
 # Temperature from North et al. (2007), MNRAS: Letters 380 (1), pp. L80-L83
 #   "The radius and mass of the subgiant star β Hyi from interferometry and asteroseismology"
+#   https://academic.oup.com/mnrasl/article/380/1/L80/1017999
 #   https://ui.adsabs.harvard.edu/abs/2007MNRAS.380L..80N/abstract
 # Rotation period from Metcalfe et al. (2024), AJ 974 (1), id.31
 #   "TESS Asteroseismology of β Hydri: A Subgiant with a Born-again Dynamo"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ad6dd6
 #   https://ui.adsabs.harvard.edu/abs/2024ApJ...974...31M/abstract
+# Rotation inclination from Hekker and Aerts (2010), A&A 515, id.A43
 2021 # Bet Hyi
 {
-	RA 6.48250499
-	Dec -77.25279547
-	Distance 24.327 # 134.07 +/- 0.11 mas
+	RA	6.48250499
+	Dec	-77.25279547
+	Distance	24.327 # 134.07 +/- 0.11 mas
 
 	Radius<rS>	1.809
 	SpectralType	"G0V"
@@ -3921,9 +4049,9 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 # Parameters from Kirkpatrick et al. (2021)
 "WISE 2000+3629:WISE J200050.19+362950.1:GJ 12908"
 {
-	RA 300.209094
-	Dec 36.497796
-	Distance 24.450 # 133.4 +/- 2.2 mas
+	RA	300.209094
+	Dec	36.497796
+	Distance	24.450 # 133.4 +/- 2.2 mas
 	SpectralType "T8"
 	Temperature 765
 	Radius 60000 # approx.
@@ -3932,16 +4060,16 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 }
 
 # Parameters from Bond et al. (2020), ApJ 904 (2), 112
-#   "Hubble Space Telescope Astrometry of the Metal-poor Visual Binary μ Cassiopeiae:
-#    Dynamical Masses, Helium Content, and Age"
+#   "Hubble Space Telescope Astrometry of the Metal-poor Visual Binary μ Cassiopeiae: Dynamical Masses, Helium Content, and Age"
 #   https://iopscience.iop.org/article/10.3847/1538-4357/abc172
 Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 {
-	RA 17.09474986
-	Dec 54.91320398
-	Distance 24.586 # 132.66 +/- 0.69 mas
+	RA	17.09474986
+	Dec	54.91320398
+	Distance	24.586 # 132.66 +/- 0.69 mas
 }
 
+# Rotation period from Justesen and Albrecht (2020), A&A 642, id.A212
 "MU Cas A:30 Cas A:Gliese 53 A"
 {
 	Radius<rS> 0.789
@@ -3959,13 +4087,26 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 		ArgOfPericenter 124.96
 		MeanAnomaly      46.34
 	}
+	
+	UniformRotation
+	{
+	    Period<d>	29.8
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Mu_Cassiopeiae"
 }
 
+# Temperature from Drummond et al. (1995), AJ 450, 380
+#   "Full Adaptive Optics Images of ADS 9731 and MU Cassiopeiae: Orbits and Masses"
+#   https://ui.adsabs.harvard.edu/abs/1995ApJ...450..380D/abstract
 "MU Cas B:30 Cas B:Gliese 53 B"
 {
 	OrbitBarycenter "MU Cas"
+
 	SpectralType "MVI"
 	AppMag 11.00
+	Temperature 3025
 
 	EllipticalOrbit {
 		Period          21.568
@@ -3976,16 +4117,15 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 		ArgOfPericenter 304.96
 		MeanAnomaly      46.34
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Mu_Cassiopeiae"
 }
 
 # Delfosse et al. (1999), A&A 344, 897
-# "New neighbours. I. 13 new companions to nearby M dwarfs"
-# http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter 83945 "GJ 3991:Giclas 203-47"
 {
-	RA 257.38347212
-	Dec 43.68010581
-	Distance 24.7840 # 131.5996 +/- 0.4285 mas
+	RA	257.38347212
+	Dec	43.68010581
+	Distance	24.7840 # 131.5996 +/- 0.4285 mas
 }
 
 "GJ 3991 A:Giclas 203-47 A"
@@ -4023,9 +4163,9 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 # Rotation period from Wright et al. (2011), AJ 743 (1), id. 48
 113283 # Fomalhaut B / TW PsA / Gliese 879
 {
-	RA 344.10194140
-	Dec -31.56626896
-	Distance 24.7929 # 131.5525 +/- 0.0275 mas
+	RA	344.10194140
+	Dec	-31.56626896
+	Distance	24.7929 # 131.5525 +/- 0.0275 mas
 
 	Radius<rS>	0.629
 	SpectralType	"K4Ve"
@@ -4035,6 +4175,8 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 	UniformRotation
 	{
 	    Period<d>	9.87
+		Inclination	0
+		AscendingNode	0
 	}
 	InfoURL "https://en.wikipedia.org/wiki/TW_Piscis_Austrini"
 }
@@ -4044,9 +4186,9 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 # Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
 7981 # 107 Psc / Gliese 68 / HD 10476
 {
-	RA 25.62258569
-	Dec 20.26551918
-	Distance 24.8046 # 131.4903 +/- 0.1515 mas
+	RA	25.62258569
+	Dec	20.26551918
+	Distance	24.8046 # 131.4903 +/- 0.1515 mas
 
 	Radius<rS>	0.8101
 	SpectralType	"K1V"
@@ -4062,9 +4204,9 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 
 "Giclas 141-36:GJ 12735"
 {
-	RA 282.07475874
-	Dec 7.69032389
-	Distance 24.8445 # 131.2790 +/- 0.0398 mas
+	RA	282.07475874
+	Dec	7.69032389
+	Distance	24.8445 # 131.2790 +/- 0.0398 mas
 	SpectralType "M5.0V"
 	Radius 140000 # approx. for class
 	AppMag 14.248
@@ -4075,15 +4217,13 @@ Modify 65859 # Ross 490
 	Radius 341000 # approx. for class
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 # BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
-# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
-# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
 "WISE 1738+2732:WISE J173835.53+273259.0:GJ 12541"
 {
-	RA 264.648568
-	Dec 27.549203
-	Distance 24.916 # 130.9 +/- 2.1 mas
+	RA	264.648568
+	Dec	27.549203
+	Distance	24.916 # 130.9 +/- 2.1 mas
 	SpectralType "Y0V"
 	Temperature 409
 	Radius 64300
@@ -4093,9 +4233,9 @@ Modify 65859 # Ross 490
 
 "GJ 4053:LP 71-165"
 {
-	RA 274.74325648
-	Dec 66.19061665
-	Distance 24.9254 # 130.8531 +/- 0.0217 mas
+	RA	274.74325648
+	Dec	66.19061665
+	Distance	24.9254 # 130.8531 +/- 0.0217 mas
 	SpectralType "M4.5V"
 	Radius 160000 # approx. for class
 	AppMag 13.406
@@ -4104,9 +4244,9 @@ Modify 65859 # Ross 490
 # Parameters from Kirkpatrick et al. (2021)
 "WISE 2354+0240:WISEA J235402.79+024014.1:GJ 13441"
 {
-	RA 358.512498
-	Dec 2.669898
-	Distance 24.974 # 130.6 +/- 3.3 mas
+	RA	358.512498
+	Dec	2.669898
+	Distance	24.974 # 130.6 +/- 3.3 mas
 	SpectralType "Y1"
 	Temperature 388
 	Radius 60000 # approx.
@@ -4114,14 +4254,14 @@ Modify 65859 # Ross 490
 }
 
 # Apparent magnitude from Henry et al. (2006) AJ 132 (6), 2360
-#   "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program:
-#    20 New Members of the RECONS 10 Parsec Sample"
-#   http://iopscience.iop.org/1538-3881/132/6/2360/pdf/1538-3881_132_6_2360.pdf
+#   "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program: 20 New Members of the RECONS 10 Parsec Sample"
+#   https://iopscience.iop.org/article/10.1086/508233
+#   https://ui.adsabs.harvard.edu/abs/2006AJ....132.2360H/abstract
 "GJ 4248:LHS 3746:Luyten 499-56"
 {
-	RA 330.62692304
-	Dec -37.08193914
-	Distance 25.0084 # 130.4186 +/- 0.0534 mas
+	RA	330.62692304
+	Dec	-37.08193914
+	Distance	25.0084 # 130.4186 +/- 0.0534 mas
 	SpectralType "M3.0V"
 	Radius 270000 # approx. for class
 	AppMag 11.76
@@ -4130,9 +4270,9 @@ Modify 65859 # Ross 490
 # Rotation period from Pass et al. (2023), AJ 166 (1), id.16
 "Fomalhaut C:ALF PsA C:LP 876-10:GJ 13282"
 {
-	RA 342.02033817
-	Dec -24.36962742
-	Distance 25.0368 # 130.2707 +/- 0.0325 mas
+	RA	342.02033817
+	Dec	-24.36962742
+	Distance	25.0368 # 130.2707 +/- 0.0325 mas
 
 	Radius 160000 # approx. for class
 	SpectralType "M4.0Ve"
@@ -4149,9 +4289,11 @@ Modify 65859 # Ross 490
 
 # Physical parameters from Monnier et al. (2012), ApJL 761 (1), L3
 #   "Resolving Vega and the Inclination Controversy with CHARA/MIRC"
+#   https://iopscience.iop.org/article/10.1088/2041-8205/761/1/L3
 #   https://ui.adsabs.harvard.edu/abs/2012ApJ...761L...3M/abstract
 # Rotation period from Petit et al. (2022), A&A 666, id.A20
 #   "A decade-long magnetic monitoring of Vega"
+#   https://www.aanda.org/articles/aa/full_html/2022/10/aa43000-21/aa43000-21.html
 #   https://ui.adsabs.harvard.edu/abs/2022A%26A...666A..20P/abstract
 Modify 91262 # Vega
 {
@@ -4162,9 +4304,10 @@ Modify 91262 # Vega
 	UniformRotation
 	{
 		Period<d>     0.6798
-		Inclination   150.91    # inclination (i) = 6.2
-		AscendingNode 208.14    # pole position angle = -58
+		Inclination   150.91    # Inclination = 6.2
+		AscendingNode 208.14    # Pole position angle = -58
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Vega"
 }
 
 Modify 12781 # Gliese 109
@@ -4173,10 +4316,10 @@ Modify 12781 # Gliese 109
 }
 
 # Physical parameters from Hadjara et al. (2014), A&A 569, id.A45
-#   "Beyond the diffraction limit of optical/IR interferometers. II.
-#    Stellar parameters of rotating stars from differential phases"
+#   "Beyond the diffraction limit of optical/IR interferometers. II. Stellar parameters of rotating stars from differential phases"
+#   https://www.aanda.org/articles/aa/full_html/2014/09/aa24185-14/aa24185-14.html
 #   https://ui.adsabs.harvard.edu/abs/2014A%26A...569A..45H/abstract
-Modify 113368 # Fomalhaut 
+Modify 113368 # Fomalhaut / Alf PsA
 {
 	Radius<rS>	1.8             # Equatorial radius: 1.8 ± 0.2
 	SemiAxes	[ 1 0.98 1 ]    # Equatorial-to-polar radii ratio: 1.02 ± 0.11
@@ -4184,27 +4327,151 @@ Modify 113368 # Fomalhaut
 	
 	UniformRotation
 	{
-		Period          0.98    # Rotation velocity: 93 ± 7 km/s
-		Inclination     90	    # Inclination: 90 ± 9 degrees
-		AscendingNode   154     # POLE position angle: 65.6 ± 4.7 degrees (add 90 degrees to get AscendingNode)
+		Period          0.98    # Rotation velocity = 93 ± 7 km/s
+		Inclination     90	    # Inclination = 90 ± 9 degrees
+		AscendingNode   154     # Pole position angle = 65.6 ± 4.7 degrees (add 90 degrees to get AscendingNode)
  	}
+	InfoURL "https://en.wikipedia.org/wiki/Fomalhaut"
 }
 
+# Radius from van Belle et al. (2009), AJ 694 (2), pp. 1085-1098
+# Temperature from Mann et al. (2015), ApJ 804 (1), 64
+# Rotation period from Wright et al. (2011), AJ 743 (1), id. 48
+85295 # GJ 673 / HD 157881
+{
+	RA	261.43588749
+	Dec	2.10615776
+	Distance	25.1575    # Gaia DR3: 129.645882 +/- 0.017464
 
+	Radius<rS>	0.564
+	SpectralType	"K7V"
+	AppMag	7.56
+	Temperature	4124
+
+	UniformRotation
+	{
+		Period<d>	11.94
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_673"
+}
+
+# Radius and temeprature (lit. weighted mean) from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Wright et al. (2004), AJ Supplement Series 152 (2), pp. 261-295
+22449 # Tabit / Pi3 Ori / HD 30652
+{
+	RA	72.46212402
+	Dec	6.96133101
+	Distance	26.1721    # Gaia DR3: 124.619801 +/- 0.224570
+
+	Radius<rS>	1.3223
+	SpectralType	"F6V"
+	AppMag	3.190
+	Temperature	6441
+
+	UniformRotation
+	{
+		Period<d>	4
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Pi3_Orionis"
+}
+
+# Chi Dra
+
+
+# p Eri
+
+
+113576 # HD 217357 / GJ 884
+{
+	RA	345.06283532
+	Dec	-22.52408921
+	Distance	26.850    # Gaia DR3: 121.472361 +/- 0.024887
+
+	SpectralType	"K7Vk"
+	AppMag	7.869
+}
+
+# Mu Her
+
+# Radius and temperature (lit. weighted mean) from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Montesinos et al. (2016), A&A 593, id.A51
+61317 # Chara / Bet CVn / HD 109358    # It's me!
+{
+	RA	188.43142838
+	Dec	41.35877669
+	Distance	27.6341    # Gaia DR3: 118.026606 +/- 0.153031
+
+	Radius<rS>	1.0999
+	SpectralType	"G0V"
+	AppMag	4.25
+	Temperature	5700
+
+	UniformRotation
+	{
+	    Period<d>	15.11
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Beta_Canum_Venaticorum"
+}
+
+# Radius and temperature from von Braun et al. (2014), MNRAS 438 (3), p.2413–2425
+# Rotation period from Laliotis et al. (2023), AJ 165 (4), id.176
+# Rotation is assumed to align with debris disk:
+# Debris disk orientation from Wyatt et al. (2012), MNRAS 424 (2), p.1206–1223
+#   "Herschel imaging of 61 Vir: implications for the prevalence of debris in low-mass planetary systems"
+#   https://academic.oup.com/mnras/article/424/2/1206/998992
+64924 # 61 Vir
+{
+	RA	199.59629813
+	Dec	-18.31592210
+	Distance	27.8355    # Gaia DR3: 117.172646 +/- 0.145593
+
+	Radius<rS>	0.9867
+	SpectralType	"G6.5V"
+	AppMag	4.740
+	Temperature	5538
+
+	UniformRotation                   # Assume coplanarity with debris disk
+	{
+		Period<d>	24.63
+		Inclination	46.508860         # Inclination = 77 degrees
+		AscendingNode	195.868079    # Major axis position angle = ~65 degrees
+	}
+	InfoURL "https://en.wikipedia.org/wiki/61_Virginis"
+}
+
+1599 # Zet Tuc / Gliese 17 / HD 1581
+{
+	RA	5.03560955
+	Dec	-64.86961714
+	Distance	28.073    # Gaia DR3: 116.182579 +/- 0.133362
+
+	Radius<rS>	1.044
+	SpectralType	"F9.5V"
+	AppMag	4.23
+	Temperature	5924
+
+	UniformRotation
+	{
+		Period<d>	15.653
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Zeta_Tucanae"
+}
+
+# Chi1 Ori
 
 
 
 # Used Gaia DR2 parallax for B
 Barycenter 55203 "Alula Australis:XI UMa:53 UMa:Gliese 423:ADS 8119"
 {
-	RA 169.545550
-	Dec 31.529289
-	Distance 28.4885 # 114.4867 +/- 0.4316 mas
+	RA	169.545550
+	Dec	31.529289
+	Distance	28.4885 # 114.4867 +/- 0.4316 mas
 }
 
 # Masses from Fuhrmann et al. (2016), MNRAS 459 (2), 1682
-# "Evidence for very nearby hidden white dwarfs"
-# https://doi.org/10.1093/mnras/stw760
+#   "Evidence for very nearby hidden white dwarfs"
+#   https://doi.org/10.1093/mnras/stw760
 Barycenter 1026342520 "Alula Australis A:XI UMa A:53 UMa A:Gliese 423 A:ADS 8119 A"
 {
 	OrbitBarycenter "Alula Australis"
@@ -4317,18 +4584,192 @@ Barycenter 2026342520 "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119
 }
 
 # Gaia DR2 suggests WDS J11182+3132C is an optical pair
-# radius and temperature from Zhang et al. (2021), ApJ 911 (1), 7
-# "The Hawaii Infrared Parallax Program. V. New T-dwarf Members and Candidate
-# Members of Nearby Young Moving Groups"
-# https://iopscience.iop.org/article/10.3847/1538-4357/abe3fa
+# Radius and temperature from Zhang et al. (2021), ApJ 911 (1), 7
+#   "The Hawaii Infrared Parallax Program. V. New T-dwarf Members and Candidate Members of Nearby Young Moving Groups"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/abe3fa
 "Alula Australis C:WISE 1118+3125:WISE J111838.70+312537.9"
 {
-	RA 169.66125400
-	Dec 31.42720000
-	Distance 28.4885
+	RA	169.66125400
+	Dec	31.42720000
+	Distance	28.4885
 	SpectralType "T8.5V"
 	Temperature 584
 	Radius 63000
 	AbsMag 40 # extremely low
 	InfoURL "https://en.wikipedia.org/wiki/Xi_Ursae_Majoris#WISE_J111838.70+312537.9"
 }
+
+# HD 50281
+
+# 41 Ara / 41 G. Ara
+
+# HD 192310
+
+# GJ 183 / HD 32147
+
+# Gam Lep
+
+# AK Lep
+
+# Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# Rotation period from Laliotis et al. (2023), AJ 165 (4), id.176
+# Rotation inclination from Hekker and Aerts (2010), A&A 515, id.A43
+17378 # Del Eri
+{
+	RA	55.81166331
+	Dec	-9.76008366
+	Distance	29.6437    # Gaia DR3: 110.025391 +/- 0.194446
+
+	Radius<rS>	2.350
+	SpectralType	"K0IV"
+	AppMag	3.54
+	Temperature	5022
+
+	UniformRotation
+	{
+		Period<d>	49.568
+		Inclination     0
+		AscendingNode   0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Delta_Eridani"
+}
+
+# Radius and temperature from Karovicova et al. (2020), A&A 640, id.A25
+#   "Fundamental stellar parameters of benchmark stars from CHARA interferometry. I. Metal-poor stars"
+#   https://www.aanda.org/articles/aa/full_html/2020/08/aa37590-20/aa37590-20.html
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...640A..25K/abstract
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+57939 # Groombridge 1830 / GJ 451 / HD 103095 / HIP 57939
+{
+	RA	178.26735321
+	Dec	37.69282695
+	Distance	29.9145    # Gaia DR3: 109.029640 +/- 0.019686
+
+	Radius<rS>	0.586
+	SpectralType	"K1V"
+	AppMag	6.45
+	Temperature	5174
+
+	UniformRotation
+	{
+	    Period<d>	31
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Groombridge_1830"
+}
+
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+64394 # Bet Com / GJ 502 / HD 114710
+{
+	RA	197.96428161
+	Dec	27.88210537
+	Distance	29.9983    # Gaia DR3: 108.725009 +/- 0.164461
+
+	Radius<rS>	1.1056
+	SpectralType	"G0V"
+	AppMag	4.25
+	Temperature	5957
+
+	UniformRotation
+	{
+	    Period<d>	12.3
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Beta_Comae_Berenices"
+}
+
+# Radius and temperature from Huber et al. (2022), AJ 163 (2), id.79
+#   "A 20 Second Cadence View of Solar-type Stars and Their Planets with TESS: Asteroseismology of Solar Analogs and a Recharacterization of π Men c"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ac3000
+#   https://ui.adsabs.harvard.edu/abs/2022AJ....163...79H/abstract
+105858 # Gam Pav / GJ 827 / HD 203608
+{
+	RA	321.61171581
+	Dec	-65.36263997
+	Distance	30.1968    # Gaia DR3: 108.010206 +/- 0.106063
+
+	Radius<rS>	1.057
+	SpectralType	"F9V"
+	AppMag	4.22
+	Temperature	6168
+
+	InfoURL "https://en.wikipedia.org/wiki/Gamma_Pavonis"
+}
+
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Strassmeier et al. (2020), A&A 644, id.A104
+#   "BRITE photometry and STELLA spectroscopy of bright stars in Auriga: Rotation, pulsation, orbits, and eclipses"
+#   https://www.aanda.org/articles/aa/full_html/2020/12/aa39310-20/aa39310-20.html
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...644A.104S/abstract
+# Rotation inclination from Walker et al. (2007), AJ 659 (2), 1611-1622
+#   "The Differential Rotation of κ1 Ceti as Observed by MOST"
+#   https://iopscience.iop.org/article/10.1086/511851
+#   https://ui.adsabs.harvard.edu/abs/2007ApJ...659.1611W/abstract
+15457 # Kap1 Cet / GJ 137 / HD 20630
+{
+	RA	49.84160069
+	Dec	3.37061619
+	Distance	30.2550    # Gaia DR3: 107.802339 +/- 0.183760
+
+	Radius<rS>	0.9193
+	SpectralType	"G5V"
+	AppMag	4.85
+	Temperature	5723
+
+	UniformRotation
+	{
+	    Period<d>	9.0648
+		Inclination     0
+		AscendingNode   0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Kappa1_Ceti"
+}
+
+# HD 102365
+
+# 20 Crt
+
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Mittag et al. (2017), A&A 607, id.A87
+#   "Stellar rotation periods determined from simultaneously measured Ca II H&K and Ca II IRT lines"
+#   https://www.aanda.org/articles/aa/full_html/2017/11/aa30262-16/aa30262-16.html
+#   https://ui.adsabs.harvard.edu/abs/2017A%26A...607A..87M/abstract
+56997 # 61 UMa / GJ 434 / HD 101501
+{
+	RA	175.26250051
+	Dec	34.19993958
+	Distance	31.2335    # Gaia DR3: 104.425170 +/- 0.100500
+
+	Radius<rS>	0.9400
+	SpectralType	"G8V"
+	AppMag	5.34
+	Temperature	5309
+
+	UniformRotation
+	{
+	    Period<d>	16.06
+	}
+	InfoURL "https://en.wikipedia.org/wiki/61_Ursae_Majoris"
+}
+
+# HD 151288
+
+# Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+81300 # 12 Oph / GJ 631 / HD 149661
+{
+	RA	249.09140230
+	Dec	-2.32596128
+	Distance	32.2697    # Gaia DR3: 101.071888 +/- 0.050076
+
+	Radius<rS>	0.7591
+	SpectralType	"K1V"
+	AppMag	5.77
+	Temperature	5337
+
+	UniformRotation
+	{
+	    Period<d>	21.1
+	}
+	InfoURL "https://en.wikipedia.org/wiki/12_Ophiuchi"
+}
+

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -1,4 +1,4 @@
-# Nearby stars and star orbits out to 25 light years, supplementary
+# Nearby stars and star orbits out to 10 parsecs, supplementary
 # to Celestia's stars.dat.
 
 # Because the RECONS survey tabulation has not been updated since 2010,
@@ -38,6 +38,26 @@
 # Barycenter positions are based on mass estimates from the papers themselves. The 
 # values used are listed below.
 
+# Common papers:
+
+# Díez Alonso et al. (2019), A&A 621, id.A126
+# "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
+# https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
+
+# Mann et al. (2013), AJ 779 (2), id. 188
+# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
+# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
+
+# Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+
+# Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
+# https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
+
+
+
 Barycenter "Solar System Barycenter:SSB"
 {
 	RA 0
@@ -72,8 +92,9 @@ Barycenter "Solar System Barycenter:SSB"
 }
 
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# V-mag from Ribas et al. (2017), A&A 603, id.A58
+# "The full spectral radiative properties of Proxima Centauri"
+# https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..58R/abstract
 # Rotation period from Collins et al. (2017), A&A 602, id.A48
 # "Calculations of periodicity from Hα profiles of Proxima Centauri"
 # https://ui.adsabs.harvard.edu/abs/2017A%26A...602A..48C/abstract
@@ -85,7 +106,7 @@ Barycenter "Solar System Barycenter:SSB"
 
 	Radius<rS>	0.154
 	SpectralType	"M5.5Ve"
-	AppMag	11.09
+	AppMag	11.083
 	Temperature	2901
 
 	UniformRotation
@@ -159,11 +180,7 @@ Barycenter "ALF Cen:Gliese 559"
 }
 
 # Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 # Temperature from Mann et al. (2013), AJ 779 (2), id. 188
-# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
-# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
 # Rotation period from Toledo-Padrón et al. (2019), MNRAS 488 (4), p.5145-5161
 # "Stellar activity analysis of Barnard's Star: very slow rotation and evidence for long-term activity cycle"
 # https://ui.adsabs.harvard.edu/abs/2019MNRAS.488.5145T/abstract
@@ -267,11 +284,7 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 }
 
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 # Rotation period from Díez Alonso et al. (2019), A&A 621, id.A126
-# "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
-# https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
 "CN Leo:Gliese 406:Wolf 359"
 {
 	RA 164.10319031
@@ -291,11 +304,7 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 }
 
 # Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 # Temperature from Mann et al. (2013), AJ 779 (2), id. 188
-# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
-# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
 # Rotation period from Díaz et al. (2019), A&A 625, id.A17
 # "The SOPHIE search for northern extrasolar planets. XIV.
 #  A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
@@ -369,6 +378,7 @@ Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_B"
 }
 
+# TODO: Update orbit reference to https://ui.adsabs.harvard.edu/abs/2024A%26A...685L...9G/abstract
 # Distance, radii, and orbit from Kervella et al. (2016), A&A 593, id.A127
 # "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
 #  Fundamental parameters from PIONIER, NACO, and UVES observations"
@@ -440,8 +450,6 @@ Barycenter "Gliese 65:Luyten 726-8"
 }
 
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 # Rotation period and inclination from Ibañez Bustos et al. (2020), A&A 644, id.A2
 # "Activity-rotation in the dM4 star Gl 729. A possible chromospheric cycle"
 # https://ui.adsabs.harvard.edu/abs/2020A%26A...644A...2I/abstract
@@ -479,8 +487,6 @@ Barycenter "Gliese 65:Luyten 726-8"
 # "Revisiting HST/FGS Astrometry of ϵ Eridani
 # https://ui.adsabs.harvard.edu/abs/2022RNAAS...6...45B/abstract
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
-# "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
-# https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
 # Rotational elements from Roettenbacher et al. (2022), AJ 163 (1), id.19
 # "EXPRES. III. Revealing the Stellar Activity Radial Velocity Signature of
 #  ϵ Eridani with Photometry and Interferometry"

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -40,21 +40,71 @@
 
 # Common papers:
 
+# Boyajian et al. (2012), AJ 746 (1), id. 101
+#   "Stellar Diameters and Temperatures. I. Main-sequence A, F, and G Stars"
+#   https://ui.adsabs.harvard.edu/abs/2012ApJ...746..101B/abstract
+
+# Boyajian et al. (2012), AJ 757 (2), id. 112
+#   "Stellar Diameters and Temperatures. II. Main-sequence K- and M-stars"
+#   https://ui.adsabs.harvard.edu/abs/2012ApJ...757..112B/abstract
+
+# Boyajian et al. (2013), AJ 771 (1), id. 40
+#   "Stellar Diameters and Temperatures. III. Main-sequence A, F, G, and K Stars:
+#    Additional High-precision Measurements and Empirical Relations"
+#   https://ui.adsabs.harvard.edu/abs/2013ApJ...771...40B/abstract
+
 # Díez Alonso et al. (2019), A&A 621, id.A126
-# "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
-# https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
+#   "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
+#   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
+
+# Engle et al. (2023), AJ Letters 954 (2), id.L50
+# "Living with a Red Dwarf: The Rotation-Age Relationships of M Dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2023ApJ...954L..50E/abstract
+
+# Houdebine et al. (2019), AJ 158 (2), id. 56
+#   "The Mass-Activity Relationships in M and K Dwarfs. I.
+#    Stellar Parameters of Our Sample of M and K Dwarfs"
+#   https://ui.adsabs.harvard.edu/abs/2019AJ....158...56H/abstract
+
+# Laliotis et al. (2023), AJ 165 (4), id.176
+#   "Doppler Constraints on Planetary Companions to Nearby Sun-like Stars:
+#    An Archival Radial Velocity Survey of Southern Targets for Proposed NASA Direct Imaging Missions"
+# https://ui.adsabs.harvard.edu/abs/2023AJ....165..176L/abstract
 
 # Mann et al. (2013), AJ 779 (2), id. 188
-# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
-# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
+#   "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
+#   https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
+
+# Mann et al. (2015), ApJ 804 (1), 64
+#   "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
+#    Bolometric Luminosity, Mass, and Radius"
+#   http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
+
+# Olspert et al. (2018), A&A 619, id.A6
+#   "Estimating activity cycles with probabilistic methods. II. The Mount Wilson Ca H&K data"
+#   https://ui.adsabs.harvard.edu/abs/2018A%26A...619A...6O/abstract
+
+# Pizzolato et al. (2003), A&A 397, p.147-157
+#   "The stellar activity-rotation relationship revisited:
+#    Dependence of saturated and non-saturated X-ray emission regimes on stellar mass for late-type dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2003A%26A...397..147P/abstract
 
 # Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# "A discontinuity in the Teff-radius relation of M-dwarfs"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+#   "A discontinuity in the Teff-radius relation of M-dwarfs"
+#   https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
 
 # Rains et al. (2020), MNRAS 493 (2), p.2377-2394
-# "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
-# https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
+#   "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
+#   https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
+
+# Reinhold et al. (2019), A&A 621, id.A21
+#   "Transition from spot to faculae domination.
+#    An alternate explanation for the dearth of intermediate Kepler rotation periods"
+#   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A..21R/abstract
+
+# Segransan et al. (2000), A&A 364, 665
+#   "Accurate masses of very low mass stars. III. 16 new or improved masses"
+#   http://adsabs.harvard.edu/abs/2000A%26A...364..665S
 
 
 
@@ -66,11 +116,11 @@ Barycenter "Solar System Barycenter:SSB"
 }
 
 # Radius from Emilio et al. (2012), AJ 750 (2), id. 135
-# "Measuring the Solar Radius from Space during the 2003 and 2006 Mercury Transits"
-# https://ui.adsabs.harvard.edu/abs/2012ApJ...750..135E/abstract
+#   "Measuring the Solar Radius from Space during the 2003 and 2006 Mercury Transits"
+#   https://ui.adsabs.harvard.edu/abs/2012ApJ...750..135E/abstract
 # AbsMag (V-band) from Willmer (2018), AJ 236 (2), id. 47
-# "The Absolute Magnitude of the Sun in Several Filters"
-# https://ui.adsabs.harvard.edu/abs/2018ApJS..236...47W/abstract
+#   "The Absolute Magnitude of the Sun in Several Filters"
+#   https://ui.adsabs.harvard.edu/abs/2018ApJS..236...47W/abstract
 0 "Sol:Sun"
 {
 	OrbitBarycenter	"Solar System Barycenter"
@@ -92,12 +142,12 @@ Barycenter "Solar System Barycenter:SSB"
 }
 
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
-# V-mag from Ribas et al. (2017), A&A 603, id.A58
-# "The full spectral radiative properties of Proxima Centauri"
-# https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..58R/abstract
+# V-magnitude from Ribas et al. (2017), A&A 603, id.A58
+#   "The full spectral radiative properties of Proxima Centauri"
+#   https://ui.adsabs.harvard.edu/abs/2017A%26A...603A..58R/abstract
 # Rotation period from Collins et al. (2017), A&A 602, id.A48
-# "Calculations of periodicity from Hα profiles of Proxima Centauri"
-# https://ui.adsabs.harvard.edu/abs/2017A%26A...602A..48C/abstract
+#   "Calculations of periodicity from Hα profiles of Proxima Centauri"
+#   https://ui.adsabs.harvard.edu/abs/2017A%26A...602A..48C/abstract
 70890 # Proxima Cen
 {
 	RA  217.39232147
@@ -119,11 +169,11 @@ Barycenter "Solar System Barycenter:SSB"
 }
 
 # Akeson et al. (2021), AJ 162 (1), 14
-# "Precision Millimeter Astrometry of the α Centauri AB System"
-# https://iopscience.iop.org/article/10.3847/1538-3881/abfaff
+#   "Precision Millimeter Astrometry of the α Centauri AB System"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/abfaff
 # Temperatures of A and B from Kervella et al. (2017), A&A 597, id.A137
-# "The radii and limb darkenings of α Centauri A and B . Interferometric measurements with VLTI/PIONIER"
-# https://ui.adsabs.harvard.edu/abs/2017A%26A...597A.137K/abstract
+#   "The radii and limb darkenings of α Centauri A and B . Interferometric measurements with VLTI/PIONIER"
+#   https://ui.adsabs.harvard.edu/abs/2017A%26A...597A.137K/abstract
 Barycenter "ALF Cen:Gliese 559"
 {
 	RA  219.85892215
@@ -182,8 +232,8 @@ Barycenter "ALF Cen:Gliese 559"
 # Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
 # Temperature from Mann et al. (2013), AJ 779 (2), id. 188
 # Rotation period from Toledo-Padrón et al. (2019), MNRAS 488 (4), p.5145-5161
-# "Stellar activity analysis of Barnard's Star: very slow rotation and evidence for long-term activity cycle"
-# https://ui.adsabs.harvard.edu/abs/2019MNRAS.488.5145T/abstract
+#   "Stellar activity analysis of Barnard's Star: very slow rotation and evidence for long-term activity cycle"
+#   https://ui.adsabs.harvard.edu/abs/2019MNRAS.488.5145T/abstract
 87937 # Barnard's Star
 {
 	RA 269.44850253
@@ -203,19 +253,19 @@ Barycenter "ALF Cen:Gliese 559"
 }
 
 # Bedin et al. (2024), AN 345 (1), e20230158
-# "HST astrometry of the closest brown dwarfs-II. Improved parameters and constraints on a third body"
-# https://ui.adsabs.harvard.edu/abs/2024AN....34530158B/abstract
+#   "HST astrometry of the closest brown dwarfs-II. Improved parameters and constraints on a third body"
+#   https://ui.adsabs.harvard.edu/abs/2024AN....34530158B/abstract
 # Magnitudes from Boffin et al. (2014), A&A 561, L4
-# "Possible astrometric discovery of a substellar companion to the closest
-# binary brown dwarf system WISE J104915.57-531906.1"
-# https://www.aanda.org/articles/aa/full_html/2014/01/aa22975-13/aa22975-13.html
+#   "Possible astrometric discovery of a substellar companion to the closest
+#    binary brown dwarf system WISE J104915.57-531906.1"
+#   https://www.aanda.org/articles/aa/full_html/2014/01/aa22975-13/aa22975-13.html
 # Temperatures from Kniazev et al. (2013), AJ 770 (2), id. 124
-# "Characterization of the nearby L/T Binary Brown Dwarf WISE J104915.57-531906.1 at 2 pc from the Sun"
-# https://ui.adsabs.harvard.edu/abs/2013ApJ...770..124K/abstract
+#   "Characterization of the nearby L/T Binary Brown Dwarf WISE J104915.57-531906.1 at 2 pc from the Sun"
+#   https://ui.adsabs.harvard.edu/abs/2013ApJ...770..124K/abstract
 # Rotation periods from Apai, Nardiello & Bedin (2021), ApJ 906 (1), 64
-# "TESS Observations of the Luhman 16 AB Brown Dwarf System: Rotational Periods,
-# Lightcurve Evolution, and Zonal Circulation"
-# https://iopscience.iop.org/article/10.3847/1538-4357/abcb97
+#   "TESS Observations of the Luhman 16 AB Brown Dwarf System: Rotational Periods,
+#    Lightcurve Evolution, and Zonal Circulation"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/abcb97
 Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 {
 	RA 162.32821578
@@ -267,8 +317,8 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 
 # Parameters from Kirkpatrick et al. (2021)
 # Temperature from Luhman et al. (2024), AJ 167 (1), id.5
-# "JWST/NIRSpec Observations of the Coldest Known Brown Dwarf"
-# https://ui.adsabs.harvard.edu/abs/2024AJ....167....5L/abstract
+#   "JWST/NIRSpec Observations of the Coldest Known Brown Dwarf"
+#   https://ui.adsabs.harvard.edu/abs/2024AJ....167....5L/abstract
 "WISE 0855-0714:WISE J085510.83-071442.5:GJ 11286"
 {
 	RA 133.780984
@@ -306,9 +356,9 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 # Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
 # Temperature from Mann et al. (2013), AJ 779 (2), id. 188
 # Rotation period from Díaz et al. (2019), A&A 625, id.A17
-# "The SOPHIE search for northern extrasolar planets. XIV.
-#  A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
-# https://ui.adsabs.harvard.edu/abs/2019A%26A...625A..17D/abstract
+#   "The SOPHIE search for northern extrasolar planets. XIV.
+#    A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
+#   https://ui.adsabs.harvard.edu/abs/2019A%26A...625A..17D/abstract
 54035 # Lalande 21185
 {
 	RA 165.83095968
@@ -328,9 +378,9 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 }
 
 # Parameters from Bond et al. (2017), ApJ 840 (2), 70
-# "The Sirius System and Its Astrophysical Puzzles: Hubble Space Telescope and 
-#  Ground-based Astrometry"
-# https://iopscience.iop.org/article/10.3847/1538-4357/aa6af8
+#   "The Sirius System and Its Astrophysical Puzzles: Hubble Space Telescope and 
+#    Ground-based Astrometry"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/aa6af8
 Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 {
 	RA 101.28715533
@@ -380,16 +430,16 @@ Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 
 # TODO: Update orbit reference to https://ui.adsabs.harvard.edu/abs/2024A%26A...685L...9G/abstract
 # Distance, radii, and orbit from Kervella et al. (2016), A&A 593, id.A127
-# "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
-#  Fundamental parameters from PIONIER, NACO, and UVES observations"
-# https://ui.adsabs.harvard.edu/abs/2016A%26A...593A.127K/abstract
+#   "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
+#    Fundamental parameters from PIONIER, NACO, and UVES observations"
+#   https://ui.adsabs.harvard.edu/abs/2016A%26A...593A.127K/abstract
 # Temperatures from MacDonald et al. (2018), AJ 860 (1), id. 15
-# "The Magnetic Binary GJ 65: A Test of Magnetic Diffusivity Effects"
-# https://ui.adsabs.harvard.edu/abs/2018ApJ...860...15M/abstract
+#   "The Magnetic Binary GJ 65: A Test of Magnetic Diffusivity Effects"
+#   https://ui.adsabs.harvard.edu/abs/2018ApJ...860...15M/abstract
 # Rotation periods and inclinations from Barnes et al. (2017), MNRAS 471 (1), 811
-# "Surprisingly different star-spot distributions on the near equal-mass 
-#  equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
-# https://ui.adsabs.harvard.edu/abs/2017MNRAS.471..811B/abstract
+#   "Surprisingly different star-spot distributions on the near equal-mass 
+#    equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
+#   https://ui.adsabs.harvard.edu/abs/2017MNRAS.471..811B/abstract
 Barycenter "Gliese 65:Luyten 726-8"
 {
 	RA 24.77161351 # mass ratio 0.1225:0.1195
@@ -451,8 +501,8 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 # Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
 # Rotation period and inclination from Ibañez Bustos et al. (2020), A&A 644, id.A2
-# "Activity-rotation in the dM4 star Gl 729. A possible chromospheric cycle"
-# https://ui.adsabs.harvard.edu/abs/2020A%26A...644A...2I/abstract
+#   "Activity-rotation in the dM4 star Gl 729. A possible chromospheric cycle"
+#   https://ui.adsabs.harvard.edu/abs/2020A%26A...644A...2I/abstract
 92403 # Gliese 729 / Ross 154
 {
 	RA 282.45878902
@@ -484,13 +534,13 @@ Barycenter "Gliese 65:Luyten 726-8"
 }
 
 # Parallax from Benedict (2022), Research Notes of the AAS 6 (3), id.45
-# "Revisiting HST/FGS Astrometry of ϵ Eridani
-# https://ui.adsabs.harvard.edu/abs/2022RNAAS...6...45B/abstract
+#   "Revisiting HST/FGS Astrometry of ϵ Eridani
+#   https://ui.adsabs.harvard.edu/abs/2022RNAAS...6...45B/abstract
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
 # Rotational elements from Roettenbacher et al. (2022), AJ 163 (1), id.19
-# "EXPRES. III. Revealing the Stellar Activity Radial Velocity Signature of
-#  ϵ Eridani with Photometry and Interferometry"
-# https://ui.adsabs.harvard.edu/abs/2022AJ....163...19R/abstract
+#   "EXPRES. III. Revealing the Stellar Activity Radial Velocity Signature of
+#    ϵ Eridani with Photometry and Interferometry"
+#   https://ui.adsabs.harvard.edu/abs/2022AJ....163...19R/abstract
 16537 # Ran / Eps Eri
 {
 	RA 53.22829342
@@ -532,8 +582,6 @@ Barycenter "Gliese 65:Luyten 726-8"
 }
 
 # Segransan et al. (2000), A&A 364, 665
-# "Accurate masses of very low mass stars. III. 16 new or improved masses"
-# http://adsabs.harvard.edu/abs/2000A%26A...364..665S
 Barycenter "Gliese 866:Luyten 789-6"
 {
 	RA 339.650693945
@@ -604,10 +652,9 @@ Barycenter "Gliese 866 A:Luyten 789-6 A"
 	}
 }
 
-# Physical parameters from Kervella et al. (2008), A&A 488 (2), 667
-# "The radii of the nearby K5V and K7V stars 61 Cygni A & B. CHARA/FLUOR 
-# interferometry and CESAM2k modeling"
-# https://arxiv.org/abs/0806.4049
+# Radii from Boyajian et al. (2012), AJ 757 (2), id. 112
+# Temperatures from Mann et al. (2013), AJ 779 (2), id. 188
+# Rotation periods from Olspert et al. (2018), A&A 619, id.A6
 Barycenter "61 Cyg:Gliese 820:ADS 14636"
 {
 	RA 316.75090091 # mass ratio 0.690:0.605
@@ -615,13 +662,17 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 	Distance 11.404 # B: 286.0054 +/- 0.0289 mas
 }
 
+# Rotational inclination from Boro Saikia et al. (2016), A&A 594, id.A29
+#   "A solar-like magnetic cycle on the mature K-dwarf 61 Cygni A (HD 201091)"
+#   https://ui.adsabs.harvard.edu/abs/2016A%26A...594A..29B/abstract
 104214 "61 Cyg A:V1803 Cyg:Gliese 820 A:ADS 14636 A"
 {
-	OrbitBarycenter "61 Cyg"
-	SpectralType "K5V"
-	AppMag 5.21
-	Radius 462600
+	Radius<rS>	0.6611
+	SpectralType	"K5V"
+	AppMag	5.21
+	Temperature	4399
 
+	OrbitBarycenter "61 Cyg"
 	EllipticalOrbit {
 		Period          618.7
 		SemiMajorAxis   41.24 # mass ratio 0.69:0.605
@@ -631,15 +682,23 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 		ArgOfPericenter 281
 		MeanAnomaly     175
 	}
+	UniformRotation
+	{
+	    Period<d>	35.54
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/61_Cygni"
 }
 
 104217 "61 Cyg B:Gliese 820 B:ADS 14636 B"
 {
-	OrbitBarycenter "61 Cyg"
-	SpectralType "K7V"
-	AppMag 6.03
-	Radius 413900
+	Radius<rS>	0.6010
+	SpectralType	"K7V"
+	AppMag	6.03
+	Temperature	4025
 
+	OrbitBarycenter "61 Cyg"
 	EllipticalOrbit {
 		Period          618.7
 		SemiMajorAxis   47.03 # mass ratio 0.69:0.605
@@ -649,28 +708,38 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 		ArgOfPericenter 101
 		MeanAnomaly     175
 	}
+	UniformRotation
+	{
+	    Period<d>	34.55
+	}
+	InfoURL "https://en.wikipedia.org/wiki/61_Cygni"
 }
 
 # Orbit from Bond et al. (2018), Res. Notes AAS 2 (3), 147
-# "Final Hubble Space Telescope Astrometry of the Procyon Binary System"
-# https://iopscience.iop.org/article/10.3847/2515-5172/aad9a4
+#   "Final Hubble Space Telescope Astrometry of the Procyon Binary System"
+#   https://iopscience.iop.org/article/10.3847/2515-5172/aad9a4
 # Parameters from Bond et al. (2015), ApJ 813 (2), 106
-# "Hubble Space Telescope Astrometry of the Procyon System"
-# https://iopscience.iop.org/article/10.1088/0004-637X/813/2/106
-Barycenter 37279 "Procyon:Elgomaisa:ALF CMi:10 CMi:Gliese 280:ADS 6251"
+#   "Hubble Space Telescope Astrometry of the Procyon System"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/813/2/106
+Barycenter 37279 "Procyon:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 {
 	RA 114.82549791
 	Dec 5.22498756
 	Distance 11.444 # 285.0 +/- 0.7 mas
 }
 
-"Procyon A:Elgomaisa A:ALF CMi A:10 CMi A:Gliese 280 A:ADS 6251 A"
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Koncewicz and Jordan (2007), MNRAS 374 (1), pp. 220-231
+#   "OI line emission in cool stars: calculations using partial redistribution"
+#   https://ui.adsabs.harvard.edu/abs/2007MNRAS.374..220K/abstract
+"Procyon A:ALF CMi A:10 CMi A:Gliese 280 A:ADS 6251 A"
 {
-	OrbitBarycenter "Procyon"
+	Radius<rS>	2.0362
 	SpectralType "F5IV"
 	AppMag 0.37
-	InfoURL "https://en.wikipedia.org/wiki/Procyon"
+	Temperature	6597
 
+	OrbitBarycenter "Procyon"
 	EllipticalOrbit {             # fully specified orientation
 		Period         40.844
 		SemiMajorAxis    4.32 # mass ratio 1.478:0.592
@@ -680,17 +749,24 @@ Barycenter 37279 "Procyon:Elgomaisa:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 		ArgOfPericenter 90.25
 		MeanAnomaly    281.41
 	}
+	UniformRotation
+	{
+	    Period<d>	23
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Procyon"
 }
 
-"Procyon B:Elgomaisa B:ALF CMi B:10 CMi B:Gliese 280 B:ADS 6251 B"
+# Temperature from Provencal et al. (2002), AJ 568 (1), pp. 324-334
+#   "Procyon B: Outside the Iron Box"
+#   https://ui.adsabs.harvard.edu/abs/2002ApJ...568..324P/abstract
+"Procyon B:ALF CMi B:10 CMi B:Gliese 280 B:ADS 6251 B"
 {
-	OrbitBarycenter "Procyon"
+	Radius<rS>	0.01232
 	SpectralType "DQZ"
-	Temperature 7740
-	Radius 8571
 	AppMag 10.82
-	InfoURL "https://en.wikipedia.org/wiki/Procyon#Procyon_B"
+	Temperature 7740
 
+	OrbitBarycenter "Procyon"
 	EllipticalOrbit {              # fully specified orientation
 		Period          40.844
 		SemiMajorAxis    10.80 # mass ratio 1.478:0.592
@@ -700,12 +776,10 @@ Barycenter 37279 "Procyon:Elgomaisa:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 		ArgOfPericenter 270.25
 		MeanAnomaly     281.41
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Procyon#Procyon_B"
 }
 
-# masses from Mann et al. (2015), ApJ 804 (1), 64
-# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
-# Bolometric Luminosity, Mass, and Radius"
-# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
+# Masses from Mann et al. (2015), ApJ 804 (1), 64
 Barycenter "Gliese 725:Struve 2398:ADS 11632"
 {
 	RA 280.68307740 # mass ratio 0.334:0.248
@@ -750,9 +824,9 @@ Barycenter "Gliese 725:Struve 2398:ADS 11632"
 }
 
 # Pinamonti et al. (2018), A&A 617, A104
-# "The HADES RV Programme with HARPS-N at TNG. VIII. GJ15A: a multiple
-# wide planetary system sculpted by binary interaction"
-# https://arxiv.org/abs/1804.03476
+#   "The HADES RV Programme with HARPS-N at TNG. VIII. GJ15A: a multiple
+#    wide planetary system sculpted by binary interaction"
+#   https://arxiv.org/abs/1804.03476
 Barycenter 1475 "Gliese 15:Groombridge 34:ADS 246"
 {
 	RA 4.61664355 # mass ratio 0.38:0.15
@@ -814,19 +888,39 @@ Barycenter "EPS Ind:Gliese 845" # orbit of A & B components unknown
 	Distance 11.853
 }
 
+# Radius from Lundkvist et al. (2024), AJ 964 (2), id.110
+#   "Low-amplitude Solar-like Oscillations in the K5 V Star ϵ Indi A"
+#   https://ui.adsabs.harvard.edu/abs/2024ApJ...964..110L/abstract
+# Temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# Rotation period from Feng et al. (2019), MNRAS 490 (4), p.5002-5016
+#   "Detection of the nearest Jupiter analogue in radial velocity and astrometry data"
+#   https://ui.adsabs.harvard.edu/abs/2019MNRAS.490.5002F/abstract
 108870 "EPS Ind A:Gliese 845 A"
 {
 	RA 330.87240788
 	Dec -56.79725466
 	Distance 11.8670 # 274.8431 +/- 0.0956 mas
-	SpectralType "K5V"
-	AppMag 4.69
+
+	Radius<rS>	0.713
+	SpectralType	"K5V"
+	AppMag	4.69
+	Temperature	4649
+	
+	UniformRotation
+	{
+	    Period<d>	35.732
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Epsilon_Indi"
 }
 
-# Dieterich et al. (2018) "Dynamical Masses of ε Indi B and C: Two Massive
-# Brown Dwarfs at the Edge of the Stellar–substellar Boundary"
-# https://arxiv.org/abs/1807.09880
 # Duplicated in CNS5: Gliese 845 B = GJ 13185
+# Dieterich et al. (2018)
+#   "Dynamical Masses of ε Indi B and C: Two Massive
+#    Brown Dwarfs at the Edge of the Stellar–substellar Boundary"
+#   https://arxiv.org/abs/1807.09880
+# V-magnitudes from King et al. (2010), A&A 510, id.A99
+#   "ɛ Indi Ba, Bb: a detailed study of the nearest known brown dwarfs
+#   https://ui.adsabs.harvard.edu/abs/2010A%26A...510A..99K/abstract
 Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 {
 	RA 331.07645260
@@ -836,12 +930,12 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 
 "EPS Ind Ba:CI Ind A:Gliese 845 Ba:GJ 13185 A"
 {
-	OrbitBarycenter "EPS Ind B"
-	SpectralType "T1.5V"
-	Temperature 1320
 	Radius 59000
+	SpectralType "T1.5V"
 	AppMag 24.12
+	Temperature 1320
 
+	OrbitBarycenter "EPS Ind B"
 	EllipticalOrbit {
 		Period          11.41
 		SemiMajorAxis    1.26 # mass ratio 75.0J:70.1J
@@ -851,16 +945,17 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 		ArgOfPericenter 87.11
 		MeanAnomaly     49.82
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Epsilon_Indi#Brown_dwarfs"
 }
 
 "EPS Ind Bb:CI Ind B:Gliese 845 Bb:GJ 13185 B"
 {
-	OrbitBarycenter "EPS Ind B"
-	SpectralType "T6V"
-	Temperature 910
 	Radius 61000
+	SpectralType "T6V"
 	AbsMag 40 # extremely low
+	Temperature 910
 
+	OrbitBarycenter "EPS Ind B"
 	EllipticalOrbit {
 		Period           11.41
 		SemiMajorAxis     1.35 # mass ratio 75.0J:70.1J
@@ -870,22 +965,28 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B:GJ 13185"
 		ArgOfPericenter 267.11
 		MeanAnomaly      49.82
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Epsilon_Indi#Brown_dwarfs"
 }
 
+# Physical parameters from Korolik et al. (2023), AJ 166 (3), id.123
+#   "Refining the Stellar Parameters of τ Ceti: a Pole-on Solar Analog"
+#   https://ui.adsabs.harvard.edu/abs/2023AJ....166..123K/abstract
 8102 # Tau Cet
 {
 	RA 26.00905506
 	Dec -15.93368020
 	Distance 11.9118 # 273.8097 +/- 0.1701 mas
+
+	Radius<rS>	0.793
 	SpectralType "G8V"
 	AppMag 3.50
-	Radius 552000 # 0.793 +/- 0.004 Sol (Teixeira et al. 2009)
-	InfoURL "https://en.wikipedia.org/wiki/Tau_Ceti"
+	Temperature	5320
 
 	UniformRotation
 	{
-	    Period         816 # 34 days (Baliunas et al. 1996)
+	    Period<d>	32
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Tau_Ceti"
 }
 
 "GJ 1061:Luyten 372-58"
@@ -1364,20 +1465,28 @@ Barycenter "GJ 1245 A"
 	AppMag 22.921
 }
 
-49908 # Groombridge 1618
+# Radius from Boyajian et al. (2012), AJ 757 (2), id. 112
+# Temperature from Mann et al. (2013), AJ 779 (2), id. 188
+# Rotation period from Pizzolato et al. (2003), A&A 397, p.147-157
+49908 # Gliese 380 / Groombridge 1618 / HD 88230
 {
 	RA 152.83292896
 	Dec 49.45198890
 	Distance 15.8857 # 205.3148 +/- 0.0224 mas
-	SpectralType "K6Ve"
-	AppMag 6.61
+
+	Radius<rS>	0.6398
+	SpectralType	"K6Ve"
+	AppMag	6.61
+	Temperature	4176
+
+	UniformRotation
+	{
+	    Period<d>	11.67
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Groombridge_1618"
 }
 
-# masses from Mann et al. (2015), ApJ 804 (1), 64
-# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
-# Bolometric Luminosity, Mass, and Radius"
-# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
+# Masses from Mann et al. (2015), ApJ 804 (1), 64
 Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 {
 	RA 166.34402770 # mass ratio 0.39:0.0952
@@ -1436,10 +1545,10 @@ Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_682"
 }
 
-# mass of component A from Ma et al. (2018), MNRAS 480 (2), 2411
-# "The first super-Earth detection from the high cadence and high radial velocity 
-# precision Dharma Planet Survey"
-# https://arxiv.org/abs/1807.07098
+# Mass of component A from Ma et al. (2018), MNRAS 480 (2), 2411
+#   "The first super-Earth detection from the high cadence and high radial velocity 
+#    precision Dharma Planet Survey"
+#   https://arxiv.org/abs/1807.07098
 Barycenter 19849 "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC) unknown
 {
 	RA 63.81919733 # mass ratio 0.78:(0.573:0.2036)
@@ -1447,13 +1556,22 @@ Barycenter 19849 "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC)
 	Distance 16.3399
 }
 
+# Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112
+# Rotation period from Laliotis et al. (2023), AJ 165 (4), id.176
 "Keid A:OMI2 Eri A:40 Eri A:Gliese 166 A:ADS 3093 A"
 {
 	RA 63.80795301
 	Dec -7.66807782
 	Distance 16.3398 # 199.6080 +/- 0.1208 mas
-	SpectralType "K0V"
-	AppMag 4.43
+
+	Radius<rS>	0.8051
+	SpectralType	"K0V"
+	AppMag	4.43
+	Temperature	5147
+	UniformRotation
+	{
+	    Period<d>	43.504
+	}
 	InfoURL "https://en.wikipedia.org/wiki/40_Eridani"
 }
 
@@ -1464,18 +1582,18 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 	Distance 16.340 # C: 199.4516 +/- 0.0692 mas
 }
 
-# radius from Bond et al. (2017), ApJ 848 (1), 16
+# Radius and temperature from Bond et al. (2017), ApJ 848 (1), 16
 # "Astrophysical Implications of a New Dynamical Mass for the 
-# Nearby White Dwarf 40 Eridani B"
+#  Nearby White Dwarf 40 Eridani B"
 # http://iopscience.iop.org/article/10.3847/1538-4357/aa8a63/meta
 "Keid B:OMI2 Eri B:40 Eri B:Gliese 166 B:ADS 3093 B"
 {
-	OrbitBarycenter "Keid BC"
-	SpectralType "DA3"
-	Radius 9100
-	AppMag 9.53
-	InfoURL "https://en.wikipedia.org/wiki/40_Eridani"
+	Radius<rS>	0.01308
+	SpectralType	"DA3"
+	AppMag	9.53
+	Temperature	17200
 
+	OrbitBarycenter "Keid BC"
 	EllipticalOrbit {	
 		Period         222.74
 		SemiMajorAxis    9.17 # mass ratio 0.573:0.2036
@@ -1485,25 +1603,33 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 		ArgOfPericenter 77.11
 		MeanAnomaly    245.29
 	}
+	InfoURL "https://en.wikipedia.org/wiki/40_Eridani"
 }
 
+# Temperature from Houdebine et al. (2019), AJ 158 (2), id. 56
+# Rotation period from Engle et al. (2023), AJ Letters 954 (2), id.L50
 "Keid C:OMI2 Eri C:40 Eri C:DY Eri:Gliese 166 C:ADS 3093 C"
 {
-	OrbitBarycenter "Keid BC"
-	SpectralType "M4.5V"
-	Radius 180000 # approx. for class
-	AppMag 11.17
-	InfoURL "https://en.wikipedia.org/wiki/40_Eridani"
+	Radius	180000                # approx. for class
+	SpectralType	"M4.5V"
+	AppMag	11.17
+	Temperature	3176
 
+	OrbitBarycenter "Keid BC"
 	EllipticalOrbit {
 		Period          222.74
-		SemiMajorAxis    25.82 # mass ratio 0.573:0.2036
+		SemiMajorAxis    25.82    # mass ratio 0.573:0.2036
 		Eccentricity     0.451
 		Inclination      83.57
 		AscendingNode   216.91
 		ArgOfPericenter 257.11
 		MeanAnomaly     245.29
 	}
+	UniformRotation
+	{
+	    Period<d>	81.0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/40_Eridani"
 }
 
 112460 # EV Lac
@@ -1520,6 +1646,7 @@ Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 # Eggenberger et al. (2008), A&A 482 (2), 631
 # "Analysis of 70 Ophiuchi AB including seismic constraints"
 # https://www.aanda.org/articles/aa/abs/2008/17/aa8624-07/aa8624-07.html
+# Radii and temperatures from Boyajian et al. (2012), AJ 757 (2), id. 112
 Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 {
 	RA 271.36511072 # mass ratio 0.89:0.73
@@ -1529,10 +1656,12 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 
 1052130434 "70 Oph A:Gliese 702 A:Struve 2272 A:ADS 11046 A"
 {
-	OrbitBarycenter "70 Oph"
-	SpectralType "K0V"
-	AppMag 4.13
+	Radius<rS>	0.8310
+	SpectralType	"K0V"
+	AppMag	4.13
+	Temperature	5407
 
+	OrbitBarycenter "70 Oph"
 	EllipticalOrbit {              # fully specified orientation
 		Period           88.44
 		SemiMajorAxis    10.42 # mass ratio 0.89:0.73
@@ -1542,14 +1671,22 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 		ArgOfPericenter 285.57
 		MeanAnomaly      63.92
 	}
+	UniformRotation
+	{
+	    Period<d>	19.5
+	}
+	InfoURL "https://en.wikipedia.org/wiki/70_Ophiuchi"
 }
 
+# Temperature from Mann et al. (2013), AJ 779 (2), id. 188
 1052120434 "70 Oph B:V2391 Oph:Gliese 702 B:Struve 2272 B:ADS 11046 B"
 {
-	OrbitBarycenter "70 Oph"
-	SpectralType "K4V"
-	AppMag 6.07
+	Radius<rS>	0.6697
+	SpectralType	"K4V"
+	AppMag	6.07
+	Temperature	4475
 
+	OrbitBarycenter "70 Oph"
 	EllipticalOrbit {              # fully specified orientation
 		Period           88.44
 		SemiMajorAxis    12.71 # mass ratio 0.89:0.73
@@ -1559,29 +1696,30 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 		ArgOfPericenter 105.57
 		MeanAnomaly      63.92
 	}
+	InfoURL "https://en.wikipedia.org/wiki/70_Ophiuchi"
 }
 
-# rotational parameters from Bouchaud et al. (2020), A&A 633, A78
-# "A realistic two-dimensional model of Altair"
-# https://arxiv.org/abs/1912.03138
+# Physical parameters from Bouchaud et al. (2020), A&A 633, A78
+#   "A realistic two-dimensional model of Altair"
+#   https://arxiv.org/abs/1912.03138
 97649 # Altair
 {
 	RA 297.69582730
 	Dec 8.86832120
 	Distance 16.730 # 194.95 +/- 0.57 mas
-	SpectralType "A7IV"
-	AppMag 0.76
-	Radius 1396700 # equatorial radius
 
-	SemiAxes [ 1 0.779 1 ] # equatorial radius 28.3% greater than polar
-	InfoURL "https://en.wikipedia.org/wiki/Altair"
+	Radius<rS>	2.008           # Equatorial radius: 2.008 ± 0.006 / Polar radius: 1.565 ± 0.014
+	SemiAxes	[ 1 0.779 1 ]   # Flattening: 0.220 ± 0.003
+	SpectralType	"A7IV"
+	AppMag	0.76
 
 	UniformRotation
 	{
-		Period          7.79 # from equatorial rotational velocity
-		Inclination    81.21 # inclination (i) = 50.65 deg
-		AscendingNode 246.44 # orientation (alpha) = 301.13 deg
+		Period          7.77    # 7 hr 46 min, derived from equatorial rotational velocity
+		Inclination    81.21    # inclination (i) = 50.65 deg
+		AscendingNode 246.44    # orientation (alpha) = 301.13 deg
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Altair"
 }
 
 # Orbit from Tokovinin et al. (2020), AJ 160 (1), 7
@@ -1629,10 +1767,10 @@ Barycenter "GJ 1116"
 	}
 }
 
-# rotation period from Burningham et al. (2016), MNRAS 463 (2), 2202
-# "A LOFAR mini-survey for low-frequency radio emission from the nearest brown
-# dwarfs"
-# https://academic.oup.com/mnras/article/463/2/2202/2892466
+# Rotation period from Burningham et al. (2016), MNRAS 463 (2), 2202
+#   "A LOFAR mini-survey for low-frequency radio emission from the nearest brown
+#    dwarfs"
+#   https://academic.oup.com/mnras/article/463/2/2202/2892466
 "WISE 1506+7027:WISE J150649.97+702736.1:GJ 12169"
 {
 	RA 226.70263615
@@ -1677,9 +1815,9 @@ Barycenter "GJ 1116"
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_445"
 }
 
-# magnitude from Perez Garrido et al. (2014), A&A 567, A6
-# "2MASS J154043.42-510135.7: a new addition to the 5 pc population"
-# https://www.aanda.org/articles/aa/abs/2014/07/aa23615-14/aa23615-14.html
+# Magnitude from Perez Garrido et al. (2014), A&A 567, A6
+#   "2MASS J154043.42-510135.7: a new addition to the 5 pc population"
+#   https://www.aanda.org/articles/aa/abs/2014/07/aa23615-14/aa23615-14.html
 # Appears to be duplicated in CNS5 GJ 12258=GJ 12259
 "WISE 1540-5101:WISE J154045.65-510139.2:GJ 12258:GJ 12259"
 {
@@ -1692,9 +1830,9 @@ Barycenter "GJ 1116"
 }
 
 # Leggett et al. (2009), ApJ 695, 1517
-# "The phyical properties of four 600K T dwarfs."
-# http://iopscience.iop.org/article/10.1088/0004-637X/695/2/1517/meta
-# unresolved binary; separation and orbit unknown
+#   "The phyical properties of four 600K T dwarfs."
+#   http://iopscience.iop.org/article/10.1088/0004-637X/695/2/1517/meta
+# Unresolved binary; separation and orbit unknown
 "2MASS 0939-2448 A:2MASS J09393548-2448279 A:GJ 11394 A"
 {
 	RA 144.897865
@@ -1739,11 +1877,11 @@ Barycenter "GJ 1116"
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_526"
 }
 
-# parameters from Sahu et al. (2017), Science 356 (6342), 1046
-# "Relativistic deflection of background starlight measures the mass of 
-# a nearby white dwarf star"
-# https://arxiv.org/abs/1706.02037
-# orbit listed in Sixth Orbit Catalogue is of poor quality, so unused
+# Parameters from Sahu et al. (2017), Science 356 (6342), 1046
+#   "Relativistic deflection of background starlight measures the mass of 
+#    a nearby white dwarf star"
+#   https://arxiv.org/abs/1706.02037
+# Orbit listed in Sixth Orbit Catalogue is of poor quality, so unused
 Barycenter 21088 "Gliese 169.1:Stein 2051"
 {
 	RA 67.81236059 # mass ratio MB/MA 2.07
@@ -1774,13 +1912,13 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 	InfoURL "https://en.wikipedia.org/wiki/Stein_2051"
 }
 
-# coordinates, parallax from Dupuy & Liu (2012), ApJS 201 (2), 19
-# "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
-# http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
-# radius and temperature from Line et al. (2017), ApJ 848 (2), 83
-# "Uniform Atmospheric Retrieval Analysis of Ultracool Dwarfs. II. Properties 
-# of 11 T dwarfs"
-# http://iopscience.iop.org/0004-637X/848/2/83/
+# Coordinates, parallax from Dupuy & Liu (2012), ApJS 201 (2), 19
+#   "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
+#   http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
+# Radius and temperature from Line et al. (2017), ApJ 848 (2), 83
+#   "Uniform Atmospheric Retrieval Analysis of Ultracool Dwarfs. II. Properties 
+#    of 11 T dwarfs"
+#   http://iopscience.iop.org/0004-637X/848/2/83/
 "2MASS 1114-2618:2MASS J11145133-2618235:GJ 11600"
 {
 	RA 168.7032979
@@ -1815,7 +1953,7 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 	InfoURL "https://en.wikipedia.org/wiki/LP_816-60"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 0350-5658:WISE J035000.32-565830.2:GJ 10528"
 {
 	RA 57.500868
@@ -1850,9 +1988,9 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_205"
 }
 
-# coordinates, parallax from Dupuy & Liu (2012), ApJS 201 (2), 19
-# "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
-# http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
+# Coordinates, parallax from Dupuy & Liu (2012), ApJS 201 (2), 19
+#   "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
+#   http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
 "2MASS 0415-0935:2MASS J04151954-0935066:GJ 10582"
 {
 	RA 63.8381022
@@ -1866,8 +2004,8 @@ Barycenter 21088 "Gliese 169.1:Stein 2051"
 }
 
 # Brandt et al. (2021), AJ 162 (6), 301
-# "Improved Dynamical Masses for Six Brown Dwarf Companions Using Hipparcos and Gaia EDR3"
-# https://iopscience.iop.org/article/10.3847/1538-3881/ac273e
+#   "Improved Dynamical Masses for Six Brown Dwarf Companions Using Hipparcos and Gaia EDR3"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/ac273e
 Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230"
 {
 	RA 92.64357908
@@ -1876,9 +2014,9 @@ Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230"
 }
 
 # Radius and rotational parameters from Bowler et al. (2023), AJ 165 (4), 164
-# "Rotation Periods, Inclinations, and Obliquities of Cool Stars Hosting
-# Directly Imaged Substellar Companions: Spin–Orbit Misalignments Are Common"
-# https://iopscience.iop.org/article/10.3847/1538-3881/acbd34
+#   "Rotation Periods, Inclinations, and Obliquities of Cool Stars Hosting
+#    Directly Imaged Substellar Companions: Spin–Orbit Misalignments Are Common"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/acbd34
 "Gliese 229 A:Luyten 668-21 A:LPM 230 A"
 {
 	OrbitBarycenter "Gliese 229"
@@ -1905,8 +2043,9 @@ Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230"
 	}
 }
 
-# Xuan et al. (2024), Nature, "The cool brown dwarf Gliese 229 B is a close binary"
-# https://arxiv.org/abs/2410.11953
+# Xuan et al. (2024), Nature
+#   "The cool brown dwarf Gliese 229 B is a close binary"
+#   https://arxiv.org/abs/2410.11953
 Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 {
 	OrbitBarycenter "Gliese 229"
@@ -1972,13 +2111,27 @@ Barycenter "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 	}
 }
 
-96100 # Sig Dra
+# Radius from Hon et al. (2024), AJ 975 (1), id.147
+#   "Asteroseismology of the Nearby K Dwarf σ Draconis Using the Keck Planet Finder and TESS"
+#   https://ui.adsabs.harvard.edu/abs/2024ApJ...975..147H/abstract
+# Temperature from Boyajian et al. (2012), AJ 746 (1), id. 101
+# Rotation period from Reinhold et al. (2019), A&A 621, id.A21
+96100 # Alsafi / Sig Dra / HD 185144
 {
 	RA 293.09759805
 	Dec 69.65345106
 	Distance 18.7993 # 173.4939 +/- 0.0748 mas
-	SpectralType "K0V"
-	AppMag 4.680
+	
+	Radius<rS>	0.772
+	SpectralType	"K0V"
+	AppMag	4.680
+	Temperature	5255
+
+	UniformRotation
+	{
+	    Period<d>	27
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Sigma_Draconis"
 }
 
 26857 # Ross 47
@@ -2750,9 +2903,7 @@ Barycenter "Gliese 644:Wolf 630" # orbit of (AB) & C unknown
 	Distance 21.1837 # 153.9659 +/- 0.0570 mas
 }
 
-# masses from Segransan et al. (2000), A&A 364, 665
-# "Accurate masses of very low mass stars. III. 16 new or improved masses"
-# http://adsabs.harvard.edu/abs/2000A%26A...364..665S
+# Masses from Segransan et al. (2000), A&A 364, 665
 Barycenter 82817 "Gliese 644 AB:Wolf 630 AB"
 {
 	RA 253.86621222
@@ -2828,9 +2979,6 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 }
 
 # Physical parameters from Mann et al. (2015), ApJ 804 (1), 64
-# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
-# Bolometric Luminosity, Mass, and Radius"
-# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
 "Gliese 644 C:Wolf 630 C:VB 8"
 {
 	RA 253.89324627

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -4403,6 +4403,7 @@ Modify 113368 # Fomalhaut / Alf PsA
 
 # Mu Her
 
+
 # Radius and temperature (lit. weighted mean) from Boyajian et al. (2013), AJ 771 (1), id. 40
 # Rotation period from Montesinos et al. (2016), A&A 593, id.A51
 61317 # Chara / Bet CVn / HD 109358    # It's me!
@@ -4675,7 +4676,7 @@ Barycenter 2026342520 "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119
 	{
 	    Period<d>	6.21
 	}
-	InfoURL "https://en.wikipedia.org/wiki/"
+	InfoURL "https://en.wikipedia.org/wiki/Gamma_Leporis"
 }
 
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
@@ -4827,7 +4828,7 @@ Barycenter 2026342520 "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119
 	SpectralType	"K5V"
 	AppMag	8.11
 
-	InfoURL "https://en.wikipedia.org/wiki/"
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_638"
 }
 
 # Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -146,6 +146,11 @@
 #   https://iopscience.iop.org/article/10.3847/1538-3881/acc067
 #   https://ui.adsabs.harvard.edu/abs/2023AJ....165..176L/abstract
 
+# Maldonado et al. (2022), A&A 663, id.A142
+#   "The GAPS programme at TNG. XXXIV. Activity-rotation, flux-flux relationships, and active-region evolution through stellar age"
+#   https://www.aanda.org/articles/aa/full_html/2022/07/aa43360-22/aa43360-22.html
+#   https://ui.adsabs.harvard.edu/abs/2022A%26A...663A.142M/abstract
+
 # Mann et al. (2013), AJ 779 (2), id. 188
 #   "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
 #   https://iopscience.iop.org/article/10.1088/0004-637X/779/2/188
@@ -190,6 +195,11 @@
 #   "Transition from spot to faculae domination. An alternate explanation for the dearth of intermediate Kepler rotation periods"
 #   https://www.aanda.org/articles/aa/full_html/2019/01/aa33754-18/aa33754-18.html
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A..21R/abstract
+
+# Saar and Osten (1997), MNRAS 284 (4), 803-810
+#   "Rotation, turbulence and evidence for magnetic fields in southern dwarfs"
+#   https://academic.oup.com/mnras/article/284/4/803/1097331
+#   https://ui.adsabs.harvard.edu/abs/1997MNRAS.284..803S/abstract
 
 # Segransan et al. (2000), A&A 364, 665
 #   "Accurate masses of very low mass stars. III. 16 new or improved masses"
@@ -4385,7 +4395,7 @@ Modify 113368 # Fomalhaut / Alf PsA
 {
 	RA	345.06283532
 	Dec	-22.52408921
-	Distance	26.850    # Gaia DR3: 121.472361 +/- 0.024887
+	Distance	26.8503    # Gaia DR3: 121.472361 +/- 0.024887
 
 	SpectralType	"K7Vk"
 	AppMag	7.869
@@ -4443,7 +4453,7 @@ Modify 113368 # Fomalhaut / Alf PsA
 {
 	RA	5.03560955
 	Dec	-64.86961714
-	Distance	28.073    # Gaia DR3: 116.182579 +/- 0.133362
+	Distance	28.0727    # Gaia DR3: 116.182579 +/- 0.133362
 
 	Radius<rS>	1.044
 	SpectralType	"F9.5V"
@@ -4603,13 +4613,70 @@ Barycenter 2026342520 "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119
 
 # 41 Ara / 41 G. Ara
 
-# HD 192310
+99825 # HD 192310 / GJ 785
+{
+	RA	303.82866493
+	Dec	-27.03378081
+	Distance	28.7395    # Gaia DR3: 113.487180 +/- 0.051575
 
-# GJ 183 / HD 32147
+	SpectralType	"K2V"
+	AppMag	5.723
 
-# Gam Lep
+	InfoURL "https://en.wikipedia.org/wiki/HD_192310"
+}
 
-# AK Lep
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+23311 # GJ 183 / HD 32147
+{
+	RA	75.20661767
+	Dec	-5.75859896
+	Distance	28.8452    # Gaia DR3: 113.071459 +/- 0.022239
+
+	SpectralType	"K3V"
+	AppMag	6.21
+
+	UniformRotation
+	{
+	    Period<d>	48
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_183"
+}
+
+# Rotation period and inclination from Saar and Osten (1997), MNRAS 284 (4), 803-810
+1021965930 # AK Lep / Gam Lep B / GJ 216 B / HD 38392 / TYC 5930-2196-1
+{
+	RA	86.10910372
+	Dec	-22.42340451
+	Distance	29.0004    # Gaia DR3: 112.466065 +/- 0.022469
+
+	SpectralType	"K3V"
+	AppMag	6.15
+
+	UniformRotation
+	{
+	    Period<d>	17.3
+		Inclination     0
+		AscendingNode   0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/AK_Leporis"
+}
+
+# Rotation period from Maldonado et al. (2022), A&A 663, id.A142
+27072 # Gam Lep A / 13 Lep / GJ 216 A / HD 38393
+{
+	RA	86.11439123
+	Dec	-22.45002336
+	Distance	29.0443    # Gaia DR3: 112.296028 +/- 0.145168
+
+	SpectralType	"F6V"
+	AppMag	3.60
+
+	UniformRotation
+	{
+	    Period<d>	6.21
+	}
+	InfoURL "https://en.wikipedia.org/wiki/"
+}
 
 # Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
 # Rotation period from Laliotis et al. (2023), AJ 165 (4), id.176
@@ -4751,7 +4818,17 @@ Barycenter 2026342520 "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119
 	InfoURL "https://en.wikipedia.org/wiki/61_Ursae_Majoris"
 }
 
-# HD 151288
+82003 # HD 151288 / GJ 638
+{
+	RA	251.27624770
+	Dec	33.51092483
+	Distance	32.1142    # Gaia DR3: 101.561486 +/- 0.015033
+
+	SpectralType	"K5V"
+	AppMag	8.11
+
+	InfoURL "https://en.wikipedia.org/wiki/"
+}
 
 # Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112
 # Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -41,15 +41,14 @@
 
 
 # Common papers:
+#   The names of these papers are not folded in order to make searching for them easier.
 
 # Baliunas et al. (1983), AJ 275, p. 752-772
-#   "Stellar rotation in lower main-sequence stars measured from time variations in H and K emission-line fluxes. II.
-#    Detailed analysis of the 1980 observing season data."
+#   "Stellar rotation in lower main-sequence stars measured from time variations in H and K emission-line fluxes. II. Detailed analysis of the 1980 observing season data."
 #   https://ui.adsabs.harvard.edu/abs/1983ApJ...275..752B/abstract
 
 # Baliunas et al. (1996), AJ Letters 457, p.L99
-#   "Magnetic Field and Rotation in Lower Main-Sequence Stars:
-#    an Empirical Time-dependent Magnetic Bode's Relation?"
+#   "Magnetic Field and Rotation in Lower Main-Sequence Stars: an Empirical Time-dependent Magnetic Bode's Relation?"
 #   https://ui.adsabs.harvard.edu/abs/1996ApJ...457L..99B/abstract
 
 # Boyajian et al. (2012), AJ 746 (1), id. 101
@@ -64,6 +63,14 @@
 #   "Stellar Diameters and Temperatures. III. Main-sequence A, F, G, and K Stars: Additional High-precision Measurements and Empirical Relations"
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...771...40B/abstract
 
+# Brandenburg et al. (2017), AJ 845 (1), id. 79
+#   "Evolution of Co-existing Long and Short Period Stellar Activity Cycles"
+#   https://ui.adsabs.harvard.edu/abs/2017ApJ...845...79B/abstract
+
+# Chevalier et al. (2023), A&A 678, id.A19
+#   "Binary masses and luminosities with Gaia DR3"
+#   https://ui.adsabs.harvard.edu/abs/2023A%26A...678A..19C/abstract
+
 # Cincunegui et al. (2007), A&A 469 (1), pp.309-317
 #   "Hα and the Ca II H and K lines as activity proxies for late-type stars"
 #   https://ui.adsabs.harvard.edu/abs/2007A%26A...469..309C/abstract
@@ -76,6 +83,10 @@
 #   "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
 
+# Donahue et al. (1996), AJ 466, p.384
+#   "A Relationship between Mean Rotation Period in Lower Main-Sequence Stars and Its Observed Range"
+#   https://ui.adsabs.harvard.edu/abs/1996ApJ...466..384D/abstract
+
 # Engle et al. (2023), AJ Letters 954 (2), id.L50
 #   "Living with a Red Dwarf: The Rotation-Age Relationships of M Dwarfs"
 #   https://ui.adsabs.harvard.edu/abs/2023ApJ...954L..50E/abstract
@@ -85,13 +96,11 @@
 #   https://ui.adsabs.harvard.edu/abs/2020A%26A...639A..35H/abstract
 
 # Houdebine et al. (2019), AJ 158 (2), id. 56
-#   "The Mass-Activity Relationships in M and K Dwarfs. I.
-#    Stellar Parameters of Our Sample of M and K Dwarfs"
+#   "The Mass-Activity Relationships in M and K Dwarfs. I. Stellar Parameters of Our Sample of M and K Dwarfs"
 #   https://ui.adsabs.harvard.edu/abs/2019AJ....158...56H/abstract
 
 # Laliotis et al. (2023), AJ 165 (4), id.176
-#   "Doppler Constraints on Planetary Companions to Nearby Sun-like Stars:
-#    An Archival Radial Velocity Survey of Southern Targets for Proposed NASA Direct Imaging Missions"
+#   "Doppler Constraints on Planetary Companions to Nearby Sun-like Stars: An Archival Radial Velocity Survey of Southern Targets for Proposed NASA Direct Imaging Missions"
 # https://ui.adsabs.harvard.edu/abs/2023AJ....165..176L/abstract
 
 # Mann et al. (2013), AJ 779 (2), id. 188
@@ -99,17 +108,19 @@
 #   https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
 
 # Mann et al. (2015), ApJ 804 (1), 64
-#   "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
-#    Bolometric Luminosity, Mass, and Radius"
+#   "How to Constrain Your M Dwarf: Measuring Effective Temperature, Bolometric Luminosity, Mass, and Radius"
 #   http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
 
 # Olspert et al. (2018), A&A 619, id.A6
 #   "Estimating activity cycles with probabilistic methods. II. The Mount Wilson Ca H&K data"
 #   https://ui.adsabs.harvard.edu/abs/2018A%26A...619A...6O/abstract
 
+# Pass et al. (2023), AJ 166 (1), id.16
+#   "Active Stars in the Spectroscopic Survey of Mid-to-late M Dwarfs within 15 pc"
+#   https://ui.adsabs.harvard.edu/abs/2023AJ....166...16P/abstract
+
 # Pizzolato et al. (2003), A&A 397, p.147-157
-#   "The stellar activity-rotation relationship revisited:
-#    Dependence of saturated and non-saturated X-ray emission regimes on stellar mass for late-type dwarfs"
+#   "The stellar activity-rotation relationship revisited: Dependence of saturated and non-saturated X-ray emission regimes on stellar mass for late-type dwarfs"
 # https://ui.adsabs.harvard.edu/abs/2003A%26A...397..147P/abstract
 
 # Rabus et al. (2019), MNRAS 484 (2), 2674-2683
@@ -121,18 +132,23 @@
 #   https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
 
 # Reinhold et al. (2019), A&A 621, id.A21
-#   "Transition from spot to faculae domination.
-#    An alternate explanation for the dearth of intermediate Kepler rotation periods"
+#   "Transition from spot to faculae domination. An alternate explanation for the dearth of intermediate Kepler rotation periods"
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...621A..21R/abstract
 
 # Segransan et al. (2000), A&A 364, 665
 #   "Accurate masses of very low mass stars. III. 16 new or improved masses"
 #   http://adsabs.harvard.edu/abs/2000A%26A...364..665S
 
+# Suárez Mascareño et al. (2015), MNRAS 452 (3), p.2745-2756
+#   "Rotation periods of late-type dwarf stars from time series high-resolution spectroscopy of chromospheric indicators"
+#   https://ui.adsabs.harvard.edu/abs/2015MNRAS.452.2745S/abstract
+
+# Wright et al. (2011), AJ 743 (1), id. 48
+#   "The Stellar-activity-Rotation Relationship and the Evolution of Stellar Dynamos"
+#   https://ui.adsabs.harvard.edu/abs/2011ApJ...743...48W/abstract
+
 # Zhang et al. (2020), AJ 891 (2), id.171
-#   "COol Companions ON Ultrawide orbiTS (COCONUTS). I.
-#    A High-gravity T4 Benchmark around an Old White Dwarf and a Re-examination of
-#    the Surface-gravity Dependence of the L/T Transition"
+#   "COol Companions ON Ultrawide orbiTS (COCONUTS). I. A High-gravity T4 Benchmark around an Old White Dwarf and a Re-examination of the Surface-gravity Dependence of the L/T Transition"
 #   https://ui.adsabs.harvard.edu/abs/2020ApJ...891..171Z/abstract
 
 
@@ -388,7 +404,7 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 #   "The SOPHIE search for northern extrasolar planets. XIV.
 #    A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
 #   https://ui.adsabs.harvard.edu/abs/2019A%26A...625A..17D/abstract
-54035 # Lalande 21185
+54035 # Gliese 411 / Lalande 21185
 {
 	RA 165.83095968
 	Dec 35.94865303
@@ -457,8 +473,12 @@ Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_B"
 }
 
-# TODO: Update orbit reference to https://ui.adsabs.harvard.edu/abs/2024A%26A...685L...9G/abstract
-# Distance, radii, and orbit from Kervella et al. (2016), A&A 593, id.A127
+# Distance and sky position from Chevalier et al. (2023), A&A 678, id.A19
+# Orbit from Gravity Collaboration (2024), A&A 685, id.L9
+#   "Astrometric detection of a Neptune-mass candidate planet in
+#    the nearest M-dwarf binary system GJ65 with VLTI/GRAVITY"
+#   https://ui.adsabs.harvard.edu/abs/2024A%26A...685L...9G/abstract
+# Radii from Kervella et al. (2016), A&A 593, id.A127
 #   "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
 #    Fundamental parameters from PIONIER, NACO, and UVES observations"
 #   https://ui.adsabs.harvard.edu/abs/2016A%26A...593A.127K/abstract
@@ -471,9 +491,9 @@ Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 #   https://ui.adsabs.harvard.edu/abs/2017MNRAS.471..811B/abstract
 Barycenter "Gliese 65:Luyten 726-8"
 {
-	RA 24.77161351 # mass ratio 0.1225:0.1195
-	Dec -17.94799520
-	Distance 8.728 # 373.70 +/- 2.70 mas
+	RA 24.77161345
+	Dec -17.94799509
+	Distance 8.78190              # 371.396 ± 0.453 mas
 }
 
 "BL Cet:Gliese 65 A:Luyten 726-8 A"
@@ -485,19 +505,20 @@ Barycenter "Gliese 65:Luyten 726-8"
 
  	OrbitBarycenter "Gliese 65"
 	EllipticalOrbit {             # fully specified orbit
-		Period          26.284
-		SemiMajorAxis     2.72    # mass ratio 0.1225:0.1195
-		Eccentricity    0.6185
-		Inclination     113.55
-		AscendingNode    47.80
-		ArgOfPericenter 357.54
-		MeanAnomaly      21.93
+		Epoch        2441333.5
+		Period           26.38
+		SemiMajorAxis    2.661    # Mass ratio: (0.122 ± 0.002):(0.116 ± 0.002)
+		Eccentricity    0.6172
+		Inclination      113.5
+		AscendingNode     48.0
+		ArgOfPericenter  177.5
+		MeanAnomaly          0
 	}
-	UniformRotation               # TODO: closest alignment with orbital plane
+	UniformRotation               # Assume closest alignment with orbital plane
 	{
 	    Period<d>	0.2430
-		Inclination	0
-		AscendingNode	0
+		Inclination	111
+		AscendingNode	40
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
 }
@@ -511,19 +532,20 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 	OrbitBarycenter "Gliese 65"
 	EllipticalOrbit {             # fully specified orbit
-		Period          26.284
-		SemiMajorAxis     2.79    # mass ratio 0.1225:0.1195
-		Eccentricity    0.6185
-		Inclination     113.55
-		AscendingNode    47.80
-		ArgOfPericenter 177.54
-		MeanAnomaly      21.93
+		Epoch        2441333.5
+		Period           26.38
+		SemiMajorAxis    2.798    # Mass ratio: (0.122 ± 0.002):(0.116 ± 0.002)
+		Eccentricity    0.6172
+		Inclination      113.5
+		AscendingNode     48.0
+		ArgOfPericenter  357.5
+		MeanAnomaly          0
 	}
-	UniformRotation               # TODO: closest alignment with orbital plane
+	UniformRotation               # Assume closest alignment with orbital plane
 	{
 	    Period<d>	0.2268
-		Inclination	0
-		AscendingNode	0
+		Inclination	110
+		AscendingNode	36
 	}
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
 }
@@ -694,7 +716,7 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 # Rotational inclination from Boro Saikia et al. (2016), A&A 594, id.A29
 #   "A solar-like magnetic cycle on the mature K-dwarf 61 Cygni A (HD 201091)"
 #   https://ui.adsabs.harvard.edu/abs/2016A%26A...594A..29B/abstract
-104214 "61 Cyg A:V1803 Cyg:Gliese 820 A:ADS 14636 A"
+104214 "61 Cyg A:HD 201091:V1803 Cyg:Gliese 820 A:ADS 14636 A"
 {
 	Radius<rS>	0.6611
 	SpectralType	"K5V"
@@ -720,7 +742,7 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 	InfoURL "https://en.wikipedia.org/wiki/61_Cygni"
 }
 
-104217 "61 Cyg B:Gliese 820 B:ADS 14636 B"
+104217 "61 Cyg B:HD 201092:Gliese 820 B:ADS 14636 B"
 {
 	Radius<rS>	0.6010
 	SpectralType	"K7V"
@@ -757,16 +779,16 @@ Barycenter 37279 "Procyon:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 	Distance 11.444 # 285.0 +/- 0.7 mas
 }
 
-# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Radius (lit. weighted mean) and temperature (lit. weighted mean) from Boyajian et al. (2013), AJ 771 (1), id. 40
 # Rotation period from Koncewicz and Jordan (2007), MNRAS 374 (1), pp. 220-231
 #   "OI line emission in cool stars: calculations using partial redistribution"
 #   https://ui.adsabs.harvard.edu/abs/2007MNRAS.374..220K/abstract
 "Procyon A:ALF CMi A:10 CMi A:Gliese 280 A:ADS 6251 A"
 {
-	Radius<rS>	2.0362
+	Radius<rS>	2.0468
 	SpectralType "F5IV"
 	AppMag 0.37
-	Temperature	6597
+	Temperature	6582
 
 	OrbitBarycenter "Procyon"
 	EllipticalOrbit {             # fully specified orientation
@@ -1742,6 +1764,7 @@ Barycenter 88601 "70 Oph:Gliese 702:Struve 2272:ADS 11046"
 	SemiAxes	[ 1 0.779 1 ]   # Flattening: 0.220 ± 0.003
 	SpectralType	"A7IV"
 	AppMag	0.76
+	Temperature	7594
 
 	UniformRotation
 	{
@@ -2393,7 +2416,7 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 		ArgOfPericenter 182.11
 		MeanAnomaly      82.68
 	}
-	InfoURL	"https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
+	InfoURL "https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
 }
 
 2026693663 "Achird B:ETA Cas B:24 Cas B:Gliese 34 B:ADS 671 B"
@@ -2411,7 +2434,7 @@ Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 		ArgOfPericenter 2.11
 		MeanAnomaly    82.68
 	}
-	InfoURL	"https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
+	InfoURL "https://en.wikipedia.org/wiki/Eta_Cassiopeiae"
 }
 
 Barycenter "Guniibuu:36 Oph:Gliese 663:ADS 10417" # orbit of (AB) & C unknown
@@ -2454,7 +2477,7 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 	{
 	    Period<d>	20.3
 	}
-	InfoURL	"https://en.wikipedia.org/wiki/36_Ophiuchi"
+	InfoURL "https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
 2003266820 "Guniibuu B:36 Oph B:Gliese 663 B:ADS 10417 B"
@@ -2476,7 +2499,7 @@ Barycenter 84405 "Guniibuu AB:36 Oph AB:Gliese 663 AB"
 	{
 	    Period<d>	22.9
 	}
-	InfoURL	"https://en.wikipedia.org/wiki/36_Ophiuchi"
+	InfoURL "https://en.wikipedia.org/wiki/36_Ophiuchi"
 }
 
 # Rotation period from Baliunas et al. (1996), AJ Letters 457, p.L99
@@ -2604,7 +2627,7 @@ Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A &
 
 	Radius<rS>	0.93    # not directly measured
 	SpectralType	"G6V"
-	AppMag	4.336
+	AppMag	4.27
 	Temperature	5368
 	
 	UniformRotation
@@ -2676,7 +2699,7 @@ Barycenter 34603 "Gliese 268:Ross 986"
 	{
 	    Period<d>	21.4
 	}
-	InfoURL	"https://en.wikipedia.org/wiki/Delta_Pavonis"
+	InfoURL "https://en.wikipedia.org/wiki/Delta_Pavonis"
 }
 
 "2MASS 0136+0933:2MASS J01365662+0933473:SIMP J013656.5+093347:GJ 10218"
@@ -3119,7 +3142,7 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 
 	Radius<rS>	0.783
 	SpectralType	"K3V"
-	AppMag	5.674
+	AppMag	5.57
 	Temperature	4678
 
 	UniformRotation
@@ -3190,8 +3213,11 @@ Barycenter "Gliese 644 B:Wolf 630 B"
 }
 
 # Söderhjelm, S. (1999), A&A 341, 121
-# "Visual binary orbits and masses post Hipparcos"
-# http://adsabs.harvard.edu/abs/1999A%26A...341..121S
+#   "Visual binary orbits and masses post Hipparcos"
+#   http://adsabs.harvard.edu/abs/1999A%26A...341..121S
+# Rotational elements and B's temperature from Strassmeier et al. (2023), A&A 674, id.A118
+#   "Zeeman Doppler imaging of ξ Boo A and B"
+#   https://ui.adsabs.harvard.edu/abs/2023A%26A...674A.118S/abstract
 Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 {
 	RA 222.84746520 # mass ratio 0.94:0.67
@@ -3199,12 +3225,17 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 	Distance 22.013 # B: 148.1793 +/- 0.0546 mas
 }
 
+# Radius and temperature from Karovicova et al. (2022), A&A 658, id.A47
+#   "Fundamental stellar parameters of benchmark stars from CHARA interferometry. II. Dwarf stars"
+#   https://ui.adsabs.harvard.edu/abs/2022A%26A...658A..47K/abstract
 1007221481 "XI Boo A:37 Boo A:Gliese 566 A:ADS 9413 A"
 {
-	OrbitBarycenter "XI Boo"
+	Radius<rS>	0.817
 	SpectralType "G7Ve"
 	AppMag 4.675
+	Temperature	5545
 
+	OrbitBarycenter "XI Boo"
 	EllipticalOrbit {
 		Period          151.6
 		SemiMajorAxis    13.87 # mass ratio 0.94:0.67
@@ -3214,14 +3245,22 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 		ArgOfPericenter 158.75
 		MeanAnomaly     215.38
 	}
+	UniformRotation    # TODO: Assume closest alignment with orbital plane
+	{
+	    Period<d>	6.43
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Xi_Boötis"
 }
 
 2007221481 "XI Boo B:37 Boo B:Gliese 566 B:ADS 9413 B"
 {
-	OrbitBarycenter "XI Boo"
 	SpectralType "K5Ve"
 	AppMag 6.816
+	Temperature	4570
 
+	OrbitBarycenter "XI Boo"
 	EllipticalOrbit {
 		Period          151.6
 		SemiMajorAxis    19.47 # mass ratio 0.94:0.67
@@ -3231,6 +3270,13 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 		ArgOfPericenter 338.75
 		MeanAnomaly     215.38
 	}
+	UniformRotation    # TODO: Assume closest alignment with orbital plane
+	{
+	    Period<d>	11.94
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Xi_Boötis"
 }
 
 "Gliese 299:Ross 619"
@@ -3245,11 +3291,11 @@ Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 }
 
 # Tokovinin et al. (2015), AJ 150 (2), 50
-# "Speckle Interferometry at SOAR in 2014"
-# http://iopscience.iop.org/article/10.1088/0004-6256/150/2/50/meta
+#   "Speckle Interferometry at SOAR in 2014"
+#   http://iopscience.iop.org/article/10.1088/0004-6256/150/2/50/meta
 # Delfosse et al. (1999), A&A 344, 897
-# "New neighbours. I. 13 new companions to nearby M dwarfs"
-# http://adsabs.harvard.edu/abs/1999A&A...344..897D
+#   "New neighbours. I. 13 new companions to nearby M dwarfs"
+#   http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter "GJ 3522:Giclas 41-14"
 {
 	RA 134.73639684 # mass ratio (0.19:0.17):0.17
@@ -3646,12 +3692,16 @@ Barycenter 12114 "Gliese 105 AC"
 	Distance 23.5599
 }
 
+# Radius and temperature from Mann et al. (2013), AJ 779 (2), id. 188
+# Rotation period from Donahue et al. (1996), AJ 466, p.384
 "Gliese 105 A"
 {
-	OrbitBarycenter "Gliese 105 AC"
-	SpectralType "K3V"
-	AppMag 5.81
+	Radius<rS>	0.7949
+	SpectralType	"K3V"
+	AppMag	5.81
+	Temperature	4704
 
+	OrbitBarycenter "Gliese 105 AC"
 	EllipticalOrbit {              # fully specified orientation
 		Period         76.107
 		SemiMajorAxis     1.9 # mass ratio 0.78:102.6J
@@ -3660,6 +3710,10 @@ Barycenter 12114 "Gliese 105 AC"
 		AscendingNode   344.9
 		ArgOfPericenter   8.3
 		MeanAnomaly     273.7
+	}
+	UniformRotation
+	{
+	    Period<d>	48.0
 	}
 }
 
@@ -3759,14 +3813,21 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 	}
 }
 
+# Rotation period from Suárez Mascareño et al. (2015), MNRAS 452 (3), p.2745-2756
 "Gliese 667 C:CD-34 11626 C"
 {
 	RA 259.75125274
 	Dec -34.99779509
 	Distance 23.6232
-	SpectralType "M1.5V"
+
 	Radius 324000 # approx. for class
+	SpectralType "M1.5V"
 	AppMag 10.22
+
+	UniformRotation
+	{
+	    Period<d>	103.9
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Gliese_667#Gliese_667_C"
 }
 
@@ -3807,28 +3868,57 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 	InfoURL "https://en.wikipedia.org/wiki/2MASS_1507%E2%88%921627"
 }
 
-3765 # HD 4628
+# Radius and temperature from Boyajian et al. (2012), AJ 757 (2), id. 112
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+3765 # Gliese 33 / HD 4628
 {
 	RA 12.09910708
 	Dec 5.27553945
 	Distance 24.2505 # 134.4948 +/- 0.0578 mas
+
+	Radius<rS>	0.6954
 	SpectralType "K2.5V"
 	AppMag 5.74
+	Temperature	4950
+
+	UniformRotation
+	{
+	    Period<d>	38.5
+	}
 	InfoURL "https://en.wikipedia.org/wiki/HD_4628"
 }
 
 # Used Hipparcos parallax instead
+# Radius from Kjeldsen et al. (2008), AJ Letters 683 (2), pp. L175
+#   "Correcting Stellar Oscillation Frequencies for Near-Surface Effects"
+#   https://ui.adsabs.harvard.edu/abs/2008ApJ...683L.175K/abstract
+# Temperature from North et al. (2007), MNRAS: Letters 380 (1), pp. L80-L83
+#   "The radius and mass of the subgiant star β Hyi from interferometry and asteroseismology"
+#   https://ui.adsabs.harvard.edu/abs/2007MNRAS.380L..80N/abstract
+# Rotation period from Metcalfe et al. (2024), AJ 974 (1), id.31
+#   "TESS Asteroseismology of β Hydri: A Subgiant with a Born-again Dynamo"
+#   https://ui.adsabs.harvard.edu/abs/2024ApJ...974...31M/abstract
 2021 # Bet Hyi
 {
 	RA 6.48250499
 	Dec -77.25279547
 	Distance 24.327 # 134.07 +/- 0.11 mas
-	SpectralType "G0V"
-	AppMag 2.79
+
+	Radius<rS>	1.809
+	SpectralType	"G0V"
+	AppMag	2.79
+	Temperature	5872
+	
+	UniformRotation
+	{
+	    Period<d>	23.0
+		Inclination	0
+		AscendingNode	0
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Beta_Hydri"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 2000+3629:WISE J200050.19+362950.1:GJ 12908"
 {
 	RA 300.209094
@@ -3842,9 +3932,9 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 }
 
 # Parameters from Bond et al. (2020), ApJ 904 (2), 112
-# "Hubble Space Telescope Astrometry of the Metal-poor Visual Binary μ Cassiopeiae:
-# Dynamical Masses, Helium Content, and Age"
-# https://iopscience.iop.org/article/10.3847/1538-4357/abc172
+#   "Hubble Space Telescope Astrometry of the Metal-poor Visual Binary μ Cassiopeiae:
+#    Dynamical Masses, Helium Content, and Age"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/abc172
 Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 {
 	RA 17.09474986
@@ -3854,11 +3944,12 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 
 "MU Cas A:30 Cas A:Gliese 53 A"
 {
-	OrbitBarycenter "MU Cas"
-	SpectralType "G5V"
-	AppMag 5.166
-	Radius 548900
+	Radius<rS> 0.789
+	SpectralType	"G5V"
+	AppMag	5.166
+	Temperature	5306
 
+	OrbitBarycenter "MU Cas"
 	EllipticalOrbit {	       # fully specified orientation
 		Period          21.568
 		SemiMajorAxis   1.4186 # mass ratio 0.7440:0.1728
@@ -3928,23 +4019,44 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 	}
 }
 
-113283 # TW PsA (Fomalhaut B)
+# Radius and temperature from Demory et al. (2009), A&A 505 (1), 205
+# Rotation period from Wright et al. (2011), AJ 743 (1), id. 48
+113283 # Fomalhaut B / TW PsA / Gliese 879
 {
 	RA 344.10194140
 	Dec -31.56626896
 	Distance 24.7929 # 131.5525 +/- 0.0275 mas
-	SpectralType "K4Ve"
-	AppMag 6.48
+
+	Radius<rS>	0.629
+	SpectralType	"K4Ve"
+	AppMag	6.48
+	Temperature	4711
+
+	UniformRotation
+	{
+	    Period<d>	9.87
+	}
+	InfoURL "https://en.wikipedia.org/wiki/TW_Piscis_Austrini"
 }
 
 # Used Gaia DR2 parallax instead
-7981 # 107 Psc
+# Radius and temperature from Boyajian et al. (2013), AJ 771 (1), id. 40
+# Rotation period from Brandenburg et al. (2017), AJ 845 (1), id. 79
+7981 # 107 Psc / Gliese 68 / HD 10476
 {
 	RA 25.62258569
 	Dec 20.26551918
 	Distance 24.8046 # 131.4903 +/- 0.1515 mas
-	SpectralType "K1V"
-	AppMag 5.24
+
+	Radius<rS>	0.8101
+	SpectralType	"K1V"
+	AppMag	5.24
+	Temperature	5242
+
+	UniformRotation
+	{
+	    Period<d>	35.2
+	}
 	InfoURL "https://en.wikipedia.org/wiki/107_Piscium"
 }
 
@@ -3989,7 +4101,7 @@ Modify 65859 # Ross 490
 	AppMag 13.406
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
 "WISE 2354+0240:WISEA J235402.79+024014.1:GJ 13441"
 {
 	RA 358.512498
@@ -4001,10 +4113,10 @@ Modify 65859 # Ross 490
 	AbsMag 40 # extremely low
 }
 
-# apparent magnitude from Henry et al. (2006) AJ 132 (6), 2360
-# "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program:
-# 20 New Members of the RECONS 10 Parsec Sample"
-# http://iopscience.iop.org/1538-3881/132/6/2360/pdf/1538-3881_132_6_2360.pdf
+# Apparent magnitude from Henry et al. (2006) AJ 132 (6), 2360
+#   "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program:
+#    20 New Members of the RECONS 10 Parsec Sample"
+#   http://iopscience.iop.org/1538-3881/132/6/2360/pdf/1538-3881_132_6_2360.pdf
 "GJ 4248:LHS 3746:Luyten 499-56"
 {
 	RA 330.62692304
@@ -4015,31 +4127,43 @@ Modify 65859 # Ross 490
 	AppMag 11.76
 }
 
+# Rotation period from Pass et al. (2023), AJ 166 (1), id.16
 "Fomalhaut C:ALF PsA C:LP 876-10:GJ 13282"
 {
 	RA 342.02033817
 	Dec -24.36962742
 	Distance 25.0368 # 130.2707 +/- 0.0325 mas
-	SpectralType "M4.0Ve"
+
 	Radius 160000 # approx. for class
+	SpectralType "M4.0Ve"
 	AppMag 12.624
-	InfoURL "https://en.wikipedia.org/wiki/Fomalhaut_C"
-}
-
-# rotational parameters from Monnier et al. (2012), ApJL 761 (1), L3
-# "Resolving Vega and the Inclination Controversy with CHARA/MIRC"
-# https://arxiv.org/abs/1211.6055
-Modify 91262 # Vega
-{
-	Radius 1896000 # equatorial radius
-
-	SemiAxes [ 1 0.887 1 ] # equatorial radius 12.7% greater than polar
 
 	UniformRotation
 	{
-		Period         17.04
-		Inclination   150.91 # inclination (i) = 6.2
-		AscendingNode 208.14 # pole position angle = -58
+	    Period<d>	0.318
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Fomalhaut_C"
+}
+
+# Physical parameters from Monnier et al. (2012), ApJL 761 (1), L3
+#   "Resolving Vega and the Inclination Controversy with CHARA/MIRC"
+#   https://ui.adsabs.harvard.edu/abs/2012ApJ...761L...3M/abstract
+# Rotation period from Petit et al. (2022), A&A 666, id.A20
+#   "A decade-long magnetic monitoring of Vega"
+#   https://ui.adsabs.harvard.edu/abs/2022A%26A...666A..20P/abstract
+Modify 91262 # Vega
+{
+	Radius<rS>	2.726           # Equatorial radius: 2.726 ± 0.006 / Polar radius: 2.418 ± 0.012
+	SemiAxes	[ 1 0.8870 1 ]     # Flattening: 0.1130
+	Temperature	9360            # Surface-averaged temperature
+
+	UniformRotation
+	{
+		Period<d>     0.6798
+		Inclination   150.91    # inclination (i) = 6.2
+		AscendingNode 208.14    # pole position angle = -58
 	}
 }
 
@@ -4048,21 +4172,27 @@ Modify 12781 # Gliese 109
 	Radius 225000 # approx. for class
 }
 
-# Rotational parameters based on disk parameters, from
-# MacGregor et al. (2017), ApJ 842 (1), 8
-# "A Complete ALMA Map of the Fomalhaut Debris Disk"
-# https://arxiv.org/abs/1705.05867
+# Physical parameters from Hadjara et al. (2014), A&A 569, id.A45
+#   "Beyond the diffraction limit of optical/IR interferometers. II.
+#    Stellar parameters of rotating stars from differential phases"
+#   https://ui.adsabs.harvard.edu/abs/2014A%26A...569A..45H/abstract
 Modify 113368 # Fomalhaut 
 {
+	Radius<rS>	1.8             # Equatorial radius: 1.8 ± 0.2
+	SemiAxes	[ 1 0.98 1 ]    # Equatorial-to-polar radii ratio: 1.02 ± 0.11
+	Temperature	8760
+	
 	UniformRotation
 	{
-		Inclination    83.2  # rotation pole matches debris disk
-		AscendingNode  177.5 # inclination 65.6 deg, position angle 337.9 deg
+		Period          0.98    # Rotation velocity: 93 ± 7 km/s
+		Inclination     90	    # Inclination: 90 ± 9 degrees
+		AscendingNode   154     # POLE position angle: 65.6 ± 4.7 degrees (add 90 degrees to get AscendingNode)
  	}
 }
 
-#========================================================================
-# Nearby multiple star with poor Hipparcos parallax
+
+
+
 
 # Used Gaia DR2 parallax for B
 Barycenter 55203 "Alula Australis:XI UMa:53 UMa:Gliese 423:ADS 8119"

--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -45,39 +45,64 @@ Barycenter "Solar System Barycenter:SSB"
 	Distance 0
 }
 
+# Radius from Emilio et al. (2012), AJ 750 (2), id. 135
+# "Measuring the Solar Radius from Space during the 2003 and 2006 Mercury Transits"
+# https://ui.adsabs.harvard.edu/abs/2012ApJ...750..135E/abstract
+# AbsMag (V-band) from Willmer (2018), AJ 236 (2), id. 47
+# "The Absolute Magnitude of the Sun in Several Filters"
+# https://ui.adsabs.harvard.edu/abs/2018ApJS..236...47W/abstract
 0 "Sol:Sun"
 {
-	OrbitBarycenter "Solar System Barycenter"
-	CustomOrbit "vsop87-sun"
+	OrbitBarycenter	"Solar System Barycenter"
+	CustomOrbit	"vsop87-sun"
 
-	SpectralType "G2V"
-	AbsMag 4.83
-	Temperature 5772
-	BoloCorrection -0.08
-	InfoURL "https://en.wikipedia.org/wiki/Sun"
-
+	Radius	696342
+	SpectralType	"G2V"
+	AbsMag	4.81
+	Temperature	5772
+	BoloCorrection	-0.08
 	UniformRotation
 	{
-	    Period         609.12  # 25.38 days
-	    Inclination      7.25
-	    AscendingNode   75.77
-	    MeridianAngle   23.00  # standard meridian
+	    Period<d>	25.38
+	    Inclination	7.25
+	    AscendingNode	75.77
+	    MeridianAngle	23.00  # standard meridian
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Sun"
 }
 
+# Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# Rotation period from Collins et al. (2017), A&A 602, id.A48
+# "Calculations of periodicity from Hα profiles of Proxima Centauri"
+# https://ui.adsabs.harvard.edu/abs/2017A%26A...602A..48C/abstract
 70890 # Proxima Cen
 {
 	RA  217.39232147
 	Dec -62.67607512
 	Distance 4.2465 # 768.0665 +/- 0.0499 mas
-	SpectralType "M5.5Ve"
-	AppMag 11.09
+
+	Radius<rS>	0.154
+	SpectralType	"M5.5Ve"
+	AppMag	11.09
+	Temperature	2901
+
+	UniformRotation
+	{
+	    Period<d>	82.6
+		Inclination	155.19863
+		AscendingNode	247.37042
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Proxima_Centauri"
 }
 
 # Akeson et al. (2021), AJ 162 (1), 14
 # "Precision Millimeter Astrometry of the α Centauri AB System"
 # https://iopscience.iop.org/article/10.3847/1538-3881/abfaff
+# Temperatures of A and B from Kervella et al. (2017), A&A 597, id.A137
+# "The radii and limb darkenings of α Centauri A and B . Interferometric measurements with VLTI/PIONIER"
+# https://ui.adsabs.harvard.edu/abs/2017A%26A...597A.137K/abstract
 Barycenter "ALF Cen:Gliese 559"
 {
 	RA  219.85892215
@@ -87,12 +112,12 @@ Barycenter "ALF Cen:Gliese 559"
 
 71683 # ALF Cen A
 {
+	Radius<rS>	1.2175
+	SpectralType	"G2V"
+	AppMag	0.01
+	Temperature	5795
+
 	OrbitBarycenter "ALF Cen"
-	SpectralType "G2V"
-	AppMag 0.01
-	Radius 847000
-	InfoURL "https://en.wikipedia.org/wiki/Alpha_Centauri"
- 
 	EllipticalOrbit {              # fully specified orientation
 		Period          79.762
 		SemiMajorAxis    10.66 # mass ratio 1.0788:0.9092
@@ -102,16 +127,21 @@ Barycenter "ALF Cen:Gliese 559"
 		ArgOfPericenter 279.48
 		MeanAnomaly     200.56
 	}
+	UniformRotation
+	{
+	    Period<d>	28.3
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Alpha_Centauri"
 }
 
 71681 # ALF Cen B
 {
-	OrbitBarycenter "ALF Cen"
-	SpectralType "K1V"
-	AppMag 1.33
-	Radius 597700
-	InfoURL "https://en.wikipedia.org/wiki/Alpha_Centauri"
+	Radius<rS>	0.8591
+	SpectralType	"K1V"
+	AppMag	1.33
+	Temperature	5231
 
+	OrbitBarycenter "ALF Cen"
 	EllipticalOrbit {              # fully specified orientation
 		Period          79.762
 		SemiMajorAxis    12.64 # mass ratio 1.0788:0.9092
@@ -121,15 +151,37 @@ Barycenter "ALF Cen:Gliese 559"
 		ArgOfPericenter  99.48
 		MeanAnomaly     200.56
 	}
+	UniformRotation
+	{
+	    Period<d>	36.66
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Alpha_Centauri"
 }
 
+# Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# Temperature from Mann et al. (2013), AJ 779 (2), id. 188
+# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
+# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
+# Rotation period from Toledo-Padrón et al. (2019), MNRAS 488 (4), p.5145-5161
+# "Stellar activity analysis of Barnard's Star: very slow rotation and evidence for long-term activity cycle"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.488.5145T/abstract
 87937 # Barnard's Star
 {
 	RA 269.44850253
 	Dec 4.73942005
 	Distance 5.9629 # 546.9759 +/- 0.0401 mas
-	SpectralType "M4V"
-	AppMag 9.511
+
+	Radius<rS>	0.185
+	SpectralType	"M4V"
+	AppMag	9.511
+	Temperature	3238
+
+	UniformRotation
+	{
+	    Period<d>	145
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Barnard%27s_Star"
 }
 
@@ -140,6 +192,9 @@ Barycenter "ALF Cen:Gliese 559"
 # "Possible astrometric discovery of a substellar companion to the closest
 # binary brown dwarf system WISE J104915.57-531906.1"
 # https://www.aanda.org/articles/aa/full_html/2014/01/aa22975-13/aa22975-13.html
+# Temperatures from Kniazev et al. (2013), AJ 770 (2), id. 124
+# "Characterization of the nearby L/T Binary Brown Dwarf WISE J104915.57-531906.1 at 2 pc from the Sun"
+# https://ui.adsabs.harvard.edu/abs/2013ApJ...770..124K/abstract
 # Rotation periods from Apai, Nardiello & Bedin (2021), ApJ 906 (1), 64
 # "TESS Observations of the Luhman 16 AB Brown Dwarf System: Rotational Periods,
 # Lightcurve Evolution, and Zonal Circulation"
@@ -153,11 +208,12 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 
 "Luhman 16 A:WISE 1049-5319 A:WISE J104915.57-531906.1 A:GJ 11551 A"
 {
-	OrbitBarycenter "Luhman 16"
+	Radius 70000 # approx.
 	SpectralType "L7.5"
 	AppMag 23.25
-	Radius 70000 # approx.
+	Temperature	1350
 
+	OrbitBarycenter "Luhman 16"
 	EllipticalOrbit {              # fully specified orientation
 		Period           26.55
 		SemiMajorAxis    1.597 # mass ratio 35.4J:29.4J
@@ -167,17 +223,18 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 		ArgOfPericenter 316.66
 		MeanAnomaly     115.12
 	}
-
-	RotationPeriod 6.94
+	RotationPeriod	6.94
+	InfoURL "https://en.wikipedia.org/wiki/Luhman_16"
 }
 
 "Luhman 16 B:WISE 1049-5319 B:WISE J104915.57-531906.1 B:GJ 11551 B"
 {
-	OrbitBarycenter "Luhman 16"
+	Radius 63000 # approx.
 	SpectralType "T0.5"
 	AppMag 24.07
-	Radius 63000 # approx.
+	Temperature	1210
 
+	OrbitBarycenter "Luhman 16"
 	EllipticalOrbit {              # fully specified orientation
 		Period           26.55
 		SemiMajorAxis    1.924 # mass ratio 35.4J:29.4J
@@ -187,61 +244,99 @@ Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1:GJ 11551"
 		ArgOfPericenter 136.66
 		MeanAnomaly     115.12
 	}
-
-	RotationPeriod 5.28
+	RotationPeriod	5.28
+	InfoURL "https://en.wikipedia.org/wiki/Luhman_16"
 }
 
-# parameters from Kirkpatrick et al. (2021)
+# Parameters from Kirkpatrick et al. (2021)
+# Temperature from Luhman et al. (2024), AJ 167 (1), id.5
+# "JWST/NIRSpec Observations of the Coldest Known Brown Dwarf"
+# https://ui.adsabs.harvard.edu/abs/2024AJ....167....5L/abstract
 "WISE 0855-0714:WISE J085510.83-071442.5:GJ 11286"
 {
 	RA 133.780984
 	Dec -7.243932
 	Distance 7.430 # 439.0 +/- 2.4 mas
-	SpectralType "Y4"
+
 	Radius 60000 # approx.
+	SpectralType "Y4"
 	AbsMag 40 # extremely low
+	Temperature	285
+	
 	InfoURL "https://en.wikipedia.org/wiki/WISE_0855%E2%88%920714"
 }
 
+# Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# Rotation period from Díez Alonso et al. (2019), A&A 621, id.A126
+# "CARMENES input catalogue of M dwarfs. IV. New rotation periods from photometric time series"
+# https://ui.adsabs.harvard.edu/abs/2019A%26A...621A.126D/abstract
 "CN Leo:Gliese 406:Wolf 359"
 {
 	RA 164.10319031
 	Dec 7.00272694
 	Distance 7.8558 # 415.1794 +/- 0.0684 mas
-	SpectralType "M6V"
-	AppMag 13.507
+
+	Radius<rS>	0.159
+	SpectralType	"M6V"
+	AppMag	13.507
+	Temperature	2657
+	
+	UniformRotation
+	{
+	    Period<d>	2.704
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Wolf_359"
 }
 
+# Radius from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# Temperature from Mann et al. (2013), AJ 779 (2), id. 188
+# "Spectro-thermometry of M Dwarfs and Their Candidate Planets: Too Hot, Too Cool, or Just Right?"
+# https://ui.adsabs.harvard.edu/abs/2013ApJ...779..188M/abstract
+# Rotation period from Díaz et al. (2019), A&A 625, id.A17
+# "The SOPHIE search for northern extrasolar planets. XIV.
+#  A temperate (Teq 300 K) super-earth around the nearby star Gliese 411"
+# https://ui.adsabs.harvard.edu/abs/2019A%26A...625A..17D/abstract
 54035 # Lalande 21185
 {
 	RA 165.83095968
 	Dec 35.94865303
 	Distance 8.3044 # 392.7529 +/- 0.0321 mas
-	SpectralType "M2V"
-	AppMag 7.520
+
+	Radius<rS>	0.387
+	SpectralType	"M2V"
+	AppMag	7.520
+	Temperature	3532
+	
+	UniformRotation
+	{
+	    Period<d>	56.15
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Lalande_21185"
 }
 
 # Parameters from Bond et al. (2017), ApJ 840 (2), 70
 # "The Sirius System and Its Astrophysical Puzzles: Hubble Space Telescope and 
-# Ground-based Astrometry"
+#  Ground-based Astrometry"
 # https://iopscience.iop.org/article/10.3847/1538-4357/aa6af8
-Barycenter 32349 "Sirius:Alhabor:ALF CMa:9 CMa:Gliese 244:ADS 5423"
+Barycenter 32349 "Sirius:Dog Star:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 {
 	RA 101.28715533
 	Dec -16.71611586
 	Distance 8.608 # 378.9 +/- 1.4 mas
 }
 
-"Sirius A:Alhabor A:ALF CMa A:9 CMa A:Gliese 244 A:ADS 5423 A"
+"Sirius A:Dog Star A:ALF CMa A:9 CMa A:Gliese 244 A:ADS 5423 A"
 {
-	OrbitBarycenter "Sirius"
-	SpectralType "A1V"
-	AppMag -1.46
-	Radius 1192700
-	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_A"
+	Radius<rS>	1.7144
+	SpectralType	"A1V"
+	AppMag	-1.46
+	Temperature	9845
 
+	OrbitBarycenter "Sirius"
 	EllipticalOrbit {              # fully specified orientation
 		Period         50.1284
 		SemiMajorAxis     6.53 # mass ratio 2.063:1.018
@@ -251,16 +346,17 @@ Barycenter 32349 "Sirius:Alhabor:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 		ArgOfPericenter  67.30
 		MeanAnomaly      38.99
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_A"
 }
 
-"Sirius B:Alhabor B:ALF CMa B:9 CMa B:Gliese 244 B:ADS 5423 B"
+"Sirius B:Dog Star B:ALF CMa B:9 CMa B:Gliese 244 B:ADS 5423 B"
 {
-	OrbitBarycenter "Sirius"
-	SpectralType "DA2"
-	AppMag 8.44
-	Radius 5634
-	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_B"
+	Radius<rS>	0.008098
+	SpectralType	"DA2"
+	AppMag	8.44
+	Temperature	25369
 
+	OrbitBarycenter "Sirius"
 	EllipticalOrbit {              # fully specified orientation
 		Period         50.1284
 		SemiMajorAxis    13.25 # mass ratio 2.063:1.018
@@ -270,13 +366,20 @@ Barycenter 32349 "Sirius:Alhabor:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 		ArgOfPericenter 247.30
 		MeanAnomaly      38.99
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Sirius#Sirius_B"
 }
 
-# Distance and radii from same source as orbit
-# Rotation periods from Barnes et al. (2017), MNRAS 471 (1), 811
+# Distance, radii, and orbit from Kervella et al. (2016), A&A 593, id.A127
+# "The red dwarf pair GJ65 AB: inflated, spinning twins of Proxima.
+#  Fundamental parameters from PIONIER, NACO, and UVES observations"
+# https://ui.adsabs.harvard.edu/abs/2016A%26A...593A.127K/abstract
+# Temperatures from MacDonald et al. (2018), AJ 860 (1), id. 15
+# "The Magnetic Binary GJ 65: A Test of Magnetic Diffusivity Effects"
+# https://ui.adsabs.harvard.edu/abs/2018ApJ...860...15M/abstract
+# Rotation periods and inclinations from Barnes et al. (2017), MNRAS 471 (1), 811
 # "Surprisingly different star-spot distributions on the near equal-mass 
-# equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
-# https://arxiv.org/abs/1706.03979
+#  equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
+# https://ui.adsabs.harvard.edu/abs/2017MNRAS.471..811B/abstract
 Barycenter "Gliese 65:Luyten 726-8"
 {
 	RA 24.77161351 # mass ratio 0.1225:0.1195
@@ -286,53 +389,79 @@ Barycenter "Gliese 65:Luyten 726-8"
 
 "BL Cet:Gliese 65 A:Luyten 726-8 A"
 {
- 	OrbitBarycenter "Gliese 65"
-	SpectralType "M5.5V"
-	AppMag 12.7
-	Radius 114790
-	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
+	Radius<rS>	0.165
+	SpectralType	"M5.5V"
+	AppMag	12.7
+	Temperature	2784
 
-	EllipticalOrbit {              # fully specified orbit
+ 	OrbitBarycenter "Gliese 65"
+	EllipticalOrbit {             # fully specified orbit
 		Period          26.284
-		SemiMajorAxis     2.72 # mass ratio 0.1225:0.1195
+		SemiMajorAxis     2.72    # mass ratio 0.1225:0.1195
 		Eccentricity    0.6185
 		Inclination     113.55
 		AscendingNode    47.80
 		ArgOfPericenter 357.54
 		MeanAnomaly      21.93
 	}
-
-	RotationPeriod 5.832
+	UniformRotation               # TODO: closest alignment with orbital plane
+	{
+	    Period<d>	0.2430
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
 }
 
 "UV Cet:Gliese 65 B:Luyten 726-8 B"
 {
-	OrbitBarycenter "Gliese 65"
+	Radius<rS>	0.159
 	SpectralType "M6V"
 	AppMag 13.2
-	Radius 110600
-	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
+	Temperature	2728
 
-	EllipticalOrbit {              # fully specified orbit
+	OrbitBarycenter "Gliese 65"
+	EllipticalOrbit {             # fully specified orbit
 		Period          26.284
-		SemiMajorAxis     2.79 # mass ratio 0.1225:0.1195
+		SemiMajorAxis     2.79    # mass ratio 0.1225:0.1195
 		Eccentricity    0.6185
 		Inclination     113.55
 		AscendingNode    47.80
 		ArgOfPericenter 177.54
 		MeanAnomaly      21.93
 	}
-
-	RotationPeriod 5.4432
+	UniformRotation               # TODO: closest alignment with orbital plane
+	{
+	    Period<d>	0.2268
+		Inclination	0
+		AscendingNode	0
+	}
+	InfoURL "https://en.wikipedia.org/wiki/Gliese_65"
 }
 
-92403 # Ross 154
+# Radius and temperature from Rabus et al. (2019), MNRAS 484 (2), 2674-2683
+# "A discontinuity in the Teff-radius relation of M-dwarfs"
+# https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2674R/abstract
+# Rotation period and inclination from Ibañez Bustos et al. (2020), A&A 644, id.A2
+# "Activity-rotation in the dM4 star Gl 729. A possible chromospheric cycle"
+# https://ui.adsabs.harvard.edu/abs/2020A%26A...644A...2I/abstract
+92403 # Gliese 729 / Ross 154
 {
 	RA 282.45878902
 	Dec -23.83709745
 	Distance 9.7063 # 336.0266 +/- 0.0317 mas
+
+	Radius<rS>	0.205
 	SpectralType "M3.5Ve"
 	AppMag 10.495
+	Temperature	3162
+	
+	UniformRotation
+	{
+	    Period<d>	2.848
+		Inclination	0
+		AscendingNode	0
+	}
 	InfoURL "https://en.wikipedia.org/wiki/Ross_154"
 }
 
@@ -346,22 +475,34 @@ Barycenter "Gliese 65:Luyten 726-8"
 	InfoURL "https://en.wikipedia.org/wiki/Ross_248"
 }
 
-16537 # Eps Eri
+# Parallax from Benedict (2022), Research Notes of the AAS 6 (3), id.45
+# "Revisiting HST/FGS Astrometry of ϵ Eridani
+# https://ui.adsabs.harvard.edu/abs/2022RNAAS...6...45B/abstract
+# Radius and temperature from Rains et al. (2020), MNRAS 493 (2), p.2377-2394
+# "Precision angular diameters for 16 southern stars with VLTI/PIONIER"
+# https://ui.adsabs.harvard.edu/abs/2020MNRAS.493.2377R/abstract
+# Rotational elements from Roettenbacher et al. (2022), AJ 163 (1), id.19
+# "EXPRES. III. Revealing the Stellar Activity Radial Velocity Signature of
+#  ϵ Eridani with Photometry and Interferometry"
+# https://ui.adsabs.harvard.edu/abs/2022AJ....163...19R/abstract
+16537 # Ran / Eps Eri
 {
 	RA 53.22829342
 	Dec -9.45816822
-	Distance 10.5016 # 310.5773 +/- 0.1355 mas
-	SpectralType "K2V"
-	AppMag 3.73
-	Temperature 5076 # 5076 +/- 30 K (Heiter et al. 2015)
-	Radius 511000 # 0.735 +/- 0.005 Sol (di Folco et al. 2007)
+	Distance 10.501 # 310.60 +/- 0.04 mas
+
+	Radius<rS>	0.738
+	SpectralType	"K2V"
+	AppMag	3.73
+	Temperature	5052
 
 	UniformRotation
 	{
-	    Period         274 # 11.4 +/- 0.2 days (Roettenbacher et al. 2022)
-	    Inclination      12 # inclination = 70 degrees
-	    AscendingNode   88 # position angle of rotation axis = 335 degrees
+	    Period<d>	11.4
+	    Inclination	12            # inclination = 70 degrees
+	    AscendingNode	88        # position angle of rotation axis = 335 degrees
 	}
+	InfoURL "https://en.wikipedia.org/wiki/Epsilon_Eridani"
 }
 
 114046 # Lacaille 9352


### PR DESCRIPTION
Major data update for nearstars.stc.

This first commit contains updated data from Sol to Epsilon Eridani.
- Radius and temperatures are complete for stars with empirical measurements.
- Rotational elements are incomplete thus far; some stars have measured Inclination, but without AscendingNode; these entries have Inclination and AscendingNode field in, both set to 0.