### PR TITLE
Add 40 pc white dwarf catalog

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,9 @@ Scientific Data Base
 
     Pulsar catalog (https://github.com/SevenSpheres/atnf-pulsars)
 
+# Pedro Garcia
+    White dwarf catalog (whitedwarfs.stc)
+
 Texture maps
 ------------
 

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -44,6 +44,7 @@ set(DATA_SOURCES
   saturnmoons_locs.ssc
   uranusmoons_locs.ssc
   venus_locs.ssc
+  whitedwarfs.stc
   world-capitals.ssc
 )
 

--- a/data/revised.stc
+++ b/data/revised.stc
@@ -82,19 +82,9 @@ Modify 8325 # Spectral class from SIMBAD, replacing "C6,3"
 	SpectralType "B6Iab"
 }
 
-Modify 8709 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
-}
-
 Modify 9115 # Spectral class from SIMBAD, replacing "G4"
 {
 	SpectralType "Bnnpe"
-}
-
-Modify 11650 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
 }
 
 Modify 12527 # V493 Per: spectral class from SIMBAD, replacing "F3"
@@ -110,11 +100,6 @@ Modify 13380 # Spectral class from SIMBAD, replacing "G9"
 Modify 14647 # Spectral class from SIMBAD, replacing "C7:,3"
 {
 	SpectralType "A0"
-}
-
-Modify 14754 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
 }
 
 Modify 17358 # Del Per: rapidly rotating star, rotational parameters from
@@ -159,11 +144,6 @@ Modify 28297 # Spectral class from SIMBAD, replacing "K3"
 	SpectralType "S2"
 }
 
-Modify 32560 # Improved spectral class from Gliese catalogue (Gliese 246)
-{
-	SpectralType "DA2"
-}
-
 Modify 45880 # Spectral class from SIMBAD, replacing "B2"
 {
 	SpectralType "sdO"
@@ -195,11 +175,6 @@ Modify 55849 # Spectral class from SIMBAD, replacing "A2+"
 	SpectralType "K0III"
 }
 
-Modify 56662 # Improved spectral class from Gliese catalogue (Gliese 433.1)
-{
-	SpectralType "DA3"
-}
-
 Modify 56709 # Spectral class from SIMBAD, replacing "B5"
 {
 	SpectralType "F8/G0p"
@@ -215,19 +190,9 @@ Modify 64929 # Spectral class from SIMBAD, replacing "A7"
 	SpectralType "WC5"
 }
 
-Modify 65877 # Gliese 515: improved spectral class from McCook & Sion
-{
-	SpectralType "DA5"
-}
-
 Modify 65925 # Spectral class from SIMBAD, replacing "G9"
 {
 	SpectralType "WC8"
-}
-
-Modify 66578 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
 }
 
 Modify 66383 # KN Cen: spectral class from SIMBAD, replacing "M0"
@@ -300,11 +265,6 @@ Modify 80488 # U Her: spectral class from SIMBAD, replacing "B2III/V+B8/9"
 Modify 80802 # R UMi: spectral class from SIMBAD, replacing "G5"
 {
 	SpectralType "M7III:e"
-}
-
-Modify 82257 # DN Dra: improved spectral class from McCook & Sion
-{
-	SpectralType "DAV4"
 }
 
 Modify 84716 # Spectral class from SIMBAD, replacing "N7"
@@ -380,11 +340,6 @@ Modify 94049 # Spectral class from SIMBAD, replacing "F5V"
 	SpectralType "R2"
 }
 
-Modify 95071 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DBZ5"
-}
-
 Modify 97629 # Chi Cyg: Spectral class from SIMBAD; replaces "K0III"
 {
 	AppMag 4.24
@@ -421,16 +376,6 @@ Modify 100287 # V1687 Cyg: spectral class from SIMBAD, replacing "O5. COMP,SB"
 	SpectralType "WC7p+O5"
 }
 
-Modify 101516 # Gliese 794: improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
-}
-
-Modify 102207 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
-}
-
 Modify 102531 # Gam1 Del: spectral class from SIMBAD, replacing "A2. IA COMP"
 {
 	SpectralType "F8V"
@@ -450,11 +395,6 @@ Modify 105199 # Alderamin: rapidly rotating star, rotational parameters from
 		Inclination   132.90 # inclination (i) = 55.70 deg
 		AscendingNode 28.56 # orientation (alpha) = -178.84 deg
 	}
-}
-
-Modify 107968 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA3"
 }
 
 Modify 108874 # Omi Aqr: rapidly rotating star, rotational parameters from
@@ -501,11 +441,6 @@ Modify 114995 # V628 Cas: spectral class from SIMBAD, replacing "M1"
 	Distance 73.27 # Parallax 44.5152 +/- 0.0550
 	AppMag 7.60
 	SpectralType "K2"
-}
-
-Modify 117059 # Improved spectral class from McCook & Sion
-{
-	SpectralType "DA4"
 }
 
 1028098626 # Eta Car - data from SIMBAD

--- a/data/whitedwarfs.stc
+++ b/data/whitedwarfs.stc
@@ -1,0 +1,13949 @@
+# SPDX-FileCopyrightText: 2025 Pedro Garcia
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Nearby white dwarfs and their companion stars, generated from the catalog of O'Brien et al.
+# (2024), MNRAS 527, p. 8687-8705, "The 40 pc sample of white dwarfs from Gaia":
+# https://cdsarc.cds.unistra.fr/viz-bin/cat/J/MNRAS/527/8687
+
+# Additional names, V-band magnitudes and missing temperatures were taken from the
+# Montreal White Dwarf Database (MWDD): https://www.montrealwhitedwarfdatabase.org/
+
+# Gaia DR3 coordinates, geometric distances from the catalog of Bailer-Jones et al. (2021),
+# AJ 161, 147, parameters for estimation of missing magnitudes (G-band magnitude and BP-RP color)
+# and, for companion stars, missing spectral types, synthetic photometry and physical parameters
+# (temperature and FLAME radius from either the GSP-Spec or GSP-Phot modules) were queried from the
+# Gaia Archive (https://gea.esac.esa.int/archive/).
+
+# Missing magnitudes are filled in with synthetic photometry from Gaia, including the GCSP-WD table
+# (Gaia Collaboration et al. 2023, A&A 674, A33; https://zenodo.org/records/6637717), or estimated
+# using the BP-RP to G-V relationship from the Gaia DR3 documentation
+# (https://gea.esac.esa.int/archive/documentation/GDR3/Data_processing/chap_cu5pho/cu5pho_sec_photSystem/cu5pho_ssec_photRelations.html).
+
+# Temperatures with low-mass correction are used, supplemented by Table A5 of O'Brien et al. (2024)
+# and the MWDD. From these, the subtype number appended to the spectral types was calculated. Radii
+# were calculated from mass (with correction) and surface gravity (log g).
+
+# Companion names, additional spectral types and V-band magnitudes were queried from SIMBAD
+# (http://simbad.cds.unistra.fr/simbad/).
+
+"Gliese 915:LAWD 96:EGGR 165:WD 2359-434:WDJ000210.72-430955.39"
+{
+	RA 0.54842422
+	Dec -43.16843962
+	Distance 27.168
+	SpectralType "DA6"
+	Temperature 8428
+	AppMag 12.97
+	Radius 6944
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2096/LAWD%2096.html"
+}
+
+"2MASS J00022257+6357443:WDJ000222.65+635744.14"
+{
+	RA 0.60366313
+	Dec 63.96274308
+	Distance 85.659
+	SpectralType "DC9"
+	Temperature 5011
+	AppMag 17.286 # synthetic
+	Radius 9856
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J00022257+6357443/2MASS%20J00022257+6357443.html"
+}
+
+"GJ 3001:LAWD 1:EGGR 406:WD 0000-345:WDJ000240.09-341339.59"
+{
+	RA 0.66787981
+	Dec -34.23105221
+	Distance 48.265
+	SpectralType "DC8"
+	Temperature 6332
+	AppMag 15.03
+	Radius 7950
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203001/GJ%203001.html"
+}
+
+"EGGR 508:WD 0000-170:WDJ000331.63-164358.41"
+{
+	RA 0.88292451
+	Dec -16.73288772
+	Distance 124.03
+	SpectralType "DBA4"
+	Temperature 12759
+	AppMag 14.69
+	Radius 8554
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20508/EGGR%20508.html"
+}
+
+"GD 408:EGGR 305:WD 0002+729:WDJ000506.82+731309.38"
+{
+	RA 1.2813158
+	Dec 73.21981578
+	Distance 112.473
+	SpectralType "DBZA4"
+	Temperature 13700
+	AppMag 14.33
+	Radius 8413
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20408/GD%20408.html"
+}
+
+"WD 0004+122:WDJ000720.55+123021.16"
+{
+	RA 1.83723771
+	Dec 12.50484548
+	Distance 56.908
+	SpectralType "DCP9"
+	Temperature 5285
+	AppMag 16.476 # synthetic
+	Radius 7577
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200004+122/WD%200004+122.html"
+}
+
+"NLTT 301:WDJ000728.90+340339.69"
+{
+	RA 1.87053008
+	Dec 34.06191103
+	Distance 110.918
+	SpectralType "DC9"
+	Temperature 5666
+	AppMag 17.407 # synthetic
+	Radius 7781
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%20301/NLTT%20301.html"
+}
+
+"LP 240-30:WD 0005+395:WDJ000754.11+394732.18"
+{
+	RA 1.97755334
+	Dec 39.79193194
+	Distance 111.918
+	SpectralType "DC9"
+	Temperature 5106
+	AppMag 17.12
+	Radius 21106
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20240-30/LP%20240-30.html"
+}
+
+"GD 5:WD 0008+424:WDJ001122.46+424040.92"
+{
+	RA 2.84328957
+	Dec 42.67702507
+	Distance 76.364
+	SpectralType "DA7"
+	Temperature 7079
+	AppMag 15.23
+	Radius 8921
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%205/GD%205.html"
+}
+
+"GJ 1004:EGGR 381:WD 0009+501:WDJ001214.75+502520.74"
+{
+	RA 3.05821931
+	Dec 50.41997493
+	Distance 35.452
+	SpectralType "DA8"
+	Temperature 6483
+	AppMag 14.36
+	Radius 7543
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201004/GJ%201004.html"
+}
+
+# Companion to WDJ001324.45+543757.64
+"G 217-38"
+{
+	RA 3.20163482
+	Dec 54.66530259
+	Distance 105.078 # mean of system components
+	SpectralType "K" # ESP-ELS
+	Temperature 3706 # GSP-Spec
+	AppMag 13.258 # synthetic
+	Radius 180027 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+217-38"
+}
+
+"Gaia DR2 420531621029108608:WDJ001324.45+543757.64"
+{
+	RA 3.35785045
+	Dec 54.63534622
+	Distance 105.078 # mean of system components
+	SpectralType "DC9"
+	Temperature 4348
+	AppMag 18.414 # synthetic
+	Radius 11843
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20420531621029108608/Gaia%20DR2%20420531621029108608.html"
+}
+
+"Gaia DR2 2541549062071571968:WDJ001333.22-021319.42"
+{
+	RA 3.3889996
+	Dec -2.22276444
+	Distance 126.571
+	SpectralType "DC9"
+	Temperature 4652
+	AppMag 18.415 # synthetic
+	Radius 11466
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202541549062071571968/Gaia%20DR2%202541549062071571968.html"
+}
+
+"Wolf 1:LAWD 3:EGGR 2:WD 0011+000:WDJ001339.15+001924.58"
+{
+	RA 3.41500099
+	Dec 0.32267849
+	Distance 130.203
+	SpectralType "DA5"
+	Temperature 9529
+	AppMag 15.31
+	Radius 8974
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%201/Wolf%201.html"
+}
+
+"WD 0011-399:WDJ001347.48-393724.28"
+{
+	RA 3.44657456
+	Dec -39.62663304
+	Distance 116.93
+	SpectralType "DC9"
+	Temperature 4732
+	AppMag 18.19
+	Radius 11000
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200011-399/WD%200011-399.html"
+}
+
+"L 50-73:WD 0011-721:WDJ001349.89-714954.26"
+{
+	RA 3.46120286
+	Dec -71.83283883
+	Distance 61.252
+	SpectralType "DAH8"
+	Temperature 6275
+	AppMag 15.17
+	Radius 9567
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%2050-73/L%2050-73.html"
+}
+
+"GJ 3016:WD 0011-134:WDJ001412.79-131101.09"
+{
+	RA 3.55080421
+	Dec -13.18681282
+	Distance 60.484
+	SpectralType "DAH9"
+	Temperature 5869
+	AppMag 15.87
+	Radius 7653
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203016/GJ%203016.html"
+}
+
+"Gaia DR2 2309122753616241280:WDJ001830.36-350144.71"
+{
+	RA 4.6277325
+	Dec -35.0291792
+	Distance 116.104
+	SpectralType "DAH7"
+	Temperature 7008
+	AppMag 16.374
+	Radius 8590
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202309122753616241280/Gaia%20DR2%202309122753616241280.html"
+}
+
+# Companion to WDJ002116.21+253134.45
+1001181733 "BD+24 32"
+{
+	RA 5.31695021
+	Dec 25.52429911
+	Distance 91.65 # mean of system components
+	SpectralType "K5"
+	Temperature 4782 # GSP-Spec
+	AppMag 9.55
+	Radius 383409 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD%2B24+32"
+}
+
+"Gaia DR2 2855386170682263424:WDJ002116.21+253134.45"
+{
+	RA 5.31779948
+	Dec 25.52627371
+	Distance 91.65 # mean of system components
+	SpectralType "DA5"
+	Temperature 9630
+	AppMag 15.467 # synthetic
+	Radius 5882
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202855386170682263424/Gaia%20DR2%202855386170682263424.html"
+}
+
+"LP 349-1:WD 0019+264:WDJ002147.30+264036.16"
+{
+	RA 5.44671874
+	Dec 26.67531124
+	Distance 106.989
+	SpectralType "DC9"
+	Temperature 5101
+	AppMag 17.723 # synthetic
+	Radius 9370
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20349-1/LP%20349-1.html"
+}
+
+"GJ 3031:EGGR 459:WD 0019+423:WDJ002215.19+423642.15"
+{
+	RA 5.56216628
+	Dec 42.61050436
+	Distance 112.369
+	SpectralType "DC9"
+	Temperature 5665
+	AppMag 16.547 # synthetic
+	Radius 11904
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203031/GJ%203031.html"
+}
+
+# Companion to WDJ002450.37+683446.85
+"G 242-54"
+{
+	RA 6.21425266
+	Dec 68.57851765
+	Distance 116.604 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 15.574 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+242-54"
+}
+
+"Gaia DR2 529594417061837824:WDJ002450.37+683446.85"
+{
+	RA 6.2148649
+	Dec 68.57978306
+	Distance 116.604 # mean of system components
+	SpectralType "DC9"
+	Temperature 5663
+	AppMag 17.639 # synthetic
+	Radius 7458
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20529594417061837824/Gaia%20DR2%20529594417061837824.html"
+}
+
+"WD 0024-55:LAWD 4:WD 0024-556:WDJ002640.74-552444.12"
+{
+	RA 6.66739309
+	Dec -55.41426868
+	Distance 78.374
+	SpectralType "DA5"
+	Temperature 9935
+	AppMag 15.21
+	Radius 5492
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200024-55/WD%200024-55.html"
+}
+
+"Gaia DR2 2747384888699406080:WDJ002702.93+055433.40"
+{
+	RA 6.76179652
+	Dec 5.90739973
+	Distance 120.649
+	SpectralType "DC9"
+	Temperature 5124
+	AppMag 18.254 # synthetic
+	Radius 7736
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202747384888699406080/Gaia%20DR2%202747384888699406080.html"
+}
+
+"NLTT 1450:WD 0025+054:WDJ002736.63+054203.13"
+{
+	RA 6.90382508
+	Dec 5.69969412
+	Distance 70.691
+	SpectralType "DA9"
+	Temperature 5607
+	AppMag 16.149
+	Radius 9227
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%201450/NLTT%201450.html"
+}
+
+# Companion to WDJ002949.72-544133.01
+"L 170-14 A"
+{
+	RA 7.455978
+	Dec -54.69404416
+	Distance 125.625 # mean of system components
+	SpectralType "M4.5e"
+	AppMag 14.44
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+170-14+A"
+}
+
+"WD 0027-549:WDJ002949.72-544133.01"
+{
+	RA 7.45483684
+	Dec -54.6934038
+	Distance 125.625 # mean of system components
+	SpectralType "DA7"
+	Temperature 7253
+	AppMag 16.128 # synthetic
+	Radius 9694
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200027-549/WD%200027-549.html"
+}
+
+# Companion to WDJ003036.62-685458.25
+"UCAC4 106-000428"
+{
+	RA 7.65210952
+	Dec -68.91567142
+	Distance 127.171 # mean of system components
+	SpectralType "M0-M4"
+	AppMag 13.72
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UCAC4+106-000428"
+}
+
+"Gaia DR2 4703464251158954496:WDJ003036.62-685458.25"
+{
+	RA 7.65113032
+	Dec -68.9165375
+	Distance 127.171 # mean of system components
+	SpectralType "DA6"
+	Temperature 8785
+	AppMag 15.759 # synthetic
+	Radius 8390
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204703464251158954496/Gaia%20DR2%204703464251158954496.html"
+}
+
+"Gaia DR2 2553935752048977792:WDJ003047.74+034657.93"
+{
+	RA 7.69979035
+	Dec 3.78387936
+	Distance 90.548
+	SpectralType "DC8"
+	Temperature 6418
+	AppMag 16.224 # synthetic
+	Radius 8366
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202553935752048977792/Gaia%20DR2%202553935752048977792.html"
+}
+
+"GJ 3037:LHS 1093:WD 0029-031:WDJ003209.86-025401.65"
+{
+	RA 8.04392584
+	Dec -2.89978361
+	Distance 76.685
+	SpectralType "DC9"
+	Temperature 4691
+	AppMag 17.32
+	Radius 11069
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201093/LHS%201093.html"
+}
+
+"LP 349-41:WDJ003325.28+250613.99"
+{
+	RA 8.35769811
+	Dec 25.104527
+	Distance 124.802
+	SpectralType "DA8"
+	Temperature 6237
+	AppMag 16.949 # synthetic
+	Radius 8769
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20349-41/LP%20349-41.html"
+}
+
+"EGGR 511:EGGR 560:WD 0032-175:WDJ003517.51-171851.57"
+{
+	RA 8.82583268
+	Dec -17.31434393
+	Distance 108.734
+	SpectralType "DAZ5"
+	Temperature 9659
+	AppMag 14.94
+	Radius 8868
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20511/EGGR%20511.html"
+}
+
+"EGGR 4:LAWD 5:WD 0033+016:WDJ003535.84+015308.62"
+{
+	RA 8.89868197
+	Dec 1.88411535
+	Distance 103.685
+	SpectralType "DA5"
+	Temperature 10805
+	AppMag 15.52
+	Radius 5290
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%204/EGGR%204.html"
+}
+
+"WD 0033-422:WDJ003614.41-415726.12"
+{
+	RA 9.06412901
+	Dec -41.95862572
+	Distance 84.007
+	SpectralType "DA9"
+	Temperature 5754
+	AppMag 16.614
+	Radius 8281
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200033-422/WD%200033-422.html"
+}
+
+"WD 0034-602:WDJ003622.31-595527.55"
+{
+	RA 9.09519745
+	Dec -59.92376876
+	Distance 74.719
+	SpectralType "DA4"
+	Temperature 14378
+	AppMag 14.08
+	Radius 5725
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200034-602/WD%200034-602.html"
+}
+
+"Gaia DR2 2319052851148048256:WDJ003713.77-281449.81"
+{
+	RA 9.30777434
+	Dec -28.24737509
+	Distance 122.884
+	SpectralType "DC9"
+	Temperature 5396
+	AppMag 17.81 # synthetic
+	Radius 8272
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202319052851148048256/Gaia%20DR2%202319052851148048256.html"
+}
+
+"LP 645-70:WDJ004056.17-080908.56"
+{
+	RA 10.23461154
+	Dec -8.15411201
+	Distance 122.06
+	SpectralType "DAP8"
+	Temperature 6080
+	AppMag 17.363 # synthetic
+	Radius 7391
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20645-70/LP%20645-70.html"
+}
+
+# Companion to WDJ004122.04+555008.35
+"GJ 1015 A:G 218-7"
+{
+	RA 10.33935205
+	Dec 55.83423241
+	Distance 74.603 # mean of system components
+	SpectralType "M4.17"
+	AppMag 11.98
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+218-7"
+}
+
+"GJ 1015 B:EGGR 245:WD 0038+555:WDJ004122.04+555008.35"
+{
+	RA 10.3443441
+	Dec 55.83534173
+	Distance 74.603 # mean of system components
+	SpectralType "DQ5"
+	Temperature 10487
+	AppMag 14.08
+	Radius 8672
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201015%20B/GJ%201015%20B.html"
+}
+
+"GJ 2012:EGGR 246:WD 0038-226:WDJ004126.03-222102.29"
+{
+	RA 10.35621993
+	Dec -22.35233354
+	Distance 29.658
+	SpectralType "DQ9"
+	Temperature 5430
+	AppMag 14.49
+	Radius 9049
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202012/GJ%202012.html"
+}
+
+"Gaia DR2 4926464691244602752:WDJ004126.61-503258.58"
+{
+	RA 10.36118967
+	Dec -50.55121291
+	Distance 102.379
+	SpectralType "DC9"
+	Temperature 4415
+	AppMag 18.224
+	Radius 12513
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204926464691244602752/Gaia%20DR2%204926464691244602752.html"
+}
+
+"BV Cet:EGGR 267:WD 0041-102:WDJ004345.98-100025.02"
+{
+	RA 10.94092869
+	Dec -10.00754835
+	Distance 101.462
+	SpectralType "DBAH2"
+	Temperature 21334
+	AppMag 14.537 # synthetic
+	Radius 4400
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20BV%20Cet/V*%20BV%20Cet.html"
+}
+
+# Companion to WDJ004434.77-114836.05
+"WT 1136"
+{
+	RA 11.1456103
+	Dec -11.81190087
+	Distance 120.43 # mean of system components
+	SpectralType "M4"
+	Temperature 3228 # GSP-Phot
+	AppMag 14.787 # synthetic
+	Radius 195597 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=WT+1136"
+}
+
+"Gaia DR2 2377344185944929152:WDJ004434.77-114836.05"
+{
+	RA 11.14530482
+	Dec -11.81074468
+	Distance 120.43 # mean of system components
+	SpectralType "DZ9"
+	Temperature 5362
+	AppMag 17.596 # synthetic
+	Radius 9161
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202377344185944929152/Gaia%20DR2%202377344185944929152.html"
+}
+
+"PHL 6585:WD 0042-064:WDJ004506.34-060819.60"
+{
+	RA 11.27690638
+	Dec -6.14182328
+	Distance 98.682
+	SpectralType "DC9"
+	Temperature 4938
+	AppMag 18.26
+	Radius 7170
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PHL%206585/PHL%206585.html"
+}
+
+"WD 0042-337:WDJ004519.60-332929.01"
+{
+	RA 11.34138856
+	Dec -33.49799318
+	Distance 107.176
+	SpectralType "DC9"
+	Temperature 4176
+	AppMag 19.01
+	Radius 8937
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200042-337/WD%200042-337.html"
+}
+
+# WDJ004909.90+052318.99: defined in nearstars.stc
+
+"LHS 1158:WD 0048-207:WDJ005110.87-202756.24"
+{
+	RA 12.79796596
+	Dec -20.46753846
+	Distance 87.735
+	SpectralType "DA9"
+	Temperature 5019
+	AppMag 17.19
+	Radius 10177
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201158/LHS%201158.html"
+}
+
+"Gaia DR2 4925740628477887232:WDJ005311.22-501322.87"
+{
+	RA 13.29722791
+	Dec -50.22359816
+	Distance 113.432
+	SpectralType "DC9"
+	Temperature 5604
+	AppMag 17.368 # synthetic
+	Radius 8440
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204925740628477887232/Gaia%20DR2%204925740628477887232.html"
+}
+
+"Gaia DR2 4987578158855872384:WDJ005411.42-394041.53"
+{
+	RA 13.54837217
+	Dec -39.67822875
+	Distance 87.272
+	SpectralType "DA8"
+	Temperature 6264
+	AppMag 16.445 # synthetic
+	Radius 7566
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204987578158855872384/Gaia%20DR2%204987578158855872384.html"
+}
+
+"EGGR 562:WD 0052+226:WDJ005445.95+225610.59"
+{
+	RA 13.69363803
+	Dec 22.93568988
+	Distance 119.052
+	SpectralType "DA5"
+	Temperature 9654
+	AppMag 16.09
+	Radius 5594
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20562/EGGR%20562.html"
+}
+
+"Gaia DR2 2582335342824976768:WDJ005503.58+101005.56"
+{
+	RA 13.76505004
+	Dec 10.16799723
+	Distance 86.591
+	SpectralType "DA8"
+	Temperature 6230
+	AppMag 16.12
+	Radius 8658
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202582335342824976768/Gaia%20DR2%202582335342824976768.html"
+}
+
+"GJ 3064:LAWD 7:EGGR 6:WD 0053-117:WDJ005550.34-112731.50"
+{
+	RA 13.95937185
+	Dec -11.45680631
+	Distance 73.131
+	SpectralType "DA7"
+	Temperature 6952
+	AppMag 15.25
+	Radius 9148
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203064/GJ%203064.html"
+}
+
+"MASTER OT J005559.13+594802.1:WD 0052+595:WDJ005558.30+594802.53"
+{
+	RA 13.99691262
+	Dec 59.80045165
+	Distance 74.46
+	SpectralType "DC9"
+	Temperature 4821
+	AppMag 17.116 # synthetic
+	Radius 10801
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/MASTER%20OT%20J005559.13+594802.1/MASTER%20OT%20J005559.13+594802.1.html"
+}
+
+"Gaia DR2 2524879812959998592:WDJ010338.56-052251.96"
+{
+	RA 15.91099281
+	Dec -5.38039204
+	Distance 94.625
+	SpectralType "DAH5"
+	Temperature 9375
+	AppMag 17.401 # synthetic
+	Radius 2685
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202524879812959998592/Gaia%20DR2%202524879812959998592.html"
+}
+
+# Companion to WDJ010349.92+050430.57
+4849 "GJ 3071"
+{
+	RA 15.60377702
+	Dec 5.06251916
+	Distance 72.165 # mean of system components
+	SpectralType "K3+K8"
+	AppMag 8.131
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+6101"
+}
+
+"GJ 1027:EGGR 7:WD 0101+048:WDJ010349.92+050430.57"
+{
+	RA 15.95946491
+	Dec 5.07618737
+	Distance 72.165 # mean of system components
+	SpectralType "DA6"
+	Temperature 8064
+	AppMag 14.05
+	Radius 12214
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%207/EGGR%207.html"
+}
+
+"Gaia DR2 2531326283993100416:WDJ010416.07-035025.39"
+{
+	RA 16.06864789
+	Dec -3.84071898
+	Distance 115.789
+	SpectralType "DA9"
+	Temperature 5413
+	AppMag 17.55
+	Radius 7127
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202531326283993100416/Gaia%20DR2%202531326283993100416.html"
+}
+
+"EGGR 462:WD 0102+210 A:WDJ010456.47+211958.87"
+{
+	RA 16.23429528
+	Dec 21.33110624
+	Distance 106.049 # mean of system components
+	SpectralType "DA9"
+	Temperature 5338
+	AppMag 17.95
+	Radius 7030
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20462/EGGR%20462.html"
+}
+
+"EGGR 463:WD 0102+210 B:WDJ010457.96+212017.54"
+{
+	RA 16.24048821
+	Dec 21.33625795
+	Distance 106.049 # mean of system components
+	SpectralType "DC9"
+	Temperature 4853
+	AppMag 18.09
+	Radius 9101
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20463/EGGR%20463.html"
+}
+
+"WD 0108+277:WDJ011044.68+275815.74"
+{
+	RA 17.6854265
+	Dec 27.97034546
+	Distance 123.822
+	SpectralType "DAZ8"
+	Temperature 6284
+	AppMag 16.15
+	Radius 11703
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200108+277/WD%200108+277.html"
+}
+
+# Companion to WDJ011103.67-722741.26
+"L 51-48"
+{
+	RA 17.7806356
+	Dec -72.46096543
+	Distance 93.749 # mean of system components
+	SpectralType "M5V"
+	Temperature 3161 # GSP-Phot
+	AppMag 15.784
+	Radius 143556 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+51-48"
+}
+
+"Gaia DR3 4687445500635789184:WDJ011103.67-722741.26"
+{
+	RA 17.76930332
+	Dec -72.46221835
+	Distance 93.749 # mean of system components
+	SpectralType "DC9"
+	Temperature 4406
+	AppMag 18.232
+	Radius 12160
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%204687445500635789184/Gaia%20DR3%204687445500635789184.html"
+}
+
+"LHS 1219:WD 0112+018:WDJ011504.60-013316.32"
+{
+	RA 18.77201078
+	Dec -1.55442928
+	Distance 110.755
+	SpectralType "DA9"
+	Temperature 5295
+	AppMag 17.59
+	Radius 8906
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201219/LHS%201219.html"
+}
+
+"GJ 1037:Wolf 1516:LAWD 8:EGGR 9:WD 0115+159:WDJ011800.08+161020.56"
+{
+	RA 19.50023348
+	Dec 16.16948659
+	Distance 54.633
+	SpectralType "DQ5"
+	Temperature 9278
+	AppMag 13.84
+	Radius 8332
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%201516/Wolf%201516.html"
+}
+
+"LHS 1233:WD 0117-145:WDJ011932.09-141526.77"
+{
+	RA 19.88296477
+	Dec -14.26003396
+	Distance 82.785
+	SpectralType "DA9"
+	Temperature 5100
+	AppMag 16.96
+	Radius 10484
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201233/LHS%201233.html"
+}
+
+"2MASS J01213782+3440431:WD 0118+344:WDJ012137.80+344042.98"
+{
+	RA 20.40672702
+	Dec 34.67863709
+	Distance 126.332
+	SpectralType "DZ7"
+	Temperature 7064
+	AppMag 16.696 # synthetic
+	Radius 7318
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J01213782+3440431/2MASS%20J01213782+3440431.html"
+}
+
+"WD 0121-429:WDJ012403.99-424038.43"
+{
+	RA 21.01841356
+	Dec -42.67967119
+	Distance 60.132
+	SpectralType "DAH8"
+	Temperature 6080
+	AppMag 14.83
+	Radius 11702
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200121-429/WD%200121-429.html"
+}
+
+"EGGR 517:WD 0121+401:WDJ012421.57+402358.09"
+{
+	RA 21.09391404
+	Dec 40.39890088
+	Distance 88.162
+	SpectralType "DA9"
+	Temperature 5325
+	AppMag 17.12
+	Radius 8648
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20517/EGGR%20517.html"
+}
+
+"WD 0123-460:WDJ012518.05-454531.05"
+{
+	RA 21.32844219
+	Dec -45.76112191
+	Distance 70.525
+	SpectralType "DA9"
+	Temperature 5808
+	AppMag 16.3
+	Radius 7651
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200123-460/WD%200123-460.html"
+}
+
+"GJ 1039:EGGR 307:WD 0123-262:WDJ012524.47-260044.45"
+{
+	RA 21.35310975
+	Dec -26.01467837
+	Distance 54.007
+	SpectralType "DC7"
+	Temperature 6941
+	AppMag 15.06
+	Radius 7517
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201039/GJ%201039.html"
+}
+
+"Gaia DR2 2587268134239449728:WDJ012833.83+135122.04"
+{
+	RA 22.14105345
+	Dec 13.85589113
+	Distance 122.597
+	SpectralType "DA4"
+	Temperature 13096
+	AppMag 14.289 # synthetic
+	Radius 9491
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202587268134239449728/Gaia%20DR2%202587268134239449728.html"
+}
+
+"Gaia DR2 406775841506041344:GD 277:WDJ012923.99+510846.97"
+{
+	RA 22.35021031
+	Dec 51.14588793
+	Distance 125.015
+	SpectralType "DA2"
+	Temperature 22090
+	AppMag 13.536
+	Radius 9154
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20406775841506041344/Gaia%20DR2%20406775841506041344.html"
+}
+
+"Wolf 72:EGGR 564:WD 0126+101:WDJ012924.26+102301.34"
+{
+	RA 22.35044974
+	Dec 10.38199292
+	Distance 95.317
+	SpectralType "DA6"
+	Temperature 8516
+	AppMag 14.38
+	Radius 12274
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%2072/Wolf%2072.html"
+}
+
+"Gaia DR2 5016473702391268096:WDJ012953.18-322425.86"
+{
+	RA 22.47277977
+	Dec -32.40791131
+	Distance 124.826
+	SpectralType "DA7"
+	Temperature 6721
+	AppMag 16.773 # synthetic
+	Radius 8217
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205016473702391268096/Gaia%20DR2%205016473702391268096.html"
+}
+
+"Gaia DR2 396963005168870528:WDJ013055.01+441423.29"
+{
+	RA 22.72994611
+	Dec 44.24018682
+	Distance 124.299
+	SpectralType "DZA9"
+	Temperature 5076
+	AppMag 18.049 # synthetic
+	Radius 9562
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20396963005168870528/Gaia%20DR2%20396963005168870528.html"
+}
+
+"WD 0129+458:WDJ013246.67+460458.78"
+{
+	RA 23.19309922
+	Dec 46.08298955
+	Distance 126.07
+	SpectralType "DA5"
+	Temperature 10473
+	AppMag 15.006 # synthetic
+	Radius 8827
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200129+458/WD%200129+458.html"
+}
+
+"WD J0135-546:WD 0133-548:WDJ013538.69-543528.10"
+{
+	RA 23.91646235
+	Dec -54.59069779
+	Distance 126.23
+	SpectralType "DC9"
+	Temperature 4793
+	AppMag 18.37
+	Radius 10290
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%20J0135-546/WD%20J0135-546.html"
+}
+
+"ZZ Cet:EGGR 10:LAWD 9:WD 0133-116:WDJ013613.62-112032.63"
+{
+	RA 24.05882063
+	Dec -11.34291525
+	Distance 106.676
+	SpectralType "DA4"
+	Temperature 11834
+	AppMag 14.2
+	Radius 9344
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20ZZ%20Cet/V*%20ZZ%20Cet.html"
+}
+
+"Gaia DR2 2484544095751034496:WDJ013705.08-020738.75"
+{
+	RA 24.27089696
+	Dec -2.12746361
+	Distance 116.418
+	SpectralType "DA7"
+	Temperature 7311
+	AppMag 16.602 # synthetic
+	Radius 7111
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202484544095751034496/Gaia%20DR2%202484544095751034496.html"
+}
+
+"Gliese 64:L 870-2:LAWD 10:EGGR 11:WD 0135-052:WDJ013759.39-045944.67"
+{
+	RA 24.50006542
+	Dec -4.99729804
+	Distance 41.139
+	SpectralType "DA7"
+	Temperature 7127
+	AppMag 12.84
+	Radius 14854
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%20870-2/L%20870-2.html"
+}
+
+"PHL 3537:WD 0136-201:WDJ013832.02-195446.58"
+{
+	RA 24.63439628
+	Dec -19.91221923
+	Distance 79.425
+	SpectralType "DA6"
+	Temperature 8431
+	AppMag 15.593 # synthetic
+	Radius 6076
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PHL%203537/PHL%203537.html"
+}
+
+"Gaia DR2 4617960488907213184:WDJ013843.16-832532.89"
+{
+	RA 24.67511729
+	Dec -83.42592232
+	Distance 102.049
+	SpectralType "DA7"
+	Temperature 7631
+	AppMag 15.736
+	Radius 8473
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204617960488907213184/Gaia%20DR2%204617960488907213184.html"
+}
+
+"PG 0136+152:WD 0136+152:WDJ013856.87+152742.39"
+{
+	RA 24.73681459
+	Dec 15.46134549
+	Distance 73.904
+	SpectralType "DA6"
+	Temperature 7874
+	AppMag 14.94
+	Radius 8604
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%200136+152/PG%200136+152.html"
+}
+
+"WD 0136-340:WDJ013914.39-334903.32"
+{
+	RA 24.81306543
+	Dec -33.81768721
+	Distance 129.002
+	SpectralType "DA7"
+	Temperature 6742
+	AppMag 17.18
+	Radius 6955
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200136-340/WD%200136-340.html"
+}
+
+"GD 419:EGGR 308:WD 0134+833:WDJ014128.80+833458.83"
+{
+	RA 25.36522564
+	Dec 83.58338558
+	Distance 88.343
+	SpectralType "DA3"
+	Temperature 19004
+	AppMag 13.109 # synthetic
+	Radius 8795
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20419/GD%20419.html"
+}
+
+"Gaia DR2 2568588664341691520:WDJ014258.08+073045.39"
+{
+	RA 25.74226477
+	Dec 7.51271373
+	Distance 129.701
+	SpectralType "DA9"
+	Temperature 5588
+	AppMag 17.577 # synthetic
+	Radius 8835
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202568588664341691520/Gaia%20DR2%202568588664341691520.html"
+}
+
+"GJ 3112:WD 0141-675:WDJ014300.98-671830.35"
+{
+	RA 25.75030397
+	Dec -67.31295816
+	Distance 31.683
+	SpectralType "DAZ8"
+	Temperature 6350
+	AppMag 13.82
+	Radius 8952
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203112/GJ%203112.html"
+}
+
+"EGGR 519:WD 0142+312:WDJ014511.23+313243.56"
+{
+	RA 26.29841024
+	Dec 31.54478113
+	Distance 119.229
+	SpectralType "DA6"
+	Temperature 8965
+	AppMag 14.78
+	Radius 11866
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20519/EGGR%20519.html"
+}
+
+"Wolf 82:EGGR 13:WD 0143+216:WDJ014641.31+215448.38"
+{
+	RA 26.67130104
+	Dec 21.91287446
+	Distance 86.383
+	SpectralType "DA5"
+	Temperature 9165
+	AppMag 15.05
+	Radius 7270
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%2082/Wolf%2082.html"
+}
+
+"G 274-95:WDJ014743.94-271136.93"
+{
+	RA 26.93254342
+	Dec -27.19487176
+	Distance 115.118
+	SpectralType "DA7"
+	Temperature 6764
+	AppMag 16.392 # synthetic
+	Radius 8926
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20274-95/G%20274-95.html"
+}
+
+"WD 0145+234:WDJ014754.82+233943.60"
+{
+	RA 26.97838186
+	Dec 23.66167776
+	Distance 95.878
+	SpectralType "DAZ4"
+	Temperature 12990
+	AppMag 14.014
+	Radius 8496
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200145+234/WD%200145+234.html"
+}
+
+"LP 244-8:WD 0145+360:WDJ014840.45+361530.98"
+{
+	RA 27.16850733
+	Dec 36.25757904
+	Distance 114.74
+	SpectralType "DA8"
+	Temperature 6105
+	AppMag 16.76
+	Radius 8562
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20244-8/LP%20244-8.html"
+}
+
+"2MASS J01503855-7207164:WD 0149-723:WDJ015038.47-720716.54"
+{
+	RA 27.65697883
+	Dec -72.12229771
+	Distance 103.327
+	SpectralType "DC7"
+	Temperature 6838
+	AppMag 16.341 # synthetic
+	Radius 8015
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J01503855-7207164/2MASS%20J01503855-7207164.html"
+}
+
+# Companion to WDJ015151.14+642552.55
+1016624040 "GJ 3117:G 244-37"
+{
+	RA 27.96550011
+	Dec 64.43411796
+	Distance 56.385 # mean of system components
+	SpectralType "M2.5V"
+	Temperature 3237 # GSP-Phot
+	AppMag 11.421 # synthetic
+	Radius 413440 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+244-37"
+}
+
+"GJ 3118:WD 0148+641:EGGR 268:WDJ015151.14+642552.55"
+{
+	RA 27.96539316
+	Dec 64.43036728
+	Distance 56.385 # mean of system components
+	SpectralType "DA6"
+	Temperature 8794
+	AppMag 13.98
+	Radius 8341
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200148+641/WD%200148+641.html"
+}
+
+8709 "GJ 3121:GD 279:EGGR 269:WD 0148+467:WDJ015202.96+470006.66"
+{
+	RA 28.01237195
+	Dec 47.00238987
+	Distance 53.823
+	SpectralType "DA4"
+	Temperature 14293
+	AppMag 12.44
+	Radius 9015
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20279/GD%20279.html"
+}
+
+"WD 0150+256:WDJ015251.94+255340.65"
+{
+	RA 28.21747173
+	Dec 25.8948218
+	Distance 113.507
+	SpectralType "DA7"
+	Temperature 7727
+	AppMag 15.71
+	Radius 9558
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200150+256/WD%200150+256.html"
+}
+
+"Gaia DR2 105240786245136256:WDJ015825.83+253051.31"
+{
+	RA 29.60851336
+	Dec 25.51248777
+	Distance 124.761
+	SpectralType "DC9"
+	Temperature 4044
+	AppMag 18.824 # synthetic
+	Radius 14771
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20105240786245136256/Gaia%20DR2%20105240786245136256.html"
+}
+
+"PG 0156+156:WD 0156+155:WDJ015939.37+154847.62"
+{
+	RA 29.91367929
+	Dec 15.81318512
+	Distance 124.579
+	SpectralType "DC6"
+	Temperature 9095
+	AppMag 15.8
+	Radius 7881
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%200156+156/PG%200156+156.html"
+}
+
+"Gaia DR2 2574620550768898432:GD 21:WDJ020110.70+121226.03"
+{
+	RA 30.29378319
+	Dec 12.20683341
+	Distance 102.686
+	SpectralType "DC7"
+	Temperature 6952
+	AppMag 16.169 # synthetic
+	Radius 8588
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202574620550768898432/Gaia%20DR2%202574620550768898432.html"
+}
+
+"Gaia DR2 78649033103100416:WDJ020210.60+160203.31"
+{
+	RA 30.54433587
+	Dec 16.03419175
+	Distance 105.209
+	SpectralType "DZ9"
+	Temperature 4981
+	AppMag 18.022 # synthetic
+	Radius 8156
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2078649033103100416/Gaia%20DR2%2078649033103100416.html"
+}
+
+"WD 0200-127:GD 1072:WDJ020304.33-122901.74"
+{
+	RA 30.76786081
+	Dec -12.48434459
+	Distance 78.478
+	SpectralType "DC5"
+	Temperature 9881
+	AppMag 14.55
+	Radius 7802
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200200-127/WD%200200-127.html"
+}
+
+"WD J0205-053:WD 0202-055:WDJ020511.61-051754.30"
+{
+	RA 31.30266523
+	Dec -5.29667101
+	Distance 104.949
+	SpectralType "DC9"
+	Temperature 4301
+	AppMag 18.59
+	Radius 11270
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%20J0205-053/WD%20J0205-053.html"
+}
+
+"LHS 1341:WD 0203+183:WDJ020614.67+183624.06"
+{
+	RA 31.56481709
+	Dec 18.60711699
+	Distance 118.689
+	SpectralType "DC9"
+	Temperature 4500
+	AppMag 18.524 # synthetic
+	Radius 11395
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201341/LHS%201341.html"
+}
+
+# Companion to WDJ020702.30-302332.57
+"LP 885-23"
+{
+	RA 31.77772205
+	Dec -30.4070142
+	Distance 95.078 # mean of system components
+	SpectralType "M0"
+	AppMag 14.13
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+885-23"
+}
+
+"WD 0204-306:WDJ020702.30-302332.57"
+{
+	RA 31.76083916
+	Dec -30.39297395
+	Distance 95.078 # mean of system components
+	SpectralType "DA9"
+	Temperature 5619
+	AppMag 16.18
+	Radius 8781
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200204-306/WD%200204-306.html"
+}
+
+"Gaia DR2 330661599315957504:WDJ020809.31+372939.12"
+{
+	RA 32.03851371
+	Dec 37.49392494
+	Distance 107.569
+	SpectralType "DA9"
+	Temperature 5701
+	AppMag 17.85 # synthetic
+	Radius 6012
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20330661599315957504/Gaia%20DR2%20330661599315957504.html"
+}
+
+"LAWD 11:EGGR 15:WD 0205+250:WDJ020847.22+251409.97"
+{
+	RA 32.19880392
+	Dec 25.23556816
+	Distance 127.298
+	SpectralType "DA3"
+	Temperature 16933
+	AppMag 13.234 # synthetic
+	Radius 13343
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2011/LAWD%2011.html"
+}
+
+"GJ 1042:EGGR 168:WD 0208+396:WDJ021120.84+395521.52"
+{
+	RA 32.84280348
+	Dec 39.92041953
+	Distance 55.976
+	SpectralType "DAZ7"
+	Temperature 7196
+	AppMag 14.526
+	Radius 9254
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201042/GJ%201042.html"
+}
+
+"NLTT 7194:WD 0207+710:WDJ021148.18+711913.48"
+{
+	RA 32.95301937
+	Dec 71.31956152
+	Distance 87.914
+	SpectralType "DC9"
+	Temperature 5135
+	AppMag 17.196 # synthetic
+	Radius 9321
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%207194/NLTT%207194.html"
+}
+
+# Companion to WDJ021228.98-080411.00
+"LP 649-66"
+{
+	RA 33.119011
+	Dec -8.07157492
+	Distance 54.504 # mean of system components
+	SpectralType "M2"
+	AppMag 11.98
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+649-66"
+}
+
+"Gaia DR2 2486388560866377856:WDJ021228.98-080411.00"
+{
+	RA 33.11800785
+	Dec -8.07171416
+	Distance 54.504 # mean of system components
+	SpectralType "DA6"
+	Temperature 8467
+	AppMag 13.763 # synthetic
+	Radius 9531
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202486388560866377856/Gaia%20DR2%202486388560866377856.html"
+}
+
+"Gaia DR2 4970215770740383616:WDJ021348.83-334530.03"
+{
+	RA 33.4543773
+	Dec -33.75673655
+	Distance 61.117
+	SpectralType "DAZ9"
+	Temperature 5150 # Table A5
+	AppMag 15.49
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204970215770740383616/Gaia%20DR2%204970215770740383616.html"
+}
+
+"2MASS J02145697+7746000:WD 0209+775:WDJ021457.04+774559.88"
+{
+	RA 33.74322312
+	Dec 77.76494924
+	Distance 129.293
+	SpectralType "DC9"
+	Temperature 4911
+	AppMag 18.601 # synthetic
+	Radius 8392
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J02145697+7746000/2MASS%20J02145697+7746000.html"
+}
+
+"GJ 3144:GD 25:EGGR 312:WD 0213+396:WDJ021616.35+395125.41"
+{
+	RA 34.067213
+	Dec 39.85662888
+	Distance 66.241
+	SpectralType "DA5"
+	Temperature 9203
+	AppMag 14.58
+	Radius 6976
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2025/GD%2025.html"
+}
+
+"Gliese 91.3:G 134-22:EGGR 16:WD 0213+427:WDJ021658.02+425805.24"
+{
+	RA 34.24694095
+	Dec 42.96552847
+	Distance 66.961
+	SpectralType "DA9"
+	Temperature 5464
+	AppMag 16.21
+	Radius 9060
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20134-22/G%20134-22.html"
+}
+
+"H PER1166:LAWD 12:EGGR 17:WD 0214+568:WDJ021733.53+570647.35"
+{
+	RA 34.39109441
+	Dec 57.11304776
+	Distance 129.524
+	SpectralType "DA2"
+	Temperature 22261
+	AppMag 13.646 # synthetic
+	Radius 8965
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NAME%20H%20PER1166/NAME%20H%20PER1166.html"
+}
+
+# Companion to WDJ021831.50-393633.22
+"LP 992-100"
+{
+	RA 34.67550002
+	Dec -39.61933828
+	Distance 97.706 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 13.35
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+992-100"
+}
+
+"WD 0216-398:WDJ021831.50-393633.22"
+{
+	RA 34.63416497
+	Dec -39.60886809
+	Distance 97.706 # mean of system components
+	SpectralType "DA7"
+	Temperature 7176
+	AppMag 15.75
+	Radius 9076
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200216-398/WD%200216-398.html"
+}
+
+"Gaia DR2 355669578975070976:WDJ021839.49+501351.28"
+{
+	RA 34.66531756
+	Dec 50.23026136
+	Distance 88.138
+	SpectralType "DA9"
+	Temperature 5019
+	AppMag 17.103 # synthetic
+	Radius 11286
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20355669578975070976/Gaia%20DR2%20355669578975070976.html"
+}
+
+# Companion to WDJ022111.49+533330.39
+10960 "BD+52 570"
+{
+	RA 35.29935349
+	Dec 53.56066378
+	Distance 94.71 # mean of system components
+	SpectralType "K8V"
+	AppMag 10.32
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD%2B52+570"
+}
+
+"Gaia DR2 455517329408362752:WDJ022111.49+533330.39"
+{
+	RA 35.29580681
+	Dec 53.55823925
+	Distance 94.71 # mean of system components
+	SpectralType "DC8"
+	Temperature 6709
+	AppMag 16.273 # synthetic
+	Radius 7901
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20455517329408362752/Gaia%20DR2%20455517329408362752.html"
+}
+
+# Companion to WDJ022157.89+044517.91
+11028
+{
+	RA 35.50346882
+	Dec 4.74711036
+	Distance 127.752 # mean of system components
+	SpectralType "G5V"
+	Temperature 5402 # GSP-Spec
+	AppMag 8.25
+	Radius 653119 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+14651"
+}
+
+"Gaia DR2 2516606022320239104:WDJ022157.89+044517.91"
+{
+	RA 35.49110338
+	Dec 4.75533594
+	Distance 127.752 # mean of system components
+	SpectralType "DA7"
+	Temperature 7262
+	AppMag 16.492 # synthetic
+	Radius 8386
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202516606022320239104/Gaia%20DR2%202516606022320239104.html"
+}
+
+"2MASS J02230030+5544272:WD 0219+555:WDJ022300.22+554427.86"
+{
+	RA 35.75187977
+	Dec 55.74054024
+	Distance 124.784
+	SpectralType "DA7"
+	Temperature 6993
+	AppMag 16.971 # synthetic
+	Radius 6998
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J02230030+5544272/2MASS%20J02230030+5544272.html"
+}
+
+"PM J02238+2055:WDJ022348.96+205553.90"
+{
+	RA 35.95406003
+	Dec 20.92951469
+	Distance 125.464
+	SpectralType "DC9"
+	Temperature 4622
+	AppMag 18.485 # synthetic
+	Radius 11129
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J02238+2055/PM%20J02238+2055.html"
+}
+
+"WD 0222-291:WDJ022432.27-285459.46"
+{
+	RA 36.13698788
+	Dec -28.91665331
+	Distance 94.438
+	SpectralType "DC9"
+	Temperature 4880 # Table A5
+	AppMag 18.05
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200222-291/WD%200222-291.html"
+}
+
+"LHS 1405:WD 0222+648:WDJ022631.96+645929.92"
+{
+	RA 36.6392828
+	Dec 64.98996325
+	Distance 100.925
+	SpectralType "DC9"
+	Temperature 4407
+	AppMag 18.29
+	Radius 11381
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%201405/LHS%201405.html"
+}
+
+"Gaia DR2 459237630076876672:WDJ022704.24+591502.04"
+{
+	RA 36.76822558
+	Dec 59.25063979
+	Distance 122.805
+	SpectralType "DA7"
+	Temperature 7361
+	AppMag 15.97
+	Radius 9693
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20459237630076876672/Gaia%20DR2%20459237630076876672.html"
+}
+
+# Companion to WDJ022724.62+180724.03
+"PM J02274+1807E"
+{
+	RA 36.85609013
+	Dec 18.12156251
+	Distance 120.82 # mean of system components
+	SpectralType "M1.5V"
+	Temperature 3594 # GSP-Spec
+	AppMag 12.561
+	Radius 391575 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=PM+J02274%2B1807E"
+}
+
+"Gaia DR2 85787470611883008:WDJ022724.62+180724.03"
+{
+	RA 36.85299944
+	Dec 18.1229509
+	Distance 120.82 # mean of system components
+	SpectralType "DA6"
+	Temperature 8540
+	AppMag 15.553 # synthetic
+	Radius 9298
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2085787470611883008/Gaia%20DR2%2085787470611883008.html"
+}
+
+11650 "Gliese 100.1:Feige 22:EGGR 19:WD 0227+050:WDJ023016.63+051550.70"
+{
+	RA 37.5696249
+	Dec 5.26397346
+	Distance 86.399
+	SpectralType "DA3"
+	Temperature 18965
+	AppMag 12.78
+	Radius 9907
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Feige%2022/Feige%2022.html"
+}
+
+# Companion to WDJ023114.82+081023.71
+"LP 530-22"
+{
+	RA 37.81543394
+	Dec 8.16605255
+	Distance 126.238 # mean of system components
+	SpectralType "M6V"
+	AppMag 17.625 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+530-22"
+}
+
+"WD 0228+079:WDJ023114.82+081023.71"
+{
+	RA 37.81316173
+	Dec 8.17190659
+	Distance 126.238 # mean of system components
+	SpectralType "DC9"
+	Temperature 5849
+	AppMag 17.341 # synthetic
+	Radius 8456
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200228+079/WD%200228+079.html"
+}
+
+"Gaia DR2 131188715200383872:WDJ023117.04+285939.88"
+{
+	RA 37.82041678
+	Dec 28.99434117
+	Distance 90.921
+	SpectralType "DA7"
+	Temperature 6985
+	AppMag 15.1
+	Radius 11917
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20131188715200383872/Gaia%20DR2%20131188715200383872.html"
+}
+
+"EGGR 411:WD 0228+269:WDJ023140.97+270950.48"
+{
+	RA 37.92267762
+	Dec 27.1647625
+	Distance 91.783
+	SpectralType "DA9"
+	Temperature 4942
+	AppMag 17.375 # synthetic
+	Radius 10828
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20411/EGGR%20411.html"
+}
+
+"GJ 3162:EGGR 471:WD 0230-144:WDJ023237.91-141151.77"
+{
+	RA 38.15810436
+	Dec -14.20074352
+	Distance 54.327
+	SpectralType "DA9"
+	Temperature 5451
+	AppMag 15.77
+	Radius 9166
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203162/GJ%203162.html"
+}
+
+"LP 410-52:WDJ023338.98+212513.29"
+{
+	RA 38.41271747
+	Dec 21.4193687
+	Distance 92.822
+	SpectralType "DC9"
+	Temperature 4892
+	AppMag 17.536 # synthetic
+	Radius 10545
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20410-52/LP%20410-52.html"
+}
+
+"GJ 2027:GD 31:EGGR 207:WD 0231-054:WDJ023407.73-051139.33"
+{
+	RA 38.53328489
+	Dec -5.19384939
+	Distance 78.237
+	SpectralType "DA4"
+	Temperature 13146
+	AppMag 14.24
+	Radius 5817
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2031/GD%2031.html"
+}
+
+"WD 0233-242:WDJ023521.79-240047.12"
+{
+	RA 38.84028885
+	Dec -24.01578805
+	Distance 60.19
+	SpectralType "DAH9"
+	Temperature 5066
+	AppMag 15.94
+	Radius 13335
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200233-242/WD%200233-242.html"
+}
+
+"GD 283:EGGR 412:WD 0231+570:WDJ023530.71+571524.50"
+{
+	RA 38.87956237
+	Dec 57.25665945
+	Distance 86.875
+	SpectralType "DA4"
+	Temperature 12658
+	AppMag 13.68
+	Radius 8696
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20283/GD%20283.html"
+}
+
+"Gaia DR2 5064259336725948672:WDJ023538.55-303225.52"
+{
+	RA 38.91197109
+	Dec -30.54124197
+	Distance 106.408
+	SpectralType "DC9"
+	Temperature 4749 # MWDD
+	AppMag 18.809 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205064259336725948672/Gaia%20DR2%205064259336725948672.html"
+}
+
+"Gaia DR2 2502097283492466560:WDJ023551.36+011845.45"
+{
+	RA 38.96392219
+	Dec 1.31245826
+	Distance 107.607
+	SpectralType "DA7"
+	Temperature 6750
+	AppMag 16.265 # synthetic
+	Radius 8872
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202502097283492466560/Gaia%20DR2%202502097283492466560.html"
+}
+
+"EGGR 314:WD 0232+525:WDJ023619.57+524412.41"
+{
+	RA 39.08281322
+	Dec 52.73604247
+	Distance 94.012
+	SpectralType "DAH3"
+	Temperature 17351
+	AppMag 13.841 # synthetic
+	Radius 7163
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20314/EGGR%20314.html"
+}
+
+"LP 410-67:WDJ023759.15+163812.95"
+{
+	RA 39.49628021
+	Dec 16.63554596
+	Distance 103.931
+	SpectralType "DC9"
+	Temperature 5490
+	AppMag 17.243 # synthetic
+	Radius 8708
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20410-67/LP%20410-67.html"
+}
+
+"WD 0236-269:WDJ023841.25-264319.88"
+{
+	RA 39.67192117
+	Dec -26.72132151
+	Distance 114.068
+	SpectralType "DXP7"
+	Temperature 7175
+	AppMag 16.6
+	Radius 7463
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200236-269/WD%200236-269.html"
+}
+
+"WD 0236+259:WDJ023919.69+260957.46"
+{
+	RA 39.83359403
+	Dec 26.16519087
+	Distance 67.982
+	SpectralType "DA9"
+	Temperature 5589
+	AppMag 16.29
+	Radius 8996
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200236+259/WD%200236+259.html"
+}
+
+"GD 32:WD 0237+315:WDJ024050.43+314256.44"
+{
+	RA 40.2093556
+	Dec 31.7152548
+	Distance 107.711
+	SpectralType "DA7"
+	Temperature 7122
+	AppMag 16.103 # synthetic
+	Radius 8648
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2032/GD%2032.html"
+}
+
+"EGGR 472:WD 0239+109:WDJ024208.44+111233.00"
+{
+	RA 40.53593988
+	Dec 11.20786348
+	Distance 110.458
+	SpectralType "DAH6"
+	Temperature 8283
+	AppMag 16.18
+	Radius 6652
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20472/EGGR%20472.html"
+}
+
+"Gaia DR2 4725208704209795712:WDJ024300.36-603414.82"
+{
+	RA 40.75160148
+	Dec -60.57185085
+	Distance 109.154
+	SpectralType "DA9"
+	Temperature 5623
+	AppMag 17.431 # synthetic
+	Radius 7815
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204725208704209795712/Gaia%20DR2%204725208704209795712.html"
+}
+
+"Gaia DR2 4725152392894633984:WDJ024527.76-603858.32"
+{
+	RA 41.36704743
+	Dec -60.64892039
+	Distance 116.048
+	SpectralType "DA9"
+	Temperature 5879
+	AppMag 17.014
+	Radius 8916
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204725152392894633984/Gaia%20DR2%204725152392894633984.html"
+}
+
+"LP 771-7:WDJ024531.84-195134.42"
+{
+	RA 41.38530829
+	Dec -19.85938524
+	Distance 104.846
+	SpectralType "DC9"
+	Temperature 4522
+	AppMag 18.248 # synthetic
+	Radius 11363
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20771-7/LP%20771-7.html"
+}
+
+"GJ 1052:EGGR 565:WD 0243-026:WDJ024630.80-022723.46"
+{
+	RA 41.62932834
+	Dec -2.45869583
+	Distance 69.964
+	SpectralType "DAZ7"
+	Temperature 6731
+	AppMag 15.53
+	Radius 8128
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201052/GJ%201052.html"
+}
+
+"GJ 3182:EGGR 473:WD 0245+541:WDJ024836.43+542322.46"
+{
+	RA 42.1485551
+	Dec 54.38786114
+	Distance 35.422
+	SpectralType "DAZ9"
+	Temperature 5056
+	AppMag 15.34
+	Radius 9291
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203182/GJ%203182.html"
+}
+
+"2MASS J02494417+3307251:WD 0246+329:WDJ024944.20+330725.66"
+{
+	RA 42.43512544
+	Dec 33.12495323
+	Distance 116.356
+	SpectralType "DA9"
+	Temperature 5690
+	AppMag 17.179 # synthetic
+	Radius 9145
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J02494417+3307251/2MASS%20J02494417+3307251.html"
+}
+
+"Gaia DR2 20484382662003968:WDJ025007.11+081753.42"
+{
+	RA 42.53054337
+	Dec 8.29630451
+	Distance 123.801
+	SpectralType "DC9"
+	Temperature 4796
+	AppMag 18.318 # synthetic
+	Radius 10601
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2020484382662003968/Gaia%20DR2%2020484382662003968.html"
+}
+
+"Gaia DR2 5077717389114829056:WDJ025017.18-224130.53"
+{
+	RA 42.57195406
+	Dec -22.69118318
+	Distance 116.769
+	SpectralType "DA9"
+	Temperature 5644
+	AppMag 17.586 # synthetic
+	Radius 7651
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205077717389114829056/Gaia%20DR2%205077717389114829056.html"
+}
+
+"WD 0253-755:WDJ025245.61-752244.56"
+{
+	RA 43.19806261
+	Dec -75.37803218
+	Distance 101.651
+	SpectralType "DAH8"
+	Temperature 6204
+	AppMag 16.7
+	Radius 7989
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200253-755/WD%200253-755.html"
+}
+
+"Gaia DR2 143076256963396480:WDJ025328.32+375959.38"
+{
+	RA 43.36809786
+	Dec 37.99924599
+	Distance 120.673
+	SpectralType "DA8"
+	Temperature 6572
+	AppMag 16.567 # synthetic
+	Radius 9101
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20143076256963396480/Gaia%20DR2%20143076256963396480.html"
+}
+
+"Gaia DR2 4696032750850438272:WDJ025332.00-654559.93"
+{
+	RA 43.38328906
+	Dec -65.76629051
+	Distance 120.715
+	SpectralType "DA9"
+	Temperature 5508
+	AppMag 17.308 # synthetic
+	Radius 9902
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204696032750850438272/Gaia%20DR2%204696032750850438272.html"
+}
+
+"LP 154-64:WD 0252+497:WDJ025617.20+495441.87"
+{
+	RA 44.07186084
+	Dec 49.91079916
+	Distance 122.915
+	SpectralType "DA8"
+	Temperature 5970
+	AppMag 17.1
+	Radius 8108
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20154-64/LP%20154-64.html"
+}
+
+"GJ 2028:LAWD 13:WD 0255-705:WDJ025617.22-702210.85"
+{
+	RA 44.08041107
+	Dec -70.37018023
+	Distance 82.231
+	SpectralType "DA5"
+	Temperature 10339
+	AppMag 14.07
+	Radius 8938
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2013/LAWD%2013.html"
+}
+
+"Gaia DR2 5065010887285008128:WDJ025759.87-302709.99"
+{
+	RA 44.49846946
+	Dec -30.45334883
+	Distance 125.56
+	SpectralType "DA8"
+	Temperature 6173
+	AppMag 16.899
+	Radius 8983
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205065010887285008128/Gaia%20DR2%205065010887285008128.html"
+}
+
+"EGGR 476:WD 0257+080:WDJ025959.15+081156.43"
+{
+	RA 44.99859717
+	Dec 8.19867282
+	Distance 96.02
+	SpectralType "DAH8"
+	Temperature 6528
+	AppMag 15.9
+	Radius 9965
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20476/EGGR%20476.html"
+}
+
+"Gaia DR2 4618550411255512448:WDJ030154.44-831446.19"
+{
+	RA 45.47055629
+	Dec -83.24626742
+	Distance 108.992
+	SpectralType "DA7"
+	Temperature 6813
+	AppMag 16.242 # synthetic
+	Radius 8942
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204618550411255512448/Gaia%20DR2%204618550411255512448.html"
+}
+
+# Companion to WDJ030350.56+060748.75
+14258
+{
+	RA 45.96276665
+	Dec 6.13352285
+	Distance 101.91 # mean of system components
+	SpectralType "G0V"
+	Temperature 6043 # GSP-Spec
+	AppMag 6.926
+	Radius 740535 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+19019"
+}
+
+"Gaia DR2 6963383233077632:WDJ030350.56+060748.75"
+{
+	RA 45.96170003
+	Dec 6.13044908
+	Distance 101.91 # mean of system components
+	SpectralType "DXP3"
+	Temperature 16018
+	AppMag 14.993 # estimate
+	Radius 4992
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206963383233077632/Gaia%20DR2%206963383233077632.html"
+}
+
+"Gaia DR2 4626680917489564160:WDJ030407.15-782454.62"
+{
+	RA 46.03114869
+	Dec -78.41503062
+	Distance 129.784
+	SpectralType "DA9"
+	Temperature 5430
+	AppMag 17.605 # synthetic
+	Radius 9697
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204626680917489564160/Gaia%20DR2%204626680917489564160.html"
+}
+
+"GD 426:EGGR 414:WD 0302+621:WDJ030616.69+622222.45"
+{
+	RA 46.57012388
+	Dec 62.37240434
+	Distance 124.187
+	SpectralType "DA5"
+	Temperature 11033
+	AppMag 14.95
+	Radius 8207
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20426/GD%20426.html"
+}
+
+"WD 0304-074:WDJ030713.90-071506.24"
+{
+	RA 46.80706049
+	Dec -7.25373798
+	Distance 99.104
+	SpectralType "DA9"
+	Temperature 5655
+	AppMag 17.35
+	Radius 7077
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200304-074/WD%200304-074.html"
+}
+
+"Gaia DR2 439905192004402304:WDJ030850.43+512822.32"
+{
+	RA 47.21087454
+	Dec 51.47208012
+	Distance 119.757
+	SpectralType "DA9"
+	Temperature 5304
+	AppMag 17.709 # synthetic
+	Radius 9181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20439905192004402304/Gaia%20DR2%20439905192004402304.html"
+}
+
+14754 "Gliese 127.1:CPD-69 177:EGGR 21:WD 0310-688:WDJ031031.02-683603.38"
+{
+	RA 47.62973152
+	Dec -68.60139794
+	Distance 33.897
+	SpectralType "DA3"
+	Temperature 15866
+	AppMag 11.38
+	Radius 8565
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/CPD-69%20177/CPD-69%20177.html"
+}
+
+"2MASS J03105758+6634022:WDJ031057.60+663402.63"
+{
+	RA 47.74766319
+	Dec 66.5654627
+	Distance 125.036
+	SpectralType "DC9"
+	Temperature 4857
+	AppMag 18.185 # synthetic
+	Radius 10915
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J03105758+6634022/2MASS%20J03105758+6634022.html"
+}
+
+"Gaia DR2 5167424240722533760:WDJ031124.57-085324.98"
+{
+	RA 47.85258982
+	Dec -8.89046213
+	Distance 126.835
+	SpectralType "DA9"
+	Temperature 5205
+	AppMag 17.851 # synthetic
+	Radius 9815
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205167424240722533760/Gaia%20DR2%205167424240722533760.html"
+}
+
+"Gaia DR2 5181816233750415488:WDJ031138.80-055117.55"
+{
+	RA 47.91361737
+	Dec -5.85456668
+	Distance 103.193
+	SpectralType "DC9"
+	Temperature 4168
+	AppMag 18.72
+	Radius 12110
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205181816233750415488/Gaia%20DR2%205181816233750415488.html"
+}
+
+"WD 0311-649:WDJ031225.70-644410.89"
+{
+	RA 48.10888271
+	Dec -64.73653036
+	Distance 119.218
+	SpectralType "DA4"
+	Temperature 12063
+	AppMag 13.28
+	Radius 15836
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200311-649/WD%200311-649.html"
+}
+
+"Gaia DR2 4733604373137759616:WDJ031318.66-560734.99"
+{
+	RA 48.32699815
+	Dec -56.12763422
+	Distance 113.512
+	SpectralType "DA5"
+	Temperature 10988
+	AppMag 14.596
+	Radius 8985
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204733604373137759616/Gaia%20DR2%204733604373137759616.html"
+}
+
+"Gaia DR2 4850844228558819584:WDJ031330.78-424243.22"
+{
+	RA 48.37872853
+	Dec -42.71244196
+	Distance 126.599
+	SpectralType "DC9"
+	Temperature 5111
+	AppMag 18.013 # synthetic
+	Radius 9562
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204850844228558819584/Gaia%20DR2%204850844228558819584.html"
+}
+
+"WD 0313-084:WDJ031613.91-081637.52"
+{
+	RA 49.0583753
+	Dec -8.27752553
+	Distance 102.33
+	SpectralType "DA8"
+	Temperature 6369
+	AppMag 16.827 # synthetic
+	Radius 7223
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200313-084/WD%200313-084.html"
+}
+
+"GD 44:WD 0313+393:WDJ031642.12+393222.85"
+{
+	RA 49.17598833
+	Dec 39.53895817
+	Distance 123.331
+	SpectralType "DC6"
+	Temperature 8749
+	AppMag 15.816 # synthetic
+	Radius 8350
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2044/GD%2044.html"
+}
+
+"Gaia DR2 4620280217923548800:WDJ031646.48-801446.19"
+{
+	RA 49.19887223
+	Dec -80.24511707
+	Distance 116.249
+	SpectralType "DA7"
+	Temperature 7356
+	AppMag 16.029
+	Radius 9151
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204620280217923548800/Gaia%20DR2%204620280217923548800.html"
+}
+
+"WD 0315-293:WDJ031712.10-291134.21"
+{
+	RA 49.30129614
+	Dec -29.19492305
+	Distance 102.613
+	SpectralType "DAZH9"
+	Temperature 5419
+	AppMag 17.49
+	Radius 8178
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200315-293/WD%200315-293.html"
+}
+
+"CL Oct:WD 0325-857:WDJ031715.85-853225.56"
+{
+	RA 49.31180923
+	Dec -85.54048624
+	Distance 95.781 # mean of system components
+	SpectralType "DAH2"
+	Temperature 26465
+	AppMag 13.66
+	Radius 3364
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20CL%20Oct/V*%20CL%20Oct.html"
+}
+
+"Gaia DR2 4613612951211823616:WDJ031719.13-853231.29"
+{
+	RA 49.32616908
+	Dec -85.54212396
+	Distance 95.781 # mean of system components
+	SpectralType "DA3"
+	Temperature 16534
+	AppMag 13.66
+	Radius 6862
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204613612951211823616/Gaia%20DR2%204613612951211823616.html"
+}
+
+"Gaia DR2 239721228805415296:WDJ031907.61+423045.45"
+{
+	RA 49.78155252
+	Dec 42.51219677
+	Distance 99.603
+	SpectralType "DBA5"
+	Temperature 10965
+	AppMag 14.79
+	Radius 7579
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20239721228805415296/Gaia%20DR2%20239721228805415296.html"
+}
+
+"PM J03196+3630:WDJ031938.27+363029.67"
+{
+	RA 49.91004801
+	Dec 36.50830888
+	Distance 104.546
+	SpectralType "DZ7"
+	Temperature 6830
+	AppMag 16.366 # synthetic
+	Radius 7324
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J03196+3630/PM%20J03196+3630.html"
+}
+
+"LP 355-59:WDJ032020.30+233331.72"
+{
+	RA 50.08489005
+	Dec 23.55718144
+	Distance 129.665
+	SpectralType "DC9"
+	Temperature 4690
+	AppMag 17.92 # synthetic
+	Radius 18113
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20355-59/LP%20355-59.html"
+}
+
+"GJ 3223:EGGR 566:WD 0322-019:WDJ032511.05-014915.05"
+{
+	RA 51.29708001
+	Dec -1.82470818
+	Distance 55.183
+	SpectralType "DAZH9"
+	Temperature 5248
+	AppMag 16.13
+	Radius 8943
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203223/GJ%203223.html"
+}
+
+"Gaia DR2 54253618862057728:WDJ032631.46+155714.79"
+{
+	RA 51.63193424
+	Dec 15.954749
+	Distance 125.789
+	SpectralType "DA9"
+	Temperature 5687
+	AppMag 17.594 # synthetic
+	Radius 8044
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2054253618862057728/Gaia%20DR2%2054253618862057728.html"
+}
+
+"Gaia DR2 4723118914857785472:WDJ032646.69-592700.23"
+{
+	RA 51.6956426
+	Dec -59.45027176
+	Distance 101.416
+	SpectralType "DA8"
+	Temperature 6333
+	AppMag 17.079 # synthetic
+	Radius 6486
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204723118914857785472/Gaia%20DR2%204723118914857785472.html"
+}
+
+# Companion to WDJ032848.80-271900.09
+"GJ 1060 B:LP 888-63"
+{
+	RA 52.20552062
+	Dec -27.31622241
+	Distance 74.966 # mean of system components
+	SpectralType "M3/4"
+	AppMag 13.8
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+888-63"
+}
+
+"GJ 1060 A:EGGR 22:LAWD 14:WD 0326-273:WDJ032848.80-271900.09"
+{
+	RA 52.20693584
+	Dec -27.31502225
+	Distance 74.966 # mean of system components
+	SpectralType "DA6"
+	Temperature 8605
+	AppMag 13.77
+	Radius 13416
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201060%20A/GJ%201060%20A.html"
+}
+
+"Gaia DR2 5053839127592396032:WDJ032850.79-323830.99"
+{
+	RA 52.21247084
+	Dec -32.64033913
+	Distance 100.352
+	SpectralType "DC9"
+	Temperature 4832
+	AppMag 17.654
+	Radius 11529
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205053839127592396032/Gaia%20DR2%205053839127592396032.html"
+}
+
+"WD 0330-000:WDJ033320.37+000720.65"
+{
+	RA 53.3352625
+	Dec 0.12236431
+	Distance 115.498
+	SpectralType "DAH7"
+	Temperature 7546
+	AppMag 16.46 # synthetic
+	Radius 7084
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200330-000/WD%200330-000.html"
+}
+
+"LP 832-30:WDJ033634.09-221524.08"
+{
+	RA 54.14316997
+	Dec -22.25767705
+	Distance 125.325
+	SpectralType "DAZH9"
+	Temperature 5913
+	AppMag 17.16
+	Radius 8968
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20832-30/LP%20832-30.html"
+}
+
+"Gaia DR2 4860061541910268160:WDJ034010.17-361038.22"
+{
+	RA 55.04572091
+	Dec -36.17740982
+	Distance 112.032
+	SpectralType "DA9"
+	Temperature 5642
+	AppMag 16.95
+	Radius 9978
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204860061541910268160/Gaia%20DR2%204860061541910268160.html"
+}
+
+"2MASS J03432310+1958133:WDJ034323.12+195813.60"
+{
+	RA 55.84669517
+	Dec 19.9711639
+	Distance 67.643
+	SpectralType "DA7"
+	Temperature 7117
+	AppMag 15.717 # synthetic
+	Radius 6497
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J03432310+1958133/2MASS%20J03432310+1958133.html"
+}
+
+"Gaia DR2 4829340465475546880:LAWD 16:WDJ034347.42-512516.55"
+{
+	RA 55.94742664
+	Dec -51.42300478
+	Distance 90.943
+	SpectralType "DAZ7"
+	Temperature 6742
+	AppMag 15.884
+	Radius 8789
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204829340465475546880/Gaia%20DR2%204829340465475546880.html"
+}
+
+"Gliese 151:Wolf 219:EGGR 24:LAWD 15:WD 0341+182:WDJ034434.85+182609.82"
+{
+	RA 56.14712981
+	Dec 18.43104008
+	Distance 61.53
+	SpectralType "DQ7"
+	Temperature 6837
+	AppMag 15.19
+	Radius 8204
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%20219/Wolf%20219.html"
+}
+
+"Gaia DR2 3249479592234269056:WDJ034501.53-034849.73"
+{
+	RA 56.2563468
+	Dec -3.81499032
+	Distance 101.226 # mean of system components
+	SpectralType "DC9"
+	Temperature 4563
+	AppMag 18.133 # synthetic
+	Radius 10974
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203249479592234269056/Gaia%20DR2%203249479592234269056.html"
+}
+
+"Gaia DR2 3249479592235301376:WDJ034501.70-034844.85"
+{
+	RA 56.25697173
+	Dec -3.81362701
+	Distance 101.226 # mean of system components
+	SpectralType "DA9"
+	Temperature 5118
+	AppMag 17.404 # synthetic
+	Radius 10237
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203249479592235301376/Gaia%20DR2%203249479592235301376.html"
+}
+
+"Gaia DR2 63054590968017408:WDJ034511.83+194026.08"
+{
+	RA 56.30025387
+	Dec 19.67340041
+	Distance 92.049
+	SpectralType "DA4"
+	Temperature 12552
+	AppMag 14.174 # synthetic
+	Radius 7646
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2063054590968017408/Gaia%20DR2%2063054590968017408.html"
+}
+
+"WD 0343+247:WDJ034646.52+245602.67"
+{
+	RA 56.69636948
+	Dec 24.92892959
+	Distance 128.719
+	SpectralType "DC9"
+	Temperature 3640 # Table A5
+	AppMag 19.04
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200343+247/WD%200343+247.html"
+}
+
+"WD 0344+014:WDJ034706.83+013847.64"
+{
+	RA 56.77948004
+	Dec 1.64475407
+	Distance 65.739
+	SpectralType "DC9"
+	Temperature 5088
+	AppMag 16.51
+	Radius 10197
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200344+014/WD%200344+014.html"
+}
+
+"Wolf 226:WDJ034722.43+435857.18"
+{
+	RA 56.8424601
+	Dec 43.98288784
+	Distance 103.955
+	SpectralType "DA4"
+	Temperature 13661
+	AppMag 13.972 # synthetic
+	Radius 8987
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%20226/Wolf%20226.html"
+}
+
+"GD 50:EGGR 288:WD 0346-011:WDJ034850.19-005832.29"
+{
+	RA 57.20948437
+	Dec -0.9763604
+	Distance 101.126
+	SpectralType "DA1"
+	Temperature 39304
+	AppMag 13.99
+	Radius 3554
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2050/GD%2050.html"
+}
+
+"Gaia DR2 4667446586695129472:WDJ035005.27-685307.56"
+{
+	RA 57.52304847
+	Dec -68.88508334
+	Distance 108.521
+	SpectralType "DA9"
+	Temperature 5057
+	AppMag 17.549 # synthetic
+	Radius 10929
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204667446586695129472/Gaia%20DR2%204667446586695129472.html"
+}
+
+"HZ 4:EGGR 26:WD 0352+096:WDJ035521.99+094718.13"
+{
+	RA 58.84239878
+	Dec 9.78834608
+	Distance 113.923
+	SpectralType "DA3"
+	Temperature 14518
+	AppMag 14.47
+	Radius 7313
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HZ%204/HZ%204.html"
+}
+
+"Gaia DR2 4683172420470864256:WDJ035531.89-561128.32"
+{
+	RA 58.88400936
+	Dec -56.19011494
+	Distance 107.34
+	SpectralType "DAH9"
+	Temperature 5778
+	AppMag 17.09
+	Radius 7802
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204683172420470864256/Gaia%20DR2%204683172420470864256.html"
+}
+
+"Gaia DR2 244214799689691904:WDJ035556.50+452510.26"
+{
+	RA 58.98552861
+	Dec 45.41834621
+	Distance 102.556
+	SpectralType "DA9"
+	Temperature 5214
+	AppMag 17.394 # synthetic
+	Radius 9674
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20244214799689691904/Gaia%20DR2%20244214799689691904.html"
+}
+
+"Gaia DR2 53278867446391040:WDJ035826.49+215726.16"
+{
+	RA 59.61145708
+	Dec 21.95612213
+	Distance 117.765
+	SpectralType "DAZ7"
+	Temperature 6777
+	AppMag 16.758 # synthetic
+	Radius 7651
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2053278867446391040/Gaia%20DR2%2053278867446391040.html"
+}
+
+"GJ 3259:WD 0357+081:WDJ040026.68+081406.93"
+{
+	RA 60.10955103
+	Dec 8.23350576
+	Distance 60.585
+	SpectralType "DA9"
+	Temperature 5512
+	AppMag 15.887
+	Radius 9433
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203259/GJ%203259.html"
+}
+
+"2MASS J04010150+5131304:WD 0357+513:WDJ040101.51+513130.09"
+{
+	RA 60.25893092
+	Dec 51.52145494
+	Distance 81.809
+	SpectralType "DC9"
+	Temperature 5104
+	AppMag 17.336 # synthetic
+	Radius 8082
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J04010150+5131304/2MASS%20J04010150+5131304.html"
+}
+
+"Gaia DR2 39387328302768640:WDJ040242.39+152742.47"
+{
+	RA 60.67688405
+	Dec 15.46193205
+	Distance 120.285
+	SpectralType "DC7"
+	Temperature 6894
+	AppMag 16.726 # synthetic
+	Radius 7913
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%2039387328302768640/Gaia%20DR2%2039387328302768640.html"
+}
+
+"Gliese 159.1:HG 8-7:EGGR 28:WD 0401+250:WDJ040434.13+250851.68"
+{
+	RA 61.14286169
+	Dec 25.14672915
+	Distance 86.256
+	SpectralType "DA4"
+	Temperature 12319
+	AppMag 13.784 # synthetic
+	Radius 8722
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HG%208-7/HG%208-7.html"
+}
+
+"EGGR 30:LAWD 17:WD 0407+179:WDJ041010.32+180223.80"
+{
+	RA 62.543348
+	Dec 18.03956294
+	Distance 111.064
+	SpectralType "DA4"
+	Temperature 12987
+	AppMag 14.14
+	Radius 9026
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2030/EGGR%2030.html"
+}
+
+"EGGR 417:WD 0407+197:WDJ041017.34+195426.31"
+{
+	RA 62.57450425
+	Dec 19.90585194
+	Distance 94.977
+	SpectralType "DC9"
+	Temperature 5060
+	AppMag 17.71
+	Radius 8255
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20417/EGGR%20417.html"
+}
+
+"G 160-51:WDJ041226.33-111747.28"
+{
+	RA 63.11097623
+	Dec -11.29663183
+	Distance 114.387
+	SpectralType "DAH7"
+	Temperature 7474
+	AppMag 15.446
+	Radius 11378
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20160-51/G%20160-51.html"
+}
+
+"Gaia DR2 551153263105246208:WDJ041246.85+754942.26"
+{
+	RA 63.19263313
+	Dec 75.82852211
+	Distance 114.225
+	SpectralType "DA6"
+	Temperature 8598
+	AppMag 15.73
+	Radius 7413
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20551153263105246208/Gaia%20DR2%20551153263105246208.html"
+}
+
+"Gaia DR2 5090109228757394048:WDJ041359.12-212222.67"
+{
+	RA 63.49578201
+	Dec -21.37462751
+	Distance 116.936
+	SpectralType "DC9"
+	Temperature 4082 # MWDD
+	AppMag 17.98 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205090109228757394048/Gaia%20DR2%205090109228757394048.html"
+}
+
+# WDJ041521.80-073929.20: defined in nearstars.stc
+
+# WDJ041630.04-591757.19: defined in extrasolar.stc
+
+"NLTT 12934:WD 0414+420:WDJ041805.54+421102.19"
+{
+	RA 64.52281719
+	Dec 42.18300213
+	Distance 96.659
+	SpectralType "DA9"
+	Temperature 5174
+	AppMag 17.06
+	Radius 10322
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2012934/NLTT%2012934.html"
+}
+
+"Gaia DR2 4782553840532147840:WDJ041823.34-500424.14"
+{
+	RA 64.599032
+	Dec -50.07644153
+	Distance 77.747
+	SpectralType "DC9"
+	Temperature 4826
+	AppMag 17.516
+	Radius 8704
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204782553840532147840/Gaia%20DR2%204782553840532147840.html"
+}
+
+"LP 714-52:WDJ041921.11-093429.44"
+{
+	RA 64.83727612
+	Dec -9.57522662
+	Distance 119.478
+	SpectralType "DAP8"
+	Temperature 5978
+	AppMag 17.417
+	Radius 7072
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20714-52/LP%20714-52.html"
+}
+
+"Gaia DR2 4885878590326674560:WDJ042021.33-293426.26"
+{
+	RA 65.08929315
+	Dec -29.57389239
+	Distance 101.306
+	SpectralType "DAH8"
+	Temperature 6423
+	AppMag 16.37 # synthetic
+	Radius 8725
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204885878590326674560/Gaia%20DR2%204885878590326674560.html"
+}
+
+"Gaia DR2 232990572675079296:WDJ042129.35+460757.74"
+{
+	RA 65.37272483
+	Dec 46.1322548
+	Distance 86.546
+	SpectralType "DA6"
+	Temperature 7813
+	AppMag 15.17
+	Radius 8907
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20232990572675079296/Gaia%20DR2%20232990572675079296.html"
+}
+
+"Gaia DR2 470639806179201792:WDJ042313.75+574526.76"
+{
+	RA 65.80689143
+	Dec 57.7563985
+	Distance 121.705
+	SpectralType "DC7"
+	Temperature 7140
+	AppMag 16.653 # synthetic
+	Radius 7758
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20470639806179201792/Gaia%20DR2%20470639806179201792.html"
+}
+
+"WD 0422-459:WDJ042357.67-455042.27"
+{
+	RA 65.98967568
+	Dec -45.84736421
+	Distance 97.589
+	SpectralType "DA9"
+	Temperature 5590
+	AppMag 16.85
+	Radius 9304
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200422-459/WD%200422-459.html"
+}
+
+"GJ 3285:EGGR 169:WD 0423+120:WDJ042553.73+121148.34"
+{
+	RA 66.47344955
+	Dec 12.19571843
+	Distance 52.234
+	SpectralType "DC8"
+	Temperature 6153
+	AppMag 15.42
+	Radius 7580
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203285/GJ%203285.html"
+}
+
+"2MASS J04255699+4614177:WDJ042556.87+461419.44"
+{
+	RA 66.48805053
+	Dec 46.23838726
+	Distance 122.529
+	SpectralType "DC9"
+	Temperature 4610
+	AppMag 18.932 # synthetic
+	Radius 8099
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J04255699+4614177/2MASS%20J04255699+4614177.html"
+}
+
+"GJ 3288:EGGR 482:WD 0423+044:WDJ042620.70+043230.62"
+{
+	RA 66.58906104
+	Dec 4.53930495
+	Distance 69.28
+	SpectralType "DA9"
+	Temperature 4972
+	AppMag 17.14
+	Radius 8386
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203288/GJ%203288.html"
+}
+
+"Gaia DR2 4839901583898106496:WDJ042643.98-415341.44"
+{
+	RA 66.68471937
+	Dec -41.89509306
+	Distance 112.156
+	SpectralType "DAZ8"
+	Temperature 6127
+	AppMag 16.942
+	Radius 8145
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204839901583898106496/Gaia%20DR2%204839901583898106496.html"
+}
+
+"Gaia DR2 3198881613315343872:WDJ042731.73-070802.80"
+{
+	RA 66.88293367
+	Dec -7.13393255
+	Distance 129.443
+	SpectralType "DC8"
+	Temperature 6717
+	AppMag 16.842 # synthetic
+	Radius 8535
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203198881613315343872/Gaia%20DR2%203198881613315343872.html"
+}
+
+"HE 0426-0455:WD 0426-049:WDJ042926.24-044845.62"
+{
+	RA 67.35906162
+	Dec -4.81239956
+	Distance 128.093
+	SpectralType "DA4"
+	Temperature 14101
+	AppMag 14.45
+	Radius 8641
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HE%200426-0455/HE%200426-0455.html"
+}
+
+# WDJ043112.57+585841.29: defined in nearstars.stc
+
+"LP 775-28:WDJ043200.36-192049.90"
+{
+	RA 68.00167505
+	Dec -19.34834634
+	Distance 110.619
+	SpectralType "DA9"
+	Temperature 5746
+	AppMag 16.97
+	Radius 8821
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20775-28/LP%20775-28.html"
+}
+
+# Companion to WDJ043236.01-390214.13
+21185 "L 447-10"
+{
+	RA 68.15633877
+	Dec -39.0310643
+	Distance 108.757 # mean of system components
+	SpectralType "K6VI"
+	Temperature 3913 # GSP-Phot
+	AppMag 11.66
+	Radius 324646 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+447-10"
+}
+
+"WD 0430-391:WDJ043236.01-390214.13"
+{
+	RA 68.1540521
+	Dec -39.03405483
+	Distance 108.757 # mean of system components
+	SpectralType "DC9"
+	Temperature 4914
+	AppMag 17.66
+	Radius 11042
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200430-391/WD%200430-391.html"
+}
+
+"2MASS J04325585-3557289:WD 0431-360:WDJ043255.87-355729.04"
+{
+	RA 68.23443472
+	Dec -35.95788434
+	Distance 85.722
+	SpectralType "DA9"
+	Temperature 5102
+	AppMag 17.03
+	Radius 10361
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J04325585-3557289/2MASS%20J04325585-3557289.html"
+}
+
+"2MASS J04332980+0414477:WDJ043329.80+041447.85"
+{
+	RA 68.37458021
+	Dec 4.24460693
+	Distance 79.157
+	SpectralType "DA9"
+	Temperature 5069
+	AppMag 17.15 # synthetic
+	Radius 9060
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J04332980+0414477/2MASS%20J04332980+0414477.html"
+}
+
+"LP 890-39:WD 0431-279:WDJ043333.60-275324.86"
+{
+	RA 68.39195604
+	Dec -27.89026691
+	Distance 75.725
+	SpectralType "DA9"
+	Temperature 5205
+	AppMag 16.8
+	Radius 9213
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20890-39/LP%20890-39.html"
+}
+
+"NLTT 13519:WD 0431+308:WDJ043420.54+305422.35"
+{
+	RA 68.58534187
+	Dec 30.90494264
+	Distance 111.053
+	SpectralType "DC9"
+	Temperature 4895
+	AppMag 18.115 # synthetic
+	Radius 9247
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2013519/NLTT%2013519.html"
+}
+
+"Gaia DR2 4677461862018523776:WDJ043537.44-610540.10"
+{
+	RA 68.90981257
+	Dec -61.09338784
+	Distance 82.275
+	SpectralType "DC9"
+	Temperature 4861
+	AppMag 17.328
+	Radius 10315
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204677461862018523776/Gaia%20DR2%204677461862018523776.html"
+}
+
+# Companion to WDJ043644.90+270951.52
+21482 "V833 Tau:Gliese 171.2 A"
+{
+	RA 69.20216846
+	Dec 27.13153568
+	Distance 56.706 # mean of system components
+	SpectralType "K2.5Ve"
+	Temperature 4025 # GSP-Spec
+	AppMag 8.1
+	Radius 765904 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+283750"
+}
+
+"Gliese 171.2 B:HD 283750 B:EGGR 40:WD 0433+270:WDJ043644.90+270951.52"
+{
+	RA 69.18820274
+	Dec 27.16365247
+	Distance 56.706 # mean of system components
+	SpectralType "DA9"
+	Temperature 5571
+	AppMag 15.79
+	Radius 8862
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HD%20283750B/HD%20283750B.html"
+}
+
+"GJ 3306:EGGR 41:WD 0435-088:WDJ043747.41-084910.62"
+{
+	RA 69.44860244
+	Dec -8.82651622
+	Distance 30.658
+	SpectralType "DQ8"
+	Temperature 6601
+	AppMag 13.75
+	Radius 8452
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203306/GJ%203306.html"
+}
+
+"EGGR 419:WD 0437+093:WDJ044028.48+092347.21"
+{
+	RA 70.1184542
+	Dec 9.39314876
+	Distance 106.156
+	SpectralType "DA8"
+	Temperature 6279
+	AppMag 16.96
+	Radius 7305
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20419/EGGR%20419.html"
+}
+
+"LP 775-37:WDJ044105.03-151903.44"
+{
+	RA 70.27146857
+	Dec -15.3169488
+	Distance 120.784
+	SpectralType "DA8"
+	Temperature 5964
+	AppMag 16.83
+	Radius 8842
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20775-37/LP%20775-37.html"
+}
+
+"Gaia DR2 4815192671404177280:WDJ044538.42-423255.05"
+{
+	RA 71.40848439
+	Dec -42.54705101
+	Distance 89.031
+	SpectralType "DAZ7"
+	Temperature 6748
+	AppMag 15.826
+	Radius 9016
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204815192671404177280/Gaia%20DR2%204815192671404177280.html"
+}
+
+"Gaia DR2 4893995356962398208:WDJ044903.21-241239.20"
+{
+	RA 72.26441455
+	Dec -24.21062435
+	Distance 96.755
+	SpectralType "DA9"
+	Temperature 5002
+	AppMag 17.53
+	Radius 9696
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204893995356962398208/Gaia%20DR2%204893995356962398208.html"
+}
+
+"2MASS J04555136+3840505:WD 0452+386:WDJ045551.43+384050.90"
+{
+	RA 73.96547641
+	Dec 38.68056477
+	Distance 105.132
+	SpectralType "DA9"
+	Temperature 5160
+	AppMag 17.631 # synthetic
+	Radius 9091
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J04555136+3840505/2MASS%20J04555136+3840505.html"
+}
+
+"GD 64:EGGR 209:WD 0453+418:WDJ045722.54+415556.48"
+{
+	RA 74.34402676
+	Dec 41.9314069
+	Distance 124.147
+	SpectralType "DA4"
+	Temperature 14268
+	AppMag 13.976
+	Radius 10368
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2064/GD%2064.html"
+}
+
+"WD 0457-004:WDJ045943.21-002238.86"
+{
+	RA 74.93084674
+	Dec -0.37847826
+	Distance 80.513
+	SpectralType "DA5"
+	Temperature 11090
+	AppMag 15.3
+	Radius 4837
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200457-004/WD%200457-004.html"
+}
+
+"WD 0501-555:WDJ050243.44-552635.24"
+{
+	RA 75.68050512
+	Dec -55.44428135
+	Distance 129.893
+	SpectralType "DC7"
+	Temperature 7451
+	AppMag 16.35
+	Radius 8790
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200501-555/WD%200501-555.html"
+}
+
+"LP 776-52:WDJ050532.42-173137.28"
+{
+	RA 76.38464292
+	Dec -17.52830166
+	Distance 125.286
+	SpectralType "DA8"
+	Temperature 6124
+	AppMag 17.194
+	Radius 7929
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20776-52/LP%20776-52.html"
+}
+
+"GJ 3329:WD 0503-174:WDJ050552.46-172243.48"
+{
+	RA 76.46937187
+	Dec -17.37579539
+	Distance 63.062
+	SpectralType "DAH9"
+	Temperature 5418
+	AppMag 15.97
+	Radius 9964
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203329/GJ%203329.html"
+}
+
+"Gaia DR2 283928743068277376:WDJ050600.41+590326.89"
+{
+	RA 76.50184482
+	Dec 59.05593017
+	Distance 117.582
+	SpectralType "DC"
+	AppMag 19.662 # estimate
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20283928743068277376/Gaia%20DR2%20283928743068277376.html"
+}
+
+"WD 0503+147:WDJ050615.82+144830.29"
+{
+	RA 76.56591488
+	Dec 14.80805117
+	Distance 125.647
+	SpectralType "DBA3"
+	Temperature 15237
+	AppMag 13.8
+	Radius 9040
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200503+147/WD%200503+147.html"
+}
+
+"LP 717-1:WDJ050818.91-145023.81"
+{
+	RA 77.07983665
+	Dec -14.8421481
+	Distance 112.952
+	SpectralType "DQ9"
+	Temperature 5472
+	AppMag 17.303 # synthetic
+	Radius 9407
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20717-1/LP%20717-1.html"
+}
+
+"LP 777-3:WDJ050836.43-152312.42"
+{
+	RA 77.15276531
+	Dec -15.38419909
+	Distance 122.031
+	SpectralType "DA9"
+	Temperature 5251
+	AppMag 17.717
+	Radius 9034
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20777-3/LP%20777-3.html"
+}
+
+"GJ 3339:EGGR 524:WD 0511+079:WDJ051403.50+080015.12"
+{
+	RA 78.51360511
+	Dec 8.00284424
+	Distance 69.945
+	SpectralType "DA8"
+	Temperature 6534
+	AppMag 15.87
+	Radius 7235
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203339/GJ%203339.html"
+}
+
+"Gaia DR2 261664427174056320:GD 289:WDJ051530.10+502141.72"
+{
+	RA 78.87440422
+	Dec 50.3608294
+	Distance 125.468
+	SpectralType "DA5"
+	Temperature 9584
+	AppMag 15.2
+	Radius 9003
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20261664427174056320/Gaia%20DR2%20261664427174056320.html"
+}
+
+"2MASS J05155350+2839169:WDJ051553.54+283916.81"
+{
+	RA 78.97396899
+	Dec 28.65421437
+	Distance 97.895
+	SpectralType "DAH8"
+	Temperature 6411
+	AppMag 16.521 # synthetic
+	Radius 7858
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J05155350+2839169/2MASS%20J05155350+2839169.html"
+}
+
+"Gaia DR2 4652123895783242112:WDJ051942.85-701401.50"
+{
+	RA 79.9276158
+	Dec -70.23248711
+	Distance 129.17
+	SpectralType "DC9"
+	Temperature 4741
+	AppMag 18.774
+	Radius 11815
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204652123895783242112/Gaia%20DR2%204652123895783242112.html"
+}
+
+"Gaia DR2 3209308900555979776:WDJ052436.27-053510.52"
+{
+	RA 81.1510733
+	Dec -5.58689903
+	Distance 116.439
+	SpectralType "DA3"
+	Temperature 17080
+	AppMag 13.89
+	Radius 8992
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203209308900555979776/Gaia%20DR2%203209308900555979776.html"
+}
+
+"2MASS J05265609+4435395:WDJ052656.11+443538.77"
+{
+	RA 81.73537138
+	Dec 44.59244444
+	Distance 126.733
+	SpectralType "DC9"
+	Temperature 4849
+	AppMag 18.244 # synthetic
+	Radius 10648
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J05265609+4435395/2MASS%20J05265609+4435395.html"
+}
+
+"Gaia DR2 4805691447831511680:WDJ052844.01-430449.21"
+{
+	RA 82.18385443
+	Dec -43.0805018
+	Distance 124.847
+	SpectralType "DA5"
+	Temperature 10537
+	AppMag 16.09
+	Radius 5303
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204805691447831511680/Gaia%20DR2%204805691447831511680.html"
+}
+
+"Gaia DR2 195470288131984128:WDJ052913.45+430025.89"
+{
+	RA 82.30621387
+	Dec 43.00671351
+	Distance 116.963
+	SpectralType "DQ6"
+	Temperature 8952
+	AppMag 15.36
+	Radius 8409
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20195470288131984128/Gaia%20DR2%20195470288131984128.html"
+}
+
+"WD 0525+526:WDJ052950.25+523953.39"
+{
+	RA 82.46206054
+	Dec 52.66239551
+	Distance 127.473
+	SpectralType "DA2"
+	Temperature 21184
+	AppMag 15.649 # synthetic
+	Radius 3599
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200525+526/WD%200525+526.html"
+}
+
+"Gaia DR2 190802650815160960:WDJ053026.01+393917.04"
+{
+	RA 82.60811631
+	Dec 39.65421647
+	Distance 110.302
+	SpectralType "DA9"
+	Temperature 5531
+	AppMag 17.181 # synthetic
+	Radius 9455
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20190802650815160960/Gaia%20DR2%20190802650815160960.html"
+}
+
+"Gaia DR2 4769136809374612992:WDJ053446.50-524150.29"
+{
+	RA 83.6947272
+	Dec -52.69685475
+	Distance 129.206
+	SpectralType "DA8"
+	Temperature 5965
+	AppMag 17.235 # synthetic
+	Radius 8494
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204769136809374612992/Gaia%20DR2%204769136809374612992.html"
+}
+
+"GJ 1082:GD 69:EGGR 319:WD 0532+414:WDJ053620.21+412955.62"
+{
+	RA 84.08341137
+	Dec 41.49894358
+	Distance 104.706
+	SpectralType "DA7"
+	Temperature 7399
+	AppMag 14.78
+	Radius 14856
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2069/GD%2069.html"
+}
+
+"Gaia DR2 481698110012697728:WDJ053714.90+675950.51"
+{
+	RA 84.31180685
+	Dec 67.99709129
+	Distance 114.156
+	SpectralType "DAH6"
+	Temperature 7783
+	AppMag 16.344 # synthetic
+	Radius 7037
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20481698110012697728/Gaia%20DR2%20481698110012697728.html"
+}
+
+# Companion to WDJ053916.45+435234.70
+"LP 203-55"
+{
+	RA 84.81643829
+	Dec 43.87800941
+	Distance 127.931 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3040 # GSP-Phot
+	AppMag 16.971 # synthetic
+	Radius 133667 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+203-55"
+}
+
+"Gaia DR2 197048460976343168:WDJ053916.45+435234.70"
+{
+	RA 84.81945048
+	Dec 43.87470038
+	Distance 127.931 # mean of system components
+	SpectralType "DC8"
+	Temperature 5950
+	AppMag 17.432 # synthetic
+	Radius 7841
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20197048460976343168/Gaia%20DR2%20197048460976343168.html"
+}
+
+"LSR J0541+3959:WDJ054103.86+395946.22"
+{
+	RA 85.26804479
+	Dec 39.99417283
+	Distance 118.473
+	SpectralType "DA9"
+	Temperature 5822
+	AppMag 17.429 # synthetic
+	Radius 7639
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSR%20J0541+3959/LSR%20J0541+3959.html"
+}
+
+"Gaia DR2 2967199704297025664:WDJ054249.69-190107.34"
+{
+	RA 85.70673859
+	Dec -19.01935646
+	Distance 99.349
+	SpectralType "DC6"
+	Temperature 8763
+	AppMag 15.536
+	Radius 7716
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202967199704297025664/Gaia%20DR2%202967199704297025664.html"
+}
+
+"LSPM J0543+3637:WDJ054307.37+363701.21"
+{
+	RA 85.77983857
+	Dec 36.61675181
+	Distance 72.445
+	SpectralType "DAZ8"
+	Temperature 6385
+	AppMag 15.679 # synthetic
+	Radius 8678
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J0543+3637/LSPM%20J0543+3637.html"
+}
+
+"WD 0541+260:WDJ054457.66+260300.14"
+{
+	RA 86.24520903
+	Dec 26.04386277
+	Distance 117.346
+	SpectralType "DC9"
+	Temperature 5059
+	AppMag 17.167 # synthetic
+	Radius 16596
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200541+260/WD%200541+260.html"
+}
+
+# Companion to WDJ054615.61+111558.70
+"LSPM J0546+1116"
+{
+	RA 86.57135779
+	Dec 11.2789506
+	Distance 119.051 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 16.229 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LSPM+J0546%2B1116"
+}
+
+"LSPM J0546+1115:WDJ054615.61+111558.70"
+{
+	RA 86.56448224
+	Dec 11.26561435
+	Distance 119.051 # mean of system components
+	SpectralType "DC9"
+	Temperature 5033
+	AppMag 17.933 # synthetic
+	Radius 9940
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J0546+1115/LSPM%20J0546+1115.html"
+}
+
+"Gaia DR2 3346603611845335424:WDJ054839.48+132551.76"
+{
+	RA 87.16540432
+	Dec 13.43002446
+	Distance 115.549
+	SpectralType "DC9"
+	Temperature 4282
+	AppMag 18.766 # synthetic
+	Radius 11283
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203346603611845335424/Gaia%20DR2%203346603611845335424.html"
+}
+
+"Gaia DR2 2914000658819492864:WDJ055118.71-260912.89"
+{
+	RA 87.82827685
+	Dec -26.15351385
+	Distance 128.889
+	SpectralType "DC9"
+	Temperature 5024
+	AppMag 17.464 # synthetic
+	Radius 15961
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202914000658819492864/Gaia%20DR2%202914000658819492864.html"
+}
+
+"GJ 1086:EGGR 248:WD 0548-001:WDJ055119.48-001021.11"
+{
+	RA 87.83167503
+	Dec -0.17152175
+	Distance 36.584
+	SpectralType "DQP8"
+	Temperature 6053
+	AppMag 14.6
+	Radius 8058
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201086/GJ%201086.html"
+}
+
+"Gaia DR2 3011223668834627328:WDJ055443.04-103521.34"
+{
+	RA 88.67903538
+	Dec -10.58994061
+	Distance 49.83
+	SpectralType "DZ8"
+	Temperature 6578
+	AppMag 14.96
+	Radius 7777
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203011223668834627328/Gaia%20DR2%203011223668834627328.html"
+}
+
+# WDJ055509.53-041007.07: defined in nearstars.stc
+
+# Companion to WDJ055543.03+465048.49
+"LP 159-33"
+{
+	RA 88.9324472
+	Dec 46.84707956
+	Distance 97.046 # mean of system components
+	SpectralType "M5"
+	Temperature 3135 # GSP-Phot
+	AppMag 15.508 # synthetic
+	Radius 160386 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+159-33"
+}
+
+"WD 0551+468:WDJ055543.03+465048.49"
+{
+	RA 88.9293957
+	Dec 46.84443796
+	Distance 97.046 # mean of system components
+	SpectralType "DA9"
+	Temperature 5222
+	AppMag 17.23
+	Radius 9940
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200551+468/WD%200551+468.html"
+}
+
+"Gaia DR2 3346787883122375680:WDJ055602.01+135446.71"
+{
+	RA 89.01004319
+	Dec 13.91082723
+	Distance 89.214
+	SpectralType "DA9"
+	Temperature 5132
+	AppMag 17.174 # synthetic
+	Radius 9880
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203346787883122375680/Gaia%20DR2%203346787883122375680.html"
+}
+
+"V1201 Ori:GJ 1087:EGGR 290:WD 0553+053:WDJ055625.46+052148.44"
+{
+	RA 89.10409822
+	Dec 5.35934471
+	Distance 26.465
+	SpectralType "DAH9"
+	Temperature 5741
+	AppMag 14.105
+	Radius 8031
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V1201%20Ori/V*%20V1201%20Ori.html"
+}
+
+"Gaia DR2 4650712810002383104:WDJ055802.46-722848.43"
+{
+	RA 89.51042589
+	Dec -72.47939985
+	Distance 126.791
+	SpectralType "DC8"
+	Temperature 6720
+	AppMag 17.209
+	Radius 7081
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204650712810002383104/Gaia%20DR2%204650712810002383104.html"
+}
+
+"Gaia DR2 4767805506952137600:WDJ055808.89-542804.68"
+{
+	RA 89.53915645
+	Dec -54.46746701
+	Distance 128.993
+	SpectralType "DA9"
+	Temperature 4988
+	AppMag 18.173 # synthetic
+	Radius 9995
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204767805506952137600/Gaia%20DR2%204767805506952137600.html"
+}
+
+"LP 659-7:WDJ055900.95-041426.99"
+{
+	RA 89.75392078
+	Dec -4.24192986
+	Distance 123.954
+	SpectralType "DA8"
+	Temperature 6136
+	AppMag 17.0
+	Radius 8243
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20659-7/LP%20659-7.html"
+}
+
+"WD 0559+15:WD 0559+158:WDJ060231.11+155304.77"
+{
+	RA 90.63094793
+	Dec 15.88405836
+	Distance 123.337
+	SpectralType "DA7"
+	Temperature 6980
+	AppMag 16.848 # synthetic
+	Radius 7318
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200559+15/WD%200559+15.html"
+}
+
+"2MASS J06023672+0904237:WD 0559+090:WDJ060236.71+090423.60"
+{
+	RA 90.6534224
+	Dec 9.07213032
+	Distance 121.442
+	SpectralType "DA8"
+	Temperature 5943
+	AppMag 16.994 # synthetic
+	Radius 9111
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06023672+0904237/2MASS%20J06023672+0904237.html"
+}
+
+"EGGR 421:WD 0600+735:WDJ060717.09+733159.70"
+{
+	RA 91.81489662
+	Dec 73.53062983
+	Distance 105.036
+	SpectralType "DA8"
+	Temperature 6522
+	AppMag 17.149 # synthetic
+	Radius 6110
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20421/EGGR%20421.html"
+}
+
+# Companion to WDJ061614.26-591227.41
+29788 "GJ 9209 A"
+{
+	RA 94.07788103
+	Dec -59.21490886
+	Distance 117.493 # mean of system components
+	SpectralType "F9.5V"
+	Temperature 6015 # GSP-Spec
+	AppMag 6.43
+	Radius 1076713 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+44120"
+}
+
+"GJ 9209 B:WD 0615-59:WD 0615-591:WDJ061614.26-591227.41"
+{
+	RA 94.05898346
+	Dec -59.209
+	Distance 117.493 # mean of system components
+	SpectralType "DB3"
+	Temperature 15349
+	AppMag 14.09
+	Radius 8960
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200615-59/WD%200615-59.html"
+}
+
+"WD 0622-801:WDJ061813.08-801155.22"
+{
+	RA 94.55365946
+	Dec -80.19720285
+	Distance 116.459
+	SpectralType "DA4"
+	Temperature 13397
+	AppMag 14.854
+	Radius 6741
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200622-801/WD%200622-801.html"
+}
+
+"Gaia DR2 1007682723024253184:WDJ061848.64+620425.54"
+{
+	RA 94.70204422
+	Dec 62.07334698
+	Distance 127.379
+	SpectralType "DC9"
+	Temperature 4905
+	AppMag 18.344 # synthetic
+	Radius 9580
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201007682723024253184/Gaia%20DR2%201007682723024253184.html"
+}
+
+# Companion to WDJ062006.01+420544.38
+"PM J06201+4205E"
+{
+	RA 95.03263974
+	Dec 42.09048015
+	Distance 122.24 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 12.972 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=PM+J06201%2B4205E"
+}
+
+"Gaia DR2 960039814744267520:WDJ062006.01+420544.38"
+{
+	RA 95.02563294
+	Dec 42.09527554
+	Distance 122.24 # mean of system components
+	SpectralType "DA8"
+	Temperature 6578
+	AppMag 17.124 # synthetic
+	Radius 7180
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20960039814744267520/Gaia%20DR2%20960039814744267520.html"
+}
+
+"GJ 3392:WD 0618+067:WDJ062047.75+064517.12"
+{
+	RA 95.20138055
+	Dec 6.75469609
+	Distance 78.308
+	SpectralType "DA9"
+	Temperature 5801
+	AppMag 16.37
+	Radius 8160
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203392/GJ%203392.html"
+}
+
+"2MASS J06214164-4016187:WD 0620-402:WDJ062141.64-401618.85"
+{
+	RA 95.42405109
+	Dec -40.27348493
+	Distance 77.181
+	SpectralType "DZ8"
+	Temperature 6151
+	AppMag 16.2
+	Radius 7731
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06214164-4016187/2MASS%20J06214164-4016187.html"
+}
+
+"Gaia DR2 2940238304793401472:WDJ062620.54-185006.83"
+{
+	RA 96.58626509
+	Dec -18.83495088
+	Distance 116.587
+	SpectralType "DAZ7"
+	Temperature 7302
+	AppMag 16.091 # synthetic
+	Radius 9055
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202940238304793401472/Gaia%20DR2%202940238304793401472.html"
+}
+
+# Companion to WDJ063038.60-020550.49
+"G 106-51"
+{
+	RA 97.66116818
+	Dec -2.09903298
+	Distance 69.638 # mean of system components
+	SpectralType "M3/4"
+	AppMag 14.69
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+106-51"
+}
+
+"WD 0628-020:WDJ063038.60-020550.49"
+{
+	RA 97.66032909
+	Dec -2.0981217
+	Distance 69.638 # mean of system components
+	SpectralType "DA7"
+	Temperature 6910 # Table A5
+	AppMag 15.36
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200628-020/WD%200628-020.html"
+}
+
+"2MASS J06322939+2230050:WDJ063229.37+223004.62"
+{
+	RA 98.12167986
+	Dec 22.50058371
+	Distance 121.258
+	SpectralType "DA9"
+	Temperature 5500
+	AppMag 17.453 # synthetic
+	Radius 9279
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06322939+2230050/2MASS%20J06322939+2230050.html"
+}
+
+"Gaia DR2 995112350178946048:WDJ063235.80+555903.12"
+{
+	RA 98.1494503
+	Dec 55.98379155
+	Distance 120.616
+	SpectralType "DAH5"
+	Temperature 9996
+	AppMag 15.859 # synthetic
+	Radius 6112
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20995112350178946048/Gaia%20DR2%20995112350178946048.html"
+}
+
+"WD 0632-285:WDJ063437.49-283420.88"
+{
+	RA 98.65819081
+	Dec -28.57388424
+	Distance 93.961
+	SpectralType "DC9"
+	Temperature 4066
+	AppMag 18.35
+	Radius 12882
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200632-285/WD%200632-285.html"
+}
+
+"WD 0632+40:WD 0632+409:WDJ063629.99+405428.14"
+{
+	RA 99.12447312
+	Dec 40.90684147
+	Distance 129.312
+	SpectralType "DA6"
+	Temperature 7826
+	AppMag 16.753 # synthetic
+	Radius 6580
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200632+40/WD%200632+40.html"
+}
+
+# Companion to WDJ063931.88+243546.15
+31850
+{
+	RA 99.88127245
+	Dec 24.60056734
+	Distance 117.12 # mean of system components
+	SpectralType "F8IV"
+	Temperature 6014 # GSP-Phot
+	AppMag 6.38
+	Radius 1101278 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+47415"
+}
+
+"Gaia DR2 3383000470383852672:WDJ063931.88+243546.15"
+{
+	RA 99.88290038
+	Dec 24.59653233
+	Distance 117.12 # mean of system components
+	SpectralType "DC5"
+	Temperature 9245
+	AppMag 15.582 # synthetic
+	Radius 8096
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203383000470383852672/Gaia%20DR2%203383000470383852672.html"
+}
+
+"Gaia DR2 3103811515783541504:WDJ064111.93-043212.31"
+{
+	RA 100.30304725
+	Dec -4.53450532
+	Distance 66.495
+	SpectralType "DC9"
+	Temperature 4292
+	AppMag 17.27
+	Radius 12053
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203103811515783541504/Gaia%20DR2%203103811515783541504.html"
+}
+
+"Gaia DR2 3326650224581677312:WDJ064400.61+092605.76"
+{
+	RA 101.00213566
+	Dec 9.43450926
+	Distance 97.939
+	SpectralType "DAH8"
+	Temperature 6171
+	AppMag 16.55 # synthetic
+	Radius 8367
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203326650224581677312/Gaia%20DR2%203326650224581677312.html"
+}
+
+"2MASS J06443019+2731115:WDJ064430.17+273111.39"
+{
+	RA 101.12498553
+	Dec 27.51963168
+	Distance 125.699
+	SpectralType "DA7"
+	Temperature 6833
+	AppMag 17.05 # synthetic
+	Radius 7068
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06443019+2731115/2MASS%20J06443019+2731115.html"
+}
+
+# WDJ064509.30-164300.72: defined in nearstars.stc
+
+"Gaia DR2 2925551818747071488:WDJ064604.27-224633.04"
+{
+	RA 101.5183261
+	Dec -22.77623328
+	Distance 104.226
+	SpectralType "DC9"
+	Temperature 4586
+	AppMag 18.075 # synthetic
+	Radius 11597
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202925551818747071488/Gaia%20DR2%202925551818747071488.html"
+}
+
+"GJ 3410:EGGR 484:WD 0644+025:WDJ064722.15+023108.91"
+{
+	RA 101.84046221
+	Dec 2.51925342
+	Distance 58.967
+	SpectralType "DA7"
+	Temperature 7109
+	AppMag 15.67
+	Radius 5744
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203410/GJ%203410.html"
+}
+
+32560 "Gliese 246:LAWD 23:EGGR 50:WD 0644+375:WDJ064737.99+373057.06"
+{
+	RA 101.90700343
+	Dec 37.51168282
+	Distance 55.668
+	SpectralType "DA2"
+	Temperature 21394
+	AppMag 12.06
+	Radius 8226
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2023/LAWD%2023.html"
+}
+
+"Gaia DR2 2926944659464115328:WDJ064806.66-205839.53"
+{
+	RA 102.02786563
+	Dec -20.97708241
+	Distance 88.173
+	SpectralType "DA9"
+	Temperature 5157
+	AppMag 17.095 # synthetic
+	Radius 9943
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202926944659464115328/Gaia%20DR2%202926944659464115328.html"
+}
+
+"Gaia DR2 1115546944012493696:WDJ064926.55+752124.97"
+{
+	RA 102.36225065
+	Dec 75.35687643
+	Distance 123.581
+	SpectralType "DAH8"
+	Temperature 6437
+	AppMag 17.047 # synthetic
+	Radius 7722
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201115546944012493696/Gaia%20DR2%201115546944012493696.html"
+}
+
+"2MASS J06503681+1657538:WD 0647+170:WDJ065036.81+165753.86"
+{
+	RA 102.6525065
+	Dec 16.96411819
+	Distance 95.162
+	SpectralType "DA9"
+	Temperature 5151
+	AppMag 17.421 # synthetic
+	Radius 9137
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06503681+1657538/2MASS%20J06503681+1657538.html"
+}
+
+"EGGR 342:WD 0648+641:WDJ065326.68+640342.05"
+{
+	RA 103.35982517
+	Dec 64.05990897
+	Distance 90.758 # mean of system components
+	SpectralType "DA9"
+	Temperature 5893
+	AppMag 16.65
+	Radius 8142
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20342/EGGR%20342.html"
+}
+
+"2MASS J06533021-3954292:WD 0651-398 A:WDJ065330.21-395429.12"
+{
+	RA 103.37550887
+	Dec -39.90709865
+	Distance 80.859 # mean of system components
+	SpectralType "DA8"
+	Temperature 6135
+	AppMag 15.46
+	Radius 8715
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06533021-3954292/2MASS%20J06533021-3954292.html"
+}
+
+"2MASS J06533533-3955335:WD 0651-398 B:WDJ065335.34-395533.29"
+{
+	RA 103.39688894
+	Dec -39.92490456
+	Distance 80.859 # mean of system components
+	SpectralType "DA7"
+	Temperature 7034
+	AppMag 16.07
+	Radius 8949
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J06533533-3955335/2MASS%20J06533533-3955335.html"
+}
+
+"G 250-27:WD 0649+639:WDJ065350.43+635558.04"
+{
+	RA 103.45877237
+	Dec 63.93102184
+	Distance 90.758 # mean of system components
+	SpectralType "DA8"
+	Temperature 6066
+	AppMag 16.28
+	Radius 8557
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20250-27/G%20250-27.html"
+}
+
+"GJ 2054:WD 0655-390:WDJ065705.91-390935.68"
+{
+	RA 104.27292323
+	Dec -39.16057903
+	Distance 53.825
+	SpectralType "DA8"
+	Temperature 6370
+	AppMag 15.11
+	Radius 8392
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200655-390/WD%200655-390.html"
+}
+
+"Gaia DR2 3129655296079487872:WDJ065729.40+055047.87"
+{
+	RA 104.37203392
+	Dec 5.84650527
+	Distance 127.227
+	SpectralType "DC8"
+	Temperature 6010
+	AppMag 17.424 # synthetic
+	Radius 7704
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203129655296079487872/Gaia%20DR2%203129655296079487872.html"
+}
+
+"Gaia DR2 3112162508466471808:WDJ065845.23-011552.84"
+{
+	RA 104.68962097
+	Dec -1.26589833
+	Distance 122.185
+	SpectralType "DA9"
+	Temperature 5050
+	AppMag 18.132 # synthetic
+	Radius 9039
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203112162508466471808/Gaia%20DR2%203112162508466471808.html"
+}
+
+"Gaia DR2 3160815489969826944:WDJ065910.86+122526.52"
+{
+	RA 104.79534998
+	Dec 12.42351206
+	Distance 120.435
+	SpectralType "DA9"
+	Temperature 5118
+	AppMag 17.823 # synthetic
+	Radius 10053
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203160815489969826944/Gaia%20DR2%203160815489969826944.html"
+}
+
+"WD 0658-075:WDJ070041.91-073418.66"
+{
+	RA 105.17391037
+	Dec -7.57121805
+	Distance 82.537
+	SpectralType "DC9"
+	Temperature 5773
+	AppMag 16.73
+	Radius 7675
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200658-075/WD%200658-075.html"
+}
+
+"GJ 3420:EGGR 485:WD 0657+320:WDJ070051.66+315743.83"
+{
+	RA 105.2171194
+	Dec 31.95952807
+	Distance 63.948
+	SpectralType "DA9"
+	Temperature 5010
+	AppMag 16.593
+	Radius 10088
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203420/GJ%203420.html"
+}
+
+"Gliese 261:WD 0659-063:WDJ070154.84-062746.23"
+{
+	RA 105.47819287
+	Dec -6.46678712
+	Distance 67.419
+	SpectralType "DA8"
+	Temperature 6445
+	AppMag 15.44
+	Radius 8908
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20261/GJ%20261.html"
+}
+
+"WD 0701-58:WD 0701-587:WDJ070219.72-585009.02"
+{
+	RA 105.58174888
+	Dec -58.83494116
+	Distance 95.783
+	SpectralType "DA4"
+	Temperature 13443
+	AppMag 14.46
+	Radius 6294
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200701-58/WD%200701-58.html"
+}
+
+"Gaia DR2 1140292479690791296:WDJ070356.98+780504.72"
+{
+	RA 105.9862571
+	Dec 78.08410615
+	Distance 78.523
+	SpectralType "DA9"
+	Temperature 5428
+	AppMag 16.46
+	Radius 9960
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201140292479690791296/Gaia%20DR2%201140292479690791296.html"
+}
+
+"Gaia DR2 883006556929519872:WDJ070357.43+253418.34"
+{
+	RA 105.98898551
+	Dec 25.57151227
+	Distance 83.448
+	SpectralType "DBA4"
+	Temperature 11428
+	AppMag 13.86
+	Radius 9093
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20883006556929519872/Gaia%20DR2%20883006556929519872.html"
+}
+
+"Gaia DR2 980918204822332416:WDJ070549.32+514250.52"
+{
+	RA 106.45639411
+	Dec 51.71198518
+	Distance 129.596
+	SpectralType "DA9"
+	Temperature 5166
+	AppMag 18.27 # synthetic
+	Radius 8181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20980918204822332416/Gaia%20DR2%20980918204822332416.html"
+}
+
+"Gaia DR3 3051506991743533184:WDJ070551.92-083526.76"
+{
+	RA 106.46631765
+	Dec -8.59266577
+	Distance 82.725
+	SpectralType "DC9"
+	Temperature 4786
+	AppMag 17.433 # synthetic
+	Radius 10400
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%203051506991743533184/Gaia%20DR3%203051506991743533184.html"
+}
+
+"WD 0704-508:WDJ070555.11-505255.45"
+{
+	RA 106.48065605
+	Dec -50.87960068
+	Distance 120.911
+	SpectralType "DC8"
+	Temperature 6202
+	AppMag 16.94
+	Radius 8443
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200704-508/WD%200704-508.html"
+}
+
+"2MASS J07085228-6706314:WD 0708-670:WDJ070852.28-670631.43"
+{
+	RA 107.21527304
+	Dec -67.10914626
+	Distance 55.299
+	SpectralType "DCP9"
+	Temperature 5007
+	AppMag 16.22
+	Radius 10426
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J07085228-6706314/2MASS%20J07085228-6706314.html"
+}
+
+"GJ 3431:EGGR 51:WD 0706+377:WDJ071014.34+374019.47"
+{
+	RA 107.55848562
+	Dec 37.67084595
+	Distance 79.431
+	SpectralType "DQ7"
+	Temperature 6807
+	AppMag 15.66
+	Radius 8956
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2051/EGGR%2051.html"
+}
+
+"Gaia DR2 3059515898856688000:WDJ071206.15-042815.30"
+{
+	RA 108.02531534
+	Dec -4.47000074
+	Distance 118.191
+	SpectralType "DA9"
+	Temperature 5421
+	AppMag 17.668 # synthetic
+	Radius 8447
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203059515898856688000/Gaia%20DR2%203059515898856688000.html"
+}
+
+"Gaia DR2 5589354543620145024:WDJ071550.55-370642.20"
+{
+	RA 108.95915709
+	Dec -37.11102125
+	Distance 111.45
+	SpectralType "DA7"
+	Temperature 7236
+	AppMag 16.687 # synthetic
+	Radius 6652
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205589354543620145024/Gaia%20DR2%205589354543620145024.html"
+}
+
+"Gaia DR2 3156974449176326528:WDJ071703.10+112541.55"
+{
+	RA 109.26142808
+	Dec 11.42740802
+	Distance 96.681
+	SpectralType "DA9"
+	Temperature 4906
+	AppMag 17.499 # synthetic
+	Radius 10987
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203156974449176326528/Gaia%20DR2%203156974449176326528.html"
+}
+
+"GD 84:EGGR 215:WD 0714+458:WDJ071801.90+454753.07"
+{
+	RA 109.50718843
+	Dec 45.797271
+	Distance 115.567
+	SpectralType "DC5"
+	Temperature 9935
+	AppMag 15.219 # synthetic
+	Radius 8507
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2084/GD%2084.html"
+}
+
+"Gaia DR2 885100916128136064:WDJ072205.61+280626.98"
+{
+	RA 110.52438123
+	Dec 28.10723776
+	Distance 118.715
+	SpectralType "DA9"
+	Temperature 5296
+	AppMag 17.749 # synthetic
+	Radius 8965
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20885100916128136064/Gaia%20DR2%20885100916128136064.html"
+}
+
+"Gaia DR2 5605383430285597696:WDJ072251.38-304234.38"
+{
+	RA 110.71580901
+	Dec -30.70789536
+	Distance 76.301
+	SpectralType "DA9"
+	Temperature 5197
+	AppMag 17.646 # synthetic
+	Radius 6081
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205605383430285597696/Gaia%20DR2%205605383430285597696.html"
+}
+
+"Gaia DR2 3169486960220617088:WDJ072300.22+161703.98"
+{
+	RA 110.7508252
+	Dec 16.28467505
+	Distance 121.098
+	SpectralType "DA4"
+	Temperature 11734
+	AppMag 15.01
+	Radius 7147
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203169486960220617088/Gaia%20DR2%203169486960220617088.html"
+}
+
+"Gaia DR2 3032020450247993600:WDJ072434.96-133828.38"
+{
+	RA 111.14659429
+	Dec -13.64327449
+	Distance 118.033
+	SpectralType "DA9"
+	Temperature 5108
+	AppMag 17.31
+	Radius 8883
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203032020450247993600/Gaia%20DR2%203032020450247993600.html"
+}
+
+"WD 0724+146:WDJ072704.15+143440.30"
+{
+	RA 111.7679543
+	Dec 14.577371
+	Distance 101.677
+	SpectralType "DA9"
+	Temperature 5713
+	AppMag 16.87 # synthetic
+	Radius 8959
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200724+146/WD%200724+146.html"
+}
+
+"Gaia DR2 983979721933760768:WDJ073024.53+533211.95"
+{
+	RA 112.60414472
+	Dec 53.53625635
+	Distance 117.851
+	SpectralType "DC9"
+	Temperature 4761
+	AppMag 18.273 # synthetic
+	Radius 10417
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20983979721933760768/Gaia%20DR2%20983979721933760768.html"
+}
+
+"Gaia DR2 5510964144860346496:WDJ073326.40-445325.34"
+{
+	RA 113.36056651
+	Dec -44.89045836
+	Distance 127.219
+	SpectralType "DA5"
+	Temperature 9409
+	AppMag 15.395
+	Radius 8922
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205510964144860346496/Gaia%20DR2%205510964144860346496.html"
+}
+
+"GJ 1098:EGGR 321:WD 0728+642:WDJ073330.88+640927.44"
+{
+	RA 113.37909878
+	Dec 64.15647613
+	Distance 65.104
+	SpectralType "DA9"
+	Temperature 5249
+	AppMag 16.22
+	Radius 10405
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201098/GJ%201098.html"
+}
+
+"GJ 2062:LAWD 24:WD 0732-427:WDJ073337.81-425357.25"
+{
+	RA 113.40795734
+	Dec -42.89622645
+	Distance 109.816
+	SpectralType "DA3"
+	Temperature 15032
+	AppMag 14.16
+	Radius 8098
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2024/LAWD%2024.html"
+}
+
+"GD 86:WD 0730+487:WDJ073427.47+484115.28"
+{
+	RA 113.61355419
+	Dec 48.68672045
+	Distance 105.92
+	SpectralType "DA4"
+	Temperature 14100
+	AppMag 14.892 # synthetic
+	Radius 5760
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2086/GD%2086.html"
+}
+
+# Companion to WDJ074020.79-172449.16
+"Gliese 283 B:LP 783-2"
+{
+	RA 115.08608297
+	Dec -17.41513772
+	Distance 29.821 # mean of system components
+	SpectralType "M6.5Ve"
+	AppMag 16.696
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+783-2"
+}
+
+"Gliese 283 A:LAWD 25:EGGR 54:WD 0738-172:WDJ074020.79-172449.16"
+{
+	RA 115.09192338
+	Dec -17.41606612
+	Distance 29.821 # mean of system components
+	SpectralType "DZA7"
+	Temperature 7650
+	AppMag 13.06
+	Radius 8009
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20283%20A/GJ%20283%20A.html"
+}
+
+"WISEP J074509.38+262659.1:WDJ074508.95+262706.45"
+{
+	RA 116.2899218
+	Dec 26.44859402
+	Distance 127.635
+	SpectralType "DC9"
+	Temperature 4010
+	AppMag 19.19 # synthetic
+	Radius 11901
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WISEP%20J074509.38+262659.1/WISEP%20J074509.38+262659.1.html"
+}
+
+# Companion to WDJ074538.43-335551.34
+37853 "171 Pup:Gliese 288 A"
+{
+	RA 116.39431123
+	Dec -34.16496181
+	Distance 50.277 # mean of system components
+	SpectralType "F9V"
+	Temperature 5578 # GSP-Spec
+	AppMag 5.362
+	Radius 921433 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=*+171+Pup"
+}
+
+"Gliese 288 B:HD 63077 B:VB 3:WD 0743-336:WDJ074538.43-335551.34"
+{
+	RA 116.40863553
+	Dec -33.92345928
+	Distance 50.277 # mean of system components
+	SpectralType "DC9"
+	Temperature 4509
+	AppMag 16.59
+	Radius 11437
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/VB%203/VB%203.html"
+}
+
+"GD 89:EGGR 343:WD 0743+442:WDJ074725.88+440848.32"
+{
+	RA 116.85726999
+	Dec 44.1460226
+	Distance 124.876
+	SpectralType "DA3"
+	Temperature 15198
+	AppMag 14.871 # synthetic
+	Radius 6526
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%2089/GD%2089.html"
+}
+
+"SDSS J074730.12+110733.8:WDJ074730.10+110734.70"
+{
+	RA 116.87574034
+	Dec 11.12549567
+	Distance 89.979
+	SpectralType "DA6"
+	Temperature 7817
+	AppMag 16.704 # synthetic
+	Radius 4668
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J074730.12+110733.8/SDSS%20J074730.12+110733.8.html"
+}
+
+"GJ 1102 A:EGGR 427:WD 0747+073.2:WDJ075014.58+071148.92"
+{
+	RA 117.56171562
+	Dec 7.18899864
+	Distance 59.199 # mean of system components
+	SpectralType "DC9"
+	Temperature 4496
+	AppMag 16.69
+	Radius 11664
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201102%20A/GJ%201102%20A.html"
+}
+
+"GJ 1102 B:EGGR 426:WD 0747+073.1:WDJ075015.34+071137.10"
+{
+	RA 117.56486467
+	Dec 7.18568055
+	Distance 59.199 # mean of system components
+	SpectralType "DC9"
+	Temperature 4842
+	AppMag 16.99
+	Radius 10347
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201102%20B/GJ%201102%20B.html"
+}
+
+"Gaia DR2 3080914632816248448:WDJ075252.85-030707.97"
+{
+	RA 118.21988931
+	Dec -3.11841412
+	Distance 121.088
+	SpectralType "DC9"
+	Temperature 4731
+	AppMag 18.346 # synthetic
+	Radius 10697
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203080914632816248448/Gaia%20DR2%203080914632816248448.html"
+}
+
+"Gaia DR2 1084764020047940096:GD 453:WDJ075305.33+612203.57"
+{
+	RA 118.27080482
+	Dec 61.3673714
+	Distance 114.072
+	SpectralType "DC6"
+	Temperature 7921
+	AppMag 16.04 # synthetic
+	Radius 8142
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201084764020047940096/Gaia%20DR2%201084764020047940096.html"
+}
+
+"Gliese 293:LAWD 26:EGGR 56:WD 0752-676:WDJ075308.14-674731.38"
+{
+	RA 118.30118446
+	Dec -67.79867245
+	Distance 26.636
+	SpectralType "DA9"
+	Temperature 5657
+	AppMag 13.96
+	Radius 9234
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2026/LAWD%2026.html"
+}
+
+"WD 0749+426:WDJ075313.28+423001.69"
+{
+	RA 118.30598915
+	Dec 42.49871431
+	Distance 89.33
+	SpectralType "DC9"
+	Temperature 4773
+	AppMag 17.45
+	Radius 11084
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200749+426/WD%200749+426.html"
+}
+
+"EGGR 344:WD 0749+526:WDJ075327.26+522931.47"
+{
+	RA 118.36293912
+	Dec 52.49093986
+	Distance 71.116
+	SpectralType "DC7"
+	Temperature 7259
+	AppMag 15.674
+	Radius 7055
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20344/EGGR%20344.html"
+}
+
+"Gaia DR2 5513896164414899456:WDJ075328.47-511436.98"
+{
+	RA 118.36808586
+	Dec -51.2428335
+	Distance 106.566
+	SpectralType "DAH5"
+	Temperature 9283
+	AppMag 15.649
+	Radius 6775
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205513896164414899456/Gaia%20DR2%205513896164414899456.html"
+}
+
+# WDJ075356.62-252401.48: defined in extrasolar.stc
+
+"Gaia DR2 5698587862747531008:WDJ075447.40-241527.71"
+{
+	RA 118.69726685
+	Dec -24.25708332
+	Distance 122.875
+	SpectralType "DAH8"
+	Temperature 5933
+	AppMag 17.403 # synthetic
+	Radius 7672
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205698587862747531008/Gaia%20DR2%205698587862747531008.html"
+}
+
+"EGGR 57:WD 0752-146:WDJ075508.95-144550.95"
+{
+	RA 118.78701095
+	Dec -14.76552917
+	Distance 127.482
+	SpectralType "DA3"
+	Temperature 19440 # Table A5
+	AppMag 13.56
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2057/EGGR%2057.html"
+}
+
+"EGGR 322:WD 0751+578:WDJ075601.23+574159.82"
+{
+	RA 119.00460879
+	Dec 57.69800026
+	Distance 95.761
+	SpectralType "DC5"
+	Temperature 9614
+	AppMag 15.08
+	Radius 7840
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20322/EGGR%20322.html"
+}
+
+"WD 0753+417:WDJ075631.12+413951.00"
+{
+	RA 119.12962779
+	Dec 41.66260011
+	Distance 106.613
+	SpectralType "DA7"
+	Temperature 6749
+	AppMag 16.769 # synthetic
+	Radius 6955
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200753+417/WD%200753+417.html"
+}
+
+"EGGR 428:WD 0756+437:WDJ075959.58+433521.10"
+{
+	RA 119.99642925
+	Dec 43.58991195
+	Distance 71.552
+	SpectralType "DCP7"
+	Temperature 7215
+	AppMag 16.297 # synthetic
+	Radius 5273
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20428/EGGR%20428.html"
+}
+
+"Gaia DR2 933287876501371520:WDJ080131.87+485252.55"
+{
+	RA 120.38204021
+	Dec 48.88128342
+	Distance 116.755
+	SpectralType "DA9"
+	Temperature 5177
+	AppMag 17.658 # synthetic
+	Radius 9968
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20933287876501371520/Gaia%20DR2%20933287876501371520.html"
+}
+
+"Gaia DR2 5597759970724418688:WDJ080151.04-282831.73"
+{
+	RA 120.4632975
+	Dec -28.47590433
+	Distance 114.165
+	SpectralType "DQ9"
+	Temperature 5705
+	AppMag 17.128 # synthetic
+	Radius 9668
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205597759970724418688/Gaia%20DR2%205597759970724418688.html"
+}
+
+"WD 0801+228:WDJ080440.63+223949.68"
+{
+	RA 121.16930816
+	Dec 22.66236019
+	Distance 128.44
+	SpectralType "DZ9"
+	Temperature 5256
+	AppMag 17.845 # synthetic
+	Radius 9199
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200801+228/WD%200801+228.html"
+}
+
+"NLTT 18922:WDJ080527.58+073535.64"
+{
+	RA 121.3645492
+	Dec 7.5915477
+	Distance 112.053
+	SpectralType "DA9"
+	Temperature 5397
+	AppMag 17.573 # synthetic
+	Radius 8541
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2018922/NLTT%2018922.html"
+}
+
+"WD 0802+387:WDJ080557.67+383344.66"
+{
+	RA 121.48675712
+	Dec 38.55995835
+	Distance 67.249
+	SpectralType "DA9"
+	Temperature 5020
+	AppMag 16.89
+	Radius 9036
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200802+387/WD%200802+387.html"
+}
+
+# WDJ080653.75-661816.70: defined in extrasolar.stc
+
+"Gaia DR2 5320436784269889792:WDJ080833.93-530059.48"
+{
+	RA 122.14154628
+	Dec -53.01703413
+	Distance 97.861
+	SpectralType "DZA9"
+	Temperature 4361
+	AppMag 18.217 # synthetic
+	Radius 11779
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205320436784269889792/Gaia%20DR2%205320436784269889792.html"
+}
+
+"WD 0805+356:WDJ080911.21+352757.08"
+{
+	RA 122.29641391
+	Dec 35.46547556
+	Distance 114.624
+	SpectralType "DA6"
+	Temperature 8771
+	AppMag 15.14
+	Radius 10085
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200805+356/WD%200805+356.html"
+}
+
+"GD 262:WD 0806+294:WDJ080946.17+292032.24"
+{
+	RA 122.44320107
+	Dec 29.34196061
+	Distance 105.067
+	SpectralType "DA7"
+	Temperature 7021
+	AppMag 16.178 # synthetic
+	Radius 8412
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20262/GD%20262.html"
+}
+
+"Gaia DR2 5290126272348542080:WDJ081200.29-610809.79"
+{
+	RA 123.00075781
+	Dec -61.1354929
+	Distance 130.217
+	SpectralType "DA8"
+	Temperature 6261
+	AppMag 17.241 # synthetic
+	Radius 7913
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205290126272348542080/Gaia%20DR2%205290126272348542080.html"
+}
+
+"Gaia DR2 5544743925212648320:WDJ081227.07-352943.32"
+{
+	RA 123.11241757
+	Dec -35.4954976
+	Distance 36.424
+	SpectralType "DAH8"
+	Temperature 6239
+	AppMag 14.47
+	Radius 7852
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205544743925212648320/Gaia%20DR2%205544743925212648320.html"
+}
+
+"GALEX J081237.8+173701:WD 0809+177:WDJ081237.81+173701.43"
+{
+	RA 123.15787858
+	Dec 17.61667539
+	Distance 88.139
+	SpectralType "DA3"
+	Temperature 16028
+	AppMag 13.46
+	Radius 8758
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GALEX%20J081237.8+173701/GALEX%20J081237.8+173701.html"
+}
+
+# Companion to WDJ081325.13+195729.18
+"2MASS J08132985+1956521"
+{
+	RA 123.37374012
+	Dec 19.9475855
+	Distance 114.987 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3117 # GSP-Phot
+	AppMag 16.061 # synthetic
+	Radius 152028 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J08132985%2B1956521"
+}
+
+"Gaia DR2 675615677264385536:WDJ081325.13+195729.18"
+{
+	RA 123.3541064
+	Dec 19.95792445
+	Distance 114.987 # mean of system components
+	SpectralType "DC9"
+	Temperature 4303
+	AppMag 18.714 # synthetic
+	Radius 11330
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20675615677264385536/Gaia%20DR2%20675615677264385536.html"
+}
+
+"WD 0810+489:WDJ081411.17+484529.81"
+{
+	RA 123.54697244
+	Dec 48.75715309
+	Distance 55.749
+	SpectralType "DC8"
+	Temperature 6709
+	AppMag 15.07
+	Radius 8080
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200810+489/WD%200810+489.html"
+}
+
+"Gaia DR2 5516345223493485952:WDJ081630.14-464113.24"
+{
+	RA 124.12809431
+	Dec -46.68607903
+	Distance 74.955
+	SpectralType "DC9"
+	Temperature 4455
+	AppMag 17.624
+	Radius 11702
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205516345223493485952/Gaia%20DR2%205516345223493485952.html"
+}
+
+"EGGR 531:WD 0813+217:WDJ081642.04+213735.82"
+{
+	RA 124.17466976
+	Dec 21.62487066
+	Distance 128.209
+	SpectralType "DA8"
+	Temperature 6129
+	AppMag 17.02
+	Radius 9098
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20531/EGGR%20531.html"
+}
+
+"Gaia DR2 5271072526109138176:WDJ081716.19-680838.31"
+{
+	RA 124.31319556
+	Dec -68.14204209
+	Distance 126.714
+	SpectralType "DQ9"
+	Temperature 4642
+	AppMag 18.598 # synthetic
+	Radius 11078
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205271072526109138176/Gaia%20DR2%205271072526109138176.html"
+}
+
+"WD 0816-310:WDJ081840.26-311020.33"
+{
+	RA 124.6689881
+	Dec -31.1758066
+	Distance 63.097
+	SpectralType "DZH7"
+	Temperature 6754
+	AppMag 15.43
+	Radius 7331
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200816-310/WD%200816-310.html"
+}
+
+"Gaia DR2 5723025990432651648:WDJ081843.92-151208.31"
+{
+	RA 124.68326365
+	Dec -15.20259718
+	Distance 107.179
+	SpectralType "DZ9"
+	Temperature 4300
+	AppMag 18.03 # synthetic
+	Radius 15824
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205723025990432651648/Gaia%20DR2%205723025990432651648.html"
+}
+
+"WD 0821-669:WDJ082126.70-670320.02"
+{
+	RA 125.3567266
+	Dec -67.05262825
+	Distance 34.807
+	SpectralType "DA9"
+	Temperature 4941
+	AppMag 15.34
+	Radius 10187
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200821-669/WD%200821-669.html"
+}
+
+"Gaia DR2 5753337533146097280:WDJ082532.35-072823.21"
+{
+	RA 126.38450037
+	Dec -7.47297159
+	Distance 115.53
+	SpectralType "DA3"
+	Temperature 15370
+	AppMag 13.91
+	Radius 9320
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205753337533146097280/Gaia%20DR2%205753337533146097280.html"
+}
+
+"Gaia DR2 5322552760038496512:WDJ082533.15-510730.83"
+{
+	RA 126.38612469
+	Dec -51.1244107
+	Distance 87.074
+	SpectralType "DC9"
+	Temperature 5072
+	AppMag 17.245
+	Radius 9655
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205322552760038496512/Gaia%20DR2%205322552760038496512.html"
+}
+
+"GJ 1112:EGGR 249:WD 0827+328:WDJ083039.46+324147.23"
+{
+	RA 127.66364152
+	Dec 32.69411028
+	Distance 72.96
+	SpectralType "DA7"
+	Temperature 7286
+	AppMag 15.73
+	Radius 6682
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201112/GJ%201112.html"
+}
+
+"SDSS J083123.38+333148.6:WDJ083123.38+333148.95"
+{
+	RA 127.84768639
+	Dec 33.52962192
+	Distance 130.03
+	SpectralType "DA9"
+	Temperature 5773
+	AppMag 17.506 # synthetic
+	Radius 8345
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J083123.38+333148.6/SDSS%20J083123.38+333148.6.html"
+}
+
+"Gaia DR2 5709868512742196608:WDJ083150.62-164329.97"
+{
+	RA 127.9635362
+	Dec -16.72721814
+	Distance 117.467
+	SpectralType "DC9"
+	Temperature 4177
+	AppMag 18.751 # synthetic
+	Radius 12369
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205709868512742196608/Gaia%20DR2%205709868512742196608.html"
+}
+
+"Gaia DR2 5748802661860766208:WDJ083601.68-100607.45"
+{
+	RA 129.00695161
+	Dec -10.10303994
+	Distance 112.285
+	SpectralType "DZA9"
+	Temperature 5227
+	AppMag 17.55
+	Radius 9564
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205748802661860766208/Gaia%20DR2%205748802661860766208.html"
+}
+
+"Gaia DR2 5322090003089341440:WDJ083759.16-501745.76"
+{
+	RA 129.49465065
+	Dec -50.29527767
+	Distance 103.371
+	SpectralType "DA4"
+	Temperature 12485
+	AppMag 14.582
+	Radius 7187
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205322090003089341440/Gaia%20DR2%205322090003089341440.html"
+}
+
+"Gliese 318:CD-32 5613:EGGR 62:LAWD 28:WD 0839-327:WDJ084132.43-325632.92"
+{
+	RA 130.37950136
+	Dec -32.93649497
+	Distance 27.771
+	SpectralType "DA6"
+	Temperature 9086
+	AppMag 11.86
+	Radius 10314
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/CD-32%205613/CD-32%205613.html"
+}
+
+"WD 0840-136:WDJ084248.46-134713.21"
+{
+	RA 130.70071948
+	Dec -13.78711311
+	Distance 48.274
+	SpectralType "DZ9"
+	Temperature 5431
+	AppMag 15.72
+	Radius 7962
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200840-136/WD%200840-136.html"
+}
+
+"WD 0840+243:WDJ084257.61+240930.84"
+{
+	RA 130.73952479
+	Dec 24.1583408
+	Distance 123.777
+	SpectralType "DA9"
+	Temperature 5816
+	AppMag 17.199 # synthetic
+	Radius 8942
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200840+243/WD%200840+243.html"
+}
+
+"Gaia DR2 1042071701528617856:WDJ084515.55+611705.79"
+{
+	RA 131.3148188
+	Dec 61.28463125
+	Distance 113.976 # mean of system components
+	SpectralType "DA9"
+	Temperature 5578
+	AppMag 17.356 # synthetic
+	Radius 8631
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201042071701528617856/Gaia%20DR2%201042071701528617856.html"
+}
+
+"Gaia DR2 1042071701528617728:WDJ084516.87+611704.81"
+{
+	RA 131.32034184
+	Dec 61.28438747
+	Distance 113.976 # mean of system components
+	SpectralType "DAH9"
+	Temperature 5872
+	AppMag 17.14 # synthetic
+	Radius 8202
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201042071701528617728/Gaia%20DR2%201042071701528617728.html"
+}
+
+"Gaia DR2 5625513014289760128:WDJ084635.27-362206.68"
+{
+	RA 131.64621063
+	Dec -36.36856459
+	Distance 105.478
+	SpectralType "DA9"
+	Temperature 5025
+	AppMag 17.67 # synthetic
+	Radius 10053
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205625513014289760128/Gaia%20DR2%205625513014289760128.html"
+}
+
+"Ton 949:GD 95:WD 0843+358:WDJ084644.41+353833.56"
+{
+	RA 131.68420144
+	Dec 35.6423593
+	Distance 80.025
+	SpectralType "DZA6"
+	Temperature 9146
+	AppMag 14.79 # synthetic
+	Radius 7299
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ton%20949/Ton%20949.html"
+}
+
+"GJ 2073:Ton 953:EGGR 323:GD 96:WD 0846+346:WDJ084909.48+342947.73"
+{
+	RA 132.28881654
+	Dec 34.49662704
+	Distance 100.436
+	SpectralType "DAZ7"
+	Temperature 7445
+	AppMag 15.71
+	Radius 9195
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ton%20953/Ton%20953.html"
+}
+
+"Gaia DR2 3073747187092773632:WDJ084957.48-015612.38"
+{
+	RA 132.48992556
+	Dec -1.93760512
+	Distance 90.974
+	SpectralType "DC9"
+	Temperature 5015
+	AppMag 17.35
+	Radius 9878
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203073747187092773632/Gaia%20DR2%203073747187092773632.html"
+}
+
+"Gaia DR2 5302618648583292800:WDJ085021.30-584806.21"
+{
+	RA 132.58517275
+	Dec -58.79968458
+	Distance 75.867
+	SpectralType "DZA9"
+	Temperature 5783
+	AppMag 17.641 # estimate
+	Radius 4368
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205302618648583292800/Gaia%20DR2%205302618648583292800.html"
+}
+
+"LP 426-17:WDJ085140.49+162454.38"
+{
+	RA 132.91681777
+	Dec 16.41442949
+	Distance 100.613
+	SpectralType "DC9"
+	Temperature 5900
+	AppMag 16.752 # synthetic
+	Radius 8510
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20426-17/LP%20426-17.html"
+}
+
+# Companion to WDJ085357.69-244656.23
+"LP 844-25"
+{
+	RA 133.48779425
+	Dec -24.78164537
+	Distance 83.891 # mean of system components
+	SpectralType "M6V"
+	AppMag 17.8
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+844-25"
+}
+
+"LHS 2068:WD 0851-246:WDJ085357.69-244656.23"
+{
+	RA 133.49338253
+	Dec -24.78159457
+	Distance 83.891 # mean of system components
+	SpectralType "DC9"
+	Temperature 3740 # Table A5
+	AppMag 18.09
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%202068/LHS%202068.html"
+}
+
+"Gaia DR2 5652689406971618048:WDJ085430.49-250848.99"
+{
+	RA 133.62751589
+	Dec -25.14718257
+	Distance 102.172
+	SpectralType "DA8"
+	Temperature 6648
+	AppMag 16.584 # synthetic
+	Radius 7480
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205652689406971618048/Gaia%20DR2%205652689406971618048.html"
+}
+
+"Gaia DR2 5755957119598921728:WDJ085534.72-083345.34"
+{
+	RA 133.89426375
+	Dec -8.5646727
+	Distance 107.911
+	SpectralType "DC9"
+	Temperature 4769
+	AppMag 18.04
+	Radius 11120
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205755957119598921728/Gaia%20DR2%205755957119598921728.html"
+}
+
+"Gaia DR2 1117334024067935872:WDJ085804.42+681338.66"
+{
+	RA 134.5189211
+	Dec 68.22716238
+	Distance 124.353
+	SpectralType "DC9"
+	Temperature 4871
+	AppMag 18.424 # synthetic
+	Radius 9156
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201117334024067935872/Gaia%20DR2%201117334024067935872.html"
+}
+
+"WD 0855+416:WDJ085830.87+412635.75"
+{
+	RA 134.62807251
+	Dec 41.4415896
+	Distance 124.367
+	SpectralType "DAH7"
+	Temperature 7097
+	AppMag 16.947 # synthetic
+	Radius 6801
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200855+416/WD%200855+416.html"
+}
+
+"LP 606-32:WD 0856-007:WDJ085912.92-005842.86"
+{
+	RA 134.8045103
+	Dec -0.979104
+	Distance 59.507
+	SpectralType "DC9"
+	Temperature 5112
+	AppMag 16.33
+	Radius 9704
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20606-32/LP%20606-32.html"
+}
+
+"GJ 1117:EGGR 182:WD 0856+331:WDJ085914.71+325712.16"
+{
+	RA 134.80958284
+	Dec 32.95336156
+	Distance 75.152
+	SpectralType "DQ5"
+	Temperature 10015
+	AppMag 15.18
+	Radius 5578
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20182/EGGR%20182.html"
+}
+
+"VW Lyn:GD 99:EGGR 219:WD 0858+363:WDJ090148.66+360707.76"
+{
+	RA 135.45219046
+	Dec 36.11803237
+	Distance 110.694
+	SpectralType "DA4"
+	Temperature 11721
+	AppMag 14.544
+	Radius 8330
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20VW%20Lyn/V*%20VW%20Lyn.html"
+}
+
+"LP 426-49:WD 0859+203:WDJ090208.37+201051.57"
+{
+	RA 135.53532091
+	Dec 20.17952759
+	Distance 124.648
+	SpectralType "DQ9"
+	Temperature 5500 # Table A5
+	AppMag 18.518 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20426-49/LP%20426-49.html"
+}
+
+"Gaia DR2 5620763437599189376:WDJ090212.89-394553.32"
+{
+	RA 135.55416571
+	Dec -39.76488139
+	Distance 118.591
+	SpectralType "DAH6"
+	Temperature 8768
+	AppMag 16.062 # synthetic
+	Radius 6875
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205620763437599189376/Gaia%20DR2%205620763437599189376.html"
+}
+
+"WD J0902-041:WD 0859-039:WDJ090217.30-040655.48"
+{
+	RA 135.57206089
+	Dec -4.1153836
+	Distance 123.547
+	SpectralType "DA2"
+	Temperature 23799
+	AppMag 12.4
+	Radius 10008
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%20J0902-041/WD%20J0902-041.html"
+}
+
+"PM J09027+3120:WD 0859+315:WDJ090242.68+312043.51"
+{
+	RA 135.67739496
+	Dec 31.34537678
+	Distance 110.36
+	SpectralType "DA5"
+	Temperature 9849
+	AppMag 14.75
+	Radius 7659
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J09027+3120/PM%20J09027+3120.html"
+}
+
+"GJ 3529:EGGR 349:WD 0900+734:WDJ090532.93+731454.95"
+{
+	RA 136.38201415
+	Dec 73.24649539
+	Distance 83.697
+	SpectralType "DC9"
+	Temperature 5129
+	AppMag 16.971 # synthetic
+	Radius 9680
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203529/GJ%203529.html"
+}
+
+"Gaia DR2 5648566371510973824:WDJ090633.51-262656.02"
+{
+	RA 136.63982167
+	Dec -26.44926337
+	Distance 78.845
+	SpectralType "DA9"
+	Temperature 5106
+	AppMag 16.957 # synthetic
+	Radius 9726
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205648566371510973824/Gaia%20DR2%205648566371510973824.html"
+}
+
+# Companion to WDJ090734.25-360907.93
+"2MASS J09073358-3609149"
+{
+	RA 136.88977311
+	Dec -36.15479797
+	Distance 128.451 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 13.711 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J09073358-3609149"
+}
+
+"Gaia DR2 5624029566946316928:WDJ090734.25-360907.93"
+{
+	RA 136.89253206
+	Dec -36.15278054
+	Distance 128.451 # mean of system components
+	SpectralType "DA9"
+	Temperature 5302
+	AppMag 17.802 # synthetic
+	Radius 9532
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205624029566946316928/Gaia%20DR2%205624029566946316928.html"
+}
+
+"Gaia DR2 611074413433751680:WDJ090834.39+172148.53"
+{
+	RA 137.14241379
+	Dec 17.3620911
+	Distance 106.195
+	SpectralType "DC9"
+	Temperature 5170
+	AppMag 16.829 # synthetic
+	Radius 15254
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20611074413433751680/Gaia%20DR2%20611074413433751680.html"
+}
+
+"Gaia DR2 5651964996310470144:WDJ090912.98-224625.86"
+{
+	RA 137.30322679
+	Dec -22.77415448
+	Distance 128.45
+	SpectralType "DC9"
+	Temperature 4641
+	AppMag 18.5
+	Radius 10355
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205651964996310470144/Gaia%20DR2%205651964996310470144.html"
+}
+
+"Gaia DR2 688606063549945600:WDJ091216.42+253822.40"
+{
+	RA 138.06870613
+	Dec 25.63908907
+	Distance 123.074
+	SpectralType "DA8"
+	Temperature 6495
+	AppMag 16.761 # synthetic
+	Radius 8706
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20688606063549945600/Gaia%20DR2%20688606063549945600.html"
+}
+
+"Gaia DR2 5649808720867457664:WDJ091228.06-264201.50"
+{
+	RA 138.11673521
+	Dec -26.70103744
+	Distance 118.561
+	SpectralType "DA4"
+	Temperature 13436
+	AppMag 16.376 # synthetic
+	Radius 3304
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205649808720867457664/Gaia%20DR2%205649808720867457664.html"
+}
+
+"WD 0909+200:WDJ091245.05+195155.93"
+{
+	RA 138.18725687
+	Dec 19.86454892
+	Distance 110.599
+	SpectralType "DA9"
+	Temperature 5209
+	AppMag 17.724 # synthetic
+	Radius 8832
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200909+200/WD%200909+200.html"
+}
+
+"Gaia DR2 1040160612880069888:WDJ091353.95+620601.69"
+{
+	RA 138.47475317
+	Dec 62.09958108
+	Distance 102.26
+	SpectralType "DA9"
+	Temperature 5702
+	AppMag 17.022 # synthetic
+	Radius 8461
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201040160612880069888/Gaia%20DR2%201040160612880069888.html"
+}
+
+"Gliese 339.1:EGGR 250:WD 0912+536:WDJ091556.08+532523.86"
+{
+	RA 138.97555325
+	Dec 53.41831058
+	Distance 33.492
+	SpectralType "DCP7"
+	Temperature 7155
+	AppMag 13.88
+	Radius 7572
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20250/EGGR%20250.html"
+}
+
+"Gaia DR2 5427528254746168192:WDJ091600.94-421520.68"
+{
+	RA 139.00408322
+	Dec -42.2566488
+	Distance 73.488
+	SpectralType "DZH9"
+	Temperature 5146
+	AppMag 16.785 # synthetic
+	Radius 9254
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205427528254746168192/Gaia%20DR2%205427528254746168192.html"
+}
+
+"PG 0913+104:WD 0913+103:WDJ091602.69+101110.69"
+{
+	RA 139.01196781
+	Dec 10.18593968
+	Distance 125.727
+	SpectralType "DQZ6"
+	Temperature 8819
+	AppMag 15.822 # synthetic
+	Radius 8394
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%200913+104/PG%200913+104.html"
+}
+
+"Gaia DR2 5297051821220130560:WDJ091620.71-631117.21"
+{
+	RA 139.08520031
+	Dec -63.18870748
+	Distance 76.089
+	SpectralType "DA5"
+	Temperature 10111
+	AppMag 14.67
+	Radius 6166
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205297051821220130560/Gaia%20DR2%205297051821220130560.html"
+}
+
+"EGGR 64:WD 0913+442:WDJ091640.76+435941.59"
+{
+	RA 139.16984718
+	Dec 43.99369151
+	Distance 109.221
+	SpectralType "DA6"
+	Temperature 8587
+	AppMag 15.35
+	Radius 8946
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2064/EGGR%2064.html"
+}
+
+"Gaia DR2 5423545067716723712:WDJ091708.67-454613.68"
+{
+	RA 139.285721
+	Dec -45.77047011
+	Distance 92.311
+	SpectralType "DAZ8"
+	Temperature 6329
+	AppMag 16.226 # synthetic
+	Radius 8722
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205423545067716723712/Gaia%20DR2%205423545067716723712.html"
+}
+
+"Gaia DR2 5423896396040719744:WDJ091808.59-443724.25"
+{
+	RA 139.53344586
+	Dec -44.62199618
+	Distance 92.416
+	SpectralType "DAH9"
+	Temperature 5396
+	AppMag 17.039 # synthetic
+	Radius 8999
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205423896396040719744/Gaia%20DR2%205423896396040719744.html"
+}
+
+"WD 0920+012:WDJ092256.07+010310.15"
+{
+	RA 140.73346095
+	Dec 1.05158113
+	Distance 105.433
+	SpectralType "DAZ8"
+	Temperature 6061
+	AppMag 16.59
+	Radius 8960
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200920+012/WD%200920+012.html"
+}
+
+"WD 0921+315:WDJ092430.85+312033.52"
+{
+	RA 141.12752659
+	Dec 31.3409863
+	Distance 124.315
+	SpectralType "DC9"
+	Temperature 4935
+	AppMag 18.243 # synthetic
+	Radius 9518
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200921+315/WD%200921+315.html"
+}
+
+"Gaia DR2 5314177402013456256:WDJ092449.05-491529.60"
+{
+	RA 141.19944577
+	Dec -49.25571623
+	Distance 73.553
+	SpectralType "DC9"
+	Temperature 5581
+	AppMag 16.45
+	Radius 8013
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205314177402013456256/Gaia%20DR2%205314177402013456256.html"
+}
+
+"Gaia DR2 1039163458912998272:WDJ092542.84+612012.85"
+{
+	RA 141.42925684
+	Dec 61.33711939
+	Distance 89.488
+	SpectralType "DA6"
+	Temperature 8009
+	AppMag 14.994 # synthetic
+	Radius 9792
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201039163458912998272/Gaia%20DR2%201039163458912998272.html"
+}
+
+"WD 0925+189:WDJ092840.23+184114.96"
+{
+	RA 142.16834589
+	Dec 18.6863867
+	Distance 118.909
+	SpectralType "DA7"
+	Temperature 7634
+	AppMag 16.643
+	Radius 6701
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200925+189/WD%200925+189.html"
+}
+
+"WD 0928-71:LAWD 30:WD 0928-713:WDJ092907.98-713358.99"
+{
+	RA 142.27912538
+	Dec -71.564857
+	Distance 83.258
+	SpectralType "DA6"
+	Temperature 8440
+	AppMag 15.44
+	Radius 7931
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200928-71/WD%200928-71.html"
+}
+
+"WD 0927-173:WDJ092943.17-173250.68"
+{
+	RA 142.43136651
+	Dec -17.54879059
+	Distance 108.322
+	SpectralType "DA7"
+	Temperature 7451
+	AppMag 16.04
+	Radius 8456
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200927-173/WD%200927-173.html"
+}
+
+"Gaia DR2 5633102260158519936:WDJ093011.42-295943.38"
+{
+	RA 142.54827449
+	Dec -29.99503844
+	Distance 106.731
+	SpectralType "DA9"
+	Temperature 5205
+	AppMag 17.482 # synthetic
+	Radius 9743
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205633102260158519936/Gaia%20DR2%205633102260158519936.html"
+}
+
+"EGGR 324:WD 0930+294:WDJ093341.05+291123.32"
+{
+	RA 143.42023388
+	Dec 29.18902252
+	Distance 95.943
+	SpectralType "DA6"
+	Temperature 8278
+	AppMag 15.98
+	Radius 6318
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20324/EGGR%20324.html"
+}
+
+"L 462-56 A:WD 0935-371 A:WDJ093659.79-372130.80"
+{
+	RA 144.24728347
+	Dec -37.35780984
+	Distance 85.469 # mean of system components
+	SpectralType "DQ5"
+	Temperature 9232
+	AppMag 14.81
+	Radius 8273
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%20462-56%20A/L%20462-56%20A.html"
+}
+
+"L 462-56 B:WD 0935-371.2:WDJ093659.94-372126.91"
+{
+	RA 144.24786564
+	Dec -37.35666914
+	Distance 85.469 # mean of system components
+	SpectralType "DA6"
+	Temperature 7911
+	AppMag 15.18
+	Radius 8601
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%20462-56%20B/L%20462-56%20B.html"
+}
+
+"Gaia DR2 5432789383518999168:WDJ093736.24-385223.21"
+{
+	RA 144.39855089
+	Dec -38.87138104
+	Distance 112.378
+	SpectralType "DA9"
+	Temperature 5679
+	AppMag 17.148 # synthetic
+	Radius 8926
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205432789383518999168/Gaia%20DR2%205432789383518999168.html"
+}
+
+"LSPM J0939+4951:WDJ093931.74+495148.29"
+{
+	RA 144.87954814
+	Dec 49.86335298
+	Distance 111.297
+	SpectralType "DA8"
+	Temperature 5985
+	AppMag 17.389 # synthetic
+	Radius 6809
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J0939+4951/LSPM%20J0939+4951.html"
+}
+
+"Gaia DR2 5688717241916173568:WDJ093948.69-145836.69"
+{
+	RA 144.95040825
+	Dec -14.97697766
+	Distance 115.574
+	SpectralType "DC9"
+	Temperature 4349
+	AppMag 18.621 # synthetic
+	Radius 11696
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205688717241916173568/Gaia%20DR2%205688717241916173568.html"
+}
+
+"Gaia DR2 5425208663166556288:WDJ094052.75-423225.46"
+{
+	RA 145.22014551
+	Dec -42.54007355
+	Distance 121.987
+	SpectralType "DC9"
+	Temperature 5856
+	AppMag 17.372 # synthetic
+	Radius 7972
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205425208663166556288/Gaia%20DR2%205425208663166556288.html"
+}
+
+"Gaia DR2 5410698683096655360:WDJ094240.23-463717.68"
+{
+	RA 145.66808539
+	Dec -46.62175556
+	Distance 66.748
+	SpectralType "DAH8"
+	Temperature 5960
+	AppMag 15.752 # synthetic
+	Radius 8723
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205410698683096655360/Gaia%20DR2%205410698683096655360.html"
+}
+
+"GJ 3565:WD 0941-068:WDJ094346.61-070348.73"
+{
+	RA 145.94399302
+	Dec -7.06545508
+	Distance 93.695
+	SpectralType "DA8"
+	Temperature 5974
+	AppMag 16.43
+	Radius 9016
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203565/GJ%203565.html"
+}
+
+"EGGR 67:LAWD 32:WD 0943+441:WDJ094639.07+435452.24"
+{
+	RA 146.66279112
+	Dec 43.91578488
+	Distance 104.365
+	SpectralType "DA4"
+	Temperature 13821
+	AppMag 13.29
+	Radius 12222
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2067/EGGR%2067.html"
+}
+
+"LP 428-41:WD 0945+206:WDJ094806.16+202315.28"
+{
+	RA 147.024758
+	Dec 20.38762289
+	Distance 121.259
+	SpectralType "DC9"
+	Temperature 5030
+	AppMag 18.08 # synthetic
+	Radius 9452
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20428-41/LP%20428-41.html"
+}
+
+"PG 0945+246:WD 0945+245:WDJ094846.64+242125.88"
+{
+	RA 147.1939922
+	Dec 24.35670791
+	Distance 117.954
+	SpectralType "DA3"
+	Temperature 17920
+	AppMag 14.25
+	Radius 7320
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%200945+246/PG%200945+246.html"
+}
+
+"GJ 3569:EGGR 251:WD 0946+534:WDJ095017.14+531514.83"
+{
+	RA 147.569473
+	Dec 53.25396386
+	Distance 89.933
+	SpectralType "DQ6"
+	Temperature 8396
+	AppMag 15.3
+	Radius 8653
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20251/EGGR%20251.html"
+}
+
+"NLTT 22727:WD 0947+153:WDJ095021.80+150909.69"
+{
+	RA 147.59053148
+	Dec 15.15131704
+	Distance 127.497
+	SpectralType "DC9"
+	Temperature 5395
+	AppMag 17.601 # synthetic
+	Radius 9614
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2022727/NLTT%2022727.html"
+}
+
+"Gaia DR2 1066726497434084864:WDJ095447.49+670208.00"
+{
+	RA 148.69513751
+	Dec 67.0348682
+	Distance 83.156
+	SpectralType "DA9"
+	Temperature 5769
+	AppMag 16.725 # synthetic
+	Radius 7610
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201066726497434084864/Gaia%20DR2%201066726497434084864.html"
+}
+
+"GJ 2076:WD 0954-710:WDJ095522.89-711808.37"
+{
+	RA 148.84355142
+	Dec -71.30279017
+	Distance 99.575
+	SpectralType "DA4"
+	Temperature 14275
+	AppMag 13.48
+	Radius 10299
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202076/GJ%202076.html"
+}
+
+"GJ 3575:EGGR 69:WD 0955+247:WDJ095748.35+243255.54"
+{
+	RA 149.45013367
+	Dec 24.54736777
+	Distance 89.817
+	SpectralType "DA6"
+	Temperature 8488
+	AppMag 15.08
+	Radius 8576
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2069/EGGR%2069.html"
+}
+
+"GJ 2077:EGGR 252:WD 0959+149:WDJ100149.36+144123.79"
+{
+	RA 150.45412521
+	Dec 14.68999088
+	Distance 63.235
+	SpectralType "DC7"
+	Temperature 6778
+	AppMag 15.37
+	Radius 7625
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20252/EGGR%20252.html"
+}
+
+"WD 0958+436:WDJ100204.09+432645.90"
+{
+	RA 150.51720088
+	Dec 43.44559172
+	Distance 113.954
+	SpectralType "DC9"
+	Temperature 4857
+	AppMag 18.049 # synthetic
+	Radius 10214
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%200958+436/WD%200958+436.html"
+}
+
+"WD 1001-033:GD 110:WDJ100338.84-033756.87"
+{
+	RA 150.91125901
+	Dec -3.63275048
+	Distance 108.729
+	SpectralType "DA6"
+	Temperature 8403
+	AppMag 15.45
+	Radius 8920
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201001-033/WD%201001-033.html"
+}
+
+# Companion to WDJ100424.18-050614.92
+"G 162-17"
+{
+	RA 151.07954249
+	Dec -5.07811106
+	Distance 115.808 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3135 # GSP-Phot
+	AppMag 15.82 # synthetic
+	Radius 166169 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+162-17"
+}
+
+"Gaia DR2 3822028007288795264:WDJ100424.18-050614.92"
+{
+	RA 151.09997208
+	Dec -5.10588137
+	Distance 115.808 # mean of system components
+	SpectralType "DC9"
+	Temperature 4475
+	AppMag 18.631 # synthetic
+	Radius 10465
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203822028007288795264/Gaia%20DR2%203822028007288795264.html"
+}
+
+"GD 462:EGGR 432:WD 1005+642:WDJ100936.36+635837.35"
+{
+	RA 152.40050034
+	Dec 63.97667092
+	Distance 128.4
+	SpectralType "DA3"
+	Temperature 19686
+	AppMag 13.692
+	Radius 9327
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20462/GD%20462.html"
+}
+
+"Gaia DR2 5407613384750351232:WDJ101039.30-471729.83"
+{
+	RA 152.66096768
+	Dec -47.29143366
+	Distance 120.958
+	SpectralType "DA9"
+	Temperature 5852
+	AppMag 17.315 # synthetic
+	Radius 8136
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205407613384750351232/Gaia%20DR2%205407613384750351232.html"
+}
+
+"Gaia DR2 5473389537569200896:WDJ101047.91-242710.93"
+{
+	RA 152.69909191
+	Dec -24.45327486
+	Distance 129.341
+	SpectralType "DAP2"
+	Temperature 21653
+	AppMag 15.2
+	Radius 4453
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205473389537569200896/Gaia%20DR2%205473389537569200896.html"
+}
+
+"LP 315-42:WD 1008+290:WDJ101141.58+284559.07"
+{
+	RA 152.9226066
+	Dec 28.76323853
+	Distance 48.034
+	SpectralType "DQP9"
+	Temperature 4340 # Table A5
+	AppMag 17.51
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20315-42/LP%20315-42.html"
+}
+
+# Companion to WDJ101201.87-184333.27
+49973 "Gliese 383:BD-17 3088"
+{
+	RA 153.03152188
+	Dec -18.6178064
+	Distance 58.937 # mean of system components
+	SpectralType "K7V"
+	AppMag 9.91
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD-17+3088"
+}
+
+"WD 1009-184:WDJ101201.87-184333.27"
+{
+	RA 153.00534869
+	Dec -18.72596658
+	Distance 58.937 # mean of system components
+	SpectralType "DZH8"
+	Temperature 6394
+	AppMag 15.44
+	Radius 7740
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201009-184/WD%201009-184.html"
+}
+
+"Gaia DR2 5356710428806242816:WDJ101341.21-523400.86"
+{
+	RA 153.42270147
+	Dec -52.56689619
+	Distance 129.021
+	SpectralType "DA7"
+	Temperature 6918
+	AppMag 16.754 # synthetic
+	Radius 8138
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205356710428806242816/Gaia%20DR2%205356710428806242816.html"
+}
+
+"2MASS J10143597+4226228:WD 1011+426:WDJ101435.97+422622.50"
+{
+	RA 153.65065908
+	Dec 42.43899864
+	Distance 101.889
+	SpectralType "DA7"
+	Temperature 7731
+	AppMag 16.306 # synthetic
+	Radius 6482
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J10143597+4226228/2MASS%20J10143597+4226228.html"
+}
+
+"WD 1012+083.2:WDJ101501.75+080611.24"
+{
+	RA 153.75596572
+	Dec 8.10382725
+	Distance 96.068 # mean of system components
+	SpectralType "DC9"
+	Temperature 4739
+	AppMag 17.806 # synthetic
+	Radius 10673
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201012+083.2/WD%201012+083.2.html"
+}
+
+"EGGR 183:WD 1012+083 A:WDJ101502.61+080635.70"
+{
+	RA 153.75957944
+	Dec 8.11064555
+	Distance 96.068 # mean of system components
+	SpectralType "DA8"
+	Temperature 6612
+	AppMag 16.03
+	Radius 9142
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20183/EGGR%20183.html"
+}
+
+"Gaia DR2 5446665014103742336:WDJ101812.80-343846.05"
+{
+	RA 154.55468672
+	Dec -34.64722225
+	Distance 106.87
+	SpectralType "DA9"
+	Temperature 5185
+	AppMag 17.654 # synthetic
+	Radius 9021
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205446665014103742336/Gaia%20DR2%205446665014103742336.html"
+}
+
+"Gaia DR2 5446784345474819968:WDJ101947.34-340221.88"
+{
+	RA 154.94534529
+	Dec -34.03873371
+	Distance 89.787
+	SpectralType "DAH8"
+	Temperature 6483
+	AppMag 16.569
+	Radius 6839
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205446784345474819968/Gaia%20DR2%205446784345474819968.html"
+}
+
+"Gaia DR2 1146403741412820864:WDJ102203.66+824310.00"
+{
+	RA 155.50570351
+	Dec 82.71861302
+	Distance 129.8
+	SpectralType "DA9"
+	Temperature 5621
+	AppMag 18.062 # synthetic
+	Radius 6850
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201146403741412820864/Gaia%20DR2%201146403741412820864.html"
+}
+
+"2MASS J10221035+4612491:WD 1022+461:WDJ102210.36+461249.40"
+{
+	RA 155.54321965
+	Dec 46.21316682
+	Distance 107.411
+	SpectralType "DA7"
+	Temperature 7076
+	AppMag 16.32 # synthetic
+	Radius 7908
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J10221035+4612491/2MASS%20J10221035+4612491.html"
+}
+
+"LP 212-60:WDJ102251.75+390414.73"
+{
+	RA 155.7131371
+	Dec 39.06992066
+	Distance 127.384
+	SpectralType "DZ8"
+	Temperature 6229
+	AppMag 17.391 # synthetic
+	Radius 7145
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20212-60/LP%20212-60.html"
+}
+
+"GJ 1133:EGGR 350:WD 1019+637:WDJ102309.06+632741.49"
+{
+	RA 155.79074604
+	Dec 63.46251156
+	Distance 51.969
+	SpectralType "DA7"
+	Temperature 6801
+	AppMag 14.71
+	Radius 8669
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201133/GJ%201133.html"
+}
+
+"WD 1024-382:WDJ102621.35-383038.82"
+{
+	RA 156.58683401
+	Dec -38.51203729
+	Distance 94.957
+	SpectralType "DA7"
+	Temperature 6790
+	AppMag 15.92
+	Radius 9220
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201024-382/WD%201024-382.html"
+}
+
+"GJ 2080:WD 1026+117:WDJ102907.46+112719.28"
+{
+	RA 157.28283984
+	Dec 11.45399213
+	Distance 109.891
+	SpectralType "DAH7"
+	Temperature 6878
+	AppMag 16.65
+	Radius 7448
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202080/GJ%202080.html"
+}
+
+"PG 1026+024:WD 1026+023:WDJ102909.81+020553.67"
+{
+	RA 157.29040307
+	Dec 2.09791139
+	Distance 109.443
+	SpectralType "DA4"
+	Temperature 12612
+	AppMag 14.2
+	Radius 8933
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201026+024/PG%201026+024.html"
+}
+
+"Gaia DR3 3883918657822146944:WDJ102926.67+125733.40"
+{
+	RA 157.36152036
+	Dec 12.95923137
+	Distance 117.28
+	SpectralType "DZH9"
+	Temperature 5526
+	AppMag 17.644 # synthetic
+	Radius 7877
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%203883918657822146944/Gaia%20DR3%203883918657822146944.html"
+}
+
+"WD 1027-261:WDJ102957.71-262405.08"
+{
+	RA 157.49020831
+	Dec -26.40232516
+	Distance 111.382
+	SpectralType "DA9"
+	Temperature 5750
+	AppMag 17.05
+	Radius 8866
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201027-261/WD%201027-261.html"
+}
+
+"Gaia DR2 3750749378584132992:WDJ103055.44-142400.53"
+{
+	RA 157.73102119
+	Dec -14.39985603
+	Distance 90.124
+	SpectralType "DA8"
+	Temperature 6028
+	AppMag 16.663 # synthetic
+	Radius 7685
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203750749378584132992/Gaia%20DR2%203750749378584132992.html"
+}
+
+"EGGR 70:WD 1031-114:WDJ103342.76-114138.34"
+{
+	RA 158.42661794
+	Dec -11.69410791
+	Distance 116.405
+	SpectralType "DA2"
+	Temperature 25388
+	AppMag 13.0
+	Radius 9600
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2070/EGGR%2070.html"
+}
+
+"Gaia DR2 5233071514480420864:WDJ103427.04-672239.24"
+{
+	RA 158.61279509
+	Dec -67.37787294
+	Distance 76.878
+	SpectralType "DA3"
+	Temperature 18779
+	AppMag 13.31
+	Radius 6846
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205233071514480420864/Gaia%20DR2%205233071514480420864.html"
+}
+
+"WD 1033+714:WDJ103702.48+711058.70"
+{
+	RA 159.2347221
+	Dec 71.18091533
+	Distance 57.458
+	SpectralType "DC9"
+	Temperature 4818
+	AppMag 16.94
+	Radius 8577
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201033+714/WD%201033+714.html"
+}
+
+"Gaia DR2 5367774809996936960:WDJ103706.75-441236.96"
+{
+	RA 159.27680659
+	Dec -44.20948791
+	Distance 127.369
+	SpectralType "DAH9"
+	Temperature 5704
+	AppMag 17.289
+	Radius 9376
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205367774809996936960/Gaia%20DR2%205367774809996936960.html"
+}
+
+"GJ 3614:EGGR 535:WD 1036-204:WDJ103855.57-204056.83"
+{
+	RA 159.73017337
+	Dec -20.68000339
+	Distance 46.015
+	SpectralType "DQP9"
+	Temperature 5761
+	AppMag 16.25
+	Radius 5891
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203614/GJ%203614.html"
+}
+
+"PM J10403+1004:WD 1037+103:WDJ104019.70+100400.78"
+{
+	RA 160.08163104
+	Dec 10.06635745
+	Distance 120.236
+	SpectralType "DC8"
+	Temperature 5970
+	AppMag 17.231 # synthetic
+	Radius 7960
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J10403+1004/PM%20J10403+1004.html"
+}
+
+"CY Leo:EGGR 72:WD 1039+145:WDJ104153.78+141548.69"
+{
+	RA 160.47488505
+	Dec 14.26243807
+	Distance 122.342
+	SpectralType "DQ7"
+	Temperature 7090
+	AppMag 16.51
+	Radius 8318
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20CY%20Leo/V*%20CY%20Leo.html"
+}
+
+"V727 Car:WD 1042-690:WDJ104410.24-691818.08"
+{
+	RA 161.03897324
+	Dec -69.30494951
+	Distance 95.313
+	SpectralType "DA2"
+	Temperature 22570 # Table A5
+	AppMag 13.09
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V727%20Car/V*%20V727%20Car.html"
+}
+
+# Companion to WDJ104539.04-190645.03
+52621 "Gliese 401 A:BD-18 3019"
+{
+	RA 161.40408369
+	Dec -19.11703218
+	Distance 61.29 # mean of system components
+	SpectralType "M0V"
+	Temperature 3559 # GSP-Spec
+	AppMag 11.21
+	Radius 344853 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD-18+3019"
+}
+
+"Gliese 401 B:BD-18 3019 B:WD 1043-188:WDJ104539.04-190645.03"
+{
+	RA 161.40389543
+	Dec -19.11519224
+	Distance 61.29 # mean of system components
+	SpectralType "DQ9"
+	Temperature 5751
+	AppMag 15.52
+	Radius 9463
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/BD-18%203019B/BD-18%203019B.html"
+}
+
+"Gaia DR2 5391794195555570048:WDJ104646.00-414638.85"
+{
+	RA 161.69292831
+	Dec -41.77805426
+	Distance 91.985
+	SpectralType "DAH7"
+	Temperature 6749
+	AppMag 15.969
+	Radius 8628
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205391794195555570048/Gaia%20DR2%205391794195555570048.html"
+}
+
+"2MASS J10480182+6334487:WD 1044+638:WDJ104801.84+633448.80"
+{
+	RA 162.00506255
+	Dec 63.57959817
+	Distance 111.928
+	SpectralType "DA9"
+	Temperature 5289
+	AppMag 17.561 # synthetic
+	Radius 9296
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J10480182+6334487/2MASS%20J10480182+6334487.html"
+}
+
+"LP 213-79:WD 1049+410:WDJ105211.73+405004.19"
+{
+	RA 163.04779499
+	Dec 40.8336664
+	Distance 110.459
+	SpectralType "DC8"
+	Temperature 6237
+	AppMag 16.844 # synthetic
+	Radius 8104
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20213-79/LP%20213-79.html"
+}
+
+"WD 1049-158:WDJ105220.53-160804.18"
+{
+	RA 163.08481813
+	Dec -16.13433318
+	Distance 126.037
+	SpectralType "DA3"
+	Temperature 19297
+	AppMag 14.357
+	Radius 6901
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201049-158/WD%201049-158.html"
+}
+
+"GD 125:EGGR 221:WD 1052+273:WDJ105443.32+270657.04"
+{
+	RA 163.67976115
+	Dec 27.11569424
+	Distance 123.04
+	SpectralType "DA2"
+	Temperature 22502
+	AppMag 14.12
+	Radius 6850
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20125/GD%20125.html"
+}
+
+"LAWD 33:WD 1053-550:WDJ105513.54-551905.16"
+{
+	RA 163.80368808
+	Dec -55.31698828
+	Distance 115.164
+	SpectralType "DA4"
+	Temperature 14227
+	AppMag 14.32
+	Radius 9051
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2033/LAWD%2033.html"
+}
+
+"WD 1054-226:WDJ105638.63-225256.08"
+{
+	RA 164.16058337
+	Dec -22.88092043
+	Distance 117.777
+	SpectralType "DAZ6"
+	Temperature 7836
+	AppMag 15.998
+	Radius 8310
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201054-226/WD%201054-226.html"
+}
+
+"GJ 1140:LAWD 34:EGGR 74:WD 1055-072:WDJ105735.13-073123.18"
+{
+	RA 164.39272991
+	Dec -7.52269891
+	Distance 39.992
+	SpectralType "DC7"
+	Temperature 7096
+	AppMag 14.32
+	Radius 7424
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2034/LAWD%2034.html"
+}
+
+"G 163-28:WD 1055-039:WDJ105747.61-041330.16"
+{
+	RA 164.44952923
+	Dec -4.22575527
+	Distance 118.397
+	SpectralType "DZ7"
+	Temperature 6949
+	AppMag 16.73
+	Radius 7529
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20163-28/G%20163-28.html"
+}
+
+"Gaia DR2 5456685104084844032:WDJ105915.98-281955.96"
+{
+	RA 164.81504311
+	Dec -28.33251984
+	Distance 128.522
+	SpectralType "DAZ8"
+	Temperature 6653
+	AppMag 16.792 # synthetic
+	Radius 8583
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205456685104084844032/Gaia%20DR2%205456685104084844032.html"
+}
+
+"Gaia DR2 3982007636324256000:WDJ110143.04+172139.39"
+{
+	RA 165.42731377
+	Dec 17.35941598
+	Distance 93.983
+	SpectralType "DA7"
+	Temperature 7709
+	AppMag 16.053 # synthetic
+	Radius 6759
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203982007636324256000/Gaia%20DR2%203982007636324256000.html"
+}
+
+"SDSS J110217.48+411315.4:WD 1059+415:WDJ110217.52+411321.18"
+{
+	RA 165.57240577
+	Dec 41.21475183
+	Distance 113.545
+	SpectralType "DC9"
+	Temperature 3790 # Table A5
+	AppMag 19.341 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J110217.48+411315.4/SDSS%20J110217.48+411315.4.html"
+}
+
+"SDSS J110318.87+393558.3:WDJ110318.84+393558.35"
+{
+	RA 165.82897762
+	Dec 39.5995099
+	Distance 126.775
+	SpectralType "DAZ9"
+	Temperature 5015
+	AppMag 17.983 # synthetic
+	Radius 10868
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J110318.87+393558.3/SDSS%20J110318.87+393558.3.html"
+}
+
+"WD 1102-183:WDJ110446.88-183713.12"
+{
+	RA 166.19593431
+	Dec -18.62053993
+	Distance 129.823
+	SpectralType "DA6"
+	Temperature 8125
+	AppMag 15.99
+	Radius 8803
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201102-183/WD%201102-183.html"
+}
+
+"WD 1104+150:WDJ110709.72+144654.40"
+{
+	RA 166.78928119
+	Dec 14.78228648
+	Distance 124.757
+	SpectralType "DA8"
+	Temperature 6662
+	AppMag 16.633 # synthetic
+	Radius 8916
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201104+150/WD%201104+150.html"
+}
+
+"EGGR 75:WD 1104+602:WDJ110742.77+595829.66"
+{
+	RA 166.92651325
+	Dec 59.97416302
+	Distance 112.417
+	SpectralType "DA3"
+	Temperature 18320
+	AppMag 13.74
+	Radius 8361
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2075/EGGR%2075.html"
+}
+
+"WD 1105-340:WDJ110747.90-342051.49"
+{
+	RA 166.94978506
+	Dec -34.34880598
+	Distance 85.317
+	SpectralType "DAH4"
+	Temperature 13603
+	AppMag 13.66
+	Radius 8516
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201105-340/WD%201105-340.html"
+}
+
+# Companion to WDJ110759.95-050926.03
+"GJ 1142 A:L 970-27"
+{
+	RA 167.02700102
+	Dec -5.23171423
+	Distance 81.016 # mean of system components
+	SpectralType "M3V"
+	Temperature 3168 # GSP-Phot
+	AppMag 12.559
+	Radius 394846 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+970-27"
+}
+
+"GJ 1142 B:EGGR 76:WD 1105-048:WDJ110759.95-050926.03"
+{
+	RA 166.99954557
+	Dec -5.15919901
+	Distance 81.016 # mean of system components
+	SpectralType "DAH3"
+	Temperature 15703
+	AppMag 12.92
+	Radius 9542
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2076/EGGR%2076.html"
+}
+
+"PG 1106+083:WD 1106+082:WDJ110844.12+080139.68"
+{
+	RA 167.18431414
+	Dec 8.02677436
+	Distance 123.56
+	SpectralType "DA7"
+	Temperature 7558
+	AppMag 16.08
+	Radius 8926
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201106+083/PG%201106+083.html"
+}
+
+"2MASS J11094130+5512289:WD 1106+554:WDJ110941.28+551228.70"
+{
+	RA 167.4227077
+	Dec 55.20716219
+	Distance 116.64
+	SpectralType "DA7"
+	Temperature 6996
+	AppMag 17.188 # synthetic
+	Radius 5856
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J11094130+5512289/2MASS%20J11094130+5512289.html"
+}
+
+"WD 1108+207:WDJ111059.34+202606.91"
+{
+	RA 167.74334514
+	Dec 20.43506442
+	Distance 90.758
+	SpectralType "DC9"
+	Temperature 4820
+	AppMag 17.7
+	Radius 10106
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201108+207/WD%201108+207.html"
+}
+
+"2MASS J11153694+0033171:WD 1113+008:WDJ111536.96+003317.11"
+{
+	RA 168.90412919
+	Dec 0.55362972
+	Distance 129.918
+	SpectralType "DA9"
+	Temperature 5199
+	AppMag 17.514 # synthetic
+	Radius 12335
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J11153694+0033171/2MASS%20J11153694+0033171.html"
+}
+
+"WD 1114+06:WD 1114+067:WDJ111640.38+062702.67"
+{
+	RA 169.16671741
+	Dec 6.45063152
+	Distance 122.28
+	SpectralType "DA8"
+	Temperature 6262
+	AppMag 16.75
+	Radius 9272
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201114+06/WD%201114+06.html"
+}
+
+"Gaia DR2 5376644127919488896:WDJ111717.11-441134.49"
+{
+	RA 169.31965747
+	Dec -44.19301517
+	Distance 86.966
+	SpectralType "DC9"
+	Temperature 5639
+	AppMag 15.934 # synthetic
+	Radius 12356
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205376644127919488896/Gaia%20DR2%205376644127919488896.html"
+}
+
+"LAWD 35:EGGR 78:WD 1115-029:WDJ111815.06-031405.57"
+{
+	RA 169.56038026
+	Dec -3.23387025
+	Distance 119.134
+	SpectralType "DQ5"
+	Temperature 9262
+	AppMag 15.34
+	Radius 9172
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2035/LAWD%2035.html"
+}
+
+"2MASS J11182722-4721570:WD 1116-470:WDJ111827.20-472156.96"
+{
+	RA 169.61115719
+	Dec -47.36566984
+	Distance 55.526
+	SpectralType "DC9"
+	Temperature 5903
+	AppMag 15.52
+	Radius 8268
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J11182722-4721570/2MASS%20J11182722-4721570.html"
+}
+
+"GD 133:WD 1116+026:WDJ111912.40+022033.05"
+{
+	RA 169.80121562
+	Dec 2.34265044
+	Distance 124.537
+	SpectralType "DAZ4"
+	Temperature 12158
+	AppMag 14.57
+	Radius 8752
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20133/GD%20133.html"
+}
+
+"Gaia DR2 3783206210217512320:WDJ111913.56-083137.22"
+{
+	RA 169.80498876
+	Dec -8.52688457
+	Distance 98.655
+	SpectralType "DA9"
+	Temperature 5585
+	AppMag 17.015 # synthetic
+	Radius 8746
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203783206210217512320/Gaia%20DR2%203783206210217512320.html"
+}
+
+"Gliese 427:Ross 627:LAWD 36:EGGR 79:WD 1121+216:WDJ112412.97+212135.57"
+{
+	RA 171.04909306
+	Dec 21.35980454
+	Distance 47.908
+	SpectralType "DA7"
+	Temperature 7373
+	AppMag 14.24
+	Radius 8658
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ross%20627/Ross%20627.html"
+}
+
+"LP 374-46:WD 1122+214:WDJ112521.40+211114.77"
+{
+	RA 171.33788793
+	Dec 21.18610634
+	Distance 124.387
+	SpectralType "DC8"
+	Temperature 6194
+	AppMag 17.025 # synthetic
+	Radius 8478
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20374-46/LP%20374-46.html"
+}
+
+"GD 309:WD 1124+595:WDJ112652.39+591917.10"
+{
+	RA 171.71966862
+	Dec 59.32117592
+	Distance 82.864
+	SpectralType "DA5"
+	Temperature 10419
+	AppMag 15.13
+	Radius 5560
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20309/GD%20309.html"
+}
+
+"WD 1124-293:WDJ112709.25-294011.20"
+{
+	RA 171.78961596
+	Dec -29.67097574
+	Distance 109.187
+	SpectralType "DAZ5"
+	Temperature 9402
+	AppMag 15.04
+	Radius 8977
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201124-293/WD%201124-293.html"
+}
+
+"Gaia DR2 5398247534240054528:WDJ113216.54-360204.95"
+{
+	RA 173.06891197
+	Dec -36.03479177
+	Distance 118.767
+	SpectralType "DZH9"
+	Temperature 4766
+	AppMag 18.243 # synthetic
+	Radius 10681
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205398247534240054528/Gaia%20DR2%205398247534240054528.html"
+}
+
+# Companion to WDJ113430.48-325002.40
+56452 "20 Crt:Gliese 432 A"
+{
+	RA 173.61931513
+	Dec -32.82768461
+	Distance 31.16 # mean of system components
+	SpectralType "K0V"
+	Temperature 5111 # GSP-Spec
+	AppMag 5.98
+	Radius 537928 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=*+20+Crt"
+}
+
+"20 Crt B:Gliese 432 B:HD 100623 B:WD 1132-325:WDJ113430.48-325002.40"
+{
+	RA 173.62327851
+	Dec -32.83031725
+	Distance 31.16 # mean of system components
+	SpectralType "DC9"
+	Temperature 5367
+	AppMag 15.0
+	Radius 8761
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20432%20B/GJ%20432%20B.html"
+}
+
+"Gaia DR2 859567752163281792:WDJ113444.64+610826.68"
+{
+	RA 173.68596256
+	Dec 61.14042175
+	Distance 91.606
+	SpectralType "DAZ7"
+	Temperature 7502
+	AppMag 15.45
+	Radius 9066
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%20859567752163281792/Gaia%20DR2%20859567752163281792.html"
+}
+
+56662 "Gliese 433.1:GD 140:EGGR 184:WD 1134+300:WDJ113705.10+294758.29"
+{
+	RA 174.27051073
+	Dec 29.79946895
+	Distance 51.148
+	SpectralType "DA2"
+	Temperature 21336
+	AppMag 12.49
+	Radius 6172
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20140/GD%20140.html"
+}
+
+# Companion to WDJ113840.67-131338.55
+56802 "IOT Crt:24 Crt:GJ 3677"
+{
+	RA 174.6671613
+	Dec -13.2013822
+	Distance 87.487 # mean of system components
+	SpectralType "F6.5V+M3"
+	Temperature 6198 # GSP-Spec
+	AppMag 5.48
+	Radius 1175110 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=*+iot+Crt"
+}
+
+"Gaia DR2 3585097235918075776:WDJ113840.67-131338.55"
+{
+	RA 174.66986374
+	Dec -13.22685919
+	Distance 87.487 # mean of system components
+	SpectralType "DC8"
+	Temperature 5930
+	AppMag 16.584 # synthetic
+	Radius 7911
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203585097235918075776/Gaia%20DR2%203585097235918075776.html"
+}
+
+"Gaia DR2 3464893058489831552:WDJ114122.38-350406.93"
+{
+	RA 175.34277987
+	Dec -35.06927741
+	Distance 95.346
+	SpectralType "DZA9"
+	Temperature 4777
+	AppMag 17.707 # synthetic
+	Radius 10775
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203464893058489831552/Gaia%20DR2%203464893058489831552.html"
+}
+
+"WD 1141-012:WDJ114352.16-013149.34"
+{
+	RA 175.96607184
+	Dec -1.53037731
+	Distance 129.052
+	SpectralType "DA8"
+	Temperature 6556
+	AppMag 17.06
+	Radius 6986
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201141-012/WD%201141-012.html"
+}
+
+# WDJ114542.92-645029.46: defined in nearstars.stc
+
+"GJ 1149:EGGR 353:WD 1143+633:WDJ114544.57+630559.15"
+{
+	RA 176.43370614
+	Dec 63.09823204
+	Distance 78.235
+	SpectralType "DA9"
+	Temperature 5533
+	AppMag 16.383 # synthetic
+	Radius 9589
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20353/EGGR%20353.html"
+}
+
+# Companion to WDJ114556.67+314930.69
+"G 148-6"
+{
+	RA 176.48235296
+	Dec 31.82410245
+	Distance 102.097 # mean of system components
+	SpectralType "M3V"
+	AppMag 14.075 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+148-6"
+}
+
+"EGGR 185:EGGR 83:WD 1143+321:WDJ114556.67+314930.69"
+{
+	RA 176.48532005
+	Dec 31.82402592
+	Distance 102.097 # mean of system components
+	SpectralType "DA3"
+	Temperature 15735
+	AppMag 13.65
+	Radius 9054
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20185/EGGR%20185.html"
+}
+
+"WD 1143-013:WDJ114625.77-013636.90"
+{
+	RA 176.60894299
+	Dec -1.61218464
+	Distance 107.262
+	SpectralType "DA8"
+	Temperature 6526
+	AppMag 16.39
+	Radius 8960
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201143-013/WD%201143-013.html"
+}
+
+"Gaia DR2 5224999346778496128:WDJ114734.45-745759.24"
+{
+	RA 176.8752539
+	Dec -74.96043554
+	Distance 65.083
+	SpectralType "DC9"
+	Temperature 4052
+	AppMag 17.633 # synthetic
+	Radius 12306
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205224999346778496128/Gaia%20DR2%205224999346778496128.html"
+}
+
+"PM J11480-4523:WD 1145-451:WDJ114803.28-452302.05"
+{
+	RA 177.01017915
+	Dec -45.38546301
+	Distance 81.836
+	SpectralType "DA8"
+	Temperature 6064
+	AppMag 15.66
+	Radius 9571
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J11480-4523/PM%20J11480-4523.html"
+}
+
+"Gaia DR2 5381346739148118016:WDJ114901.67-405114.98"
+{
+	RA 177.2554731
+	Dec -40.85446156
+	Distance 127.111
+	SpectralType "DC9"
+	Temperature 4513
+	AppMag 18.573 # synthetic
+	Radius 11941
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205381346739148118016/Gaia%20DR2%205381346739148118016.html"
+}
+
+"WD 1146-290:WD 1146-291:WDJ114904.52-292151.76"
+{
+	RA 177.26984536
+	Dec -29.3635189
+	Distance 101.0
+	SpectralType "DA9"
+	Temperature 5722
+	AppMag 17.3
+	Radius 7031
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201146-290/WD%201146-290.html"
+}
+
+"Gaia DR2 4004185576130620288:WDJ115007.08+240403.54"
+{
+	RA 177.52638073
+	Dec 24.06456842
+	Distance 98.185
+	SpectralType "DC"
+	AppMag 20.072 # estimate
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204004185576130620288/Gaia%20DR2%204004185576130620288.html"
+}
+
+"Gaia DR2 3490527755479959936:WDJ115020.14-255335.40"
+{
+	RA 177.58339168
+	Dec -25.89372302
+	Distance 95.672
+	SpectralType "DC8"
+	Temperature 6686
+	AppMag 16.4 # synthetic
+	Radius 7811
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203490527755479959936/Gaia%20DR2%203490527755479959936.html"
+}
+
+"2MASS J11505233+6831161:WD 1148+687:WDJ115052.33+683115.97"
+{
+	RA 177.71833791
+	Dec 68.52092072
+	Distance 55.711
+	SpectralType "DA8"
+	Temperature 6696
+	AppMag 15.25
+	Radius 7433
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J11505233+6831161/2MASS%20J11505233+6831161.html"
+}
+
+"WD 1149-272:WDJ115136.10-273221.13"
+{
+	RA 177.8993411
+	Dec -27.53899308
+	Distance 82.009
+	SpectralType "DQ7"
+	Temperature 6773
+	AppMag 15.87
+	Radius 8163
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201149-272/WD%201149-272.html"
+}
+
+"Gaia DR2 3479615106870788864:WDJ115403.49-310145.29"
+{
+	RA 178.5151278
+	Dec -31.02920487
+	Distance 128.307
+	SpectralType "DC8"
+	Temperature 6105
+	AppMag 17.26 # synthetic
+	Radius 8120
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203479615106870788864/Gaia%20DR2%203479615106870788864.html"
+}
+
+"WD 1151+246:WDJ115434.57+242239.72"
+{
+	RA 178.64403769
+	Dec 24.37715553
+	Distance 86.432
+	SpectralType "DA6"
+	Temperature 8699
+	AppMag 15.26
+	Radius 6233
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201151+246/WD%201151+246.html"
+}
+
+"Gaia DR3 5334619419176460928:WDJ115454.07-623919.42"
+{
+	RA 178.71821605
+	Dec -62.65467749
+	Distance 73.189
+	SpectralType "DAZ9"
+	Temperature 5087
+	AppMag 16.686 # synthetic
+	Radius 10517
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%205334619419176460928/Gaia%20DR3%205334619419176460928.html"
+}
+
+"LHS 2478:WD 1153+135:WDJ115612.37+131555.45"
+{
+	RA 179.04860828
+	Dec 13.26580379
+	Distance 115.986
+	SpectralType "DC9"
+	Temperature 4954
+	AppMag 17.73
+	Radius 12168
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%202478/LHS%202478.html"
+}
+
+"EGGR 85:LAWD 39:WD 1154+186:WDJ115643.84+182219.54"
+{
+	RA 179.18110449
+	Dec 18.37212532
+	Distance 87.155
+	SpectralType "DC7"
+	Temperature 7472
+	AppMag 15.61
+	Radius 8241
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2085/EGGR%2085.html"
+}
+
+"SDSS J115814.51+000458.2:WD 1155+003:WDJ115814.52+000458.51"
+{
+	RA 179.56038833
+	Dec 0.08374505
+	Distance 112.818
+	SpectralType "DC9"
+	Temperature 4621
+	AppMag 18.268 # synthetic
+	Radius 11292
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J115814.51+000458.2/SDSS%20J115814.51+000458.2.html"
+}
+
+"PG 1157+004:WD 1157+004:WDJ115952.05+000751.87"
+{
+	RA 179.96715969
+	Dec 0.13090294
+	Distance 92.187
+	SpectralType "DA5"
+	Temperature 9420
+	AppMag 15.73
+	Radius 5466
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201157+004/PG%201157+004.html"
+}
+
+"Gaia DR3 5341271911184522880:WDJ115954.88-601625.45"
+{
+	RA 179.97657273
+	Dec -60.27427792
+	Distance 84.67
+	SpectralType "DA9"
+	Temperature 4947
+	AppMag 17.108 # synthetic
+	Radius 11157
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%205341271911184522880/Gaia%20DR3%205341271911184522880.html"
+}
+
+"WD 1157+438:WDJ120003.37+433541.71"
+{
+	RA 180.01226296
+	Dec 43.5947382
+	Distance 121.579
+	SpectralType "DA6"
+	Temperature 7887
+	AppMag 15.71
+	Radius 9582
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201157+438/WD%201157+438.html"
+}
+
+"Gaia DR2 3575728709655386752:WDJ120055.89-103220.61"
+{
+	RA 180.23245044
+	Dec -10.53920132
+	Distance 109.643
+	SpectralType "DA6"
+	Temperature 7949
+	AppMag 16.45
+	Radius 6478
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203575728709655386752/Gaia%20DR2%203575728709655386752.html"
+}
+
+"WD 1159-098:WDJ120207.65-100439.65"
+{
+	RA 180.53102732
+	Dec -10.07816771
+	Distance 103.103
+	SpectralType "DA5"
+	Temperature 9274
+	AppMag 15.97
+	Radius 5972
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201159-098/WD%201159-098.html"
+}
+
+"WD 1202-232:WDJ120526.67-233312.14"
+{
+	RA 181.36134404
+	Dec -23.55236503
+	Distance 33.996
+	SpectralType "DAZ6"
+	Temperature 8540
+	AppMag 12.8
+	Radius 9134
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201202-232/WD%201202-232.html"
+}
+
+"WD 1208+076:WDJ121118.82+072448.16"
+{
+	RA 182.82811451
+	Dec 7.41236573
+	Distance 82.522
+	SpectralType "DA9"
+	Temperature 5281
+	AppMag 16.53
+	Radius 9852
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201208+076/WD%201208+076.html"
+}
+
+"GJ 3710:WD 1208+576:WDJ121129.27+572417.24"
+{
+	RA 182.87538613
+	Dec 57.40314953
+	Distance 65.1
+	SpectralType "DAZ9"
+	Temperature 5831
+	AppMag 15.79
+	Radius 8934
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203710/GJ%203710.html"
+}
+
+"LP 20-214:WDJ121431.83+782256.54"
+{
+	RA 183.63529947
+	Dec 78.38119987
+	Distance 106.424
+	SpectralType "DZ9"
+	Temperature 4979
+	AppMag 17.708 # synthetic
+	Radius 10414
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%2020-214/LP%2020-214.html"
+}
+
+"LHS 2534:WD 1212-023:WDJ121456.38-023402.84"
+{
+	RA 183.73652416
+	Dec -2.56931854
+	Distance 123.971
+	SpectralType "DZH9"
+	Temperature 5279
+	AppMag 17.85
+	Radius 8061
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%202534/LHS%202534.html"
+}
+
+"Gaia DR2 6151294355090597504:WDJ121616.94-375848.13"
+{
+	RA 184.07019938
+	Dec -37.98125459
+	Distance 123.967
+	SpectralType "DC9"
+	Temperature 4651
+	AppMag 18.492 # synthetic
+	Radius 10676
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206151294355090597504/Gaia%20DR2%206151294355090597504.html"
+}
+
+"WD 1214+690:EGGR 356:WDJ121701.84+684851.45"
+{
+	RA 184.25245054
+	Dec 68.81427579
+	Distance 106.749
+	SpectralType "DA8"
+	Temperature 6500
+	AppMag 17.008 # synthetic
+	Radius 6682
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201214+690/WD%201214+690.html"
+}
+
+"Gaia DR2 6054148143441683072:WDJ121724.77-632945.73"
+{
+	RA 184.35608524
+	Dec -63.49585035
+	Distance 122.226
+	SpectralType "DZ6"
+	Temperature 7996
+	AppMag 16.11 # synthetic
+	Radius 7477
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206054148143441683072/Gaia%20DR2%206054148143441683072.html"
+}
+
+"WD 1218+095:WDJ122048.70+091413.08"
+{
+	RA 185.20136409
+	Dec 9.23524055
+	Distance 122.225
+	SpectralType "DC9"
+	Temperature 3890 # Table A5
+	AppMag 19.67
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201218+095/WD%201218+095.html"
+}
+
+"WD 1223+188:WDJ122619.77+183634.46"
+{
+	RA 186.58165633
+	Dec 18.60947274
+	Distance 116.896
+	SpectralType "DAH6"
+	Temperature 7972
+	AppMag 16.325 # synthetic
+	Radius 7053
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201223+188/WD%201223+188.html"
+}
+
+"LHS 2559:WD 1224+354:WDJ122635.58+351309.86"
+{
+	RA 186.64461213
+	Dec 35.21941125
+	Distance 113.794
+	SpectralType "DA9"
+	Temperature 5221
+	AppMag 17.444 # synthetic
+	Radius 10666
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%202559/LHS%202559.html"
+}
+
+"GJ 2092:WD 1223-659:WDJ122642.02-661218.47"
+{
+	RA 186.6747223
+	Dec -66.20594261
+	Distance 50.157
+	SpectralType "DA7"
+	Temperature 7582
+	AppMag 13.952
+	Radius 9478
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202092/GJ%202092.html"
+}
+
+"WD 1224+321:WDJ122724.28+315024.04"
+{
+	RA 186.85155488
+	Dec 31.83917986
+	Distance 126.722
+	SpectralType "DA8"
+	Temperature 6547
+	AppMag 16.698 # synthetic
+	Radius 9142
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201224+321/WD%201224+321.html"
+}
+
+"PG 1225-079:WD 1225-079:WDJ122747.36-081437.97"
+{
+	RA 186.94677934
+	Dec -8.24406114
+	Distance 106.599
+	SpectralType "DZAB4"
+	Temperature 11248
+	AppMag 14.8
+	Radius 7797
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201225-079/PG%201225-079.html"
+}
+
+"WD 1225+006:WDJ122807.73+002219.62"
+{
+	RA 187.03196035
+	Dec 0.37253246
+	Distance 105.228
+	SpectralType "DAZ5"
+	Temperature 9300
+	AppMag 14.8
+	Radius 9008
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201225+006/WD%201225+006.html"
+}
+
+"Gaia DR2 3583402849843287680:WDJ122956.02-070727.57"
+{
+	RA 187.48238709
+	Dec -7.12463441
+	Distance 115.251
+	SpectralType "DA9"
+	Temperature 5090
+	AppMag 17.45
+	Radius 10937
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203583402849843287680/Gaia%20DR2%203583402849843287680.html"
+}
+
+"Gaia DR2 6127190796769848960:WDJ123156.66-503247.99"
+{
+	RA 187.98572575
+	Dec -50.54721117
+	Distance 106.892
+	SpectralType "DA3"
+	Temperature 18012
+	AppMag 13.459 # synthetic
+	Radius 9480
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206127190796769848960/Gaia%20DR2%206127190796769848960.html"
+}
+
+"WD 1230+063:WDJ123322.45+060711.07"
+{
+	RA 188.34317652
+	Dec 6.11815659
+	Distance 124.417
+	SpectralType "DA9"
+	Temperature 5508
+	AppMag 17.923 # synthetic
+	Radius 7449
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201230+063/WD%201230+063.html"
+}
+
+# Companion to WDJ123445.37-444001.75
+61379
+{
+	RA 188.67615972
+	Dec -44.67393783
+	Distance 92.781 # mean of system components
+	SpectralType "G3IV"
+	Temperature 5772 # GSP-Spec
+	AppMag 5.76
+	Radius 1267219 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+109409"
+}
+
+"Gaia DR2 6133033635912545280:WDJ123445.37-444001.75"
+{
+	RA 188.68853914
+	Dec -44.66804403
+	Distance 92.781 # mean of system components
+	SpectralType "DC8"
+	Temperature 6665
+	AppMag 16.306 # synthetic
+	Radius 7699
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206133033635912545280/Gaia%20DR2%206133033635912545280.html"
+}
+
+"WD 1235+422:WDJ123752.23+415624.69"
+{
+	RA 189.46554408
+	Dec 41.94173713
+	Distance 117.55
+	SpectralType "DQP9"
+	Temperature 5324
+	AppMag 17.6 # synthetic
+	Radius 10588
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201235+422/WD%201235+422.html"
+}
+
+"V886 Cen:GJ 2095:LAWD 41:WD 1236-495:WDJ123849.78-494800.22"
+{
+	RA 189.70358523
+	Dec -49.80039009
+	Distance 48.359
+	SpectralType "DA4"
+	Temperature 11359
+	AppMag 13.81
+	Radius 5313
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V886%20Cen/V*%20V886%20Cen.html"
+}
+
+"WD 1236+457:WDJ123914.70+452514.14"
+{
+	RA 189.80716443
+	Dec 45.41820847
+	Distance 87.519
+	SpectralType "DA8"
+	Temperature 6407
+	AppMag 16.494 # synthetic
+	Radius 7126
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201236+457/WD%201236+457.html"
+}
+
+"WD 1238+183:WDJ124030.49+180728.84"
+{
+	RA 190.12428907
+	Dec 18.12421769
+	Distance 128.491
+	SpectralType "DA9"
+	Temperature 5418
+	AppMag 17.659 # synthetic
+	Radius 9454
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201238+183/WD%201238+183.html"
+}
+
+"Gaia DR2 3500086050578451712:WDJ124112.37-243428.54"
+{
+	RA 190.29992429
+	Dec -24.57483367
+	Distance 123.568
+	SpectralType "DZ8"
+	Temperature 6551
+	AppMag 17.07 # synthetic
+	Radius 7396
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203500086050578451712/Gaia%20DR2%203500086050578451712.html"
+}
+
+"Gaia DR2 3528871819044810368:WDJ124155.92-133501.27"
+{
+	RA 190.48175701
+	Dec -13.58446129
+	Distance 117.062
+	SpectralType "DC6"
+	Temperature 8254
+	AppMag 15.79
+	Radius 8736
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203528871819044810368/Gaia%20DR2%203528871819044810368.html"
+}
+
+"WD 1242-348:WDJ124445.04-350744.18"
+{
+	RA 191.18691726
+	Dec -35.12991272
+	Distance 72.433
+	SpectralType "DQ6"
+	Temperature 8743
+	AppMag 14.62
+	Radius 8508
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201242-348/WD%201242-348.html"
+}
+
+"LAWD 42:WD 1241-798:WDJ124452.69-800927.91"
+{
+	RA 191.20905271
+	Dec -80.15617625
+	Distance 69.66
+	SpectralType "DC9"
+	Temperature 5647
+	AppMag 16.18
+	Radius 8638
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2042/LAWD%2042.html"
+}
+
+"Gaia DR2 6079710620510474240:WDJ124504.52-491336.69"
+{
+	RA 191.26928102
+	Dec -49.227257
+	Distance 94.662
+	SpectralType "DQ6"
+	Temperature 8497
+	AppMag 15.322 # synthetic
+	Radius 8427
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206079710620510474240/Gaia%20DR2%206079710620510474240.html"
+}
+
+"Gaia DR2 3530520910392199680:WDJ124828.17-102857.82"
+{
+	RA 192.11692029
+	Dec -10.48315392
+	Distance 129.418
+	SpectralType "DC7"
+	Temperature 7106
+	AppMag 16.907 # synthetic
+	Radius 7374
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203530520910392199680/Gaia%20DR2%203530520910392199680.html"
+}
+
+"GJ 3754:EGGR 536:WD 1247+550:WDJ125007.73+544706.17"
+{
+	RA 192.53008583
+	Dec 54.77947761
+	Distance 77.252
+	SpectralType "DC9"
+	Temperature 4054
+	AppMag 17.79
+	Radius 14403
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20536/EGGR%20536.html"
+}
+
+"LP 267-311:WD 1251+366:WDJ125411.51+362058.45"
+{
+	RA 193.54569553
+	Dec 36.34946669
+	Distance 93.038
+	SpectralType "DC9"
+	Temperature 4900
+	AppMag 17.448 # synthetic
+	Radius 11026
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20267-311/LP%20267-311.html"
+}
+
+"WD 1252+471:WDJ125508.46+465518.88"
+{
+	RA 193.77814661
+	Dec 46.92140694
+	Distance 121.476
+	SpectralType "DC9"
+	Temperature 4827
+	AppMag 18.75
+	Radius 7861
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201252+471/WD%201252+471.html"
+}
+
+"EGGR 94:WD 1257+278:WDJ125946.66+273404.14"
+{
+	RA 194.9427774
+	Dec 27.56814515
+	Distance 107.446
+	SpectralType "DAZ6"
+	Temperature 8586
+	AppMag 15.41
+	Radius 8621
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%2094/EGGR%2094.html"
+}
+
+"Gliese 492:Wolf 457:EGGR 95:LAWD 43:WD 1257+037:WDJ130009.06+032841.06"
+{
+	RA 195.03580969
+	Dec 3.47422444
+	Distance 53.788
+	SpectralType "DA9"
+	Temperature 5669
+	AppMag 15.83
+	Radius 7855
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%20457/Wolf%20457.html"
+}
+
+"2MASS J13002125+0130453:WD 1257+017:WDJ130021.26+013045.42"
+{
+	RA 195.08692832
+	Dec 1.5132531
+	Distance 117.188
+	SpectralType "DA9"
+	Temperature 5423
+	AppMag 17.492 # synthetic
+	Radius 9225
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J13002125+0130453/2MASS%20J13002125+0130453.html"
+}
+
+"GD 484:WD 1259+674:WDJ130121.13+671307.35"
+{
+	RA 195.33966646
+	Dec 67.21882982
+	Distance 100.435
+	SpectralType "DA8"
+	Temperature 6573
+	AppMag 16.553 # synthetic
+	Radius 7595
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20484/GD%20484.html"
+}
+
+"WD 1300+263:WDJ130317.88+260313.51"
+{
+	RA 195.82033304
+	Dec 26.05422897
+	Distance 123.525
+	SpectralType "DC9"
+	Temperature 4520
+	AppMag 18.77
+	Radius 10131
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201300+263/WD%201300+263.html"
+}
+
+"WD 1300-355:WDJ130329.44-355124.90"
+{
+	RA 195.87083443
+	Dec -35.85777103
+	Distance 93.766
+	SpectralType "DQ6"
+	Temperature 7920
+	AppMag 15.77
+	Radius 7549
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201300-355/WD%201300-355.html"
+}
+
+"LP 676-58:WDJ130446.37-052837.60"
+{
+	RA 196.19194211
+	Dec -5.47712454
+	Distance 94.791
+	SpectralType "DA9"
+	Temperature 5282
+	AppMag 17.12
+	Radius 9265
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20676-58/LP%20676-58.html"
+}
+
+"Gaia DR2 1686322048672412288:WDJ130503.44+702243.05"
+{
+	RA 196.26097713
+	Dec 70.37922224
+	Distance 112.81
+	SpectralType "DC9"
+	Temperature 5042 # MWDD
+	AppMag 19.621 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201686322048672412288/Gaia%20DR2%201686322048672412288.html"
+}
+
+"Gaia DR2 5784706428090844160:WDJ130744.29-792511.64"
+{
+	RA 196.92316044
+	Dec -79.42059964
+	Distance 128.438
+	SpectralType "DC9"
+	Temperature 4821
+	AppMag 18.477 # synthetic
+	Radius 9765
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205784706428090844160/Gaia%20DR2%205784706428090844160.html"
+}
+
+"GJ 3768:EGGR 436:WD 1309+853:WDJ130841.20+850228.16"
+{
+	RA 197.18266883
+	Dec 85.04004183
+	Distance 53.703
+	SpectralType "DAH9"
+	Temperature 5324
+	AppMag 15.99
+	Radius 8700
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203768/GJ%203768.html"
+}
+
+"GJ 3770:ER 8:WD 1310-472:WDJ131256.47-472807.91"
+{
+	RA 198.22106256
+	Dec -47.46913588
+	Distance 54.704
+	SpectralType "DC9"
+	Temperature 4097
+	AppMag 17.05
+	Radius 12762
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NAME%20ER%208/NAME%20ER%208.html"
+}
+
+"WD 1310+583:WDJ131257.90+580511.29"
+{
+	RA 198.24286778
+	Dec 58.08610465
+	Distance 100.214
+	SpectralType "DA5"
+	Temperature 10313
+	AppMag 14.09
+	Radius 10966
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201310+583/WD%201310+583.html"
+}
+
+"2MASS J13131314+0226457:WD 1310+027:WDJ131313.14+022645.82"
+{
+	RA 198.30142471
+	Dec 2.44556357
+	Distance 100.721
+	SpectralType "DC9"
+	Temperature 4384
+	AppMag 18.274 # synthetic
+	Radius 11638
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J13131314+0226457/2MASS%20J13131314+0226457.html"
+}
+
+"LHS 2710:WD 1313-198:WDJ131619.57-200732.06"
+{
+	RA 199.07856135
+	Dec -20.12539842
+	Distance 75.406
+	SpectralType "DZ9"
+	Temperature 5165
+	AppMag 17.16
+	Radius 7480
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%202710/LHS%202710.html"
+}
+
+"Gaia DR2 6067215083178616704:WDJ131727.39-543808.28"
+{
+	RA 199.35978487
+	Dec -54.63775809
+	Distance 80.325
+	SpectralType "DA9"
+	Temperature 5771
+	AppMag 16.273
+	Radius 9146
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206067215083178616704/Gaia%20DR2%206067215083178616704.html"
+}
+
+# Companion to WDJ131730.86+483333.05
+"2MASS J13173072+4833343"
+{
+	RA 199.37745202
+	Dec 48.5590271
+	Distance 127.016 # mean of system components
+	SpectralType "M8.8"
+	AppMag 20.687 # estimate
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J13173072%2B4833343"
+}
+
+"SDSS J131730.85+483332.8:WDJ131730.86+483333.05"
+{
+	RA 199.37812494
+	Dec 48.55867771
+	Distance 127.016 # mean of system components
+	SpectralType "DA9"
+	Temperature 5803
+	AppMag 17.29 # synthetic
+	Radius 8864
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/SDSS%20J131730.85+483332.8/SDSS%20J131730.85+483332.8.html"
+}
+
+"WD 1315-110:WDJ131747.24-112106.03"
+{
+	RA 199.44619521
+	Dec -11.35163298
+	Distance 129.304
+	SpectralType "DAZ6"
+	Temperature 9052
+	AppMag 15.6
+	Radius 8654
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201315-110/WD%201315-110.html"
+}
+
+"LSPM J1317+2157:WD 1315+222:WDJ131748.97+215713.60"
+{
+	RA 199.4539134
+	Dec 21.9525377
+	Distance 103.599
+	SpectralType "DCP8"
+	Temperature 6334
+	AppMag 16.828 # synthetic
+	Radius 7446
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J1317+2157/LSPM%20J1317+2157.html"
+}
+
+"Gaia DR2 1688618481786030336:WDJ131830.01+735318.25"
+{
+	RA 199.62250319
+	Dec 73.8881948
+	Distance 118.707
+	SpectralType "DA9"
+	Temperature 5205
+	AppMag 17.076 # synthetic
+	Radius 14816
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201688618481786030336/Gaia%20DR2%201688618481786030336.html"
+}
+
+"WD 1316-215:WDJ131924.74-214754.87"
+{
+	RA 199.85306656
+	Dec -21.80062259
+	Distance 64.405
+	SpectralType "DA9"
+	Temperature 5880
+	AppMag 16.67
+	Radius 5618
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201316-215/WD%201316-215.html"
+}
+
+"WD 1315-781:LAWD 45:WDJ131925.56-782328.17"
+{
+	RA 199.86311537
+	Dec -78.39274226
+	Distance 62.848
+	SpectralType "DAH9"
+	Temperature 5575
+	AppMag 16.15
+	Radius 8243
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201315-781/WD%201315-781.html"
+}
+
+"Gaia DR2 6063252374582712320:WDJ131958.95-563928.42"
+{
+	RA 199.99584344
+	Dec -56.65813191
+	Distance 116.606
+	SpectralType "DC7"
+	Temperature 7009
+	AppMag 16.519 # synthetic
+	Radius 8145
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206063252374582712320/Gaia%20DR2%206063252374582712320.html"
+}
+
+"WD 1319+466:WDJ132115.10+462323.65"
+{
+	RA 200.31139952
+	Dec 46.39027683
+	Distance 107.186
+	SpectralType "DA3"
+	Temperature 14627
+	AppMag 14.55
+	Radius 6889
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201319+466/WD%201319+466.html"
+}
+
+"Gaia DR2 5869567658943170048:WDJ132550.44-601508.04"
+{
+	RA 201.45974926
+	Dec -60.25189014
+	Distance 117.064
+	SpectralType "DB5"
+	Temperature 11080
+	AppMag 14.821 # synthetic
+	Radius 8882
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205869567658943170048/Gaia%20DR2%205869567658943170048.html"
+}
+
+# Companion to WDJ132756.43-281716.98
+65674 "GJ 9445:CD-27 9236"
+{
+	RA 201.98105755
+	Dec -28.28846689
+	Distance 118.566 # mean of system components
+	SpectralType "K7"
+	Temperature 4286 # GSP-Spec
+	AppMag 10.2
+	Radius 525268 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=CD-27+9236"
+}
+
+"GJ 9445 B:Gaia DR2 6188345358621778816:WDJ132756.43-281716.98"
+{
+	RA 201.98273098
+	Dec -28.28860457
+	Distance 118.566 # mean of system components
+	SpectralType "DQ8"
+	Temperature 6439
+	AppMag 16.034 # synthetic
+	Radius 11566
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206188345358621778816/Gaia%20DR2%206188345358621778816.html"
+}
+
+# Companion to WDJ133013.64-083429.47
+"Gliese 514.1:GJ 9447:Ross 476"
+{
+	RA 202.50664238
+	Dec -8.70917932
+	Distance 52.388 # mean of system components
+	SpectralType "M4V"
+	AppMag 14.18
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Ross+476"
+}
+
+65877 "Gliese 515:BD-07 3632:LAWD 47:EGGR 99:WD 1327-083:WDJ133013.64-083429.47"
+{
+	RA 202.55182636
+	Dec -8.57695247
+	Distance 52.388 # mean of system components
+	SpectralType "DA3"
+	Temperature 14563
+	AppMag 12.33
+	Radius 9188
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/BD-07%203632/BD-07%203632.html"
+}
+
+"EGGR 391:WD 1328+307:WDJ133059.42+302953.65"
+{
+	RA 202.74510954
+	Dec 30.49777919
+	Distance 83.199
+	SpectralType "DZH8"
+	Temperature 6351
+	AppMag 16.03
+	Radius 8215
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20391/EGGR%20391.html"
+}
+
+"Gaia DR2 6087659745978472064:WDJ133216.49-440838.71"
+{
+	RA 203.0669553
+	Dec -44.14469611
+	Distance 111.431
+	SpectralType "DC9"
+	Temperature 5719
+	AppMag 17.346 # synthetic
+	Radius 7838
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206087659745978472064/Gaia%20DR2%206087659745978472064.html"
+}
+
+# Companion to WDJ133314.60-675117.19
+"L 106-69"
+{
+	RA 203.47739826
+	Dec -67.89907695
+	Distance 85.787 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3019 # GSP-Phot
+	AppMag 14.415 # synthetic
+	Radius 214610 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+106-69"
+}
+
+"Gaia DR2 5845312191917620224:WDJ133314.60-675117.19"
+{
+	RA 203.30228744
+	Dec -67.85618835
+	Distance 85.787 # mean of system components
+	SpectralType "DZ9"
+	Temperature 5544
+	AppMag 17.24
+	Radius 8230
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205845312191917620224/Gaia%20DR2%205845312191917620224.html"
+}
+
+# Companion to WDJ133601.82+482846.25
+"GD 325 B"
+{
+	RA 204.00790301
+	Dec 48.4795622
+	Distance 119.949 # mean of system components
+	SpectralType "M2"
+	Temperature 3121 # GSP-Phot
+	AppMag 16.367 # synthetic
+	Radius 135954 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=GD+325B"
+}
+
+"GJ 2103:GD 325:EGGR 359:WD 1333+487:WDJ133601.82+482846.25"
+{
+	RA 204.00669564
+	Dec 48.47932295
+	Distance 119.949 # mean of system components
+	SpectralType "DB3"
+	Temperature 14480
+	AppMag 14.02
+	Radius 9306
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20325/GD%20325.html"
+}
+
+"WD 1334+366:WDJ133630.61+362348.54"
+{
+	RA 204.12623679
+	Dec 36.39617273
+	Distance 115.456
+	SpectralType "DA7"
+	Temperature 6747
+	AppMag 16.364 # synthetic
+	Radius 9107
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201334+366/WD%201334+366.html"
+}
+
+"Gliese 518:Wolf 489:LAWD 49:EGGR 100:WD 1334+039:WDJ133631.85+034045.94"
+{
+	RA 204.11607941
+	Dec 3.67447929
+	Distance 27.225
+	SpectralType "DA9"
+	Temperature 5010
+	AppMag 14.66
+	Radius 10707
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%20489/Wolf%20489.html"
+}
+
+"WD 1334-67:LAWD 48:WD 1334-678:WDJ133807.43-680434.65"
+{
+	RA 204.52426351
+	Dec -68.07667622
+	Distance 129.559
+	SpectralType "DA6"
+	Temperature 8832
+	AppMag 15.57
+	Radius 8998
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201334-67/WD%201334-67.html"
+}
+
+66578 "LAWD 52:EGGR 102:WD 1337+705:WDJ133850.48+701707.64"
+{
+	RA 204.70502791
+	Dec 70.28534668
+	Distance 86.389
+	SpectralType "DAZ2"
+	Temperature 20319
+	AppMag 12.77
+	Radius 9573
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2052/LAWD%2052.html"
+}
+
+"WD 1336+052:WD 1338+052:WDJ134121.80+050045.85"
+{
+	RA 205.33890852
+	Dec 5.01282002
+	Distance 47.832
+	SpectralType "DC9"
+	Temperature 4255
+	AppMag 16.71
+	Radius 12191
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201336+052/WD%201336+052.html"
+}
+
+"WD 1339-340:WDJ134202.88-341519.45"
+{
+	RA 205.49961108
+	Dec -34.2503035
+	Distance 67.737
+	SpectralType "DA9"
+	Temperature 5254
+	AppMag 16.45
+	Radius 9477
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201339-340/WD%201339-340.html"
+}
+
+"Gaia DR2 6165010320266420096:WDJ134349.01-344749.39"
+{
+	RA 205.95155876
+	Dec -34.79738426
+	Distance 117.688
+	SpectralType "DA9"
+	Temperature 5247
+	AppMag 17.493 # synthetic
+	Radius 10521
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206165010320266420096/Gaia%20DR2%206165010320266420096.html"
+}
+
+"Gaia DR3 5851860818806598528:WDJ134441.03-650942.13"
+{
+	RA 206.17182448
+	Dec -65.16083776
+	Distance 125.837
+	SpectralType "DA9"
+	Temperature 4955
+	AppMag 18.005 # synthetic
+	Radius 10980
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%205851860818806598528/Gaia%20DR3%205851860818806598528.html"
+}
+
+"2MASS J13453297+4200437:WD 1343+422:WDJ134532.97+420043.66"
+{
+	RA 206.3862134
+	Dec 42.01269695
+	Distance 122.072
+	SpectralType "DC9"
+	Temperature 4968
+	AppMag 17.343 # synthetic
+	Radius 17771
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J13453297+4200437/2MASS%20J13453297+4200437.html"
+}
+
+"GJ 3805:WD 1344+572:WDJ134602.06+570032.79"
+{
+	RA 206.50700408
+	Dec 57.0099512
+	Distance 81.407
+	SpectralType "DA4"
+	Temperature 14095
+	AppMag 13.3
+	Radius 8730
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201344+572/WD%201344+572.html"
+}
+
+"GJ 1178:EGGR 360:WD 1344+106:WDJ134724.37+102138.01"
+{
+	RA 206.84747992
+	Dec 10.35993413
+	Distance 67.815
+	SpectralType "DAZ7"
+	Temperature 6926
+	AppMag 15.08
+	Radius 8996
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20360/EGGR%20360.html"
+}
+
+# Companion to WDJ134803.01+233446.44
+"GJ 1179 A:LP 380-6"
+{
+	RA 207.04869238
+	Dec 23.61407329
+	Distance 38.688 # mean of system components
+	SpectralType "M5"
+	AppMag 15.371 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+380-6"
+}
+
+"GJ 1179 B:EGGR 438:WD 1345+238:WDJ134803.01+233446.44"
+{
+	RA 207.00533858
+	Dec 23.58012342
+	Distance 38.688 # mean of system components
+	SpectralType "DC9"
+	Temperature 4769
+	AppMag 15.65
+	Radius 11532
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201179%20B/GJ%201179%20B.html"
+}
+
+"WD 1346+121:WDJ134902.30+115513.53"
+{
+	RA 207.26032349
+	Dec 11.91808297
+	Distance 92.251
+	SpectralType "DCP9"
+	Temperature 4607
+	AppMag 18.17
+	Radius 9368
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201346+121/WD%201346+121.html"
+}
+
+"G 150-43:WD 1347+281:WDJ134944.61+275521.76"
+{
+	RA 207.43457407
+	Dec 27.92301808
+	Distance 97.735
+	SpectralType "DA7"
+	Temperature 7240
+	AppMag 16.373 # synthetic
+	Radius 6739
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20150-43/G%20150-43.html"
+}
+
+"LSPM J1351+4253:WD 1349+431:WDJ135118.41+425316.90"
+{
+	RA 207.82807062
+	Dec 42.88691458
+	Distance 128.075
+	SpectralType "DZ7"
+	Temperature 6748
+	AppMag 16.948 # synthetic
+	Radius 7339
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J1351+4253/LSPM%20J1351+4253.html"
+}
+
+"LAWD 53:EGGR 104:WD 1348-273:WDJ135122.69-273357.82"
+{
+	RA 207.84484604
+	Dec -27.56693607
+	Distance 122.467
+	SpectralType "DA5"
+	Temperature 9701
+	AppMag 15.0
+	Radius 9055
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2053/LAWD%2053.html"
+}
+
+"NLTT 35504:WD 1349+111:WDJ135211.79+105351.87"
+{
+	RA 208.04801123
+	Dec 10.89689561
+	Distance 115.145
+	SpectralType "DA8"
+	Temperature 5944
+	AppMag 16.916 # synthetic
+	Radius 8967
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2035504/NLTT%2035504.html"
+}
+
+"GJ 3814:PG 1350-090:WD 1350-090:WDJ135315.53-091633.37"
+{
+	RA 208.31631314
+	Dec -9.27753106
+	Distance 64.227
+	SpectralType "DAH6"
+	Temperature 8881
+	AppMag 14.55
+	Radius 7101
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201350-090/PG%201350-090.html"
+}
+
+"Gaia DR2 6178524211524592640:WDJ135509.42-262248.95"
+{
+	RA 208.7904608
+	Dec -26.3806458
+	Distance 106.01
+	SpectralType "DA8"
+	Temperature 6090
+	AppMag 16.71
+	Radius 8474
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206178524211524592640/Gaia%20DR2%206178524211524592640.html"
+}
+
+"GJ 3819:LP 856-26:WD 1356-233:WDJ135907.82-233327.18"
+{
+	RA 209.78098316
+	Dec -23.55779742
+	Distance 109.297
+	SpectralType "DA5"
+	Temperature 9441
+	AppMag 14.96
+	Radius 8958
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20856-26/LP%20856-26.html"
+}
+
+"Gaia DR2 6114344102909485824:WDJ140115.27-391432.21"
+{
+	RA 210.31205387
+	Dec -39.24232589
+	Distance 90.544
+	SpectralType "DAH9"
+	Temperature 5540
+	AppMag 17.42 # synthetic
+	Radius 6628
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206114344102909485824/Gaia%20DR2%206114344102909485824.html"
+}
+
+"WD J1403+4533:WD 1401+457:WDJ140324.75+453333.02"
+{
+	RA 210.85141442
+	Dec 45.55879684
+	Distance 112.181
+	SpectralType "DC9"
+	Temperature 4820 # Table A5
+	AppMag 18.91
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%20J1403+4533/WD%20J1403+4533.html"
+}
+
+"EGGR 539:WD 1404+670:WDJ140556.01+664802.01"
+{
+	RA 211.47791788
+	Dec 66.80051737
+	Distance 119.66
+	SpectralType "DC9"
+	Temperature 4159
+	AppMag 18.883 # synthetic
+	Radius 12347
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20539/EGGR%20539.html"
+}
+
+# Companion to WDJ140608.61-695726.60
+"2MASS J14061314-6957172"
+{
+	RA 211.552871
+	Dec -69.95496776
+	Distance 116.755 # mean of system components
+	SpectralType "M7"
+	AppMag 19.592 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J14061314-6957172"
+}
+
+"Gaia DR2 5846206030463663232:WDJ140608.61-695726.60"
+{
+	RA 211.53397922
+	Dec -69.95755326
+	Distance 116.755 # mean of system components
+	SpectralType "DA7"
+	Temperature 6768
+	AppMag 16.362 # synthetic
+	Radius 9176
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205846206030463663232/Gaia%20DR2%205846206030463663232.html"
+}
+
+"LP 324-69:WD 1404+317:WDJ140644.61+313022.68"
+{
+	RA 211.68476793
+	Dec 31.50718033
+	Distance 128.58
+	SpectralType "DC9"
+	Temperature 4936
+	AppMag 18.259 # synthetic
+	Radius 10035
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20324-69/LP%20324-69.html"
+}
+
+"Gaia DR2 3643555726544985088:WDJ140709.63-062641.95"
+{
+	RA 211.79068041
+	Dec -6.44467309
+	Distance 80.117
+	SpectralType "DA6"
+	Temperature 8344
+	AppMag 15.074
+	Radius 7918
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%203643555726544985088/Gaia%20DR2%203643555726544985088.html"
+}
+
+"WD 1407+425:WDJ140945.24+421600.65"
+{
+	RA 212.43841383
+	Dec 42.26680458
+	Distance 116.942
+	SpectralType "DAZ5"
+	Temperature 9965
+	AppMag 15.03
+	Radius 8545
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201407+425/WD%201407+425.html"
+}
+
+"WD 1408+029:WDJ141039.98+024513.10"
+{
+	RA 212.66641694
+	Dec 2.75255055
+	Distance 90.283
+	SpectralType "DAZ9"
+	Temperature 5598
+	AppMag 16.702 # synthetic
+	Radius 9165
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201408+029/WD%201408+029.html"
+}
+
+"Gaia DR2 5790182751914903424:WDJ141041.67-751030.18"
+{
+	RA 212.67067284
+	Dec -75.17557456
+	Distance 108.656
+	SpectralType "DZA9"
+	Temperature 5073
+	AppMag 17.653 # synthetic
+	Radius 10029
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205790182751914903424/Gaia%20DR2%205790182751914903424.html"
+}
+
+"Gaia DR2 5867776696271127424:WDJ141159.17-592044.99"
+{
+	RA 212.99724975
+	Dec -59.34609725
+	Distance 46.947
+	SpectralType "DA8"
+	Temperature 6653
+	AppMag 14.55
+	Radius 8246
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205867776696271127424/Gaia%20DR2%205867776696271127424.html"
+}
+
+"EGGR 105:WDJ141215.41+153253.03"
+{
+	RA 213.06115792
+	Dec 15.54819248
+	Distance 118.896
+	SpectralType "DC9"
+	Temperature 5081
+	AppMag 18.158 # synthetic
+	Radius 8469
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20105/EGGR%20105.html"
+}
+
+# Companion to WDJ141220.36-184241.64
+"LP 799-74"
+{
+	RA 213.09878899
+	Dec -18.71905424
+	Distance 108.779 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3104 # GSP-Phot
+	AppMag 16.343 # estimate
+	Radius 131320 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+799-74"
+}
+
+"WD 1409-184:WDJ141220.36-184241.64"
+{
+	RA 213.08541807
+	Dec -18.71208177
+	Distance 108.779 # mean of system components
+	SpectralType "DAH9"
+	Temperature 5734
+	AppMag 17.131 # synthetic
+	Radius 8431
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201409-184/WD%201409-184.html"
+}
+
+"WD 1411-362:WDJ141421.47-363020.36"
+{
+	RA 213.58857637
+	Dec -36.50680106
+	Distance 114.49
+	SpectralType "DA9"
+	Temperature 5187
+	AppMag 17.86
+	Radius 8855
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201411-362/WD%201411-362.html"
+}
+
+"Gaia DR2 5852538324131652736:WDJ141622.47-653126.81"
+{
+	RA 214.08991618
+	Dec -65.5244828
+	Distance 125.746
+	SpectralType "DA6"
+	Temperature 8609
+	AppMag 16.408 # synthetic
+	Radius 6340
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205852538324131652736/Gaia%20DR2%205852538324131652736.html"
+}
+
+"WD 1418-088:WDJ142054.81-090508.76"
+{
+	RA 215.22625535
+	Dec -9.08597335
+	Distance 124.91
+	SpectralType "DA6"
+	Temperature 7785
+	AppMag 15.36
+	Radius 11937
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201418-088/WD%201418-088.html"
+}
+
+"Gaia DR2 6093257119157372160:WDJ142254.17-460549.72"
+{
+	RA 215.72387969
+	Dec -46.09695644
+	Distance 123.206
+	SpectralType "DC8"
+	Temperature 6480
+	AppMag 17.065 # synthetic
+	Radius 7579
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206093257119157372160/Gaia%20DR2%206093257119157372160.html"
+}
+
+"Gaia DR2 5898935893701856128:WDJ142428.39-510233.63"
+{
+	RA 216.11627807
+	Dec -51.04321985
+	Distance 103.128
+	SpectralType "DQ8"
+	Temperature 6553
+	AppMag 16.452 # synthetic
+	Radius 8253
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205898935893701856128/Gaia%20DR2%205898935893701856128.html"
+}
+
+"CX Boo:GD 165:EGGR 222:GD 165 A:WD 1422+095:WDJ142439.15+091714.16"
+{
+	RA 216.16216206
+	Dec 9.28660191
+	Distance 108.621
+	SpectralType "DA4"
+	Temperature 12392
+	AppMag 14.3
+	Radius 8601
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20165/GD%20165.html"
+}
+
+"WD 1425+495:WDJ142659.43+492100.45"
+{
+	RA 216.74691987
+	Dec 49.35032673
+	Distance 110.436
+	SpectralType "DC7"
+	Temperature 6760
+	AppMag 16.865 # synthetic
+	Radius 6924
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201425+495/WD%201425+495.html"
+}
+
+# Companion to WDJ143015.38-240326.12
+"LP 857-46"
+{
+	RA 217.57232226
+	Dec -24.05622544
+	Distance 105.748 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 15.25
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+857-46"
+}
+
+"Gaia DR2 6272326022391660928:WDJ143015.38-240326.12"
+{
+	RA 217.56159413
+	Dec -24.05898956
+	Distance 105.748 # mean of system components
+	SpectralType "DA9"
+	Temperature 5004
+	AppMag 17.699 # synthetic
+	Radius 10122
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206272326022391660928/Gaia%20DR2%206272326022391660928.html"
+}
+
+# Companion to WDJ143019.96-252040.40
+"UPM J1430-2520"
+{
+	RA 217.58510435
+	Dec -25.34536124
+	Distance 103.113 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 13.17
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UPM+J1430-2520"
+}
+
+"Gaia DR2 6271903947364173056:WDJ143019.96-252040.40"
+{
+	RA 217.58272828
+	Dec -25.34431796
+	Distance 103.113 # mean of system components
+	SpectralType "DA7"
+	Temperature 6742
+	AppMag 16.662 # synthetic
+	Radius 7094
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206271903947364173056/Gaia%20DR2%206271903947364173056.html"
+}
+
+"MY Aps:GJ 2108:EGGR 110:LAWD 54:WD 1425-811:WDJ143307.64-812014.13"
+{
+	RA 218.27725146
+	Dec -81.33899068
+	Distance 68.073
+	SpectralType "DA4"
+	Temperature 12147
+	AppMag 13.75
+	Radius 8291
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20MY%20Aps/V*%20MY%20Aps.html"
+}
+
+"WD 1434+437:WDJ143642.85+433234.61"
+{
+	RA 219.17654632
+	Dec 43.54518886
+	Distance 88.502
+	SpectralType "DC9"
+	Temperature 4809
+	AppMag 17.509 # synthetic
+	Radius 10727
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201434+437/WD%201434+437.html"
+}
+
+"Gaia DR2 5893318763718868736:WDJ143826.23-560110.20"
+{
+	RA 219.60755366
+	Dec -56.0198331
+	Distance 127.183
+	SpectralType "DC6"
+	Temperature 8210
+	AppMag 16.326 # synthetic
+	Radius 7484
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205893318763718868736/Gaia%20DR2%205893318763718868736.html"
+}
+
+"WD 1436-781:WDJ144251.51-782353.67"
+{
+	RA 220.70555085
+	Dec -78.39811546
+	Distance 78.195
+	SpectralType "DA8"
+	Temperature 6206
+	AppMag 16.11
+	Radius 8141
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201436-781/WD%201436-781.html"
+}
+
+"Gaia DR2 6310804634396281984:WDJ144318.17-143715.32"
+{
+	RA 220.82466832
+	Dec -14.62149171
+	Distance 93.598
+	SpectralType "DA8"
+	Temperature 6669
+	AppMag 16.34
+	Radius 7683
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206310804634396281984/Gaia%20DR2%206310804634396281984.html"
+}
+
+"Gaia DR2 1282448170543051520:WDJ144528.12+292124.29"
+{
+	RA 221.36675906
+	Dec 29.35677691
+	Distance 125.068 # mean of system components
+	SpectralType "DA9"
+	Temperature 5473
+	AppMag 17.565 # synthetic
+	Radius 9261
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201282448170543051520/Gaia%20DR2%201282448170543051520.html"
+}
+
+"HS 1443+2934:WD 1443+295:WDJ144528.47+292132.07"
+{
+	RA 221.36825769
+	Dec 29.35890026
+	Distance 125.068 # mean of system components
+	SpectralType "DA4"
+	Temperature 12445
+	AppMag 14.481 # synthetic
+	Radius 9192
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HS%201443+2934/HS%201443+2934.html"
+}
+
+"Gaia DR2 5799644049485006848:WDJ144710.68-694040.21"
+{
+	RA 221.78917524
+	Dec -69.67808916
+	Distance 96.55
+	SpectralType "DC9"
+	Temperature 4804
+	AppMag 17.076
+	Radius 17352
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205799644049485006848/Gaia%20DR2%205799644049485006848.html"
+}
+
+"GJ 3866:WD 1444-174:WDJ144725.34-174215.75"
+{
+	RA 221.85046184
+	Dec -17.70590075
+	Distance 43.359
+	SpectralType "DC9"
+	Temperature 5055
+	AppMag 16.43
+	Radius 6728
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%203866/GJ%203866.html"
+}
+
+"EGGR 298:WD 1455+298:WDJ145806.49+293729.52"
+{
+	RA 224.5277617
+	Dec 29.62220582
+	Distance 93.119
+	SpectralType "DAZ7"
+	Temperature 7342
+	AppMag 15.6
+	Radius 9014
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20298/EGGR%20298.html"
+}
+
+"Gaia DR2 6227687980608264064:WDJ150324.74-244129.02"
+{
+	RA 225.85243534
+	Dec -24.69155272
+	Distance 84.616
+	SpectralType "DA9"
+	Temperature 5697
+	AppMag 15.943 # synthetic
+	Radius 11731
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206227687980608264064/Gaia%20DR2%206227687980608264064.html"
+}
+
+"GJ 3889:GD 175:EGGR 190:WD 1503-070:WDJ150549.31-071440.95"
+{
+	RA 226.45454433
+	Dec -7.24479285
+	Distance 87.855
+	SpectralType "DAH8"
+	Temperature 6668
+	AppMag 15.88
+	Radius 8846
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20175/GD%20175.html"
+}
+
+"GD 340:EGGR 364:WD 1508+637:WDJ150938.86+633225.48"
+{
+	RA 227.41111122
+	Dec 63.53996865
+	Distance 113.525
+	SpectralType "DA5"
+	Temperature 10318
+	AppMag 14.65
+	Radius 9203
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20340/GD%20340.html"
+}
+
+"GD 178:EGGR 191:WD 1509+322:WDJ151127.63+320417.92"
+{
+	RA 227.8642338
+	Dec 32.07191631
+	Distance 111.303
+	SpectralType "DA3"
+	Temperature 14772
+	AppMag 14.107 # synthetic
+	Radius 8499
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20178/GD%20178.html"
+}
+
+"Gaia DR2 6255777749623059584:WDJ151358.72-201445.94"
+{
+	RA 228.49419535
+	Dec -20.246013
+	Distance 89.835
+	SpectralType "DA5"
+	Temperature 10903
+	AppMag 14.086 # synthetic
+	Radius 9049
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206255777749623059584/Gaia%20DR2%206255777749623059584.html"
+}
+
+"Gaia DR2 5903884280152869632:WDJ151431.85-462555.28"
+{
+	RA 228.62919182
+	Dec -46.43210733
+	Distance 73.593
+	SpectralType "DQZ7"
+	Temperature 7541
+	AppMag 15.135
+	Radius 8605
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205903884280152869632/Gaia%20DR2%205903884280152869632.html"
+}
+
+"Gaia DR2 1722236328978172928:WDJ151534.80+823028.99"
+{
+	RA 228.88976229
+	Dec 82.50875584
+	Distance 124.603
+	SpectralType "DZH9"
+	Temperature 4662
+	AppMag 18.523 # synthetic
+	Radius 10586
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201722236328978172928/Gaia%20DR2%201722236328978172928.html"
+}
+
+"WD 1515+668:WDJ151552.91+664242.88"
+{
+	RA 228.9706585
+	Dec 66.71233966
+	Distance 124.584
+	SpectralType "DA5"
+	Temperature 10298
+	AppMag 15.428 # synthetic
+	Radius 7396
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201515+668/WD%201515+668.html"
+}
+
+"Gaia DR2 5902612969841664768:WDJ151907.38-485423.83"
+{
+	RA 229.78128197
+	Dec -48.90772837
+	Distance 115.289
+	SpectralType "DQZ6"
+	Temperature 8872
+	AppMag 15.617
+	Radius 8375
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205902612969841664768/Gaia%20DR2%205902612969841664768.html"
+}
+
+"Gaia DR2 6206195620664214400:LAWD 57:WDJ152316.52-341207.40"
+{
+	RA 230.81688081
+	Dec -34.20315653
+	Distance 106.278
+	SpectralType "DC6"
+	Temperature 8711
+	AppMag 15.43
+	Radius 8589
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206206195620664214400/Gaia%20DR2%206206195620664214400.html"
+}
+
+"EGGR 489:WD 1524+566:WDJ152542.94+562908.61"
+{
+	RA 231.42836404
+	Dec 56.48507562
+	Distance 104.961
+	SpectralType "DA9"
+	Temperature 5547
+	AppMag 16.942 # synthetic
+	Radius 9917
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20489/EGGR%20489.html"
+}
+
+"NLTT 40234:WD 1524+297:WDJ152621.06+293622.69"
+{
+	RA 231.58818633
+	Dec 29.60706552
+	Distance 75.653
+	SpectralType "DA9"
+	Temperature 5191
+	AppMag 17.18
+	Radius 9855
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2040234/NLTT%2040234.html"
+}
+
+"Gaia DR3 5826604589994061312:WDJ152915.63-642811.20"
+{
+	RA 232.31347908
+	Dec -64.46922083
+	Distance 105.677
+	SpectralType "DA9"
+	Temperature 5304
+	AppMag 17.087 # synthetic
+	Radius 10861
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%205826604589994061312/Gaia%20DR3%205826604589994061312.html"
+}
+
+"Gaia DR2 6265877455415860224:WDJ152926.39-141614.44"
+{
+	RA 232.35895402
+	Dec -14.27210133
+	Distance 122.395
+	SpectralType "DA9"
+	Temperature 5325
+	AppMag 18.26
+	Radius 7672
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206265877455415860224/Gaia%20DR2%206265877455415860224.html"
+}
+
+"Gaia DR2 5827454649955072256:WDJ153044.96-620304.10"
+{
+	RA 232.68526922
+	Dec -62.05249301
+	Distance 122.639
+	SpectralType "DAZ9"
+	Temperature 5876
+	AppMag 17.386 # synthetic
+	Radius 7890
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205827454649955072256/Gaia%20DR2%205827454649955072256.html"
+}
+
+"WD 1531+024:WDJ153417.50+021848.12"
+{
+	RA 233.57240228
+	Dec 2.31299512
+	Distance 110.007
+	SpectralType "DA6"
+	Temperature 8195
+	AppMag 16.43
+	Radius 6392
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201531+024/WD%201531+024.html"
+}
+
+# Companion to WDJ153451.17+464948.77
+"LP 176-59"
+{
+	RA 233.67716914
+	Dec 46.82350268
+	Distance 100.289 # mean of system components
+	SpectralType "M5V"
+	AppMag 17.557 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+176-59"
+}
+
+"LHS 3088:WD 1533+469:WDJ153451.17+464948.77"
+{
+	RA 233.71014323
+	Dec 46.83119199
+	Distance 100.289 # mean of system components
+	SpectralType "DC9"
+	Temperature 4520
+	AppMag 18.162 # synthetic
+	Radius 11308
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS%203088/LHS%203088.html"
+}
+
+"WD 1532+12:WD 1532+129:WDJ153505.81+124745.20"
+{
+	RA 233.77345317
+	Dec 12.79509004
+	Distance 62.749
+	SpectralType "DZH9"
+	Temperature 5786
+	AppMag 15.7
+	Radius 8771
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201532+12/WD%201532+12.html"
+}
+
+"GD 348:WD 1537+651:WDJ153744.44+650148.75"
+{
+	RA 234.43392019
+	Dec 65.03095128
+	Distance 94.035
+	SpectralType "DA5"
+	Temperature 9589
+	AppMag 14.64
+	Radius 8913
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20348/GD%20348.html"
+}
+
+"GD 187:WD 1538+333:WDJ154033.36+330852.51"
+{
+	RA 235.13812228
+	Dec 33.14829299
+	Distance 96.345
+	SpectralType "DA6"
+	Temperature 8726
+	AppMag 15.03
+	Radius 8673
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20187/GD%20187.html"
+}
+
+"Gaia DR3 5985749857190372480:WDJ154053.08-485837.95"
+{
+	RA 235.22114036
+	Dec -48.97807939
+	Distance 118.723
+	SpectralType "DZA9"
+	Temperature 4958
+	AppMag 18.079 # synthetic
+	Radius 9617
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%205985749857190372480/Gaia%20DR3%205985749857190372480.html"
+}
+
+"WD 1540+236:WDJ154234.63+232941.56"
+{
+	RA 235.64453414
+	Dec 23.49306272
+	Distance 90.553
+	SpectralType "DA9"
+	Temperature 5840
+	AppMag 16.77 # synthetic
+	Radius 7891
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201540+236/WD%201540+236.html"
+}
+
+"HS 1544+3800:WD 1544+380:WDJ154605.44+375127.50"
+{
+	RA 236.5222606
+	Dec 37.85769921
+	Distance 122.16
+	SpectralType "DA4"
+	Temperature 13290
+	AppMag 14.46
+	Radius 8667
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HS%201544+3800/HS%201544+3800.html"
+}
+
+# WDJ154730.02-375508.46: defined in extrasolar.stc
+
+"WD 1547+572:WDJ154835.89+570826.43"
+{
+	RA 237.14779029
+	Dec 57.14005967
+	Distance 123.552
+	SpectralType "DC9"
+	Temperature 5778
+	AppMag 17.514 # synthetic
+	Radius 7859
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201547+572/WD%201547+572.html"
+}
+
+# Companion to WDJ154937.89-395455.21
+"2MASS J15493700-3954588"
+{
+	RA 237.40383109
+	Dec -39.91664307
+	Distance 123.148 # mean of system components
+	SpectralType "M6.3"
+	AppMag 19.307 # estimate
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J15493700-3954588"
+}
+
+"Gaia DR2 6008386881767536128:WDJ154937.89-395455.21"
+{
+	RA 237.4075543
+	Dec -39.91568719
+	Distance 123.148 # mean of system components
+	SpectralType "DB4"
+	Temperature 13268
+	AppMag 14.41
+	Radius 8965
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206008386881767536128/Gaia%20DR2%206008386881767536128.html"
+}
+
+"Gaia DR2 6008581907636919936:WDJ155131.68-385049.90"
+{
+	RA 237.88222216
+	Dec -38.84799575
+	Distance 115.818
+	SpectralType "DC9"
+	Temperature 5356
+	AppMag 17.655
+	Radius 8614
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206008581907636919936/Gaia%20DR2%206008581907636919936.html"
+}
+
+"GD 194:EGGR 273:WD 1550+183:WDJ155226.38+181018.69"
+{
+	RA 238.10918727
+	Dec 18.17237693
+	Distance 120.145
+	SpectralType "DA3"
+	Temperature 14813
+	AppMag 14.83
+	Radius 6718
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20194/GD%20194.html"
+}
+
+"GD 353:WD 1554+505:WDJ155534.21+502547.74"
+{
+	RA 238.89089589
+	Dec 50.42990396
+	Distance 99.513
+	SpectralType "DA8"
+	Temperature 6103
+	AppMag 16.568 # synthetic
+	Radius 8673
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20353/GD%20353.html"
+}
+
+"Gaia DR2 4348098485293072128:WDJ155647.51-080601.24"
+{
+	RA 239.19966693
+	Dec -8.10124773
+	Distance 106.541
+	SpectralType "DC9"
+	Temperature 4880 # Table A5
+	AppMag 18.297 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204348098485293072128/Gaia%20DR2%204348098485293072128.html"
+}
+
+"PM J15589+0417:WD 1556+044:WDJ155857.70+041705.16"
+{
+	RA 239.740234
+	Dec 4.28444051
+	Distance 73.362
+	SpectralType "DCP7"
+	Temperature 6730
+	AppMag 16.16
+	Radius 6534
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J15589+0417/PM%20J15589+0417.html"
+}
+
+"Gaia DR2 6264127170346899712:WDJ160027.92-131949.93"
+{
+	RA 240.11566582
+	Dec -13.33103218
+	Distance 119.856
+	SpectralType "DC9"
+	Temperature 5073
+	AppMag 17.88 # synthetic
+	Radius 9745
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206264127170346899712/Gaia%20DR2%206264127170346899712.html"
+}
+
+"Gaia DR2 6250213984568447872:WDJ160041.14-165430.24"
+{
+	RA 240.16772844
+	Dec -16.90752823
+	Distance 98.925
+	SpectralType "DC9"
+	Temperature 4091
+	AppMag 18.36
+	Radius 12559
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206250213984568447872/Gaia%20DR2%206250213984568447872.html"
+}
+
+"WD 1559+534:WDJ160112.71+531659.84"
+{
+	RA 240.30182069
+	Dec 53.28449783
+	Distance 122.739
+	SpectralType "DA7"
+	Temperature 6723
+	AppMag 16.582 # synthetic
+	Radius 8859
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201559+534/WD%201559+534.html"
+}
+
+"TY CrB:Ross 808:LAWD 61:EGGR 115:WD 1559+369:WDJ160123.19+364834.29"
+{
+	RA 240.34717327
+	Dec 36.80710083
+	Distance 106.952
+	SpectralType "DA5"
+	Temperature 11120
+	AppMag 14.4
+	Radius 9113
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ross%20808/Ross%20808.html"
+}
+
+"Gaia DR2 5998095590373665792:WDJ160137.01-383209.35"
+{
+	RA 240.40583698
+	Dec -38.53669913
+	Distance 106.135
+	SpectralType "DA9"
+	Temperature 5067
+	AppMag 17.359
+	Radius 11809
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205998095590373665792/Gaia%20DR2%205998095590373665792.html"
+}
+
+"PG 1601+581:WD 1601+581:WDJ160241.98+575815.32"
+{
+	RA 240.67479538
+	Dec 57.9711562
+	Distance 105.493
+	SpectralType "DA3"
+	Temperature 15563
+	AppMag 14.3
+	Radius 9017
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201601+581/PG%201601+581.html"
+}
+
+"Gaia DR2 4349513797276615680:WDJ160415.07-072658.01"
+{
+	RA 241.06154742
+	Dec -7.45140813
+	Distance 87.55
+	SpectralType "DCP9"
+	Temperature 4995
+	AppMag 18.17 # synthetic
+	Radius 6233
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204349513797276615680/Gaia%20DR2%204349513797276615680.html"
+}
+
+"Gaia DR2 4341773063622911872:WDJ160420.47-133123.84"
+{
+	RA 241.08487204
+	Dec -13.52374582
+	Distance 122.175
+	SpectralType "DA9"
+	Temperature 5140
+	AppMag 17.676 # synthetic
+	Radius 10926
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204341773063622911872/Gaia%20DR2%204341773063622911872.html"
+}
+
+"LHS 3151:EGGR 492:WD 1602+010:WDJ160453.59+005512.97"
+{
+	RA 241.22047389
+	Dec 0.92008567
+	Distance 105.854
+	SpectralType "DC9"
+	Temperature 4984
+	AppMag 17.76
+	Radius 10407
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LHS3151/LHS3151.html"
+}
+
+"Gaia DR2 5806672265237931776:WDJ160454.29-720347.59"
+{
+	RA 241.22286805
+	Dec -72.06261303
+	Distance 120.392
+	SpectralType "DC9"
+	Temperature 4716
+	AppMag 17.597 # synthetic
+	Radius 26878
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205806672265237931776/Gaia%20DR2%205806672265237931776.html"
+}
+
+# Companion to WDJ160606.17+702226.94
+"2MASS J16060442+7021438"
+{
+	RA 241.51882522
+	Dec 70.3620194
+	Distance 116.835 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3086 # GSP-Phot
+	AppMag 14.91 # synthetic
+	Radius 227671 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J16060442%2B7021438"
+}
+
+"Gaia DR2 1647162396588999552:WDJ160606.17+702226.94"
+{
+	RA 241.52613666
+	Dec 70.37403022
+	Distance 116.835 # mean of system components
+	SpectralType "DA8"
+	Temperature 6264
+	AppMag 16.711 # synthetic
+	Radius 8994
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201647162396588999552/Gaia%20DR2%201647162396588999552.html"
+}
+
+# Companion to WDJ160700.89-140423.88
+78955
+{
+	RA 241.76284166
+	Dec -14.07125451
+	Distance 89.901 # mean of system components
+	SpectralType "G2V"
+	Temperature 5835 # GSP-Spec
+	AppMag 6.32
+	Radius 931643 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+144585"
+}
+
+"Gaia DR2 4341495230772911616:WDJ160700.89-140423.88"
+{
+	RA 241.752481
+	Dec -14.07324369
+	Distance 89.901 # mean of system components
+	SpectralType "DAH9"
+	Temperature 5732
+	AppMag 16.664 # synthetic
+	Radius 8595
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204341495230772911616/Gaia%20DR2%204341495230772911616.html"
+}
+
+"WD 1605+345:WDJ160714.17+342346.59"
+{
+	RA 241.80923165
+	Dec 34.39515072
+	Distance 111.952
+	SpectralType "DA9"
+	Temperature 5591
+	AppMag 17.172 # synthetic
+	Radius 9235
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201605+345/WD%201605+345.html"
+}
+
+"GJ 1199:EGGR 117:WD 1609+135:WDJ161125.61+132217.94"
+{
+	RA 242.85675511
+	Dec 13.36923087
+	Distance 72.58
+	SpectralType "DA5"
+	Temperature 9235
+	AppMag 15.103
+	Radius 5950
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20117/EGGR%20117.html"
+}
+
+# Companion to WDJ161330.58+442754.13
+79512 "BD+44 2555"
+{
+	RA 243.37292411
+	Dec 44.46809573
+	Distance 99.178 # mean of system components
+	SpectralType "K4V"
+	Temperature 4472 # GSP-Spec
+	AppMag 9.681 # synthetic
+	Radius 477392 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD%2B44+2555"
+}
+
+"Gaia DR2 1385719147346936064:WDJ161330.58+442754.13"
+{
+	RA 243.37674075
+	Dec 44.46673148
+	Distance 99.178 # mean of system components
+	SpectralType "DA9"
+	Temperature 5338
+	AppMag 17.204 # synthetic
+	Radius 9304
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201385719147346936064/Gaia%20DR2%201385719147346936064.html"
+}
+
+"LSPM J1614+0906:WDJ161424.60+090603.91"
+{
+	RA 243.60253936
+	Dec 9.09938361
+	Distance 90.744
+	SpectralType "DC9"
+	Temperature 4919
+	AppMag 17.466 # synthetic
+	Radius 10326
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J1614+0906/LSPM%20J1614+0906.html"
+}
+
+"Gaia DR2 6246049446837287680:WDJ161916.31-183114.19"
+{
+	RA 244.81721958
+	Dec -18.52030427
+	Distance 125.406
+	SpectralType "DA9"
+	Temperature 5680
+	AppMag 18.17 # synthetic
+	Radius 6135
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206246049446837287680/Gaia%20DR2%206246049446837287680.html"
+}
+
+"Gaia DR2 4355229123137665792:WDJ162125.64-055219.84"
+{
+	RA 245.35651706
+	Dec -5.87232349
+	Distance 127.366
+	SpectralType "DC9"
+	Temperature 4844
+	AppMag 18.163 # synthetic
+	Radius 11191
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204355229123137665792/Gaia%20DR2%204355229123137665792.html"
+}
+
+"Gaia DR2 5931881969426463616:WDJ162224.44-551132.01"
+{
+	RA 245.60272991
+	Dec -55.19181472
+	Distance 118.926
+	SpectralType "DA9"
+	Temperature 5456
+	AppMag 17.472 # synthetic
+	Radius 9313
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205931881969426463616/Gaia%20DR2%205931881969426463616.html"
+}
+
+# WDJ162333.84-391346.16: defined in extrasolar.stc
+
+"Gaia DR2 6022366686772364288:WDJ162558.78-344145.71"
+{
+	RA 246.49360513
+	Dec -34.69593289
+	Distance 113.88
+	SpectralType "DAH9"
+	Temperature 5129
+	AppMag 17.559 # synthetic
+	Radius 10756
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206022366686772364288/Gaia%20DR2%206022366686772364288.html"
+}
+
+"NLTT 42805:WD 1624+197:WDJ162626.33+193839.32"
+{
+	RA 246.60889984
+	Dec 19.64520751
+	Distance 89.856
+	SpectralType "DA8"
+	Temperature 6104
+	AppMag 16.635 # synthetic
+	Radius 7533
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2042805/NLTT%2042805.html"
+}
+
+"GJ 1201:EGGR 327:WD 1625+093:WDJ162753.49+091216.02"
+{
+	RA 246.97243579
+	Dec 9.20235941
+	Distance 81.759
+	SpectralType "DA7"
+	Temperature 6800
+	AppMag 16.14
+	Radius 7005
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201201/GJ%201201.html"
+}
+
+"Gaia DR2 4323956302321933952:WDJ162818.90-173917.89"
+{
+	RA 247.07819309
+	Dec -17.65547647
+	Distance 105.18
+	SpectralType "DA9"
+	Temperature 5017
+	AppMag 17.559 # synthetic
+	Radius 10835
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204323956302321933952/Gaia%20DR2%204323956302321933952.html"
+}
+
+"Gliese 626.2:GJ 9564:Ross 640:EGGR 119:LAWD 62:WD 1626+368:WDJ162825.00+364615.85"
+{
+	RA 247.10143736
+	Dec 36.77438727
+	Distance 51.822
+	SpectralType "DZA6"
+	Temperature 8964
+	AppMag 13.83
+	Radius 7553
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ross%20640/Ross%20640.html"
+}
+
+"NLTT 42988:WDJ162838.60+705321.70"
+{
+	RA 247.16082705
+	Dec 70.88732927
+	Distance 106.594
+	SpectralType "DA9"
+	Temperature 5026
+	AppMag 17.786 # synthetic
+	Radius 9544
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2042988/NLTT%2042988.html"
+}
+
+"Gaia DR2 6018613473779340928:WDJ163029.74-373936.84"
+{
+	RA 247.62219141
+	Dec -37.66146912
+	Distance 108.355
+	SpectralType "DC8"
+	Temperature 6449
+	AppMag 17.95 # synthetic
+	Radius 4293
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206018613473779340928/Gaia%20DR2%206018613473779340928.html"
+}
+
+"Gaia DR2 6044265144466741888:WDJ163058.32-281815.48"
+{
+	RA 247.7417021
+	Dec -28.30430795
+	Distance 128.011
+	SpectralType "DC9"
+	Temperature 4190
+	AppMag 18.948 # synthetic
+	Radius 12477
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206044265144466741888/Gaia%20DR2%206044265144466741888.html"
+}
+
+"WD 1630+089:WDJ163233.17+085122.67"
+{
+	RA 248.13945312
+	Dec 8.85514677
+	Distance 42.143
+	SpectralType "DA9"
+	Temperature 5624
+	AppMag 15.08
+	Radius 8862
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201630+089/WD%201630+089.html"
+}
+
+"Gaia DR2 6018693257096471424:WDJ163337.05-371314.28"
+{
+	RA 248.40166562
+	Dec -37.22102381
+	Distance 68.748
+	SpectralType "DC9"
+	Temperature 5475
+	AppMag 16.18
+	Radius 7592
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206018693257096471424/Gaia%20DR2%206018693257096471424.html"
+}
+
+# Companion to WDJ163411.51+755857.56
+81139 "Gliese 632.2 A:GJ 9570 A:BD+76 614"
+{
+	RA 248.55606811
+	Dec 75.98277359
+	Distance 109.145 # mean of system components
+	SpectralType "K7"
+	Temperature 4412 # GSP-Phot
+	AppMag 9.918
+	Radius 494141 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=BD%2B76+614"
+}
+
+"Gliese 632.2 B:GJ 9570 B:Gaia DR2 1703379704562897280:WDJ163411.51+755857.56"
+{
+	RA 248.54986257
+	Dec 75.98331289
+	Distance 109.145 # mean of system components
+	SpectralType "DA4"
+	Temperature 12816
+	AppMag 14.189 # synthetic
+	Radius 8943
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201703379704562897280/Gaia%20DR2%201703379704562897280.html"
+}
+
+# Companion to WDJ163421.55+571008.87
+"CM Dra:Gliese 630.1 A"
+{
+	RA 248.57558061
+	Dec 57.16757382
+	Distance 48.422 # mean of system components
+	SpectralType "M4.5V"
+	AppMag 12.87
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=V*+CM+Dra"
+}
+
+"Gliese 630.1 B:WD 1633+572:EGGR 258:WDJ163421.55+571008.87"
+{
+	RA 248.58069229
+	Dec 57.17446098
+	Distance 48.422 # mean of system components
+	SpectralType "DQ8"
+	Temperature 6126
+	AppMag 15.004
+	Radius 8603
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201633+572/WD%201633+572.html"
+}
+
+"PG 1632+177:WD 1632+177:WDJ163441.85+173634.09"
+{
+	RA 248.67472885
+	Dec 17.60932388
+	Distance 83.491
+	SpectralType "DAZ5"
+	Temperature 9754
+	AppMag 13.106
+	Radius 15087
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201632+177/PG%201632+177.html"
+}
+
+"GJ 3965:PG 1633+434:WD 1633+433:WDJ163501.43+431736.35"
+{
+	RA 248.75733561
+	Dec 43.29208824
+	Distance 47.261
+	SpectralType "DAZ8"
+	Temperature 6516
+	AppMag 14.834
+	Radius 7995
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PG%201633+434/PG%201633+434.html"
+}
+
+"Gaia DR2 5765270154886903168:WDJ163626.53-873706.08"
+{
+	RA 249.08060794
+	Dec -87.61997811
+	Distance 123.311
+	SpectralType "DQ9"
+	Temperature 5674
+	AppMag 17.669 # synthetic
+	Radius 7681
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205765270154886903168/Gaia%20DR2%205765270154886903168.html"
+}
+
+"EGGR 328:WD 1636+057:WDJ163854.47+054041.63"
+{
+	RA 249.7255796
+	Dec 5.67634116
+	Distance 117.451
+	SpectralType "DA6"
+	Temperature 8496
+	AppMag 15.76
+	Radius 6120
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20328/EGGR%20328.html"
+}
+
+"EGGR 120:WD 1637+335:WDJ163927.82+332522.24"
+{
+	RA 249.86581267
+	Dec 33.42077106
+	Distance 99.391
+	SpectralType "DA5"
+	Temperature 9989
+	AppMag 14.65
+	Radius 8859
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20120/EGGR%20120.html"
+}
+
+"GJ 1205:GD 356:EGGR 329:WD 1639+537:WDJ164057.15+534109.32"
+{
+	RA 250.23722257
+	Dec 53.68507501
+	Distance 65.67
+	SpectralType "DAH7"
+	Temperature 7729
+	AppMag 15.05
+	Radius 7471
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20356/GD%20356.html"
+}
+
+"EGGR 196:WD 1639+153:WDJ164136.61+151237.93"
+{
+	RA 250.40262073
+	Dec 15.20755474
+	Distance 101.092
+	SpectralType "DA7"
+	Temperature 7329
+	AppMag 15.66
+	Radius 9331
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20196/EGGR%20196.html"
+}
+
+"Gaia DR2 5929529014509678720:WDJ164725.24-544237.58"
+{
+	RA 251.85428166
+	Dec -54.7116585
+	Distance 72.094
+	SpectralType "DA6"
+	Temperature 8530
+	AppMag 14.993 # synthetic
+	Radius 7061
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205929529014509678720/Gaia%20DR2%205929529014509678720.html"
+}
+
+82257 "DN Dra:GJ 1206:EGGR 368:WD 1647+591:WDJ164825.63+590322.66"
+{
+	RA 252.10793778
+	Dec 59.05497069
+	Distance 35.702
+	SpectralType "DA4"
+	Temperature 12182
+	AppMag 12.24
+	Radius 7342
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20DN%20Dra/V*%20DN%20Dra.html"
+}
+
+"Gaia DR2 4126670518631322880:WDJ164951.45-215503.96"
+{
+	RA 252.4631907
+	Dec -21.91799539
+	Distance 119.715
+	SpectralType "DA9"
+	Temperature 5223
+	AppMag 17.768 # synthetic
+	Radius 9393
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204126670518631322880/Gaia%20DR2%204126670518631322880.html"
+}
+
+"WD 1647-327:LAWD 64:WDJ165044.34-324923.08"
+{
+	RA 252.68421278
+	Dec -32.82524774
+	Distance 88.356
+	SpectralType "DA9"
+	Temperature 5899
+	AppMag 16.21
+	Radius 9665
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201647-327/WD%201647-327.html"
+}
+
+"WD 1650-011:WDJ165237.59-011356.41"
+{
+	RA 253.15721773
+	Dec -1.23396096
+	Distance 98.556
+	SpectralType "DA9"
+	Temperature 5571
+	AppMag 17.338 # synthetic
+	Radius 7538
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201650-011/WD%201650-011.html"
+}
+
+"Gaia DR2 4334641562477923712:WDJ165335.21-100116.33"
+{
+	RA 253.39740924
+	Dec -10.02214099
+	Distance 106.278
+	SpectralType "DA7"
+	Temperature 7345
+	AppMag 15.69
+	Radius 9385
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204334641562477923712/Gaia%20DR2%204334641562477923712.html"
+}
+
+"LP 70-238:WD 1653+630:WDJ165401.26+625354.91"
+{
+	RA 253.49992631
+	Dec 62.89925239
+	Distance 100.317
+	SpectralType "DC9"
+	Temperature 4990 # Table A5
+	AppMag 18.047 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%2070-238/LP%2070-238.html"
+}
+
+"WD 1653+385:WDJ165445.69+382936.63"
+{
+	RA 253.69046513
+	Dec 38.49205533
+	Distance 88.953
+	SpectralType "DAZH9"
+	Temperature 5812
+	AppMag 15.86
+	Radius 7886
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201653+385/WD%201653+385.html"
+}
+
+"Gaia DR2 4125468645047515904:WDJ165538.10-232555.73"
+{
+	RA 253.90875574
+	Dec -23.43262153
+	Distance 124.505
+	SpectralType "DA7"
+	Temperature 6994
+	AppMag 16.577 # synthetic
+	Radius 8326
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204125468645047515904/Gaia%20DR2%204125468645047515904.html"
+}
+
+"WD 1653+256:WDJ165538.91+253346.61"
+{
+	RA 253.91237657
+	Dec 25.56207665
+	Distance 118.956
+	SpectralType "DA4"
+	Temperature 11455
+	AppMag 16.961 # synthetic
+	Radius 3045
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201653+256/WD%201653+256.html"
+}
+
+"V749 Her:GJ 1208:EGGR 197:WD 1655+215:WDJ165709.86+212648.66"
+{
+	RA 254.29120145
+	Dec 21.44429976
+	Distance 68.422
+	SpectralType "DA5"
+	Temperature 9206
+	AppMag 14.09
+	Radius 8851
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V749%20Her/V*%20V749%20Her.html"
+}
+
+"Gaia DR2 5775307733975564160:WDJ165823.76-805857.14"
+{
+	RA 254.60281678
+	Dec -80.98114435
+	Distance 73.015
+	SpectralType "DC9"
+	Temperature 4858
+	AppMag 17.025 # synthetic
+	Radius 10655
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205775307733975564160/Gaia%20DR2%205775307733975564160.html"
+}
+
+# Companion to WDJ165847.03-061708.94
+"LP 686-33"
+{
+	RA 254.71321345
+	Dec -6.25992835
+	Distance 103.226 # mean of system components
+	SpectralType "M5V"
+	Temperature 3217 # GSP-Phot
+	AppMag 15.527 # synthetic
+	Radius 168318 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+686-33"
+}
+
+"WD 1656-062:WDJ165847.03-061708.94"
+{
+	RA 254.69744435
+	Dec -6.28638946
+	Distance 103.226 # mean of system components
+	SpectralType "DA9"
+	Temperature 5559
+	AppMag 17.14
+	Radius 8671
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201656-062/WD%201656-062.html"
+}
+
+"WD 1658+445:WDJ165935.92+442543.45"
+{
+	RA 254.89783674
+	Dec 44.42764103
+	Distance 92.881
+	SpectralType "DA9"
+	Temperature 5580
+	AppMag 16.765 # synthetic
+	Radius 9288
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201658+445/WD%201658+445.html"
+}
+
+"WD 1657+321:WDJ165940.02+320320.46"
+{
+	RA 254.91549116
+	Dec 32.05460573
+	Distance 122.016
+	SpectralType "DA8"
+	Temperature 6407
+	AppMag 17.489 # synthetic
+	Radius 6322
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201657+321/WD%201657+321.html"
+}
+
+"WD 1658+440:WDJ165948.42+440104.04"
+{
+	RA 254.95157128
+	Dec 44.01822731
+	Distance 103.215
+	SpectralType "DAH2"
+	Temperature 29613
+	AppMag 15.02
+	Radius 3179
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201658+440/WD%201658+440.html"
+}
+
+"Gaia DR2 5765288880944438144:WDJ170038.34-872352.90"
+{
+	RA 255.16288399
+	Dec -87.39842964
+	Distance 106.022
+	SpectralType "DA5"
+	Temperature 10897
+	AppMag 14.57
+	Radius 8510
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205765288880944438144/Gaia%20DR2%205765288880944438144.html"
+}
+
+"Gaia DR2 5808208420421074560:WDJ170054.19-690832.65"
+{
+	RA 255.22365345
+	Dec -69.14277842
+	Distance 116.947
+	SpectralType "DA6"
+	Temperature 7946
+	AppMag 16.571
+	Radius 6370
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205808208420421074560/Gaia%20DR2%205808208420421074560.html"
+}
+
+"NLTT 44063:WDJ170246.27+102241.24"
+{
+	RA 255.69307888
+	Dec 10.37917494
+	Distance 95.618
+	SpectralType "DA9"
+	Temperature 5209
+	AppMag 17.904 # synthetic
+	Radius 6898
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2044063/NLTT%2044063.html"
+}
+
+# Companion to WDJ170256.34-531436.57
+83431 "EPS2 Ara:GJ 3985"
+{
+	RA 255.7863069
+	Dec -53.23757509
+	Distance 87.002 # mean of system components
+	SpectralType "F5V+F5V"
+	Temperature 6228 # GSP-Phot
+	AppMag 5.278
+	Radius 1256138 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=*+eps02+Ara"
+}
+
+"GJ 2125:BPM 24602:WD 1659-531:WDJ170256.34-531436.57"
+{
+	RA 255.73472301
+	Dec -53.244144
+	Distance 87.002 # mean of system components
+	SpectralType "DA3"
+	Temperature 15052
+	AppMag 13.47
+	Radius 8665
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/BPM%2024602/BPM%2024602.html"
+}
+
+"Gaia DR2 4380188694219651456:WDJ170427.96-005026.31"
+{
+	RA 256.11543858
+	Dec -0.84089272
+	Distance 87.974
+	SpectralType "DA8"
+	Temperature 6540
+	AppMag 16.402 # synthetic
+	Radius 7200
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204380188694219651456/Gaia%20DR2%204380188694219651456.html"
+}
+
+"Gaia DR2 5938773880045035776:WDJ170430.68-481953.11"
+{
+	RA 256.12793653
+	Dec -48.33251713
+	Distance 84.029
+	SpectralType "DC9"
+	Temperature 5157
+	AppMag 17.213 # synthetic
+	Radius 8536
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205938773880045035776/Gaia%20DR2%205938773880045035776.html"
+}
+
+"Gaia DR2 4139348334376604928:WDJ170438.32-144620.79"
+{
+	RA 256.15851037
+	Dec -14.77397042
+	Distance 106.435
+	SpectralType "DA7"
+	Temperature 7433
+	AppMag 16.504 # synthetic
+	Radius 6625
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204139348334376604928/Gaia%20DR2%204139348334376604928.html"
+}
+
+"Gaia DR2 4379812558164849408:WDJ170502.87-014502.70"
+{
+	RA 256.26125851
+	Dec -1.75149875
+	Distance 92.254
+	SpectralType "DC9"
+	Temperature 4853
+	AppMag 17.629 # synthetic
+	Radius 10021
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204379812558164849408/Gaia%20DR2%204379812558164849408.html"
+}
+
+"EGGR 577:WD 1704+481.2:WDJ170530.44+480312.36"
+{
+	RA 256.37698594
+	Dec 48.0531226
+	Distance 128.498 # mean of system components
+	SpectralType "DA6"
+	Temperature 8918
+	AppMag 14.45
+	Radius 15104
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20577/EGGR%20577.html"
+}
+
+"EGGR 576:WD 1704+481.1:WDJ170530.97+480310.27"
+{
+	RA 256.3791474
+	Dec 48.05253988
+	Distance 128.498 # mean of system components
+	SpectralType "DA4"
+	Temperature 14224
+	AppMag 13.8
+	Radius 8519
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20576/EGGR%20576.html"
+}
+
+# Companion to WDJ170552.58+260551.20
+"G 169-46"
+{
+	RA 256.46896054
+	Dec 26.0909508
+	Distance 113.323 # mean of system components
+	SpectralType "M1.5V"
+	Temperature 3609 # GSP-Spec
+	AppMag 12.179 # synthetic
+	Radius 479282 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+169-46"
+}
+
+"WD 1703+261:WDJ170552.58+260551.20"
+{
+	RA 256.46891658
+	Dec 26.0962961
+	Distance 113.323 # mean of system components
+	SpectralType "DA8"
+	Temperature 6038
+	AppMag 17.193 # synthetic
+	Radius 7565
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201703+261/WD%201703+261.html"
+}
+
+"Gaia DR2 4108828945319007744:WDJ170641.36-264334.71"
+{
+	RA 256.67220635
+	Dec -26.72673303
+	Distance 42.52
+	SpectralType "DAH8"
+	Temperature 6128
+	AppMag 15.35
+	Radius 6981
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204108828945319007744/Gaia%20DR2%204108828945319007744.html"
+}
+
+"GJ 1211:EGGR 494:WD 1705+030:WDJ170807.97+025737.08"
+{
+	RA 257.03313524
+	Dec 2.95853244
+	Distance 58.162
+	SpectralType "DZ8"
+	Temperature 6720
+	AppMag 15.194
+	Radius 7439
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201211/GJ%201211.html"
+}
+
+"LAWD 66:EGGR 122:WD 1708-147:WDJ171126.76-144753.69"
+{
+	RA 257.86278606
+	Dec -14.79946455
+	Distance 73.919
+	SpectralType "DQ5"
+	Temperature 9916
+	AppMag 14.32
+	Radius 8248
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2066/LAWD%2066.html"
+}
+
+"EGGR 370:WD 1713+695:WDJ171306.09+693125.51"
+{
+	RA 258.27467307
+	Dec 69.52222687
+	Distance 85.589
+	SpectralType "DA3"
+	Temperature 15732
+	AppMag 13.299 # synthetic
+	Radius 9037
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20370/EGGR%20370.html"
+}
+
+"Gaia DR2 4361621688038664064:WDJ171409.55-053419.96"
+{
+	RA 258.53979522
+	Dec -5.57261187
+	Distance 85.286
+	SpectralType "DA5"
+	Temperature 9628
+	AppMag 14.627
+	Radius 8009
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204361621688038664064/Gaia%20DR2%204361621688038664064.html"
+}
+
+"Gaia DR2 4136103572502555264:WDJ171436.16-161243.30"
+{
+	RA 258.65026115
+	Dec -16.21200911
+	Distance 120.642
+	SpectralType "DAH5"
+	Temperature 11135
+	AppMag 15.994 # synthetic
+	Radius 5086
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204136103572502555264/Gaia%20DR2%204136103572502555264.html"
+}
+
+"WD 1713+393:WDJ171450.80+391837.43"
+{
+	RA 258.71159682
+	Dec 39.31128736
+	Distance 128.997
+	SpectralType "DAH8"
+	Temperature 6694
+	AppMag 16.416 # synthetic
+	Radius 10177
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201713+393/WD%201713+393.html"
+}
+
+"Gaia DR2 4359722208685335552:WDJ171620.72-082118.60"
+{
+	RA 259.08473264
+	Dec -8.3547179
+	Distance 125.311
+	SpectralType "DQ8"
+	Temperature 6065
+	AppMag 16.928 # synthetic
+	Radius 9358
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204359722208685335552/Gaia%20DR2%204359722208685335552.html"
+}
+
+"Gaia DR2 5915797694789556096:WDJ171652.09-590636.29"
+{
+	RA 259.21692233
+	Dec -59.11012542
+	Distance 97.195
+	SpectralType "DAH6"
+	Temperature 8608
+	AppMag 15.682 # synthetic
+	Radius 6867
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205915797694789556096/Gaia%20DR2%205915797694789556096.html"
+}
+
+"Wolf 672 A:LAWD 67:EGGR 123:WD 1716+020:WDJ171835.16+015653.21"
+{
+	RA 259.64457601
+	Dec 1.94684392
+	Distance 124.283
+	SpectralType "DA4"
+	Temperature 12685
+	AppMag 14.26
+	Radius 9512
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Wolf%20672%20A/Wolf%20672%20A.html"
+}
+
+"WD 1717-014:EGGR 495:WDJ171952.83-013001.84"
+{
+	RA 259.96867019
+	Dec -1.50135264
+	Distance 125.304
+	SpectralType "DC9"
+	Temperature 4737
+	AppMag 18.411 # synthetic
+	Radius 10513
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201717-014/WD%201717-014.html"
+}
+
+# Companion to WDJ171955.76+363936.32
+"Wolf 692"
+{
+	RA 259.98125711
+	Dec 36.65862743
+	Distance 114.053 # mean of system components
+	SpectralType "M3"
+	Temperature 3412 # GSP-Phot
+	AppMag 13.75
+	Radius 270957 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Wolf+692"
+}
+
+"Gaia DR3 1336988963803208192:WDJ171955.76+363936.32"
+{
+	RA 259.98169818
+	Dec 36.65784991
+	Distance 114.053 # mean of system components
+	SpectralType "DQ7"
+	Temperature 6727
+	AppMag 17.117 # synthetic
+	Radius 6856
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%201336988963803208192/Gaia%20DR3%201336988963803208192.html"
+}
+
+"Gaia DR2 4491748511228743808:WDJ172006.79+102227.98"
+{
+	RA 260.02810591
+	Dec 10.37485788
+	Distance 122.463
+	SpectralType "DC9"
+	Temperature 5092
+	AppMag 17.895 # synthetic
+	Radius 9891
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204491748511228743808/Gaia%20DR2%204491748511228743808.html"
+}
+
+"Gaia DR2 5975317695158795776:WDJ172239.79-355441.65"
+{
+	RA 260.66620016
+	Dec -35.91119589
+	Distance 119.788
+	SpectralType "DA7"
+	Temperature 7098
+	AppMag 16.849 # synthetic
+	Radius 6881
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205975317695158795776/Gaia%20DR2%205975317695158795776.html"
+}
+
+"WD 1722+279:WDJ172413.32+275655.30"
+{
+	RA 261.05572037
+	Dec 27.94843037
+	Distance 125.589
+	SpectralType "DA8"
+	Temperature 5971
+	AppMag 17.466 # synthetic
+	Radius 7487
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201722+279/WD%201722+279.html"
+}
+
+"Gaia DR2 4542785981266940416:WDJ172945.19+143541.28"
+{
+	RA 262.43867945
+	Dec 14.5949002
+	Distance 103.906
+	SpectralType "DC9"
+	Temperature 4890
+	AppMag 18.266 # synthetic
+	Radius 7807
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204542785981266940416/Gaia%20DR2%204542785981266940416.html"
+}
+
+"NLTT 45205:WD 1737+798:WDJ173334.29+794916.65"
+{
+	RA 263.40263825
+	Dec 79.82104546
+	Distance 87.464
+	SpectralType "DC9"
+	Temperature 5633
+	AppMag 17.093 # synthetic
+	Radius 7193
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2045205/NLTT%2045205.html"
+}
+
+"Gaia DR2 4598775557191664384:WDJ173337.18+290338.04"
+{
+	RA 263.40501306
+	Dec 29.06126363
+	Distance 128.976
+	SpectralType "DC8"
+	Temperature 6458
+	AppMag 17.155 # synthetic
+	Radius 7721
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204598775557191664384/Gaia%20DR2%204598775557191664384.html"
+}
+
+"Gaia DR2 4110161965722210432:WDJ173351.73-250759.90"
+{
+	RA 263.46489603
+	Dec -25.13457521
+	Distance 121.244
+	SpectralType "DA9"
+	Temperature 5623
+	AppMag 17.611 # synthetic
+	Radius 8016
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204110161965722210432/Gaia%20DR2%204110161965722210432.html"
+}
+
+"Gaia DR2 1348795004265872000:WDJ173404.42+442303.09"
+{
+	RA 263.51794884
+	Dec 44.38389225
+	Distance 122.153
+	SpectralType "DA9"
+	Temperature 5217
+	AppMag 17.933 # synthetic
+	Radius 8857
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201348795004265872000/Gaia%20DR2%201348795004265872000.html"
+}
+
+"GJ 4012:LAWD 68:WD 1733-544:WDJ173700.72-542556.56"
+{
+	RA 264.25229731
+	Dec -54.43440977
+	Distance 65.95
+	SpectralType "DA8"
+	Temperature 6567
+	AppMag 15.8
+	Radius 7345
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204012/GJ%204012.html"
+}
+
+"Gaia DR2 4055353888055627008:WDJ173800.77-311237.21"
+{
+	RA 264.50184556
+	Dec -31.21139251
+	Distance 128.935
+	SpectralType "DC9"
+	Temperature 4816
+	AppMag 18.463 # synthetic
+	Radius 9857
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204055353888055627008/Gaia%20DR2%204055353888055627008.html"
+}
+
+"Gaia DR2 4168312459956062208:WDJ173834.39-082614.02"
+{
+	RA 264.64381661
+	Dec -8.43744572
+	Distance 99.06
+	SpectralType "DAZ7"
+	Temperature 7094
+	AppMag 15.96 # synthetic
+	Radius 8577
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204168312459956062208/Gaia%20DR2%204168312459956062208.html"
+}
+
+# Companion to WDJ173837.46-342729.28
+"PM J17386-3427"
+{
+	RA 264.65322799
+	Dec -34.46028814
+	Distance 125.818 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3194 # GSP-Phot
+	AppMag 15.2
+	Radius 221762 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=PM+J17386-3427"
+}
+
+"Gaia DR3 4053455379420643584:WDJ173837.46-342729.28"
+{
+	RA 264.65436339
+	Dec -34.45985961
+	Distance 125.818 # mean of system components
+	SpectralType "DA9"
+	Temperature 4980
+	AppMag 18.029 # synthetic
+	Radius 10701
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%204053455379420643584/Gaia%20DR3%204053455379420643584.html"
+}
+
+"NLTT 45288:WD 1739+240:WDJ174146.25+240149.67"
+{
+	RA 265.44255901
+	Dec 24.02887118
+	Distance 103.043
+	SpectralType "DA7"
+	Temperature 7190
+	AppMag 16.529 # synthetic
+	Radius 6705
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2045288/NLTT%2045288.html"
+}
+
+"Gaia DR2 4118171568655203328:WDJ174220.63-203935.92"
+{
+	RA 265.58571066
+	Dec -20.66059782
+	Distance 94.699
+	SpectralType "DC9"
+	Temperature 5618
+	AppMag 17.098 # synthetic
+	Radius 7908
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204118171568655203328/Gaia%20DR2%204118171568655203328.html"
+}
+
+"Gaia DR2 5909078751020702080:WDJ174246.61-650514.67"
+{
+	RA 265.69626698
+	Dec -65.08677868
+	Distance 97.446
+	SpectralType "DC6"
+	Temperature 8580
+	AppMag 15.969
+	Radius 6356
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205909078751020702080/Gaia%20DR2%205909078751020702080.html"
+}
+
+"WD 1741+436:WDJ174248.51+433809.21"
+{
+	RA 265.701932
+	Dec 43.63494619
+	Distance 102.322
+	SpectralType "DA9"
+	Temperature 5513
+	AppMag 17.119 # synthetic
+	Radius 9051
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201741+436/WD%201741+436.html"
+}
+
+"LP 448-24:WDJ174300.75+170145.74"
+{
+	RA 265.75195462
+	Dec 17.02811431
+	Distance 108.859
+	SpectralType "DC9"
+	Temperature 4585
+	AppMag 18.436 # synthetic
+	Radius 9807
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20448-24/LP%20448-24.html"
+}
+
+# Companion to WDJ174322.98+143452.25
+"LSPM J1743+1434N"
+{
+	RA 265.84256568
+	Dec 14.58453482
+	Distance 112.019 # mean of system components
+	SpectralType "M3.5V"
+	Temperature 3124 # GSP-Phot
+	AppMag 13.808 # synthetic
+	Radius 336601 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LSPM+J1743%2B1434N"
+}
+
+"2MASS J17432300+1434519:WD 1741+146:WDJ174322.98+143452.25"
+{
+	RA 265.84457603
+	Dec 14.58248126
+	Distance 112.019 # mean of system components
+	SpectralType "DC5"
+	Temperature 10224
+	AppMag 14.908 # synthetic
+	Radius 9081
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J17432300+1434519/2MASS%20J17432300+1434519.html"
+}
+
+"Gaia DR2 5961193055261256320:WDJ174349.28-390825.95"
+{
+	RA 265.95465666
+	Dec -39.1403293
+	Distance 69.593
+	SpectralType "DA4"
+	Temperature 11605
+	AppMag 13.72
+	Radius 8444
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205961193055261256320/Gaia%20DR2%205961193055261256320.html"
+}
+
+"Gaia DR3 4117081643422165120:WDJ174512.54-215309.25"
+{
+	RA 266.30004249
+	Dec -21.8891065
+	Distance 127.866
+	SpectralType "DC9"
+	Temperature 4233
+	AppMag 18.723 # synthetic
+	Radius 13203
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%204117081643422165120/Gaia%20DR3%204117081643422165120.html"
+}
+
+# Companion to WDJ174554.56-131755.39
+86938 "GJ 2131 A:G 154-B5 A"
+{
+	RA 266.47254849
+	Dec -13.30579298
+	Distance 126.398 # mean of system components
+	SpectralType "M1V"
+	Temperature 3677 # GSP-Spec
+	AppMag 11.937
+	Radius 562036 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+154-B5A"
+}
+
+"GJ 2131 B:EGGR 175:WD 1743-132:WDJ174554.56-131755.39"
+{
+	RA 266.47758503
+	Dec -13.29828979
+	Distance 126.398 # mean of system components
+	SpectralType "DA4"
+	Temperature 11902
+	AppMag 14.22
+	Radius 9288
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202131%20B/GJ%202131%20B.html"
+}
+
+# Companion to WDJ174611.08-625141.41
+86991
+{
+	RA 266.64923413
+	Dec -62.75354168
+	Distance 112.092 # mean of system components
+	SpectralType "G1V"
+	Temperature 5766 # GSP-Spec
+	AppMag 7.51
+	Radius 693657 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+160859"
+}
+
+"Gaia DR2 5909739660590724224:WDJ174611.08-625141.41"
+{
+	RA 266.54567398
+	Dec -62.86321502
+	Distance 112.092 # mean of system components
+	SpectralType "DA7"
+	Temperature 7403
+	AppMag 15.981
+	Radius 8928
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205909739660590724224/Gaia%20DR2%205909739660590724224.html"
+}
+
+"Gaia DR2 4150020774057837440:WDJ174620.41-123425.48"
+{
+	RA 266.58499278
+	Dec -12.57405123
+	Distance 120.761
+	SpectralType "DA8"
+	Temperature 6066
+	AppMag 17.343 # synthetic
+	Radius 7395
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204150020774057837440/Gaia%20DR2%204150020774057837440.html"
+}
+
+"2MASS J17470830+2859098:WD 1745+290:WDJ174708.31+285909.76"
+{
+	RA 266.7839679
+	Dec 28.98534949
+	Distance 119.12
+	SpectralType "DC9"
+	Temperature 4996
+	AppMag 17.782 # synthetic
+	Radius 11438
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J17470830+2859098/2MASS%20J17470830+2859098.html"
+}
+
+"PM J17476-5436:WD 1743-545:WDJ174736.82-543631.16"
+{
+	RA 266.9004493
+	Dec -54.61001942
+	Distance 44.058
+	SpectralType "DC9"
+	Temperature 4565
+	AppMag 16.279
+	Radius 11192
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J17476-5436/PM%20J17476-5436.html"
+}
+
+"V820 Ara:L 270-31:WD 1743-521:WDJ174746.92-520710.89"
+{
+	RA 266.94588262
+	Dec -52.12016758
+	Distance 126.75
+	SpectralType "DAH3"
+	Temperature 14852
+	AppMag 15.62
+	Radius 4713
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%20270-31/L%20270-31.html"
+}
+
+# WDJ174807.99+705235.92: defined in nearstars.stc
+
+"GD 366:WD 1747+450:WDJ174826.86+450327.85"
+{
+	RA 267.11295907
+	Dec 45.05754696
+	Distance 97.499
+	SpectralType "DC6"
+	Temperature 8685
+	AppMag 15.602 # synthetic
+	Radius 7337
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20366/GD%20366.html"
+}
+
+"Gaia DR2 4068499305485306240:WDJ174935.61-235500.63"
+{
+	RA 267.39883527
+	Dec -23.91741162
+	Distance 86.668
+	SpectralType "DAZ7"
+	Temperature 7255
+	AppMag 15.42
+	Radius 9102
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204068499305485306240/Gaia%20DR2%204068499305485306240.html"
+}
+
+"Gliese 699.1:GJ 9610:EGGR 199:WD 1756+827:WDJ174950.15+824626.06"
+{
+	RA 267.40817655
+	Dec 82.78863974
+	Distance 53.295
+	SpectralType "DA7"
+	Temperature 7188
+	AppMag 14.309
+	Radius 9643
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20699.1/GJ%20699.1.html"
+}
+
+"Gaia DR2 5767614206300408576:WDJ175325.53-840510.03"
+{
+	RA 268.34825163
+	Dec -84.08562873
+	Distance 124.112
+	SpectralType "DC9"
+	Temperature 5123
+	AppMag 18.052 # synthetic
+	Radius 8989
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205767614206300408576/Gaia%20DR2%205767614206300408576.html"
+}
+
+"Gaia DR2 4604247070649603584:WDJ175352.16+330622.62"
+{
+	RA 268.46713441
+	Dec 33.1064217
+	Distance 116.382
+	SpectralType "DA3"
+	Temperature 17089
+	AppMag 13.24
+	Radius 9207
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204604247070649603584/Gaia%20DR2%204604247070649603584.html"
+}
+
+"Gaia DR2 4067477554248982528:WDJ175554.31-245648.94"
+{
+	RA 268.97634115
+	Dec -24.94684725
+	Distance 122.354
+	SpectralType "DA4"
+	Temperature 13001
+	AppMag 14.818 # synthetic
+	Radius 7324
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204067477554248982528/Gaia%20DR2%204067477554248982528.html"
+}
+
+"WD 1755+408:WDJ175704.46+405249.39"
+{
+	RA 269.26869569
+	Dec 40.88184327
+	Distance 100.893
+	SpectralType "DC9"
+	Temperature 5404
+	AppMag 17.186 # synthetic
+	Radius 9158
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201755+408/WD%201755+408.html"
+}
+
+"WD 1756+143:WDJ175822.90+141737.92"
+{
+	RA 269.59165944
+	Dec 14.29132364
+	Distance 69.464
+	SpectralType "DA9"
+	Temperature 5412
+	AppMag 16.27
+	Radius 9581
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201756+143/WD%201756+143.html"
+}
+
+"Gaia DR2 4611204329256349312:WDJ175919.66+392504.95"
+{
+	RA 269.83135395
+	Dec 39.41622773
+	Distance 127.622
+	SpectralType "DC9"
+	Temperature 4757
+	AppMag 18.372 # synthetic
+	Radius 10961
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204611204329256349312/Gaia%20DR2%204611204329256349312.html"
+}
+
+"Gaia DR2 5911160263973498496:WDJ175931.34-620108.87"
+{
+	RA 269.88065754
+	Dec -62.01961806
+	Distance 125.259
+	SpectralType "DA3"
+	Temperature 16224
+	AppMag 15.948 # synthetic
+	Radius 3746
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%205911160263973498496/Gaia%20DR2%205911160263973498496.html"
+}
+
+"NLTT 45830:WD 1800+508:WDJ180127.52+504958.36"
+{
+	RA 270.36376381
+	Dec 50.83403667
+	Distance 100.971
+	SpectralType "DC9"
+	Temperature 4936
+	AppMag 17.657 # synthetic
+	Radius 10474
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2045830/NLTT%2045830.html"
+}
+
+"Gaia DR2 6363592840482769792:WDJ180314.84-805750.43"
+{
+	RA 270.81448993
+	Dec -80.96550865
+	Distance 109.683
+	SpectralType "DC9"
+	Temperature 4906
+	AppMag 18.336 # synthetic
+	Radius 7918
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206363592840482769792/Gaia%20DR2%206363592840482769792.html"
+}
+
+"Gaia DR2 4037085334973293824:WDJ180315.18-371725.54"
+{
+	RA 270.81362823
+	Dec -37.29228983
+	Distance 86.132
+	SpectralType "DA9"
+	Temperature 5456
+	AppMag 16.959
+	Radius 8265
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204037085334973293824/Gaia%20DR2%204037085334973293824.html"
+}
+
+"Gaia DR2 6414612172876713472:WDJ180345.86-752318.35"
+{
+	RA 270.94361879
+	Dec -75.38762374
+	Distance 102.025
+	SpectralType "DAH9"
+	Temperature 5624
+	AppMag 17.039
+	Radius 8761
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206414612172876713472/Gaia%20DR2%206414612172876713472.html"
+}
+
+"PM J18073+0357:WD 1804+039:WDJ180723.38+035701.80"
+{
+	RA 271.84741227
+	Dec 3.94993658
+	Distance 98.308
+	SpectralType "DA5"
+	Temperature 10229
+	AppMag 15.08
+	Radius 8539
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J18073+0357/PM%20J18073+0357.html"
+}
+
+"Gaia DR2 6431530976766770560:WDJ180853.83-704231.62"
+{
+	RA 272.22699119
+	Dec -70.7110481
+	Distance 115.824
+	SpectralType "DC9"
+	Temperature 4860
+	AppMag 18.231 # synthetic
+	Radius 9462
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206431530976766770560/Gaia%20DR2%206431530976766770560.html"
+}
+
+# Companion to WDJ180901.95-410140.69
+"UCAC4 245-156444"
+{
+	RA 272.18194247
+	Dec -41.03973643
+	Distance 101.492 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3174 # GSP-Phot
+	AppMag 13.479 # synthetic
+	Radius 329747 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UCAC4+245-156444"
+}
+
+"Gaia DR3 6725656144031366144:WDJ180901.95-410140.69"
+{
+	RA 272.25923909
+	Dec -41.02824592
+	Distance 101.492 # mean of system components
+	SpectralType "DC9"
+	Temperature 5746
+	AppMag 16.728 # estimate
+	Radius 9426
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%206725656144031366144/Gaia%20DR3%206725656144031366144.html"
+}
+
+"HD 166435 B:Gaia DR2 4590489981163833984:WDJ180919.46+295720.85"
+{
+	RA 272.33141454
+	Dec 29.95612101
+	Distance 79.723
+	SpectralType "DA2"
+	Temperature 22522
+	AppMag 13.122 # synthetic
+	Radius 6878
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204590489981163833984/Gaia%20DR2%204590489981163833984.html"
+}
+
+"Gaia DR2 6345857271249415424:WDJ181311.31-860811.23"
+{
+	RA 273.29541628
+	Dec -86.13746925
+	Distance 125.701
+	SpectralType "DA9"
+	Temperature 5069
+	AppMag 18.04 # synthetic
+	Radius 9709
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206345857271249415424/Gaia%20DR2%206345857271249415424.html"
+}
+
+"Gaia DR2 4153937891610652928:WDJ181539.13-114041.83"
+{
+	RA 273.91228199
+	Dec -11.67900524
+	Distance 127.348
+	SpectralType "DC9"
+	Temperature 5081
+	AppMag 18.089 # synthetic
+	Radius 9494
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204153937891610652928/Gaia%20DR2%204153937891610652928.html"
+}
+
+"Gaia DR2 2149331587745863680:WDJ181548.96+553232.22"
+{
+	RA 273.95464163
+	Dec 55.54195242
+	Distance 123.561
+	SpectralType "DC9"
+	Temperature 4955
+	AppMag 17.402 # synthetic
+	Radius 17648
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202149331587745863680/Gaia%20DR2%202149331587745863680.html"
+}
+
+"WD 1814+24:WD 1814+248:WDJ181608.87+245442.85"
+{
+	RA 274.03684455
+	Dec 24.91026132
+	Distance 122.601
+	SpectralType "DAP7"
+	Temperature 6800
+	AppMag 16.932 # synthetic
+	Radius 7338
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201814+24/WD%201814+24.html"
+}
+
+"WD 1814+134:WDJ181706.50+132824.99"
+{
+	RA 274.27507713
+	Dec 13.46865079
+	Distance 49.314
+	SpectralType "DA9"
+	Temperature 5022
+	AppMag 15.86
+	Radius 10921
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201814+134/WD%201814+134.html"
+}
+
+"Gaia DR2 4146666271458052352:WDJ181745.57-133531.54"
+{
+	RA 274.44086424
+	Dec -13.59073687
+	Distance 106.057
+	SpectralType "DA8"
+	Temperature 6002
+	AppMag 17.276 # synthetic
+	Radius 6911
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204146666271458052352/Gaia%20DR2%204146666271458052352.html"
+}
+
+"Gaia DR2 4094555467661923328:WDJ181909.96-193438.00"
+{
+	RA 274.79043183
+	Dec -19.57827565
+	Distance 128.693
+	SpectralType "DC9"
+	Temperature 4448
+	AppMag 18.48 # synthetic
+	Radius 13118
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204094555467661923328/Gaia%20DR2%204094555467661923328.html"
+}
+
+# Companion to WDJ181959.24+173919.13
+"LSPM J1820+1739"
+{
+	RA 275.00592928
+	Dec 17.65422343
+	Distance 111.501 # mean of system components
+	SpectralType "M4.0V"
+	AppMag 14.225 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LSPM+J1820%2B1739"
+}
+
+"2MASS J18195921+1739190:WDJ181959.24+173919.13"
+{
+	RA 274.9978425
+	Dec 17.65569217
+	Distance 111.501 # mean of system components
+	SpectralType "DC9"
+	Temperature 4967
+	AppMag 17.945 # synthetic
+	Radius 9658
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J18195921+1739190/2MASS%20J18195921+1739190.html"
+}
+
+"Gaia DR2 4585067258532443776:WDJ182021.81+261936.58"
+{
+	RA 275.09025831
+	Dec 26.32685732
+	Distance 129.579
+	SpectralType "DA9"
+	Temperature 4971
+	AppMag 18.461 # synthetic
+	Radius 8437
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204585067258532443776/Gaia%20DR2%204585067258532443776.html"
+}
+
+"GJ 4054:WD 1820+609:WDJ182119.83+610107.38"
+{
+	RA 275.33398632
+	Dec 61.01561311
+	Distance 44.693
+	SpectralType "DA9"
+	Temperature 4985
+	AppMag 15.67
+	Radius 11279
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204054/GJ%204054.html"
+}
+
+"Gaia DR2 2149253075743572224:WDJ182147.11+550906.70"
+{
+	RA 275.44680378
+	Dec 55.15206878
+	Distance 100.865
+	SpectralType "DA9"
+	Temperature 5083
+	AppMag 17.489 # synthetic
+	Radius 10117
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202149253075743572224/Gaia%20DR2%202149253075743572224.html"
+}
+
+"2MASS J18215954-5951484:WD 1817-598:WDJ182159.54-595148.52"
+{
+	RA 275.49747718
+	Dec -59.86506917
+	Distance 98.233
+	SpectralType "DA9"
+	Temperature 5029
+	AppMag 16.85
+	Radius 16364
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J18215954-5951484/2MASS%20J18215954-5951484.html"
+}
+
+"Gaia DR2 6437614815119680768:WDJ182228.37-653738.06"
+{
+	RA 275.61626679
+	Dec -65.62832624
+	Distance 116.799
+	SpectralType "DA9"
+	Temperature 5160
+	AppMag 17.78
+	Radius 9575
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206437614815119680768/Gaia%20DR2%206437614815119680768.html"
+}
+
+"Gaia DR2 4154063678315488640:WDJ182347.60-112347.38"
+{
+	RA 275.94793376
+	Dec -11.39664318
+	Distance 117.71
+	SpectralType "DA9"
+	Temperature 5668
+	AppMag 17.342 # synthetic
+	Radius 8581
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204154063678315488640/Gaia%20DR2%204154063678315488640.html"
+}
+
+# Companion to WDJ182359.62+202248.81
+"LSPM J1824+2023"
+{
+	RA 276.01779612
+	Dec 20.39527611
+	Distance 125.232 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 18.527 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LSPM+J1824%2B2023"
+}
+
+"Gaia DR2 4528439381757452928:WDJ182359.62+202248.81"
+{
+	RA 275.99760365
+	Dec 20.37990023
+	Distance 125.232 # mean of system components
+	SpectralType "DC9"
+	Temperature 5103
+	AppMag 18.105 # synthetic
+	Radius 9192
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204528439381757452928/Gaia%20DR2%204528439381757452928.html"
+}
+
+"GJ 2135:EGGR 176:WD 1821-131:WDJ182404.55-130842.29"
+{
+	RA 276.01801514
+	Dec -13.14792143
+	Distance 62.105
+	SpectralType "DAZ8"
+	Temperature 6079
+	AppMag 15.56
+	Radius 8707
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202135/GJ%202135.html"
+}
+
+"Gaia DR2 4484277256704949376:WDJ182417.72+120945.86"
+{
+	RA 276.07404878
+	Dec 12.16144222
+	Distance 106.949
+	SpectralType "DA9"
+	Temperature 5219
+	AppMag 17.577 # synthetic
+	Radius 9086
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204484277256704949376/Gaia%20DR2%204484277256704949376.html"
+}
+
+"Gaia DR2 4484289866726156160:WDJ182458.45+121316.82"
+{
+	RA 276.24226139
+	Dec 12.21654626
+	Distance 130.877
+	SpectralType "DZ9"
+	Temperature 4417
+	AppMag 18.999 # synthetic
+	Radius 11579
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204484289866726156160/Gaia%20DR2%204484289866726156160.html"
+}
+
+"Gaia DR2 4484184592790777728:WDJ182524.24+113557.34"
+{
+	RA 276.3495179
+	Dec 11.59946082
+	Distance 64.011
+	SpectralType "DA9"
+	Temperature 5022
+	AppMag 16.558 # synthetic
+	Radius 10221
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204484184592790777728/Gaia%20DR2%204484184592790777728.html"
+}
+
+# Companion to WDJ182624.44+112049.58
+"GJ 4059:G 141-10"
+{
+	RA 276.60243564
+	Dec 11.34803936
+	Distance 87.968 # mean of system components
+	SpectralType "M3.5V"
+	Temperature 3219 # GSP-Phot
+	AppMag 12.875
+	Radius 377973 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+141-10"
+}
+
+"Gaia DR2 4483974792231866624:WDJ182624.44+112049.58"
+{
+	RA 276.6017657
+	Dec 11.34585946
+	Distance 87.968 # mean of system components
+	SpectralType "DA9"
+	Temperature 5027
+	AppMag 17.209 # synthetic
+	Radius 10381
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204483974792231866624/Gaia%20DR2%204483974792231866624.html"
+}
+
+"EGGR 126:WD 1826-045:WDJ182909.86-042935.49"
+{
+	RA 277.29114857
+	Dec -4.49450975
+	Distance 84.071
+	SpectralType "DAZ6"
+	Temperature 8993
+	AppMag 14.57
+	Radius 9124
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20126/EGGR%20126.html"
+}
+
+"Gaia DR3 4257063458004688896:WDJ182951.89-053623.17"
+{
+	RA 277.46673439
+	Dec -5.60592013
+	Distance 129.602 # mean of system components
+	SpectralType "DA9"
+	Temperature 5630
+	AppMag 17.569 # synthetic
+	Radius 8666
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%204257063458004688896/Gaia%20DR3%204257063458004688896.html"
+}
+
+"Gaia DR2 4257063453704172416:WDJ182952.07-053622.88"
+{
+	RA 277.46749142
+	Dec -5.60581049
+	Distance 129.602 # mean of system components
+	SpectralType "DC8"
+	Temperature 6601
+	AppMag 16.955 # synthetic
+	Radius 8176
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204257063453704172416/Gaia%20DR2%204257063453704172416.html"
+}
+
+"GJ 1228:EGGR 374:WD 1829+547:WDJ183020.27+544727.21"
+{
+	RA 277.58240469
+	Dec 54.79216972
+	Distance 55.546
+	SpectralType "DXP8"
+	Temperature 6711
+	AppMag 15.53
+	Radius 6329
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201228/GJ%201228.html"
+}
+
+"Gaia DR2 2118649750133781376:WDJ183158.72+465828.98"
+{
+	RA 277.99512133
+	Dec 46.9748802
+	Distance 76.041
+	SpectralType "DA7"
+	Temperature 7396
+	AppMag 15.176 # synthetic
+	Radius 8775
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202118649750133781376/Gaia%20DR2%202118649750133781376.html"
+}
+
+"Gaia DR2 6432020637402543616:WDJ183351.29-694203.57"
+{
+	RA 278.46459533
+	Dec -69.70102517
+	Distance 107.178
+	SpectralType "DA6"
+	Temperature 8010
+	AppMag 14.692 # synthetic
+	Radius 13487
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206432020637402543616/Gaia%20DR2%206432020637402543616.html"
+}
+
+"Gaia DR2 4589139574728058880:WDJ183352.68+321757.25"
+{
+	RA 278.46941522
+	Dec 32.29882902
+	Distance 128.289
+	SpectralType "DZA7"
+	Temperature 7743
+	AppMag 16.102 # synthetic
+	Radius 8222
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204589139574728058880/Gaia%20DR2%204589139574728058880.html"
+}
+
+"WD 1831+19:WD 1831+197:WDJ183358.35+194552.99"
+{
+	RA 278.49326219
+	Dec 19.76296151
+	Distance 127.943
+	SpectralType "DQ7"
+	Temperature 7236
+	AppMag 16.41
+	Radius 8818
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201831+19/WD%201831+19.html"
+}
+
+"Gaia DR2 2256410856215182464:WDJ183518.23+642117.68"
+{
+	RA 278.82458962
+	Dec 64.3554192
+	Distance 98.514
+	SpectralType "DC9"
+	Temperature 5028
+	AppMag 17.636 # synthetic
+	Radius 9382
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202256410856215182464/Gaia%20DR2%202256410856215182464.html"
+}
+
+"Gaia DR2 6709854989379725056:WDJ183852.85-441631.32"
+{
+	RA 279.72113325
+	Dec -44.27605784
+	Distance 110.182
+	SpectralType "DA9"
+	Temperature 5590
+	AppMag 17.439
+	Radius 8015
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206709854989379725056/Gaia%20DR2%206709854989379725056.html"
+}
+
+"Gaia DR2 6651133479247436032:WDJ183856.35-535726.05"
+{
+	RA 279.73641833
+	Dec -53.95866093
+	Distance 116.4
+	SpectralType "DA9"
+	Temperature 5232
+	AppMag 17.778 # synthetic
+	Radius 8984
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206651133479247436032/Gaia%20DR2%206651133479247436032.html"
+}
+
+"WD 1837-619:LAWD 71:WDJ184228.68-615153.66"
+{
+	RA 280.61691049
+	Dec -61.86628043
+	Distance 83.597
+	SpectralType "DC5"
+	Temperature 9194
+	AppMag 14.69
+	Radius 8657
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201837-619/WD%201837-619.html"
+}
+
+# Companion to WDJ184257.75-110853.18
+"UCAC4 395-088811"
+{
+	RA 280.74599604
+	Dec -11.15635438
+	Distance 78.721 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3096 # GSP-Phot
+	AppMag 15.469 # synthetic
+	Radius 143775 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UCAC4+395-088811"
+}
+
+"GJ 2139:EGGR 200:WD 1840-111:WDJ184257.75-110853.18"
+{
+	RA 280.73956205
+	Dec -11.14922246
+	Distance 78.721 # mean of system components
+	SpectralType "DA5"
+	Temperature 9746
+	AppMag 14.182 # synthetic
+	Radius 8950
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202139/GJ%202139.html"
+}
+
+"GJ 4072:GD 215:EGGR 225:WD 1840+042:WDJ184325.72+042022.83"
+{
+	RA 280.85660388
+	Dec 4.3399809
+	Distance 81.087
+	SpectralType "DA6"
+	Temperature 8797
+	AppMag 16.35
+	Radius 8283
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20215/GD%20215.html"
+}
+
+"WD 1841-367:WDJ184506.32-364113.39"
+{
+	RA 281.2782185
+	Dec -36.68910319
+	Distance 83.52
+	SpectralType "DC8"
+	Temperature 6312
+	AppMag 16.16
+	Radius 8255
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201841-367/WD%201841-367.html"
+}
+
+"Gaia DR2 6705845452725619072:WDJ184650.69-452139.33"
+{
+	RA 281.71061496
+	Dec -45.36069464
+	Distance 91.601
+	SpectralType "DC9"
+	Temperature 4994
+	AppMag 17.414 # synthetic
+	Radius 10040
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206705845452725619072/Gaia%20DR2%206705845452725619072.html"
+}
+
+"111 Her B:Gaia DR3 4512265810525783680:WDJ184700.42+181107.49"
+{
+	RA 281.75212011
+	Dec 18.18592163
+	Distance 94.482
+	SpectralType "DA6"
+	Temperature 8541
+	AppMag 15.337 # synthetic
+	Radius 7802
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%204512265810525783680/Gaia%20DR3%204512265810525783680.html"
+}
+
+"Gaia DR2 4539227892919675648:WDJ184733.18+282057.54"
+{
+	RA 281.88982126
+	Dec 28.34779078
+	Distance 130.377
+	SpectralType "DC9"
+	Temperature 4900
+	AppMag 18.725 # synthetic
+	Radius 7950
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204539227892919675648/Gaia%20DR2%204539227892919675648.html"
+}
+
+"HD 229513 B:Gaia DR2 4504577986571873280:WDJ184741.53+122631.75"
+{
+	RA 281.92332847
+	Dec 12.44216285
+	Distance 94.01
+	SpectralType "DA5"
+	Temperature 10052
+	AppMag 15.051 # synthetic
+	Radius 6852
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204504577986571873280/Gaia%20DR2%204504577986571873280.html"
+}
+
+# Companion to WDJ184907.50-073619.82
+"UCAC4 412-090312"
+{
+	RA 282.27736157
+	Dec -7.60767529
+	Distance 113.889 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3522 # GSP-Spec
+	AppMag 12.379 # synthetic
+	Radius 432295 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UCAC4+412-090312"
+}
+
+"Gaia DR2 4252064631569619712:WDJ184907.50-073619.82"
+{
+	RA 282.28099804
+	Dec -7.60564843
+	Distance 113.889 # mean of system components
+	SpectralType "DC8"
+	Temperature 6286
+	AppMag 16.995 # synthetic
+	Radius 7728
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204252064631569619712/Gaia%20DR2%204252064631569619712.html"
+}
+
+"GJ 2141:Gaia DR2 4203108841963846016:GD 216:WDJ184947.86-095744.38"
+{
+	RA 282.44943018
+	Dec -9.96325723
+	Distance 106.44
+	SpectralType "DA4"
+	Temperature 12133
+	AppMag 14.25
+	Radius 8673
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204203108841963846016/Gaia%20DR2%204203108841963846016.html"
+}
+
+"Gaia DR2 6761581964903088256:WDJ185005.58-285117.29"
+{
+	RA 282.52288627
+	Dec -28.85470969
+	Distance 115.057
+	SpectralType "DA9"
+	Temperature 5391
+	AppMag 17.526 # synthetic
+	Radius 8989
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206761581964903088256/Gaia%20DR2%206761581964903088256.html"
+}
+
+"NLTT 47202:WDJ185105.72+773837.50"
+{
+	RA 282.77922084
+	Dec 77.64345475
+	Distance 99.207
+	SpectralType "DCP9"
+	Temperature 5211
+	AppMag 17.265 # synthetic
+	Radius 9871
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2047202/NLTT%2047202.html"
+}
+
+"Gaia DR2 2146645790077864704:WDJ185517.99+535923.18"
+{
+	RA 283.82469498
+	Dec 53.9896191
+	Distance 91.27
+	SpectralType "DC9"
+	Temperature 4812
+	AppMag 17.636 # synthetic
+	Radius 10380
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202146645790077864704/Gaia%20DR2%202146645790077864704.html"
+}
+
+# Companion to WDJ185709.09-265059.22
+"LP 867-21"
+{
+	RA 284.29734804
+	Dec -26.86835204
+	Distance 129.079 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3549 # GSP-Spec
+	AppMag 12.806
+	Radius 397099 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=LP+867-21"
+}
+
+"Gaia DR2 4073522222505044224:WDJ185709.09-265059.22"
+{
+	RA 284.28930308
+	Dec -26.8502092
+	Distance 129.079 # mean of system components
+	SpectralType "DA7"
+	Temperature 7020
+	AppMag 16.486
+	Radius 9058
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204073522222505044224/Gaia%20DR2%204073522222505044224.html"
+}
+
+"2MASS J18571395+2026292:WD 1855+203:WDJ185713.94+202628.60"
+{
+	RA 284.30800821
+	Dec 20.43988554
+	Distance 106.267
+	SpectralType "DA8"
+	Temperature 6616
+	AppMag 16.716 # synthetic
+	Radius 7354
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J18571395+2026292/2MASS%20J18571395+2026292.html"
+}
+
+"V470 Lyr:EGGR 127:WD 1855+338:WDJ185730.18+335725.78"
+{
+	RA 284.37596555
+	Dec 33.95872723
+	Distance 98.943
+	SpectralType "DA4"
+	Temperature 11904
+	AppMag 14.6
+	Radius 7084
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V470%20Lyr/V*%20V470%20Lyr.html"
+}
+
+# WDJ185739.34+533033.30: defined in extrasolar.stc
+
+"Gaia DR2 4088653838978654336:WDJ185934.75-162656.29"
+{
+	RA 284.89474888
+	Dec -16.44900441
+	Distance 125.914
+	SpectralType "DA6"
+	Temperature 7995
+	AppMag 15.951 # synthetic
+	Radius 8928
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204088653838978654336/Gaia%20DR2%204088653838978654336.html"
+}
+
+"Gliese 742:LAWD 73:EGGR 129:WD 1900+705:WDJ190010.25+703951.42"
+{
+	RA 285.04387402
+	Dec 70.66652754
+	Distance 41.98
+	SpectralType "DAH4"
+	Temperature 12540
+	AppMag 13.23
+	Radius 5397
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20742/GJ%20742.html"
+}
+
+"Gaia DR2 4254454797960984192:WDJ190255.35-044012.64"
+{
+	RA 285.73067801
+	Dec -4.67202928
+	Distance 114.138
+	SpectralType "DC9"
+	Temperature 4813
+	AppMag 18.267 # synthetic
+	Radius 9445
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204254454797960984192/Gaia%20DR2%204254454797960984192.html"
+}
+
+"Gaia DR2 6658005048964693760:WDJ190525.34-495625.77"
+{
+	RA 286.35620865
+	Dec -49.94067369
+	Distance 96.318
+	SpectralType "DZ5"
+	Temperature 10917
+	AppMag 14.611 # synthetic
+	Radius 7860
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206658005048964693760/Gaia%20DR2%206658005048964693760.html"
+}
+
+"Gaia DR2 6718079679950008704:WDJ191100.25-382031.89"
+{
+	RA 287.7542741
+	Dec -38.34312399
+	Distance 91.254
+	SpectralType "DC9"
+	Temperature 4328
+	AppMag 17.933
+	Radius 12779
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206718079679950008704/Gaia%20DR2%206718079679950008704.html"
+}
+
+"Gaia DR2 6763036202147206912:WDJ191144.26-272954.76"
+{
+	RA 287.9349926
+	Dec -27.49899092
+	Distance 112.825
+	SpectralType "DB4"
+	Temperature 11475
+	AppMag 14.715
+	Radius 8684
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206763036202147206912/Gaia%20DR2%206763036202147206912.html"
+}
+
+"Gaia DR2 4268167357267580160:WDJ191246.12+024239.11"
+{
+	RA 288.1910816
+	Dec 2.708949
+	Distance 103.633
+	SpectralType "DZ8"
+	Temperature 6466
+	AppMag 16.566 # synthetic
+	Radius 7783
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204268167357267580160/Gaia%20DR2%204268167357267580160.html"
+}
+
+"NLTT 47551:WD 1911+536:WDJ191248.57+534313.45"
+{
+	RA 288.20344525
+	Dec 53.72100624
+	Distance 72.278
+	SpectralType "DA3"
+	Temperature 17190
+	AppMag 13.18
+	Radius 7356
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2047551/NLTT%2047551.html"
+}
+
+"2MASS J19131653+2949275:WDJ191316.54+294928.33"
+{
+	RA 288.31868985
+	Dec 29.82579804
+	Distance 120.864
+	SpectralType "DA8"
+	Temperature 6197
+	AppMag 17.087 # synthetic
+	Radius 8074
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J19131653+2949275/2MASS%20J19131653+2949275.html"
+}
+
+# Companion to WDJ191338.68+133627.36
+"GJ 2144 A:G 142-B2 A"
+{
+	RA 288.41356608
+	Dec 13.60242228
+	Distance 109.887 # mean of system components
+	SpectralType "M2V"
+	AppMag 12.726 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+142-B2A"
+}
+
+"GJ 2144 B:EGGR 130:WD 1911+135:WDJ191338.68+133627.36"
+{
+	RA 288.41121771
+	Dec 13.60679683
+	Distance 109.887 # mean of system components
+	SpectralType "DA4"
+	Temperature 13757
+	AppMag 14.0
+	Radius 9089
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20130/EGGR%20130.html"
+}
+
+"GJ 2145:WD 1912+143:WDJ191435.99+142825.88"
+{
+	RA 288.64951496
+	Dec 14.47210048
+	Distance 127.5
+	SpectralType "DA7"
+	Temperature 6842
+	AppMag 16.03
+	Radius 7953
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202145/GJ%202145.html"
+}
+
+"LSPM J1916+8044:WDJ191647.11+804430.04"
+{
+	RA 289.19828028
+	Dec 80.74241998
+	Distance 115.377
+	SpectralType "DA9"
+	Temperature 5360
+	AppMag 17.626 # synthetic
+	Radius 8825
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J1916+8044/LSPM%20J1916+8044.html"
+}
+
+"Gaia DR2 6664729284121316864:WDJ191858.23-434920.40"
+{
+	RA 289.74255558
+	Dec -43.82181442
+	Distance 112.027
+	SpectralType "DC9"
+	Temperature 5403
+	AppMag 18.127 # synthetic
+	Radius 6240
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206664729284121316864/Gaia%20DR2%206664729284121316864.html"
+}
+
+"GJ 1234:EGGR 375:WD 1917+386:WDJ191858.63+384321.48"
+{
+	RA 289.74443825
+	Dec 38.72151455
+	Distance 38.703
+	SpectralType "DC8"
+	Temperature 6310
+	AppMag 14.59
+	Radius 7774
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201234/GJ%201234.html"
+}
+
+"Gaia DR2 2127093140445053696:WDJ191936.23+452743.55"
+{
+	RA 289.90025582
+	Dec 45.46348676
+	Distance 91.447
+	SpectralType "DA9"
+	Temperature 5039
+	AppMag 16.716 # synthetic
+	Radius 15726
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202127093140445053696/Gaia%20DR2%202127093140445053696.html"
+}
+
+"2MASS J19200281-3611025:WD 1916-362:WDJ192002.82-361102.65"
+{
+	RA 290.01236602
+	Dec -36.18465145
+	Distance 120.946
+	SpectralType "DB2"
+	Temperature 21963
+	AppMag 13.6
+	Radius 8116
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J19200281-3611025/2MASS%20J19200281-3611025.html"
+}
+
+# Companion to WDJ192034.92-074000.07
+"Gliese 754.1 B:L 923-22"
+{
+	RA 290.13909488
+	Dec -7.66294447
+	Distance 34.252 # mean of system components
+	SpectralType "M5"
+	Temperature 3300 # GSP-Phot
+	AppMag 11.676
+	Radius 191276 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+923-22"
+}
+
+95071 "Gliese 754.1 A:GJ 9653:LAWD 74:EGGR 131:WD 1917-077:WDJ192034.92-074000.07"
+{
+	RA 290.14523764
+	Dec -7.6674043
+	Distance 34.252 # mean of system components
+	SpectralType "DBQA5"
+	Temperature 10805
+	AppMag 12.31
+	Radius 8498
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2074/LAWD%2074.html"
+}
+
+"Gaia DR2 4293873732939569920:WDJ192126.76+061322.71"
+{
+	RA 290.36210073
+	Dec 6.22266017
+	Distance 59.152
+	SpectralType "DA9"
+	Temperature 5902
+	AppMag 15.47
+	Radius 7991
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204293873732939569920/Gaia%20DR2%204293873732939569920.html"
+}
+
+"Gliese 755.1:GD 219:EGGR 201:WD 1919+145:WDJ192140.42+144041.40"
+{
+	RA 290.41825636
+	Dec 14.67783043
+	Distance 64.785
+	SpectralType "DA3"
+	Temperature 15162
+	AppMag 13.0
+	Radius 8123
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20219/GD%20219.html"
+}
+
+"Gaia DR2 4288942973032203904:WDJ192206.20+023313.29"
+{
+	RA 290.5261441
+	Dec 2.55356275
+	Distance 128.773
+	SpectralType "DZ9"
+	Temperature 3340 # Table A5
+	AppMag 19.279 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204288942973032203904/Gaia%20DR2%204288942973032203904.html"
+}
+
+"Gaia DR2 2018864362679341824:WDJ192359.24+214103.62"
+{
+	RA 290.99701232
+	Dec 21.68397918
+	Distance 115.267
+	SpectralType "DA6"
+	Temperature 8773
+	AppMag 14.671 # synthetic
+	Radius 12463
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202018864362679341824/Gaia%20DR2%202018864362679341824.html"
+}
+
+"Gaia DR2 2127566548919332608:WDJ192626.93+462015.10"
+{
+	RA 291.61190777
+	Dec 46.3377615
+	Distance 109.716
+	SpectralType "DA6"
+	Temperature 8149
+	AppMag 15.96
+	Radius 7711
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202127566548919332608/Gaia%20DR2%202127566548919332608.html"
+}
+
+"Gaia DR2 2142307563871222912:WDJ192724.75+564455.34"
+{
+	RA 291.85417216
+	Dec 56.74902273
+	Distance 103.65
+	SpectralType "DA8"
+	Temperature 6551
+	AppMag 16.827 # synthetic
+	Radius 6943
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202142307563871222912/Gaia%20DR2%202142307563871222912.html"
+}
+
+"Gaia DR2 4213409341688406912:WDJ192743.10-035555.23"
+{
+	RA 291.92958062
+	Dec -3.93115931
+	Distance 77.722
+	SpectralType "DZ7"
+	Temperature 6848
+	AppMag 15.567 # synthetic
+	Radius 8364
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204213409341688406912/Gaia%20DR2%204213409341688406912.html"
+}
+
+# Companion to WDJ192938.65+111752.41
+"2MASS J19293859+1118050"
+{
+	RA 292.41088932
+	Dec 11.30183714
+	Distance 119.016 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 14.114 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=2MASS+J19293859%2B1118050"
+}
+
+"Gaia DR2 4314903198513595776:WDJ192938.65+111752.41"
+{
+	RA 292.41112977
+	Dec 11.29832606
+	Distance 119.016 # mean of system components
+	SpectralType "DA2"
+	Temperature 20415
+	AppMag 13.493 # synthetic
+	Radius 9445
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204314903198513595776/Gaia%20DR2%204314903198513595776.html"
+}
+
+"Gaia DR2 4215241712185612544:WDJ193019.71-005730.56"
+{
+	RA 292.58214712
+	Dec -0.95850823
+	Distance 114.306
+	SpectralType "DC7"
+	Temperature 7601
+	AppMag 16.25 # synthetic
+	Radius 7944
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204215241712185612544/Gaia%20DR2%204215241712185612544.html"
+}
+
+"Gaia DR2 6744843579679059968:WDJ193538.63-325225.56"
+{
+	RA 293.9103317
+	Dec -32.87367454
+	Distance 111.35
+	SpectralType "DZAH9"
+	Temperature 5369
+	AppMag 17.411 # synthetic
+	Radius 9308
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206744843579679059968/Gaia%20DR2%206744843579679059968.html"
+}
+
+"Gaia DR2 2024985481361040384:WDJ193618.58+263255.79"
+{
+	RA 294.07736937
+	Dec 26.5488141
+	Distance 98.271
+	SpectralType "DA2"
+	Temperature 24229
+	AppMag 13.688 # synthetic
+	Radius 6181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202024985481361040384/Gaia%20DR2%202024985481361040384.html"
+}
+
+"PY Vul:GJ 1241:EGGR 277:WD 1935+276:WDJ193713.75+274318.74"
+{
+	RA 294.30949971
+	Dec 27.72196584
+	Distance 59.511
+	SpectralType "DA4"
+	Temperature 12022
+	AppMag 12.987
+	Radius 8693
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20PY%20Vul/V*%20PY%20Vul.html"
+}
+
+"WD 1939+662:EGGR 497:WDJ193955.83+661856.08"
+{
+	RA 294.983513
+	Dec 66.31721134
+	Distance 114.714
+	SpectralType "DC9"
+	Temperature 5199
+	AppMag 17.918 # synthetic
+	Radius 8236
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%201939+662/WD%201939+662.html"
+}
+
+"2MASS J19400895+8348579:WDJ194008.62+834857.77"
+{
+	RA 295.001492
+	Dec 83.8142442
+	Distance 116.527
+	SpectralType "DC9"
+	Temperature 4905
+	AppMag 18.559 # synthetic
+	Radius 7576
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J19400895+8348579/2MASS%20J19400895+8348579.html"
+}
+
+"Gaia DR2 6740493675455190784:WDJ194454.70-360310.92"
+{
+	RA 296.22831293
+	Dec -36.05364091
+	Distance 96.455
+	SpectralType "DA4"
+	Temperature 13084
+	AppMag 14.041
+	Radius 8349
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206740493675455190784/Gaia%20DR2%206740493675455190784.html"
+}
+
+"Gaia DR2 6671045050707117568:WDJ194522.76-490420.23"
+{
+	RA 296.34306341
+	Dec -49.07289753
+	Distance 111.84
+	SpectralType "DC9"
+	Temperature 4536
+	AppMag 18.372
+	Radius 11328
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206671045050707117568/Gaia%20DR2%206671045050707117568.html"
+}
+
+"Gaia DR2 2080526555267049984:WDJ194530.33+465006.84"
+{
+	RA 296.37343387
+	Dec 46.83344808
+	Distance 93.808 # mean of system components
+	SpectralType "DA9"
+	Temperature 4996
+	AppMag 17.439 # synthetic
+	Radius 10202
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202080526555267049984/Gaia%20DR2%202080526555267049984.html"
+}
+
+"LSR J1945+4650 A:WDJ194530.35+465015.52"
+{
+	RA 296.37353353
+	Dec 46.83584606
+	Distance 93.808 # mean of system components
+	SpectralType "DA9"
+	Temperature 5435
+	AppMag 17.17 # synthetic
+	Radius 8420
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSR%20J1945+4650A/LSR%20J1945+4650A.html"
+}
+
+"Gaia DR2 4181798519823760256:WDJ194549.13-153135.63"
+{
+	RA 296.45452938
+	Dec -15.52681209
+	Distance 100.731
+	SpectralType "DA4"
+	Temperature 12377
+	AppMag 14.645 # synthetic
+	Radius 6802
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204181798519823760256/Gaia%20DR2%204181798519823760256.html"
+}
+
+"2MASS J19492350+0747318:WDJ194923.50+074731.69"
+{
+	RA 297.34850241
+	Dec 7.79158722
+	Distance 118.988
+	SpectralType "DA5"
+	Temperature 9245
+	AppMag 15.399 # synthetic
+	Radius 8457
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J19492350+0747318/2MASS%20J19492350+0747318.html"
+}
+
+"Gaia DR2 4240231824768647040:WDJ195003.62+003357.09"
+{
+	RA 297.51534354
+	Dec 0.56647137
+	Distance 116.872
+	SpectralType "DA9"
+	Temperature 5834
+	AppMag 17.01 # synthetic
+	Radius 9171
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204240231824768647040/Gaia%20DR2%204240231824768647040.html"
+}
+
+"Gaia DR2 2078430778727685632:WDJ195119.15+420941.40"
+{
+	RA 297.82914454
+	Dec 42.16091793
+	Distance 125.206
+	SpectralType "DA9"
+	Temperature 5200
+	AppMag 17.995 # synthetic
+	Radius 9036
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202078430778727685632/Gaia%20DR2%202078430778727685632.html"
+}
+
+"Gaia DR2 2073772770741915264:WDJ195151.76+402629.07"
+{
+	RA 297.9655705
+	Dec 40.44024933
+	Distance 130.109
+	SpectralType "DC9"
+	Temperature 5051
+	AppMag 18.364 # synthetic
+	Radius 8472
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202073772770741915264/Gaia%20DR2%202073772770741915264.html"
+}
+
+"Gaia DR2 6368021054841781376:WDJ195211.78-732235.48"
+{
+	RA 298.04460721
+	Dec -73.37539794
+	Distance 104.842
+	SpectralType "DC9"
+	Temperature 4938 # MWDD
+	AppMag 19.935 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206368021054841781376/Gaia%20DR2%206368021054841781376.html"
+}
+
+"Gliese 772:LAWD 79:EGGR 135:WD 1953-011:WDJ195629.23-010232.67"
+{
+	RA 299.11983049
+	Dec -1.04554736
+	Distance 37.703
+	SpectralType "DAH6"
+	Temperature 7790
+	AppMag 13.698
+	Radius 7932
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20772/GJ%20772.html"
+}
+
+"Gaia DR2 6666783962114636288:WDJ195639.81-511544.83"
+{
+	RA 299.16597527
+	Dec -51.26238218
+	Distance 102.947
+	SpectralType "DC9"
+	Temperature 4799
+	AppMag 17.94 # synthetic
+	Radius 10153
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206666783962114636288/Gaia%20DR2%206666783962114636288.html"
+}
+
+"Gaia DR2 6670827416123874688:WDJ200348.80-474800.18"
+{
+	RA 300.95307422
+	Dec -47.80099792
+	Distance 99.491
+	SpectralType "DA9"
+	Temperature 5915
+	AppMag 16.618
+	Radius 8968
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206670827416123874688/Gaia%20DR2%206670827416123874688.html"
+}
+
+# Companion to WDJ200445.49+010929.21
+98878
+{
+	RA 301.19418594
+	Dec 1.15591207
+	Distance 105.454 # mean of system components
+	SpectralType "G6/8V"
+	Temperature 5379 # GSP-Spec
+	AppMag 7.68
+	Radius 864841 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+190412"
+}
+
+"HD 190412 C:Gaia DR2 4237555506083389568:WDJ200445.49+010929.21"
+{
+	RA 301.189554
+	Dec 1.15798886
+	Distance 105.454 # mean of system components
+	SpectralType "DA8"
+	Temperature 6642
+	AppMag 16.814 # synthetic
+	Radius 6862
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204237555506083389568/Gaia%20DR2%204237555506083389568.html"
+}
+
+"GJ 4133:EGGR 498:WD 2002-110:WDJ200534.87-105654.43"
+{
+	RA 301.40011923
+	Dec -10.94881626
+	Distance 56.379
+	SpectralType "DC9"
+	Temperature 4713
+	AppMag 16.9
+	Radius 8733
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204133/GJ%204133.html"
+}
+
+"Gaia DR2 6673731810450381056:WDJ200610.36-435554.45"
+{
+	RA 301.5419554
+	Dec -43.93199448
+	Distance 128.381
+	SpectralType "DA6"
+	Temperature 9131
+	AppMag 15.729
+	Radius 8071
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206673731810450381056/Gaia%20DR2%206673731810450381056.html"
+}
+
+"Gaia DR2 6865904860773722496:WDJ200632.25-210142.90"
+{
+	RA 301.63434791
+	Dec -21.02840893
+	Distance 127.407
+	SpectralType "DA9"
+	Temperature 5218
+	AppMag 17.862 # synthetic
+	Radius 9671
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206865904860773722496/Gaia%20DR2%206865904860773722496.html"
+}
+
+"NLTT 48779:WD 2006+615:WDJ200654.88+614310.27"
+{
+	RA 301.73026368
+	Dec 61.71879805
+	Distance 108.561
+	SpectralType "DA9"
+	Temperature 5448
+	AppMag 16.574 # synthetic
+	Radius 13741
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2048779/NLTT%2048779.html"
+}
+
+"Gaia DR2 6424223313252632576:WDJ200707.98-673442.18"
+{
+	RA 301.78371734
+	Dec -67.57905823
+	Distance 125.28
+	SpectralType "DAH6"
+	Temperature 7768
+	AppMag 16.536
+	Radius 7084
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206424223313252632576/Gaia%20DR2%206424223313252632576.html"
+}
+
+"Gaia DR2 6874124023727679104:WDJ200850.81-161943.62"
+{
+	RA 302.2126082
+	Dec -16.32894379
+	Distance 125.226
+	SpectralType "DC9"
+	Temperature 5568
+	AppMag 17.75
+	Radius 7220
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206874124023727679104/Gaia%20DR2%206874124023727679104.html"
+}
+
+"Gliese 781.3:LAWD 80:EGGR 137:WD 2007-219:WDJ201017.52-214645.80"
+{
+	RA 302.57349008
+	Dec -21.78080519
+	Distance 87.658
+	SpectralType "DA5"
+	Temperature 9720
+	AppMag 14.4
+	Radius 9108
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2080/LAWD%2080.html"
+}
+
+99438 "GJ 2147:WD 2007-303:WDJ201056.85-301306.63"
+{
+	RA 302.73511635
+	Dec -30.2196161
+	Distance 52.828
+	SpectralType "DA3"
+	Temperature 15124
+	AppMag 12.24
+	Radius 9393
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202147/GJ%202147.html"
+}
+
+"Gaia DR2 6853523539508720000:WDJ201216.01-221023.03"
+{
+	RA 303.06710233
+	Dec -22.17292993
+	Distance 115.905
+	SpectralType "DC9"
+	Temperature 5551
+	AppMag 17.516 # synthetic
+	Radius 8199
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206853523539508720000/Gaia%20DR2%206853523539508720000.html"
+}
+
+"GD 229:EGGR 333:WD 2010+310:WDJ201222.27+311348.88"
+{
+	RA 303.09295615
+	Dec 31.23065565
+	Distance 100.296
+	SpectralType "DBP3"
+	Temperature 18365
+	AppMag 14.85
+	Radius 4431
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20229/GD%20229.html"
+}
+
+"WD 2008-600:WDJ201231.78-595651.67"
+{
+	RA 303.13547787
+	Dec -59.9538723
+	Distance 53.606
+	SpectralType "DC9"
+	Temperature 4910 # Table A5
+	AppMag 15.82
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202008-600/WD%202008-600.html"
+}
+
+"2MASS J20124874-4659024:WD 2009-471:WDJ201248.76-465902.59"
+{
+	RA 303.20435878
+	Dec -46.98495591
+	Distance 90.459
+	SpectralType "DA9"
+	Temperature 5813
+	AppMag 16.541 # synthetic
+	Radius 8882
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J20124874-4659024/2MASS%20J20124874-4659024.html"
+}
+
+"V1412 Aql:Gliese 784.2 B:EGGR 138:WD 2011+065:WDJ201355.68+064244.83"
+{
+	RA 303.48085463
+	Dec 6.70986375
+	Distance 74.782
+	SpectralType "DC8"
+	Temperature 6646
+	AppMag 15.751
+	Radius 7916
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20V1412%20Aql/V*%20V1412%20Aql.html"
+}
+
+"Gaia DR2 4230380819051252736:WDJ201530.35+000111.80"
+{
+	RA 303.87640686
+	Dec 0.01960703
+	Distance 82.97
+	SpectralType "DC9"
+	Temperature 5032
+	AppMag 17.288 # synthetic
+	Radius 9195
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204230380819051252736/Gaia%20DR2%204230380819051252736.html"
+}
+
+"WD 2008-799:WDJ201649.72-794553.12"
+{
+	RA 304.21563811
+	Dec -79.76596975
+	Distance 78.709
+	SpectralType "DA9"
+	Temperature 5605
+	AppMag 16.35
+	Radius 9314
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202008-799/WD%202008-799.html"
+}
+
+"Gaia DR2 6692573110423893376:WDJ201722.68-401043.73"
+{
+	RA 304.34486913
+	Dec -40.17987545
+	Distance 128.704
+	SpectralType "DZA9"
+	Temperature 5083
+	AppMag 18.049 # synthetic
+	Radius 9769
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206692573110423893376/Gaia%20DR2%206692573110423893376.html"
+}
+
+"Gaia DR2 6879524790480960896:WDJ201756.19-124639.44"
+{
+	RA 304.48399395
+	Dec -12.77930673
+	Distance 91.428
+	SpectralType "DC9"
+	Temperature 4928
+	AppMag 17.61
+	Radius 7989
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206879524790480960896/Gaia%20DR2%206879524790480960896.html"
+}
+
+"Gaia DR2 6693352488073255936:WDJ202011.65-382445.66"
+{
+	RA 305.04930564
+	Dec -38.41296555
+	Distance 91.743
+	SpectralType "DA7"
+	Temperature 7290
+	AppMag 16.273 # synthetic
+	Radius 6538
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206693352488073255936/Gaia%20DR2%206693352488073255936.html"
+}
+
+"Gaia DR2 6429048245152936320:WDJ202016.78-652523.10"
+{
+	RA 305.07187402
+	Dec -65.42402123
+	Distance 125.303
+	SpectralType "DAZ8"
+	Temperature 6342
+	AppMag 17.291 # synthetic
+	Radius 7215
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206429048245152936320/Gaia%20DR2%206429048245152936320.html"
+}
+
+"Gaia DR2 6797171060323993728:WDJ202025.46-302714.65"
+{
+	RA 305.10570467
+	Dec -30.45449972
+	Distance 56.907
+	SpectralType "DC5"
+	Temperature 9934
+	AppMag 13.65
+	Radius 8522
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206797171060323993728/Gaia%20DR2%206797171060323993728.html"
+}
+
+"Gaia DR2 6680097978480311040:WDJ202030.93-420256.74"
+{
+	RA 305.12962671
+	Dec -42.05106581
+	Distance 130.114
+	SpectralType "DQ7"
+	Temperature 6969
+	AppMag 16.52
+	Radius 8630
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206680097978480311040/Gaia%20DR2%206680097978480311040.html"
+}
+
+"Gaia DR2 2185261016407220224:WDJ202157.83+545438.25"
+{
+	RA 305.49141961
+	Dec 54.91176636
+	Distance 123.713
+	SpectralType "DC8"
+	Temperature 5956
+	AppMag 17.404 # synthetic
+	Radius 7720
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202185261016407220224/Gaia%20DR2%202185261016407220224.html"
+}
+
+"NLTT 49358:WDJ202221.70+833355.41"
+{
+	RA 305.5855433
+	Dec 83.56616033
+	Distance 126.196
+	SpectralType "DC9"
+	Temperature 5837
+	AppMag 17.371 # synthetic
+	Radius 8390
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2049358/NLTT%2049358.html"
+}
+
+"Gaia DR2 6468965052723781888:WDJ202748.03-563031.58"
+{
+	RA 306.95070286
+	Dec -56.51056148
+	Distance 116.391
+	SpectralType "DZ9"
+	Temperature 4356
+	AppMag 18.682 # synthetic
+	Radius 11382
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206468965052723781888/Gaia%20DR2%206468965052723781888.html"
+}
+
+"Gaia DR2 6679105566157898880:WDJ202749.54-430115.21"
+{
+	RA 306.95766636
+	Dec -43.0244373
+	Distance 69.346
+	SpectralType "DC9"
+	Temperature 4966
+	AppMag 17.505
+	Radius 7091
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206679105566157898880/Gaia%20DR2%206679105566157898880.html"
+}
+
+"Gaia DR2 4217793816094052480:WDJ202837.91-060842.77"
+{
+	RA 307.15892489
+	Dec -6.14502458
+	Distance 115.955
+	SpectralType "DA4"
+	Temperature 11335
+	AppMag 15.195 # synthetic
+	Radius 6717
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%204217793816094052480/Gaia%20DR2%204217793816094052480.html"
+}
+
+"Gaia DR2 6429465338016396928:WDJ202956.94-643420.13"
+{
+	RA 307.48934677
+	Dec -64.57225181
+	Distance 121.625
+	SpectralType "DQ7"
+	Temperature 7287
+	AppMag 16.37
+	Radius 8570
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206429465338016396928/Gaia%20DR2%206429465338016396928.html"
+}
+
+"Gaia DR2 6875432476922523520:WDJ203100.56-145041.38"
+{
+	RA 307.75250488
+	Dec -14.84483979
+	Distance 123.231
+	SpectralType "DC9"
+	Temperature 4819
+	AppMag 18.654 # synthetic
+	Radius 8287
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206875432476922523520/Gaia%20DR2%206875432476922523520.html"
+}
+
+"Gaia DR2 2064284054100290048:WDJ203102.15+393454.05"
+{
+	RA 307.76131813
+	Dec 39.58228599
+	Distance 114.665
+	SpectralType "DC9"
+	Temperature 4801
+	AppMag 18.164 # synthetic
+	Radius 10231
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202064284054100290048/Gaia%20DR2%202064284054100290048.html"
+}
+
+"LP 815-31:WD 2028-171:WDJ203109.57-165841.93"
+{
+	RA 307.78898627
+	Dec -16.97802379
+	Distance 74.354
+	SpectralType "DAZ9"
+	Temperature 5513
+	AppMag 16.286
+	Radius 9638
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20815-31/LP%20815-31.html"
+}
+
+"Gaia DR2 2064689567732385792:WDJ203321.86+395409.76"
+{
+	RA 308.34127538
+	Dec 39.90226201
+	Distance 67.631
+	SpectralType "DA9"
+	Temperature 5908
+	AppMag 16.35
+	Radius 6772
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202064689567732385792/Gaia%20DR2%202064689567732385792.html"
+}
+
+101516 "Gliese 794:EGGR 139:LAWD 82:WD 2032+248:WDJ203421.89+250349.75"
+{
+	RA 308.58920706
+	Dec 25.06131556
+	Distance 48.335
+	SpectralType "DAZ3"
+	Temperature 20145
+	AppMag 11.55
+	Radius 9545
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HD%20340611/HD%20340611.html"
+}
+
+"WD 2035-369:WDJ203841.42-364913.60"
+{
+	RA 309.67379793
+	Dec -36.82071392
+	Distance 103.044
+	SpectralType "DA5"
+	Temperature 9500
+	AppMag 14.93
+	Radius 8732
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202035-369/WD%202035-369.html"
+}
+
+102207 "Gliese 799.1:EGGR 141:WD 2039-202:WDJ204234.75-200435.94"
+{
+	RA 310.64649209
+	Dec -20.07707576
+	Distance 70.943
+	SpectralType "DA3"
+	Temperature 19507
+	AppMag 12.4
+	Radius 9742
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20799.1/GJ%20799.1.html"
+}
+
+"WD 2040-392:WDJ204349.21-390318.02"
+{
+	RA 310.95500102
+	Dec -39.05656385
+	Distance 76.064
+	SpectralType "DA4"
+	Temperature 11228
+	AppMag 13.74
+	Radius 8666
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202040-392/WD%202040-392.html"
+}
+
+"GJ 2149:EGGR 140:WD 2039-682:WDJ204421.46-680521.36"
+{
+	RA 311.09157996
+	Dec -68.09028006
+	Distance 63.792
+	SpectralType "DA3"
+	Temperature 16420
+	AppMag 13.25
+	Radius 6431
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20140/EGGR%20140.html"
+}
+
+"Gaia DR2 2169971345155578752:WDJ204832.02+511047.25"
+{
+	RA 312.13165167
+	Dec 51.17897071
+	Distance 126.218
+	SpectralType "DC9"
+	Temperature 5031
+	AppMag 18.125 # synthetic
+	Radius 9855
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202169971345155578752/Gaia%20DR2%202169971345155578752.html"
+}
+
+"GJ 4165:EGGR 261:WD 2047+372:WDJ204906.70+372814.05"
+{
+	RA 312.27882303
+	Dec 37.47122797
+	Distance 57.328
+	SpectralType "DAP3"
+	Temperature 14710
+	AppMag 13.0
+	Radius 7302
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204165/GJ%204165.html"
+}
+
+"Gaia DR2 6470278694244646912:WDJ204911.00-544617.50"
+{
+	RA 312.2972638
+	Dec -54.77276405
+	Distance 127.835
+	SpectralType "DA7"
+	Temperature 7552
+	AppMag 16.078 # synthetic
+	Radius 9409
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206470278694244646912/Gaia%20DR2%206470278694244646912.html"
+}
+
+"GJ 4166:WD 2048+263:WDJ205020.65+263040.76"
+{
+	RA 312.58399314
+	Dec 26.50998587
+	Distance 62.399
+	SpectralType "DA9"
+	Temperature 5154
+	AppMag 15.61
+	Radius 15951
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204166/GJ%204166.html"
+}
+
+"Gaia DR2 6454251250683840896:WDJ205050.50-612235.61"
+{
+	RA 312.71047409
+	Dec -61.37694056
+	Distance 111.858
+	SpectralType "DA7"
+	Temperature 6962
+	AppMag 16.886 # synthetic
+	Radius 6531
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206454251250683840896/Gaia%20DR2%206454251250683840896.html"
+}
+
+"WD 2048-250:WDJ205059.90-245203.79"
+{
+	RA 312.75063543
+	Dec -24.86856478
+	Distance 87.325
+	SpectralType "DA7"
+	Temperature 7512
+	AppMag 15.42
+	Radius 8479
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202048-250/WD%202048-250.html"
+}
+
+"Gaia DR2 6805792571514600960:WDJ205213.41-250415.13"
+{
+	RA 313.05629209
+	Dec -25.07154908
+	Distance 58.612
+	SpectralType "DCP9"
+	Temperature 5048
+	AppMag 16.292 # synthetic
+	Radius 10427
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206805792571514600960/Gaia%20DR2%206805792571514600960.html"
+}
+
+"WD 2049-222:WDJ205216.84-220633.42"
+{
+	RA 313.07019359
+	Dec -22.10863862
+	Distance 66.215
+	SpectralType "DCP6"
+	Temperature 7811
+	AppMag 15.0
+	Radius 7733
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202049-222/WD%202049-222.html"
+}
+
+"WD 2051-208:WDJ205442.80-203925.93"
+{
+	RA 313.67865801
+	Dec -20.65715607
+	Distance 101.94
+	SpectralType "DAH2"
+	Temperature 20362
+	AppMag 15.06
+	Radius 3806
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202051-208/WD%202051-208.html"
+}
+
+# Companion to WDJ205647.78-045039.54
+103393 "FR Aqr:Gliese 812 A:Ross 193"
+{
+	RA 314.20579832
+	Dec -4.84795265
+	Distance 52.76 # mean of system components
+	SpectralType "M3Vnne"
+	Temperature 3054 # GSP-Phot
+	AppMag 11.916
+	Radius 432685 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Ross+193"
+}
+
+"Gliese 812 B:VB 11:EGGR 202:WD 2054-050:WDJ205647.78-045039.54"
+{
+	RA 314.20256506
+	Dec -4.84530759
+	Distance 52.76 # mean of system components
+	SpectralType "DC9"
+	Temperature 4606
+	AppMag 16.69
+	Radius 10693
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/VB%2011/VB%2011.html"
+}
+
+"LSPM J2059+5517:WDJ205944.90+551730.02"
+{
+	RA 314.93919953
+	Dec 55.2935308
+	Distance 74.16
+	SpectralType "DC9"
+	Temperature 4690
+	AppMag 17.397 # synthetic
+	Radius 10181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LSPM%20J2059+5517/LSPM%20J2059+5517.html"
+}
+
+"GD 393:EGGR 446:WD 2058+506:WDJ210031.31+505117.73"
+{
+	RA 315.13006824
+	Dec 50.85447907
+	Distance 110.915
+	SpectralType "DA5"
+	Temperature 9622
+	AppMag 15.93
+	Radius 8551
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20393/GD%20393.html"
+}
+
+# Companion to WDJ210105.20-490624.27
+"WT 766"
+{
+	RA 315.27888909
+	Dec -49.1245698
+	Distance 43.497 # mean of system components
+	SpectralType "M4.5"
+	AppMag 13.33
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=WT+766"
+}
+
+"WD 2057-493:WDJ210105.20-490624.27"
+{
+	RA 315.26972351
+	Dec -49.10774848
+	Distance 43.497 # mean of system components
+	SpectralType "DA9"
+	Temperature 5219
+	AppMag 15.485
+	Radius 9770
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202057-493/WD%202057-493.html"
+}
+
+"EGGR 262:WD 2059+316:WDJ210144.81+314839.47"
+{
+	RA 315.43555738
+	Dec 31.80952697
+	Distance 105.045
+	SpectralType "DQ5"
+	Temperature 9851
+	AppMag 15.04
+	Radius 8463
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20262/EGGR%20262.html"
+}
+
+"EGGR 377:WD 2059+190:WDJ210202.67+191257.67"
+{
+	RA 315.51053041
+	Dec 19.21466748
+	Distance 106.782
+	SpectralType "DA8"
+	Temperature 6666
+	AppMag 16.36
+	Radius 8688
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20377/EGGR%20377.html"
+}
+
+"WD 2059+247:WDJ210212.07+245736.37"
+{
+	RA 315.5517237
+	Dec 24.96114661
+	Distance 91.359
+	SpectralType "DA8"
+	Temperature 6013
+	AppMag 16.57
+	Radius 8129
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202059+247/WD%202059+247.html"
+}
+
+"Gaia DR2 6479860113444922368:WDJ210222.23-482749.59"
+{
+	RA 315.59326494
+	Dec -48.46346919
+	Distance 124.955
+	SpectralType "DA6"
+	Temperature 8869
+	AppMag 15.07
+	Radius 11342
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206479860113444922368/Gaia%20DR2%206479860113444922368.html"
+}
+
+"WD 2103-397:WDJ210632.02-393556.68"
+{
+	RA 316.63406911
+	Dec -39.59995154
+	Distance 82.288
+	SpectralType "DA6"
+	Temperature 7804
+	AppMag 15.31
+	Radius 8130
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202103-397/WD%202103-397.html"
+}
+
+"Gaia DR2 2690697646876721152:WDJ210646.77+010635.24"
+{
+	RA 316.6953108
+	Dec 1.10929694
+	Distance 125.345
+	SpectralType "DA8"
+	Temperature 6096
+	AppMag 17.014 # synthetic
+	Radius 8942
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202690697646876721152/Gaia%20DR2%202690697646876721152.html"
+}
+
+"PM J21077+0740:WD 2105+074:WDJ210745.04+074044.48"
+{
+	RA 316.93762285
+	Dec 7.67846691
+	Distance 124.907
+	SpectralType "DA7"
+	Temperature 7103
+	AppMag 15.91
+	Radius 8686
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J21077+0740/PM%20J21077+0740.html"
+}
+
+"Gaia DR2 6912866381081015552:WDJ210854.87-031202.98"
+{
+	RA 317.22861243
+	Dec -3.20158806
+	Distance 114.257
+	SpectralType "DC9"
+	Temperature 5339
+	AppMag 17.49 # synthetic
+	Radius 9444
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206912866381081015552/Gaia%20DR2%206912866381081015552.html"
+}
+
+"EGGR 581:WD 2107-216:WDJ211050.04-212922.52"
+{
+	RA 317.70885807
+	Dec -21.49206971
+	Distance 103.778
+	SpectralType "DA8"
+	Temperature 5970
+	AppMag 16.8
+	Radius 8372
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20581/EGGR%20581.html"
+}
+
+"Gaia DR2 6788656957673130112:WDJ211240.64-292217.96"
+{
+	RA 318.16971814
+	Dec -29.37232061
+	Distance 106.793
+	SpectralType "DZQ5"
+	Temperature 9773
+	AppMag 15.21
+	Radius 7593
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206788656957673130112/Gaia%20DR2%206788656957673130112.html"
+}
+
+"Gliese 820.1:LAWD 83:EGGR 142:WD 2105-820:WDJ211316.85-814912.88"
+{
+	RA 318.32847993
+	Dec -81.82193284
+	Distance 52.734
+	SpectralType "DAZH5"
+	Temperature 9914
+	AppMag 13.62
+	Radius 7556
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20820.1/GJ%20820.1.html"
+}
+
+"GJ 2152:WD 2111+072:WDJ211328.93+072704.19"
+{
+	RA 318.37195757
+	Dec 7.4516856
+	Distance 95.755
+	SpectralType "DA8"
+	Temperature 6307
+	AppMag 16.12
+	Radius 9353
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%202152/GJ%202152.html"
+}
+
+"GJ 1260:EGGR 447:WD 2111+261:WDJ211345.93+262133.27"
+{
+	RA 318.44188156
+	Dec 26.3575638
+	Distance 103.259
+	SpectralType "DA6"
+	Temperature 8201
+	AppMag 14.68
+	Radius 12588
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201260/GJ%201260.html"
+}
+
+105230 "V2151 Cyg:GJ 1261:Lan 51:EGGR 378:WD 2117+539:WDJ211856.26+541241.24"
+{
+	RA 319.73378229
+	Dec 54.21231529
+	Distance 56.44
+	SpectralType "DA3"
+	Temperature 14785
+	AppMag 12.35
+	Radius 9641
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Lan%2051/Lan%2051.html"
+}
+
+"GJ 4191:LAWD 84:WD 2115-560:WDJ211936.53-555014.47"
+{
+	RA 319.90563073
+	Dec -55.83819947
+	Distance 81.633
+	SpectralType "DAZ5"
+	Temperature 9529
+	AppMag 14.28
+	Radius 9105
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204191/GJ%204191.html"
+}
+
+"GD 548:EGGR 301:WD 2119+581:WDJ212042.15+581923.35"
+{
+	RA 320.17569004
+	Dec 58.3225371
+	Distance 126.299
+	SpectralType "DA6"
+	Temperature 8159
+	AppMag 16.0
+	Radius 8700
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20548/GD%20548.html"
+}
+
+"Gaia DR2 6791196382856581376:WDJ212121.30-255716.33"
+{
+	RA 320.34054319
+	Dec -25.95502642
+	Distance 79.896
+	SpectralType "DA3"
+	Temperature 19206
+	AppMag 12.8
+	Radius 8657
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206791196382856581376/Gaia%20DR2%206791196382856581376.html"
+}
+
+"WD 2119-017:WDJ212147.85-013032.20"
+{
+	RA 320.44870625
+	Dec -1.51006265
+	Distance 114.465
+	SpectralType "DA8"
+	Temperature 6474
+	AppMag 16.59
+	Radius 8748
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202119-017/WD%202119-017.html"
+}
+
+"2MASS J21220558-3838347:WD 2118-388:WDJ212205.59-383834.68"
+{
+	RA 320.52425957
+	Dec -38.64325211
+	Distance 76.24
+	SpectralType "DC9"
+	Temperature 5175
+	AppMag 16.57
+	Radius 10645
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J21220558-3838347/2MASS%20J21220558-3838347.html"
+}
+
+"WD 2119+040:WDJ212212.35+041356.77"
+{
+	RA 320.55110612
+	Dec 4.23059836
+	Distance 78.933
+	SpectralType "DA9"
+	Temperature 5105
+	AppMag 16.78
+	Radius 10843
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202119+040/WD%202119+040.html"
+}
+
+"Gaia DR2 6578917727331681536:WDJ212602.02-422453.76"
+{
+	RA 321.50808945
+	Dec -42.41465342
+	Distance 83.404
+	SpectralType "DC9"
+	Temperature 5554
+	AppMag 15.96
+	Radius 12505
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206578917727331681536/Gaia%20DR2%206578917727331681536.html"
+}
+
+"Gliese 828.3:GJ 9741:Ross 198:LAWD 85:EGGR 143:WD 2124+550:WDJ212625.46+551332.38"
+{
+	RA 321.6081843
+	Dec 55.22650625
+	Distance 109.89
+	SpectralType "DA4"
+	Temperature 13073
+	AppMag 14.75
+	Radius 6888
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ross%20198/Ross%20198.html"
+}
+
+# Companion to WDJ212657.66+733844.66
+"G 263-3 B"
+{
+	RA 321.74153031
+	Dec 73.64383349
+	Distance 72.468 # mean of system components
+	SpectralType "DC9" # DC10
+	AppMag 16.571 # estimate
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+263-3B"
+}
+
+"Gliese 828.5:GJ 9743:LAWD 86:EGGR 144:WD 2126+734:WDJ212657.66+733844.66"
+{
+	RA 321.74110737
+	Dec 73.64434474
+	Distance 72.468 # mean of system components
+	SpectralType "DA3"
+	Temperature 15127
+	AppMag 12.88
+	Radius 9703
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2086/LAWD%2086.html"
+}
+
+"Gliese 836.2:GJ 9746:LAWD 88:EGGR 147:WD 2136+828:WDJ213343.31+830332.43"
+{
+	RA 323.44086042
+	Dec 83.06153062
+	Distance 86.116
+	SpectralType "DA3"
+	Temperature 17488
+	AppMag 13.03 # synthetic
+	Radius 9513
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LAWD%2088/LAWD%2088.html"
+}
+
+"Gaia DR2 1797472370615364992:WDJ213343.70+241457.72"
+{
+	RA 323.43176784
+	Dec 24.24854153
+	Distance 114.17
+	SpectralType "DA8"
+	Temperature 6433
+	AppMag 17.218 # synthetic
+	Radius 6667
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201797472370615364992/Gaia%20DR2%201797472370615364992.html"
+}
+
+"GD 395:EGGR 448:WD 2132+367:WDJ213424.51+365519.95"
+{
+	RA 323.60151363
+	Dec 36.92168734
+	Distance 128.483
+	SpectralType "DA7"
+	Temperature 7556
+	AppMag 16.427 # synthetic
+	Radius 8178
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20395/GD%20395.html"
+}
+
+# Companion to WDJ213517.95+463318.21
+"G 212-45"
+{
+	RA 323.82241655
+	Dec 46.55289115
+	Distance 126.942 # mean of system components
+	SpectralType "M4V"
+	Temperature 3090 # GSP-Phot
+	AppMag 16.05
+	Radius 191509 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+212-45"
+}
+
+"WD 2133+463:WDJ213517.95+463318.21"
+{
+	RA 323.82395305
+	Dec 46.55324767
+	Distance 126.942 # mean of system components
+	SpectralType "DA9"
+	Temperature 5044
+	AppMag 17.97
+	Radius 10210
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202133+463/WD%202133+463.html"
+}
+
+"Ross 203:WD 2133-135:WDJ213616.39-131834.50"
+{
+	RA 324.06947789
+	Dec -13.310216
+	Distance 76.263
+	SpectralType "DA5"
+	Temperature 9928
+	AppMag 13.68
+	Radius 10634
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Ross%20203/Ross%20203.html"
+}
+
+"Gaia DR2 6585792870460638336:WDJ213721.24-380838.22"
+{
+	RA 324.33847296
+	Dec -38.14399362
+	Distance 105.473
+	SpectralType "DC7"
+	Temperature 6856
+	AppMag 16.642 # synthetic
+	Radius 7081
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206585792870460638336/Gaia%20DR2%206585792870460638336.html"
+}
+
+"LP 426-26:WD 2135-409:WDJ213849.48-404127.74"
+{
+	RA 324.70535765
+	Dec -40.69081374
+	Distance 105.66
+	SpectralType "DA3"
+	Temperature 19013
+	AppMag 13.526
+	Radius 8765
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20426-26/LP%20426-26.html"
+}
+
+"Gaia DR2 6844375121726139520:WDJ213957.13-124549.09"
+{
+	RA 324.98911367
+	Dec -12.76391156
+	Distance 119.715
+	SpectralType "DA6"
+	Temperature 7914
+	AppMag 16.46
+	Radius 6743
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206844375121726139520/Gaia%20DR2%206844375121726139520.html"
+}
+
+"Gaia DR2 6589369272547881856:WDJ214023.96-363757.44"
+{
+	RA 325.09822501
+	Dec -36.63268509
+	Distance 129.788
+	SpectralType "DQ4"
+	Temperature 13294
+	AppMag 15.994
+	Radius 4604
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206589369272547881856/Gaia%20DR2%206589369272547881856.html"
+}
+
+"WD 2138-332:WDJ214157.57-330029.80"
+{
+	RA 325.48889307
+	Dec -33.00878182
+	Distance 52.509
+	SpectralType "DZAH7"
+	Temperature 7113
+	AppMag 13.75
+	Radius 8021
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202138-332/WD%202138-332.html"
+}
+
+"Gliese 836.5:EGGR 148:WD 2140+207:WDJ214241.01+205958.12"
+{
+	RA 325.66979005
+	Dec 20.99659169
+	Distance 36.008
+	SpectralType "DQ6"
+	Temperature 8495
+	AppMag 13.253
+	Radius 8257
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20836.5/GJ%20836.5.html"
+}
+
+"NLTT 51908:WD 2140+078:WDJ214254.49+080527.35"
+{
+	RA 325.72666722
+	Dec 8.09006414
+	Distance 97.467
+	SpectralType "DA9"
+	Temperature 4987
+	AppMag 15.66
+	Radius 11568
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2051908/NLTT%2051908.html"
+}
+
+"Gaia DR2 2667464656943675392:WDJ214324.09-065947.99"
+{
+	RA 325.85031303
+	Dec -6.99707191
+	Distance 59.15
+	SpectralType "DA6"
+	Temperature 8905
+	AppMag 14.57 # synthetic
+	Radius 6587
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202667464656943675392/Gaia%20DR2%202667464656943675392.html"
+}
+
+"Gaia DR2 6584418167391671808:WDJ214756.59-403527.79"
+{
+	RA 326.98530198
+	Dec -40.59155146
+	Distance 91.165
+	SpectralType "DZQH9"
+	Temperature 3050 # Table A5
+	AppMag 20.656 # estimate
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206584418167391671808/Gaia%20DR2%206584418167391671808.html"
+}
+
+"NLTT 52166:WDJ214913.61+041550.35"
+{
+	RA 327.30677133
+	Dec 4.26300928
+	Distance 114.332
+	SpectralType "DA9"
+	Temperature 5324
+	AppMag 16.862 # synthetic
+	Radius 13758
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2052166/NLTT%2052166.html"
+}
+
+"EGGR 583:WD 2147+280:WDJ214954.57+281659.59"
+{
+	RA 327.47861432
+	Dec 28.28288281
+	Distance 113.223
+	SpectralType "DB4"
+	Temperature 11808
+	AppMag 14.68
+	Radius 8622
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20583/EGGR%20583.html"
+}
+
+"Gaia DR2 2669936427801840256:WDJ215008.33-043900.36"
+{
+	RA 327.5358545
+	Dec -4.65104817
+	Distance 115.733
+	SpectralType "DC9"
+	Temperature 5357
+	AppMag 17.982 # synthetic
+	Radius 7328
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202669936427801840256/Gaia%20DR2%202669936427801840256.html"
+}
+
+# Companion to WDJ215140.11+591734.85
+1010813980 "IRAS 21500+5903"
+{
+	RA 327.90897024
+	Dec 59.29444662
+	Distance 27.599 # mean of system components
+	SpectralType "M3"
+	AppMag 10.64
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=IRAS+21500%2B5903"
+}
+
+"Gaia DR2 2202703050401536000:WDJ215140.11+591734.85"
+{
+	RA 327.91636042
+	Dec 59.29292978
+	Distance 27.599 # mean of system components
+	SpectralType "DAH9"
+	Temperature 5202
+	AppMag 14.599 # synthetic
+	Radius 9355
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202202703050401536000/Gaia%20DR2%202202703050401536000.html"
+}
+
+107968 "Gliese 838.4:EGGR 150:WD 2149+021:WDJ215225.38+022319.58"
+{
+	RA 328.10581385
+	Dec 2.38743546
+	Distance 73.5
+	SpectralType "DAZ3"
+	Temperature 17508
+	AppMag 12.74
+	Radius 9181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20838.4/GJ%20838.4.html"
+}
+
+"GJ 4236:EGGR 151:WD 2151-015:WDJ215406.45-011709.55"
+{
+	RA 328.5269214
+	Dec -1.28714066
+	Distance 83.198
+	SpectralType "DA5"
+	Temperature 9190 # Table A5
+	AppMag 14.515
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204236/GJ%204236.html"
+}
+
+"WD 2152-280:WDJ215500.60-275038.15"
+{
+	RA 328.75341194
+	Dec -27.84320299
+	Distance 76.605
+	SpectralType "DC9"
+	Temperature 5462
+	AppMag 16.26
+	Radius 9301
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202152-280/WD%202152-280.html"
+}
+
+# Companion to WDJ215738.36-510031.52
+108405 "Gliese 841 A:CD-51 13128"
+{
+	RA 329.42143201
+	Dec -51.00786556
+	Distance 48.446 # mean of system components
+	SpectralType "M2Ve"
+	AppMag 10.487
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=CD-51+13128"
+}
+
+"Gliese 841 B:WD 2154-512:WDJ215738.36-510031.52"
+{
+	RA 329.40949351
+	Dec -51.01052235
+	Distance 48.446 # mean of system components
+	SpectralType "DQP8"
+	Temperature 6549
+	AppMag 14.74
+	Radius 8894
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20841%20B/GJ%20841%20B.html"
+}
+
+"Gaia DR2 1892992267183979776:WDJ215759.55+270519.13"
+{
+	RA 329.49987517
+	Dec 27.09022147
+	Distance 120.363
+	SpectralType "DC9"
+	Temperature 4741
+	AppMag 18.159 # synthetic
+	Radius 11862
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201892992267183979776/Gaia%20DR2%201892992267183979776.html"
+}
+
+"Gaia DR2 2676567307551465088:WDJ215839.14-023916.44"
+{
+	RA 329.66265411
+	Dec -2.65468936
+	Distance 91.259 # mean of system components
+	SpectralType "DC9"
+	Temperature 5010
+	AppMag 17.361 # synthetic
+	Radius 10185
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202676567307551465088/Gaia%20DR2%202676567307551465088.html"
+}
+
+"Gaia DR2 2676566272464334720:WDJ215847.13-024024.42"
+{
+	RA 329.69595897
+	Dec -2.67356706
+	Distance 91.259 # mean of system components
+	SpectralType "DC9"
+	Temperature 4901
+	AppMag 17.441 # synthetic
+	Radius 10774
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202676566272464334720/Gaia%20DR2%202676566272464334720.html"
+}
+
+"WD 2157-574:WDJ220045.37-571123.28"
+{
+	RA 330.18731507
+	Dec -57.19006305
+	Distance 95.66
+	SpectralType "DAZ7"
+	Temperature 7114
+	AppMag 15.96
+	Radius 8313
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202157-574/WD%202157-574.html"
+}
+
+"Gaia DR2 2199371701965748992:WDJ220052.62+582202.29"
+{
+	RA 330.21931034
+	Dec 58.36719534
+	Distance 123.937
+	SpectralType "DA9"
+	Temperature 5553
+	AppMag 17.515 # synthetic
+	Radius 8982
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202199371701965748992/Gaia%20DR2%202199371701965748992.html"
+}
+
+"Gaia DR2 2683452758602312192:WDJ220253.65+023741.53"
+{
+	RA 330.72427924
+	Dec 2.62733225
+	Distance 97.596
+	SpectralType "DA9"
+	Temperature 5783
+	AppMag 17.022 # synthetic
+	Radius 7748
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202683452758602312192/Gaia%20DR2%202683452758602312192.html"
+}
+
+"CD Oct:WD 2159-754:WDJ220420.86-751326.06"
+{
+	RA 331.07771605
+	Dec -75.22357717
+	Distance 62.01
+	SpectralType "DA6"
+	Temperature 8875
+	AppMag 15.04
+	Radius 5588
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20CD%20Oct/V*%20CD%20Oct.html"
+}
+
+"Gaia DR2 6613289285448236288:WDJ220437.98-312713.76"
+{
+	RA 331.15994422
+	Dec -31.45571405
+	Distance 80.108
+	SpectralType "DA9"
+	Temperature 4953
+	AppMag 17.145
+	Radius 10065
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206613289285448236288/Gaia%20DR2%206613289285448236288.html"
+}
+
+"Gaia DR2 6397887600292497408:WDJ220552.11-665934.73"
+{
+	RA 331.46692326
+	Dec -66.99264319
+	Distance 102.446
+	SpectralType "DAH9"
+	Temperature 5352
+	AppMag 17.106 # synthetic
+	Radius 10190
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206397887600292497408/Gaia%20DR2%206397887600292497408.html"
+}
+
+"Gaia DR2 6409446323650635264:WDJ220655.28-600135.32"
+{
+	RA 331.72833032
+	Dec -60.0269228
+	Distance 121.514
+	SpectralType "DA9"
+	Temperature 5158
+	AppMag 17.782
+	Radius 10000
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206409446323650635264/Gaia%20DR2%206409446323650635264.html"
+}
+
+"Gaia DR2 1900382604528495744:WDJ220751.81+342845.79"
+{
+	RA 331.96608591
+	Dec 34.47924563
+	Distance 129.527
+	SpectralType "DA5"
+	Temperature 10295
+	AppMag 15.11
+	Radius 8743
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201900382604528495744/Gaia%20DR2%201900382604528495744.html"
+}
+
+"GJ 4259:EGGR 302:WD 2207+142:WDJ220947.10+142947.13"
+{
+	RA 332.44743067
+	Dec 14.4975362
+	Distance 88.496
+	SpectralType "DA7"
+	Temperature 7630
+	AppMag 15.61
+	Radius 7980
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20302/EGGR%20302.html"
+}
+
+# Companion to WDJ221153.92+564946.77
+109572
+{
+	RA 332.95511827
+	Dec 56.83993043
+	Distance 123.25 # mean of system components
+	SpectralType "F8V"
+	Temperature 6284 # GSP-Spec
+	AppMag 5.256 # synthetic
+	Radius 1778170 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+210855"
+}
+
+"G 233-2:WD 2210+565:WDJ221153.92+564946.77"
+{
+	RA 332.97655822
+	Dec 56.83023137
+	Distance 123.25 # mean of system components
+	SpectralType "DA3"
+	Temperature 16833
+	AppMag 12.78
+	Radius 8598
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/G%20233-2/G%20233-2.html"
+}
+
+"WD 2209-147:WDJ221217.96-142945.98"
+{
+	RA 333.07597858
+	Dec -14.49570189
+	Distance 123.657
+	SpectralType "DA7"
+	Temperature 7742
+	AppMag 15.09
+	Radius 13848
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202209-147/WD%202209-147.html"
+}
+
+"EGGR 584:WD 2211+372:WDJ221408.94+372713.33"
+{
+	RA 333.53545536
+	Dec 37.45182089
+	Distance 95.153
+	SpectralType "DCP8"
+	Temperature 6424
+	AppMag 16.945 # synthetic
+	Radius 6305
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20584/EGGR%20584.html"
+}
+
+"WD J2214-390:WD 2211-392:WDJ221434.75-385907.27"
+{
+	RA 333.65059011
+	Dec -38.98698989
+	Distance 59.184
+	SpectralType "DA8"
+	Temperature 6063
+	AppMag 15.91
+	Radius 6931
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%20J2214-390/WD%20J2214-390.html"
+}
+
+"WD 2215+368:WDJ221747.62+370750.92"
+{
+	RA 334.45097021
+	Dec 37.13121464
+	Distance 66.221
+	SpectralType "DC9"
+	Temperature 4634
+	AppMag 17.16
+	Radius 10709
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202215+368/WD%202215+368.html"
+}
+
+"Gaia DR2 2006217676803960960:WDJ221800.59+560214.92"
+{
+	RA 334.50334167
+	Dec 56.03850779
+	Distance 128.319
+	SpectralType "DC9"
+	Temperature 4637
+	AppMag 18.351 # synthetic
+	Radius 12403
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202006217676803960960/Gaia%20DR2%202006217676803960960.html"
+}
+
+"GD 402:EGGR 452:WD 2216+484:WDJ221851.14+483929.00"
+{
+	RA 334.71406961
+	Dec 48.65785972
+	Distance 128.996
+	SpectralType "DA7"
+	Temperature 7206
+	AppMag 16.13
+	Radius 10354
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20402/GD%20402.html"
+}
+
+"WD 2216-657:LAWD 91:WDJ221948.31-652917.49"
+{
+	RA 334.9534392
+	Dec -65.49105939
+	Distance 83.177
+	SpectralType "DZ5"
+	Temperature 9821
+	AppMag 14.55
+	Radius 7774
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202216-657/WD%202216-657.html"
+}
+
+"WD 2220+121.1:WDJ222233.82+122142.65"
+{
+	RA 335.64412988
+	Dec 12.36269082
+	Distance 125.535
+	SpectralType "DC9"
+	Temperature 4415
+	AppMag 18.817 # synthetic
+	Radius 11433
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202220+121.1/WD%202220+121.1.html"
+}
+
+"Gaia DR2 2205493129867600256:WDJ222547.07+635727.37"
+{
+	RA 336.45715867
+	Dec 63.96357794
+	Distance 123.764
+	SpectralType "DC9"
+	Temperature 5187
+	AppMag 17.701 # synthetic
+	Radius 10305
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202205493129867600256/Gaia%20DR2%202205493129867600256.html"
+}
+
+"2MASS J22280206+1207334:WD 2225+118:WDJ222802.06+120733.38"
+{
+	RA 337.00842018
+	Dec 12.1257321
+	Distance 110.533
+	SpectralType "DZ7"
+	Temperature 7189
+	AppMag 16.275 # synthetic
+	Radius 7491
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J22280206+1207334/2MASS%20J22280206+1207334.html"
+}
+
+"WD 2227+232:WDJ222933.96+232742.24"
+{
+	RA 337.39259045
+	Dec 23.46073543
+	Distance 119.124
+	SpectralType "DA9"
+	Temperature 5153
+	AppMag 18.059 # synthetic
+	Radius 8525
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202227+232/WD%202227+232.html"
+}
+
+"WD 2226-755:WD 2226-754 B:WDJ223033.53-751524.30"
+{
+	RA 337.64687647
+	Dec -75.26487529
+	Distance 49.031 # mean of system components
+	SpectralType "DC9"
+	Temperature 4147
+	AppMag 16.87
+	Radius 12431
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202226-755/WD%202226-755.html"
+}
+
+"WD 2226-754:WD 2226-754 A:WDJ223039.98-751355.24"
+{
+	RA 337.67375451
+	Dec -75.24012453
+	Distance 49.031 # mean of system components
+	SpectralType "DC9"
+	Temperature 4426
+	AppMag 16.56
+	Radius 12241
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202226-754/WD%202226-754.html"
+}
+
+"WD 2228+151:WDJ223055.62+152353.66"
+{
+	RA 337.73400449
+	Dec 15.39913314
+	Distance 125.689
+	SpectralType "DA9"
+	Temperature 5429
+	AppMag 17.873 # synthetic
+	Radius 8181
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202228+151/WD%202228+151.html"
+}
+
+"Gaia DR2 1875301369907249024:WDJ223059.16+225454.09"
+{
+	RA 337.74688179
+	Dec 22.91508735
+	Distance 101.013
+	SpectralType "DC9"
+	Temperature 5781
+	AppMag 17.126 # synthetic
+	Radius 7645
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201875301369907249024/Gaia%20DR2%201875301369907249024.html"
+}
+
+"Gaia DR2 6505318682415051520:WDJ223418.67-553403.40"
+{
+	RA 338.57858879
+	Dec -55.5667877
+	Distance 122.945
+	SpectralType "DC9"
+	Temperature 4857
+	AppMag 18.171 # synthetic
+	Radius 10721
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206505318682415051520/Gaia%20DR2%206505318682415051520.html"
+}
+
+# Companion to WDJ223418.83+145654.42
+"UCAC4 525-147220"
+{
+	RA 338.58343575
+	Dec 14.96595605
+	Distance 110.351 # mean of system components
+	SpectralType "M" # ESP-ELS
+	Temperature 3542 # GSP-Phot
+	AppMag 13.045 # estimate
+	Radius 336918 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=UCAC4+525-147220"
+}
+
+"Gaia DR2 2733055335904034432:WDJ223418.83+145654.42"
+{
+	RA 338.5790836
+	Dec 14.9483047
+	Distance 110.351 # mean of system components
+	SpectralType "DA8"
+	Temperature 6294
+	AppMag 16.642 # synthetic
+	Radius 8769
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202733055335904034432/Gaia%20DR2%202733055335904034432.html"
+}
+
+"Gaia DR2 6505113009316709760:WDJ223601.50-554852.02"
+{
+	RA 339.00553194
+	Dec -55.8151418
+	Distance 103.988
+	SpectralType "DZ9"
+	Temperature 5220
+	AppMag 17.433 # synthetic
+	Radius 9164
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206505113009316709760/Gaia%20DR2%206505113009316709760.html"
+}
+
+"Gaia DR2 2628943473222829440:WDJ223607.66-014059.65"
+{
+	RA 339.03293786
+	Dec -1.68317235
+	Distance 127.012
+	SpectralType "DAH5"
+	Temperature 10019
+	AppMag 15.65
+	Radius 6895
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202628943473222829440/Gaia%20DR2%202628943473222829440.html"
+}
+
+"Gaia DR2 6520844168856463104:WDJ223634.58-432911.11"
+{
+	RA 339.14606248
+	Dec -43.48789814
+	Distance 98.697
+	SpectralType "DA8"
+	Temperature 6244
+	AppMag 16.313
+	Radius 9327
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206520844168856463104/Gaia%20DR2%206520844168856463104.html"
+}
+
+"Gaia DR2 6506903598362207872:WDJ223700.03-542241.81"
+{
+	RA 339.2499336
+	Dec -54.3784298
+	Distance 95.983
+	SpectralType "DA6"
+	Temperature 8223
+	AppMag 15.269 # synthetic
+	Radius 8855
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206506903598362207872/Gaia%20DR2%206506903598362207872.html"
+}
+
+"2MASS J22415762+1332390:WD 2239+132:WDJ224157.63+133239.12"
+{
+	RA 340.49039799
+	Dec 13.54244743
+	Distance 116.251
+	SpectralType "DA8"
+	Temperature 5974
+	AppMag 17.313 # synthetic
+	Radius 7416
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J22415762+1332390/2MASS%20J22415762+1332390.html"
+}
+
+"GJ 1273:EGGR 155:WD 2246+223:WDJ224905.55+223631.99"
+{
+	RA 342.27564454
+	Dec 22.60915123
+	Distance 58.113
+	SpectralType "DA5"
+	Temperature 10534
+	AppMag 14.36
+	Radius 5432
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20155/EGGR%20155.html"
+}
+
+"GJ 1275:EGGR 283:WD 2248+293:WDJ225123.02+293944.49"
+{
+	RA 342.85232345
+	Dec 29.66295927
+	Distance 65.158
+	SpectralType "DA9"
+	Temperature 5669
+	AppMag 15.55
+	Radius 11108
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201275/GJ%201275.html"
+}
+
+"Gaia DR2 1929287700069881856:WDJ225257.98+392817.40"
+{
+	RA 343.24297222
+	Dec 39.47206141
+	Distance 128.791
+	SpectralType "DC9"
+	Temperature 5024
+	AppMag 18.209 # synthetic
+	Radius 9677
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201929287700069881856/Gaia%20DR2%201929287700069881856.html"
+}
+
+"LP 821-3:WDJ225335.70-143828.19"
+{
+	RA 343.4014451
+	Dec -14.6413149
+	Distance 119.021
+	SpectralType "DA9"
+	Temperature 5384
+	AppMag 17.713 # synthetic
+	Radius 8536
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20821-3/LP%20821-3.html"
+}
+
+# Companion to WDJ225338.11+813039.98
+1000314613 "G 242-15"
+{
+	RA 343.40304233
+	Dec 81.51307549
+	Distance 122.207 # mean of system components
+	SpectralType "M0.0V"
+	AppMag 11.802 # synthetic
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+242-15"
+}
+
+"WD 2253+812:WDJ225338.11+813039.98"
+{
+	RA 343.41491993
+	Dec 81.51161528
+	Distance 122.207 # mean of system components
+	SpectralType "DC9"
+	Temperature 5264
+	AppMag 17.3
+	Radius 8788
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202253+812/WD%202253+812.html"
+}
+
+"GJ 1276:EGGR 453:WD 2251-070:WDJ225353.39-064654.49"
+{
+	RA 343.48356406
+	Dec -6.78483021
+	Distance 27.833
+	SpectralType "DZ9"
+	Temperature 4433
+	AppMag 15.7
+	Radius 9483
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%201276/GJ%201276.html"
+}
+
+# Companion to WDJ225549.47-075002.39
+113231 "Gliese 878.1 A:GJ 9803 A"
+{
+	RA 343.96071437
+	Dec -7.82282573
+	Distance 117.271 # mean of system components
+	SpectralType "G6V"
+	Temperature 5595 # GSP-Spec
+	AppMag 8.01
+	Radius 622292 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+216777"
+}
+
+"Gliese 878.1 B:GJ 9803 B:HD 216777 B:EGGR 178:WD 2253-081:WDJ225549.47-075002.39"
+{
+	RA 343.95859927
+	Dec -7.83420546
+	Distance 117.271 # mean of system components
+	SpectralType "DA8"
+	Temperature 6612
+	AppMag 16.5
+	Radius 9127
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HD%20216777B/HD%20216777B.html"
+}
+
+"GJ 4305:LP 581-35:WD 2253+054:WDJ225555.71+054522.59"
+{
+	RA 343.98369759
+	Dec 5.75509915
+	Distance 80.801
+	SpectralType "DA9"
+	Temperature 5922
+	AppMag 15.71
+	Radius 8796
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20581-35/LP%20581-35.html"
+}
+
+"Gaia DR2 1989342372349280384:WDJ225725.27+513008.56"
+{
+	RA 344.3558838
+	Dec 51.50155494
+	Distance 119.146
+	SpectralType "DA7"
+	Temperature 7125
+	AppMag 16.83 # synthetic
+	Radius 6936
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201989342372349280384/Gaia%20DR2%201989342372349280384.html"
+}
+
+"Gaia DR2 2208530698238308736:WDJ230056.46+640815.95"
+{
+	RA 345.23440339
+	Dec 64.13724683
+	Distance 118.851
+	SpectralType "DC9"
+	Temperature 4768
+	AppMag 18.254 # synthetic
+	Radius 10631
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202208530698238308736/Gaia%20DR2%202208530698238308736.html"
+}
+
+"Gaia DR2 6554977369168846720:WDJ230232.34-330907.96"
+{
+	RA 345.63637149
+	Dec -33.15284682
+	Distance 115.44
+	SpectralType "DC9"
+	Temperature 4867
+	AppMag 18.176
+	Radius 10291
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206554977369168846720/Gaia%20DR2%206554977369168846720.html"
+}
+
+"Gaia DR2 1936315366080098432:WDJ230303.62+463241.98"
+{
+	RA 345.7680836
+	Dec 46.54434134
+	Distance 129.011
+	SpectralType "DC9"
+	Temperature 4870
+	AppMag 18.616 # synthetic
+	Radius 8619
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201936315366080098432/Gaia%20DR2%201936315366080098432.html"
+}
+
+"Gaia DR2 6552878165248320896:WDJ230345.52-371051.56"
+{
+	RA 345.93965391
+	Dec -37.1836068
+	Distance 105.479
+	SpectralType "DZ9"
+	Temperature 4467
+	AppMag 18.279
+	Radius 10745
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206552878165248320896/Gaia%20DR2%206552878165248320896.html"
+}
+
+"Gaia DR2 1929838143078434432:WDJ230550.09+392232.88"
+{
+	RA 346.45811075
+	Dec 39.37368479
+	Distance 117.015
+	SpectralType "DC9"
+	Temperature 4550 # Table A5
+	AppMag 17.955 # synthetic
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%201929838143078434432/Gaia%20DR2%201929838143078434432.html"
+}
+
+"WD 2305+239:WDJ230812.71+241425.53"
+{
+	RA 347.05408787
+	Dec 24.24009323
+	Distance 130.297
+	SpectralType "DC9"
+	Temperature 5035
+	AppMag 18.131 # synthetic
+	Radius 10212
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202305+239/WD%202305+239.html"
+}
+
+"WD 2306-220:WDJ230840.77-214459.60"
+{
+	RA 347.17132699
+	Dec -21.75032269
+	Distance 106.743
+	SpectralType "DA3"
+	Temperature 16050
+	AppMag 13.744 # synthetic
+	Radius 9064
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202306-220/WD%202306-220.html"
+}
+
+# Companion to WDJ230958.53+550649.43
+"G 233-42"
+{
+	RA 347.49426024
+	Dec 55.11334934
+	Distance 53.51 # mean of system components
+	SpectralType "M5V"
+	Temperature 2931 # GSP-Phot
+	AppMag 15.932 # synthetic
+	Radius 121471 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+233-42"
+}
+
+"2MASS J23095848+5506491:WD 2307+548:WDJ230958.53+550649.43"
+{
+	RA 347.49706027
+	Dec 55.11394371
+	Distance 53.51 # mean of system components
+	SpectralType "DA9"
+	Temperature 5566
+	AppMag 15.793 # synthetic
+	Radius 8374
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/2MASS%20J23095848+5506491/2MASS%20J23095848+5506491.html"
+}
+
+# Companion to WDJ231022.85-685023.96
+114416 "GJ 1280"
+{
+	RA 347.58653011
+	Dec -68.83747677
+	Distance 68.676 # mean of system components
+	SpectralType "K3+Vk:"
+	Temperature 4700 # GSP-Spec
+	AppMag 8.78
+	Radius 434429 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=HD+218572"
+}
+
+"HD 218572 B:WD 2307-691:WDJ231022.85-685023.96"
+{
+	RA 347.5960284
+	Dec -68.83856317
+	Distance 68.676 # mean of system components
+	SpectralType "DB5"
+	Temperature 10780
+	AppMag 13.571
+	Radius 9313
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/HD%20218572B/HD%20218572B.html"
+}
+
+"WD 2309+129:WDJ231206.10+131058.07"
+{
+	RA 348.02479614
+	Dec 13.18166619
+	Distance 104.138
+	SpectralType "DA9"
+	Temperature 5258
+	AppMag 17.371 # synthetic
+	Radius 9726
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202309+129/WD%202309+129.html"
+}
+
+"Gliese 893.1:GJ 9814:EGGR 553:WD 2311-068:WDJ231425.18-063247.88"
+{
+	RA 348.60340454
+	Dec -6.54738913
+	Distance 84.465
+	SpectralType "DQ7"
+	Temperature 7630
+	AppMag 15.42
+	Radius 8562
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%20893.1/GJ%20893.1.html"
+}
+
+"EGGR 554:WD 2312-024:WDJ231518.81-020940.60"
+{
+	RA 348.83099563
+	Dec -2.16048755
+	Distance 96.839
+	SpectralType "DZ8"
+	Temperature 6634
+	AppMag 16.31
+	Radius 7932
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20554/EGGR%20554.html"
+}
+
+"Gaia DR2 2407167579853954688:WDJ231530.40-144005.68"
+{
+	RA 348.87746
+	Dec -14.6685084
+	Distance 94.059
+	SpectralType "DA6"
+	Temperature 8853
+	AppMag 15.13
+	Radius 6782
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202407167579853954688/Gaia%20DR2%202407167579853954688.html"
+}
+
+"Gaia DR2 2818957013992481280:WDJ231726.74+183052.75"
+{
+	RA 349.36125063
+	Dec 18.51264244
+	Distance 123.742
+	SpectralType "DZ9"
+	Temperature 4756
+	AppMag 19.677 # synthetic
+	Radius 5171
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%202818957013992481280/Gaia%20DR2%202818957013992481280.html"
+}
+
+# Companion to WDJ231732.63-460816.77
+"L 359-109"
+{
+	RA 349.39055682
+	Dec -46.13753522
+	Distance 125.626 # mean of system components
+	SpectralType "M" # ESP-ELS
+	AppMag 14.12
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+359-109"
+}
+
+"Gaia DR3 6527675297155337472:WDJ231732.63-460816.77"
+{
+	RA 349.38930735
+	Dec -46.13887799
+	Distance 125.626 # mean of system components
+	SpectralType "DQ9"
+	Temperature 4080 # Table A5
+	AppMag 19.969 # estimate
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR3%206527675297155337472/Gaia%20DR3%206527675297155337472.html"
+}
+
+"EGGR 555:WD 2316-064:WDJ231909.52-061249.96"
+{
+	RA 349.78695015
+	Dec -6.22094448
+	Distance 118.134
+	SpectralType "DC9"
+	Temperature 4750
+	AppMag 18.15
+	Radius 11196
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20555/EGGR%20555.html"
+}
+
+"PHL 459:EGGR 264:WD 2316-173:WDJ231935.39-170528.47"
+{
+	RA 349.89857637
+	Dec -17.09119498
+	Distance 83.236
+	SpectralType "DBA4"
+	Temperature 11263
+	AppMag 14.08
+	Radius 8559
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PHL%20459/PHL%20459.html"
+}
+
+"PM J23243+2835:WD 2321+283:WDJ232418.87+283554.82"
+{
+	RA 351.07839792
+	Dec 28.5979759
+	Distance 127.395
+	SpectralType "DA7"
+	Temperature 7251
+	AppMag 15.96
+	Radius 8830
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J23243+2835/PM%20J23243+2835.html"
+}
+
+"WD 2322+137:WDJ232519.87+140339.61"
+{
+	RA 351.33436318
+	Dec 14.06151048
+	Distance 76.681
+	SpectralType "DA9"
+	Temperature 5218
+	AppMag 15.81
+	Radius 15098
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202322+137/WD%202322+137.html"
+}
+
+"GD 248:EGGR 335:WD 2323+157.1:WDJ232606.59+160019.28"
+{
+	RA 351.52725412
+	Dec 16.00484269
+	Distance 110.08
+	SpectralType "DC5"
+	Temperature 9915
+	AppMag 15.13
+	Radius 8535
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%20248/GD%20248.html"
+}
+
+"ZZ Psc:Gliese 895.2:EGGR 159:WD 2326+049:WDJ232847.64+051454.24"
+{
+	RA 352.19670802
+	Dec 5.2472131
+	Distance 57.113
+	SpectralType "DAZ4"
+	Temperature 11529
+	AppMag 13.04
+	Radius 8705
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/V*%20ZZ%20Psc/V*%20ZZ%20Psc.html"
+}
+
+"CASE 3:EGGR 160:WD 2329+407:WDJ233135.66+410130.68"
+{
+	RA 352.90014365
+	Dec 41.02475243
+	Distance 116.293
+	SpectralType "DA3"
+	Temperature 16665
+	AppMag 13.865 # synthetic
+	Radius 9129
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NAME%20CASE%203/NAME%20CASE%203.html"
+}
+
+"Gaia DR2 6389551313580046464:WDJ233145.31-665607.80"
+{
+	RA 352.94070557
+	Dec -66.9357935
+	Distance 128.682
+	SpectralType "DA7"
+	Temperature 7658
+	AppMag 16.223
+	Radius 8610
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206389551313580046464/Gaia%20DR2%206389551313580046464.html"
+}
+
+"EGGR 161:WD 2329+267:WDJ233203.52+265846.12"
+{
+	RA 353.01688716
+	Dec 26.97960651
+	Distance 94.989
+	SpectralType "DAH5"
+	Temperature 9809
+	AppMag 15.29
+	Radius 6354
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20161/EGGR%20161.html"
+}
+
+"GJ 4344:GD 1192:WD 2333-165:WDJ233536.62-161743.66"
+{
+	RA 353.90299258
+	Dec -16.29609284
+	Distance 79.317
+	SpectralType "DA4"
+	Temperature 13507
+	AppMag 13.57
+	Radius 9151
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%201192/GD%201192.html"
+}
+
+"GJ 4355:GD 1212:WD 2336-079:WDJ233850.74-074119.97"
+{
+	RA 354.71155852
+	Dec -7.68897989
+	Distance 60.819
+	SpectralType "DA5"
+	Temperature 10873
+	AppMag 13.26
+	Radius 8890
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GD%201212/GD%201212.html"
+}
+
+"EGGR 557:WD 2336-187:WDJ233852.80-182612.68"
+{
+	RA 354.7203651
+	Dec -18.43747869
+	Distance 121.152
+	SpectralType "DA6"
+	Temperature 7901
+	AppMag 15.6
+	Radius 10476
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20557/EGGR%20557.html"
+}
+
+# Companion to WDJ233856.32+210118.30
+"GJ 4356:G 68-34"
+{
+	RA 354.73331708
+	Dec 21.02346583
+	Distance 128.312 # mean of system components
+	SpectralType "M4+M4"
+	Temperature 3007 # GSP-Phot
+	AppMag 14.253 # synthetic
+	Radius 394849 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=G+68-34"
+}
+
+"GJ 4357:NLTT 57507:WD 2336+207:WDJ233856.32+210118.30"
+{
+	RA 354.73596048
+	Dec 21.02253401
+	Distance 128.312 # mean of system components
+	SpectralType "DA9"
+	Temperature 5316
+	AppMag 17.897 # synthetic
+	Radius 8903
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2057507/NLTT%2057507.html"
+}
+
+# Companion to WDJ234300.85-644737.90
+117011 "CPD-65 4158"
+{
+	RA 355.77309111
+	Dec -64.78755028
+	Distance 120.846 # mean of system components
+	SpectralType "K5+V"
+	Temperature 4291 # GSP-Spec
+	AppMag 10.25
+	Radius 500913 # FLAME (GSP-Spec)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=CPD-65+4158"
+}
+
+"Gaia DR2 6485572518732377856:WDJ234300.85-644737.90"
+{
+	RA 355.75129109
+	Dec -64.79435009
+	Distance 120.846 # mean of system components
+	SpectralType "DC9"
+	Temperature 5705
+	AppMag 17.152 # synthetic
+	Radius 9321
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206485572518732377856/Gaia%20DR2%206485572518732377856.html"
+}
+
+"LP 823-44:WDJ234315.00-165941.02"
+{
+	RA 355.81123206
+	Dec -16.9957658
+	Distance 80.825
+	SpectralType "DZ9"
+	Temperature 5136
+	AppMag 17.01
+	Radius 7752
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20823-44/LP%20823-44.html"
+}
+
+117059 "Gliese 905.2 B:GJ 9838 B:EGGR 162:LAWD 93:WD 2341+322:WDJ234350.72+323246.73"
+{
+	RA 355.96020005
+	Dec 32.54604733
+	Distance 60.627
+	SpectralType "DA4"
+	Temperature 12587
+	AppMag 12.93
+	Radius 8949
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20162/EGGR%20162.html"
+}
+
+"PM J23462+1158:WD 2343+117:WDJ234612.48+115850.20"
+{
+	RA 356.55153879
+	Dec 11.98017512
+	Distance 118.134
+	SpectralType "DC8"
+	Temperature 6073
+	AppMag 17.278 # synthetic
+	Radius 7534
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/PM%20J23462+1158/PM%20J23462+1158.html"
+}
+
+"NLTT 57978:WD 2345+027:WDJ234735.13+030431.87"
+{
+	RA 356.89714084
+	Dec 3.07654736
+	Distance 82.032
+	SpectralType "DC9"
+	Temperature 5129
+	AppMag 16.9
+	Radius 10964
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/NLTT%2057978/NLTT%2057978.html"
+}
+
+"WD 2345-447:WDJ234816.77-442811.76"
+{
+	RA 357.07170467
+	Dec -44.47116135
+	Distance 118.946
+	SpectralType "DZ9"
+	Temperature 5396
+	AppMag 17.87
+	Radius 7692
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/WD%202345-447/WD%202345-447.html"
+}
+
+"Gaia DR2 6521660556236440960:WDJ234935.57-521528.02"
+{
+	RA 357.39854243
+	Dec -52.25803847
+	Distance 100.738
+	SpectralType "DC8"
+	Temperature 6246
+	AppMag 17.112 # synthetic
+	Radius 6548
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206521660556236440960/Gaia%20DR2%206521660556236440960.html"
+}
+
+"GJ 4365:EGGR 506:WD 2347+292:WDJ234955.03+293404.02"
+{
+	RA 357.47900109
+	Dec 29.56555497
+	Distance 68.263
+	SpectralType "DA9"
+	Temperature 5817
+	AppMag 15.72
+	Radius 9645
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/GJ%204365/GJ%204365.html"
+}
+
+"LP 703-6:WD 2349-031:WDJ235231.92-025311.75"
+{
+	RA 358.13584048
+	Dec -2.88532995
+	Distance 97.728
+	SpectralType "DA5"
+	Temperature 10587
+	AppMag 16.98
+	Radius 2776
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/LP%20703-6/LP%20703-6.html"
+}
+
+# Companion to WDJ235401.07-331631.08
+"L 577-72"
+{
+	RA 358.5028824
+	Dec -33.27529057
+	Distance 75.618 # mean of system components
+	SpectralType "M4V"
+	Temperature 3172 # GSP-Phot
+	AppMag 13.485 # synthetic
+	Radius 251828 # FLAME (GSP-Phot)
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=L+577-72"
+}
+
+# Companion to WDJ235401.07-331631.08
+"APMPM J2354-3316 C"
+{
+	RA 358.53703452
+	Dec -33.27592236
+	Distance 75.618 # mean of system components
+	SpectralType "M8.7Ve"
+	AppMag 20.96 # estimate
+	InfoURL "https://simbad.cds.unistra.fr/simbad/sim-id?Ident=APMPM+J2354-3316C"
+}
+
+"L 577-71:LAWD 94:EGGR 163:WD 2351-335:WDJ235401.07-331631.08"
+{
+	RA 358.50281735
+	Dec -33.27708791
+	Distance 75.618 # mean of system components
+	SpectralType "DA6"
+	Temperature 8559
+	AppMag 13.56
+	Radius 9118
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/L%20577-71/L%20577-71.html"
+}
+
+"Gaia DR2 6350786278796634112:WDJ235419.41-814104.96"
+{
+	RA 358.58382867
+	Dec -81.68455056
+	Distance 87.844
+	SpectralType "DZH9"
+	Temperature 4676
+	AppMag 17.542 # synthetic
+	Radius 11584
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206350786278796634112/Gaia%20DR2%206350786278796634112.html"
+}
+
+"Gaia DR2 6521875098442800512:WDJ235422.99-514930.65"
+{
+	RA 358.59611825
+	Dec -51.82701618
+	Distance 99.063
+	SpectralType "DC9"
+	Temperature 4670
+	AppMag 17.897 # synthetic
+	Radius 11203
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/Gaia%20DR2%206521875098442800512/Gaia%20DR2%206521875098442800512.html"
+}
+
+"EGGR 507:WD 2352+401:WDJ235456.28+402729.54"
+{
+	RA 358.73571765
+	Dec 40.45584924
+	Distance 71.974
+	SpectralType "DQ6"
+	Temperature 7902
+	AppMag 14.94
+	Radius 8562
+	InfoURL "https://montrealwhitedwarfdatabase.org/WDs/EGGR%20507/EGGR%20507.html"
+}


### PR DESCRIPTION
Includes 1065 white dwarfs and 94 companion stars (one of which is itself a WD) from the sample of [O'Brien et al. (2024), MNRAS 527, p. 8687-8705](https://cdsarc.cds.unistra.fr/viz-bin/cat/J/MNRAS/527/8687). The remaining 13 WDs are already in other data files (extrasolar.stc and nearstars.stc). I've also removed several entries from revised.stc which correspond to objects in this catalog.

Not all WDs within 40 pc (~130 ly) are here, but completeness is almost reached, with 28 objects missing from the source catalog, most of which are in binary systems.