### PR TITLE
Rotation period for C/2006 P1 (McNaught)

### DIFF
--- a/data/comets.ssc
+++ b/data/comets.ssc
@@ -603,7 +603,7 @@
 	# Rotation period from Kharchuk (2010)
 	# https://doi.org/10.3103/S0884591310060048
 	
-	RotationPeriod	 21.00
+	RotationPeriod	 21
 	GeomAlbedo		 0.04
 	InfoURL	"https://en.wikipedia.org/wiki/Comet_McNaught"
 }


### PR DESCRIPTION
Comet McNaught rotates once every 21 hours according to [Kharchuk (2010)](https://doi.org/10.3103/S0884591310060048)