### PR TITLE
Updates to TNO systems

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -6,6 +6,11 @@
 # Solar System Barycenter (SSB) were queried from the Horizons system:
 # https://ssd.jpl.nasa.gov/horizons/
 
+# Sizes and albedos (geometric and Bond) of Pluto, Haumea, Makemake and Eris
+# are taken from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
+# "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
+# https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
+
 
 # Stern et al. (2018), Annu. Rev. Astro. Astrophys. 56, p. 357-392
 # "The Pluto System After New Horizons"
@@ -42,9 +47,6 @@ ReferencePoint "Pluto-Charon" "Sol"
 	Clickable true
 }
 
-# Albedos from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
-# "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
-# https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "Pluto:134340 Pluto" "Sol"
 {
 	Class	"dwarfplanet"
@@ -93,7 +95,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 # Photometric parameters from Buratti et al. (2019), ApJL 874, L3
 # "New Horizons Photometry of Pluto's Moon Charon"
 # https://ui.adsabs.harvard.edu/abs/2019ApJ...874L...3B/abstract
-"Charon:Pluto I:134340 Pluto I:S 1978 P 1" "Sol/Pluto"
+"Charon:Pluto I:134340 Pluto I:S 1978 P 1:P1" "Sol/Pluto"
 {
 	Class	"moon"
 	Texture	"charon.*"
@@ -295,10 +297,7 @@ ReferencePoint "Pluto-Charon" "Sol"
 		ArgOfPericenter	73.2425761850776
 		MeanAnomaly	39.86375930207814
 	}
-	BodyFrame
-	{
-		EquatorJ2000	{ Center "Sol/Ceres" }
-	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 	        # C. Raymond, JPL and T. Roatsch, DLR (28-Jun-2018)
@@ -368,10 +367,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		AscendingNode	53.49
 		LongOfPericenter	148
 	}
-	BodyFrame
-	{
-		EquatorJ2000	{ Center "Sol/Orcus-Vanth" }
-	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation  # to match mutual orbit
 	{
 		Epoch	2454000  # 2006 Sept 21 12:00
@@ -387,7 +383,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # Orbit from Grundy et al. (2019), Icarus 334, 62-78
 # "Mutual orbit orientations of transneptunian binaries"
 # http://www2.lowell.edu/users/grundy/abstracts/2019.TNB_orbits.html
-"Vanth:Orcus I:90482 Orcus I:S 2005 (90482) 1" "Sol/Orcus"
+"Vanth:Orcus I:90482 Orcus I" "Sol/Orcus"
 {
 	Class	"moon"
 	Mesh	"roughsphere.cms"
@@ -411,10 +407,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		AscendingNode	53.49
 		LongOfPericenter	328
 	}
-	BodyFrame
-	{
-		EquatorJ2000	{ Center "Sol/Orcus-Vanth" }
-	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation  # to match mutual orbit
 	{
 		Epoch	2454000  # 2006 Sept 21 12:00
@@ -427,13 +420,10 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/Vanth_(moon)"
 }
 
-# Masses from Ragozzine and Brown (2009), AJ 137, 4766
-# "Orbits and Masses of the Satellites of the Dwarf Planet Haumea (2003 EL61)"
-# https://ui.adsabs.harvard.edu/abs/2009AJ....137.4766R/abstract
-# Secondaries' orbits from Gourgeot et al. (2016), A&A 593, A19
-# "Near-infrared spatially resolved spectroscopy of (136108) Haumea's multiple system"
-# https://ui.adsabs.harvard.edu/abs/2016A%26A...593A..19G
-# Rings from Ortiz et al. (2017), Nature 550 (7675), pp. 219-223
+# Masses and moon orbits from Proudfoot et al. (2024), Planet. Sci. J. 5, 69
+# "Beyond Point Masses. III. Detecting Haumea's Nonspherical Gravitational Field"
+# https://ui.adsabs.harvard.edu/abs/2024PSJ.....5...69P/abstract
+# Rotational parameters and rings from Ortiz et al. (2017), Nature 550 (7675), p. 219-223
 # "The size, shape, density and ring of the dwarf planet Haumea from a stellar occultation"
 # https://ui.adsabs.harvard.edu/abs/2017Natur.550..219O/abstract
 "Haumea:136108 Haumea:2003 EL61" "Sol"
@@ -443,7 +433,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Color	[ 0.635 0.635 0.636 ]
 	BlendTexture	true
 	SemiAxes	[ 1050 840 537 ]
-	Mass<kg>	4.006e21
+	Mass<kg>	3952.44e18  # HST-only fit
 	OrbitFrame
 	{
 		EclipticJ2000	{ Center "SSB" }
@@ -462,11 +452,13 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	UniformRotation
 	{
 		Period	3.915341
-		Inclination	126.356
-		AscendingNode	206.766
+		Inclination	258.0  # assume same as rings; ecliptic
+		AscendingNode	15.2
+		MeridianAngle	210  # absolute brightness (projected area) minimum during occultation on 2017 Jan 21 03:09 UT
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.66
+	# GeomAlbedo	0.66
+	Reflectivity	0.29  # for phase integral = 0.44 ± 0.03
 	Rings
 	{
 		Inner	2252
@@ -476,108 +468,98 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/Haumea"
 }
 
+# Size and albedo from Müller et al. (2019), Icarus 334, p. 39-51
+# "Haumea's thermal emission revisited in the light of the occultation results"
+# https://ui.adsabs.harvard.edu/abs/2019Icar..334...39M/abstract
 "Namaka:Haumea II:136108 Haumea II:S 2005 (2003 EL61) 2" "Sol/Haumea"
 {
 	Class	"moon"
 	Mesh	"asteroid.cms"
 	Texture	"icymoon.*"
-	Radius	80
-	Mass<kg>	1.79e18
-	OrbitFrame
+	Radius	75
+	Mass<kg>	1.18e18  # HST-only fit
+	# Density	650
+	OrbitFrame	{ EclipticJ2000 {} }
+	EllipticalOrbit  # HST-only fit
 	{
-		EquatorJ2000	{ Center "Sol/Haumea" }
+		Epoch	2454615.0  # 2008 May 28 12:00 UT
+		Period	18.24  # from SMA and masses
+		SemiMajorAxis	25506
+		Eccentricity	0.2179
+		Inclination	69.005
+		ArgOfPericenter	118.35
+		AscendingNode	23.725
+		MeanAnomaly	185.19
 	}
-	EllipticalOrbit
+	BodyFrame	{ EclipticJ2000 {} }
+	UniformRotation  # assumed to match orbit plane
 	{
-		Epoch	2452167.5299  # Tperi = 2001 Sep 15 00:43:03
-		Period	18.323535
-		SemiMajorAxis	25147.829
-		Eccentricity	0.15543
-		Inclination	88.83
-		AscendingNode	206.73
-		ArgOfPericenter	143.44
-		MeanAnomaly	0
-	}
-	UniformRotation	# assumed to match orbit plane
-	{
-		Period	10	# unknown, very likely asynchronous
+		Period	144  # unknown, very likely asynchronous
+		Inclination	69.005
+		AscendingNode	23.725
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.8
+	# GeomAlbedo	0.7  # approximate for H = 5.1
+	Reflectivity	0.31  # for phase integral = 0.44 ± 0.03
 	InfoURL	"https://en.wikipedia.org/wiki/Namaka_(moon)"
 }
 
-# Size from Fernández-Valenzuela et al. (2021), EPSC2021-609
-# "The stellar occultations by the largest satellite of the dwarf planet Haumea, Hi'iaka"
-# https://ui.adsabs.harvard.edu/abs/2021EPSC...15..609F
-# Shape and rotation from Hastings et al. (2016), AJ 152 (6), 195
-# "The Short Rotation Period of Hi’iaka, Haumea’s Largest Satellite"
-# https://ui.adsabs.harvard.edu/abs/2016AJ....152..195H
-# Obliquity from Fernández-Valenzuela et al. (2022), EPSC2022-406
-# "Hi'iaka's physical and dynamical properties using long-term photometric data"
-# https://ui.adsabs.harvard.edu/abs/2022EPSC...16..406F
+# Dimensions, density, rotational parameters and albedo from Vara Lubiano (2023)
+# "Propiedades físicas de objetos trans-neptunianos y centauros combinando
+# técnicas fotométricas, astrométricas, radiométricas y de ocultación estelar"
+# https://digibug.ugr.es/handle/10481/89038
 "Hi'iaka:Haumea I:136108 Haumea I:S 2005 (2003 EL61) 1" "Sol/Haumea"
 {
 	Class	"moon"
 	Mesh	"roughsphere.cms"
 	Texture	"icymoon.*"
-	Radius	175	 # "...a larger effective diameter than what has been published so far."
-	SemiAxes	[ 1 0.81 0.81 ]	# Amag=0.23, b/a=0.81 if edge-on
-	Mass<kg>	1.79e19
-	OrbitFrame
+	SemiAxes	[ 238 185 143 ]
+	Mass<kg>	12.13e18  # HST-only fit
+	Density	685
+	OrbitFrame	{ EclipticJ2000 {} }
+	EllipticalOrbit  # HST-only fit
 	{
-		EquatorJ2000	{ Center "Sol/Haumea" }
+		Epoch	2454615.0  # 2008 May 28 12:00 UT
+		Period	49.04  # from SMA and masses
+		SemiMajorAxis	49371
+		Eccentricity	0.0542
+		Inclination	77.394
+		ArgOfPericenter	98.34
+		AscendingNode	13.11
+		MeanAnomaly	154.53
 	}
-	EllipticalOrbit
+	BodyFrame	{ EquatorJ2000 {} }
+	UniformRotation  # average of two occultations
 	{
-		Epoch	2452190.3944	# Tperi = 2001 Oct 07 21:27:56
-		Period	49.031527
-		SemiMajorAxis	49502.940
-		Eccentricity	0.05260
-		Inclination	79.48
-		AscendingNode	192.99
-		ArgOfPericenter	276.14
-		MeanAnomaly	0
-	}
-	UniformRotation
-	{
-		Period	9.79736
-		Inclination	90	# relative to orbit plane
+		Period	9.68
+		Inclination	112
+		AscendingNode	54
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.66
+	# GeomAlbedo	0.68
+	Reflectivity	0.30  # for phase integral = 0.44 ± 0.03
 	InfoURL	"https://en.wikipedia.org/wiki/Hi'iaka_(moon)"
 }
 
-# Braga-Ribas et al. (2013), ApJ 773 (1), 26
-# "The Size, Shape, Albedo, Density, and Atmospheric Limit of Transneptunian Object
-# (50000) Quaoar from Multi-chord Stellar Occultations"
-# https://iopscience.iop.org/article/10.1088/0004-637X/773/1/26
-# Mass and rotation period from Morgado et al. (2023), Nature 614, 239–243
-# "A dense ring of the trans-Neptunian object Quaoar outside its Roche limit"
-# https://ui.adsabs.harvard.edu/abs/2023Natur.614..239M/abstract
-# Radius and shape from Kiss et al. (2024), A&A 684, A50
+# Radius, shape and albedos from Kiss et al. (2024), A&A 684, A50
 # "The visible and thermal light curve of the large Kuiper belt object (50000) Quaoar"
 # https://ui.adsabs.harvard.edu/abs/2024A%26A...684A..50K/abstract
-# Ring rotation axis and geometric albedo from Pereira et al. (2023), A&A 673, 14
-# "The two rings of (50000) Quaoar"
-# https://ui.adsabs.harvard.edu/abs/2023A%26A...673L...4P/abstract
-# https://ui.adsabs.harvard.edu/abs/2024A%26A...683C...4P/abstract
+# Mass and Weywot orbit from Braga-Ribas et al. (2025), Phil. Trans. R. Soc. A. 383, 20240200
+# "Investigating the formation of small Solar System objects using stellar
+# occultations by satellites: present, future and its use to update satellite orbits"
+# https://ui.adsabs.harvard.edu/abs/2025RSPTA.38340200B/abstract
 # Photometric color calculated with spectral data from Marchi et al. (2003), A&A 408, L17-L19
 # "Visible spectroscopy of the two largest known trans-Neptunian objects: Ixion and Quaoar"
 # https://ui.adsabs.harvard.edu/abs/2003A%26A...408L..17M/abstract
-# Color calculated with phase integral from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
-# "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
-# https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "Quaoar:50000 Quaoar:2002 LM60" "Sol"
 {
 	Class	"dwarfplanet"
 	Texture	"icy.*"
-	Color	[ 0.335 0.307 0.266 ]
+	Color	[ 0.324 0.288 0.251 ]
 	BlendTexture	true
-	Radius	545  # equatorial
-	SemiAxes	[ 1.18 0.992 0.855 ]	# a/b = 1.19, b/c = 1.16
-	Mass<kg>	1.2e21
+	Radius	545  # volume-equivalent
+	SemiAxes	[ 1.18 0.992 0.855 ]  # a/b = 1.19, b/c = 1.16
+	Mass<kg>	1.208e21
 	OrbitFrame
 	{
 		EclipticJ2000	{ Center "SSB" }
@@ -593,13 +575,23 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		ArgOfPericenter	157.5485109164584
 		MeanAnomaly	265.1494956186123
 	}
+
+	# Ring pole from Proudfoot et al. (2025), Planet. Sci. J. 6, 146
+	# "Constraints on Quaoar's Rings and Atmosphere from JWST/NIRCam
+	# Observations of a Stellar Occultation"
+	# https://ui.adsabs.harvard.edu/abs/2025PSJ.....6..146P/abstract
 	BodyFrame	{ EquatorJ2000 {} }
-	UniformRotation	# assume alignment of ring and equator
+	UniformRotation
 	{
-		Period	17.6788
-		Inclination	36.55
-		AscendingNode	349.82
+		Period	17.6788  # Morgado et al. (2023), 2023Natur.614..239M
+		Inclination	35.0
+		AscendingNode	349.5
 	}
+
+	# Radii and widths from Pereira et al. (2023), A&A 673, 14
+	# "The two rings of (50000) Quaoar"
+	# https://ui.adsabs.harvard.edu/abs/2023A%26A...673L...4P/abstract
+	# https://ui.adsabs.harvard.edu/abs/2024A%26A...683C...4P/abstract
 	Rings
 	{
 		Inner	2515
@@ -607,14 +599,15 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		Texture	"quaoar-rings.*"
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.124
+	# GeomAlbedo	0.11
+	Reflectivity	0.057  # Bond albedo
 	InfoURL	"https://en.wikipedia.org/wiki/Quaoar"
 }
 
 # Radius and geometric albedo from Fernandez-Valenzuela et al., 55th Annual DPS Meeting Joint with EPSC
 # "Weywot: the darkest known satellite in the trans-Neptunian region"
-# https://submissions.mirasmart.com/DPS55/Itinerary/PresentationDetail.aspx?evdid=75
-"Weywot:Quaoar I:50000 Quaoar I:S 2006 (50000) 1" "Sol/Quaoar"
+# https://ui.adsabs.harvard.edu/abs/2023DPS....5520204F/abstract
+"Weywot:Quaoar I:50000 Quaoar I" "Sol/Quaoar"
 {
 	Class	"moon"
 	Mesh	"asteroid.cms"  # almost 200 km effective diameter
@@ -622,25 +615,24 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Color	[ 0.359 0.328 0.282 ]  # assume same photometric color as primary
 	BlendTexture	true
 	Radius	100
-	OrbitFrame
-	{
-		EquatorJ2000	{ Center "Sol/Quaoar" }
-	}
+	OrbitFrame	{ EquatorJ2000 {} }
 	EllipticalOrbit
 	{
-		Epoch	2453300.5  # 2004 Oct 22
-		Period	12.4315
-		SemiMajorAxis	13583
-		Eccentricity	0.057
-		Inclination	36.9
-		AscendingNode	357.0
-		ArgOfPericenter	10.1
-		MeanAnomaly	69.2
+		Period	12.431013
+		SemiMajorAxis	13309
+		Eccentricity	0.018
+		Inclination	38.04
+		AscendingNode	356.9
+		ArgOfPericenter	292
+		Epoch	2453780.42
 	}
-	UniformRotation  # to match orbit plane
+	BodyFrame	{ EquatorJ2000 {} }
+	UniformRotation  # assume synchronous rotation
 	{
-		Inclination	13.5
-		AscendingNode	352.3
+		Epoch	2453780.42
+		Inclination	38.04
+		AscendingNode	356.9
+		MeridianAngle	112
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.04
@@ -653,9 +645,6 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # Photometric color calculated with spectral data from Alvarez-Candal et al. (2020), MNRAS 497 (4), 5473-5479
 # "The dwarf planet Makemake as seen by X-Shooter"
 # https://ui.adsabs.harvard.edu/abs/2020MNRAS.497.5473A/abstract
-# Color calculated with phase integral from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
-# "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
-# https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "Makemake:136472 Makemake:2005 FY9" "Sol"
 {
 	Class	"dwarfplanet"
@@ -685,7 +674,8 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		Period	22.82657
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.81
+	# GeomAlbedo	0.82
+	Reflectivity	0.74  # Bond albedo
 	InfoURL	"https://en.wikipedia.org/wiki/Makemake"
 }
 
@@ -749,14 +739,14 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/Gonggong_(dwarf_planet)"
 }
 
-# Radius from Arakawa et al. (2021), AJ 162, no. 6, 226
+# Radius and rotation from Arakawa et al. (2021), AJ 162, no. 6, 226
 # "Tidal Evolution of the Eccentric Moon around Dwarf Planet (225088) Gonggong"
 # https://ui.adsabs.harvard.edu/abs/2021AJ....162..226A/abstract
 # Geometric albedo is calculated using this radius.
 # Color indices from Kiss et al. (2019), Icarus 334, 3
 # "The mass and density of the dwarf planet (225088) 2007 OR10"
 # https://ui.adsabs.harvard.edu/abs/2019Icar..334....3K/abstract
-"Xiangliu:Gonggong I:225088 Gonggong I:S 2010 (225088) 1" "Sol/Gonggong"
+"Xiangliu:Gonggong I:225088 Gonggong I" "Sol/Gonggong"
 {
 	Class	"moon"
 	Mesh	"asteroid.cms"
@@ -764,10 +754,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 	Color	[ 0.495 0.468 0.445 ]
 	BlendTexture	true
 	Radius	100
-	OrbitFrame
-	{
-		EquatorJ2000	{ Center "Sol/Gonggong" }
-	}
+	OrbitFrame	{ EquatorJ2000 {} }
 	EllipticalOrbit  # prograde solution
 	{
 		Epoch	2457000.0  # 2014 Dec 08 12:00
@@ -778,6 +765,13 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		MeanLongitude	205.57
 		AscendingNode	31.99
 		LongOfPericenter	109.05
+	}
+	BodyFrame	{ EquatorJ2000 {} }
+	UniformRotation  # assumed to match orbit plane
+	{
+		Period	100  # assumed; cannot be tidally locked
+		Inclination	83.08
+		AscendingNode	31.99
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.08
@@ -795,9 +789,6 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # "Synchronous Rotation in the (136199) Eris-Dysnomia System"
 # https://ui.adsabs.harvard.edu/abs/2023PSJ.....4..115B/abstract
 # (Orientation assumes tidal locking with Dysnomia.)
-# Color calculated with phase integral from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
-# "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
-# https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "Eris:136199 Eris:2003 UB313" "Sol"
 {
 	Class	"dwarfplanet"
@@ -832,7 +823,8 @@ ReferencePoint "Orcus-Vanth" "Sol"
 		MeridianAngle	359.61
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.96
+	# GeomAlbedo	0.96
+	Reflectivity	0.99  # Bond albedo
 	InfoURL	"https://en.wikipedia.org/wiki/Eris_(dwarf_planet)"
 }
 

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -116,7 +116,7 @@
 		ArgOfPericenter	241.8770167366896
 		MeanAnomaly	337.0949942257109
 	}
-	BodyFrame	{ EquatorJ2000 { } }
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 		Period	7.004
@@ -236,10 +236,11 @@
 	InfoURL	"https://en.wikipedia.org/wiki/20000_Varuna"
 }
 
+# Dimensions and orientation from https://www.asteroidoccultation.com/observations/Results/Reviewed/Data2020/20201013_28978_Ixion_Profile_fit.gif
 # Photometric color calculated with spectral data from Marchi et al. (2003), A&A 408, L17-L19
 # "Visible spectroscopy of the two largest known trans-Neptunian objects: Ixion and Quaoar"
 # https://ui.adsabs.harvard.edu/abs/2003A%26A...408L..17M/abstract
-# Geometric albedo and phase integral for color from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
+# Albedos from Verbiscer et al. (2022), Planet. Sci. J. 3, 95
 # "The Diverse Shapes of Dwarf Planet and Large KBO Phase Curves Observed from New Horizons"
 # https://ui.adsabs.harvard.edu/abs/2022PSJ.....3...95V/abstract
 "28978 Ixion:Ixion:2001 KX76" "Sol"
@@ -248,7 +249,7 @@
 	Texture	"asteroid.*"
 	Color	[ 0.342 0.316 0.277 ]
 	BlendTexture	true
-	Radius	308.5
+	SemiAxes	[ 378.45 378.45 342.45 ]  # projected
 	OrbitFrame
 	{
 		EclipticJ2000	{ Center "SSB" }
@@ -264,17 +265,27 @@
 		ArgOfPericenter	299.8597254480305
 		MeanAnomaly	257.4104890036214
 	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 		Period	12.4
+		Inclination	65.1  # assume equator-on orientation on 2020 Oct 13
+		AscendingNode	72.2
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.108
+	# GeomAlbedo	0.108
+	Reflectivity	0.037  # Bond albedo
 	InfoURL	"https://en.wikipedia.org/wiki/28978_Ixion"
 }
 
+# Rommel et al. (2025), Planet. Sci. J. 6, 48
+# "Stellar Occultation Observations of (38628) Huya and Its Satellite:
+# A Detailed Look into the System"
+# https://ui.adsabs.harvard.edu/abs/2025PSJ.....6...48R/abstract
 ReferencePoint "Huya System" "Sol"
 {
+	# Mass<kg>	45.2e18
+	# Density	1073
 	OrbitFrame
 	{
 		EclipticJ2000	{ Center "SSB" }
@@ -295,9 +306,6 @@ ReferencePoint "Huya System" "Sol"
 	Clickable true
 }
 
-# Geometric albedo from Santos-Sanz et al. (2022), A&A 664, A130
-# "Physical properties of the trans-Neptunian object (38628) Huya from a multi-chord stellar occultation"
-# https://ui.adsabs.harvard.edu/abs/2022A%26A...664A.130S/abstract
 "38628 Huya:Huya:2000 EB173" "Sol"
 {
 	Class	"asteroid"
@@ -305,27 +313,34 @@ ReferencePoint "Huya System" "Sol"
 	Texture	"asteroid.*"
 	Color	[ 0.301 0.273 0.23 ]
 	BlendTexture	true
-	Radius	203
+	SemiAxes	[ 218.05 218.05 187.5 ]
 	OrbitFrame
 	{
 		EclipticJ2000	{ Center "Sol/Huya System" }
 	}
-	EllipticalOrbit
+	EllipticalOrbit  # best fit
 	{
-		Period	3.2
-		SemiMajorAxis	220
-		ArgOfPericenter	180
+		Epoch	2452400.0  # 2002 May 05 12:00 UT
+		Period	3.46293
+		SemiMajorAxis	226
+		Eccentricity	0.034
+		Inclination	65.8
+		ArgOfPericenter	280
+		AscendingNode	122.9
+		MeanAnomaly	147
 	}
-	UniformRotation
+	UniformRotation  # to match orbit plane
 	{
-		Period	5.28
+		Period	6.725
+		Inclination	65.8
+		AscendingNode	122.9
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.079
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya"
 }
 
-"S 2012 (38628) 1" "Sol/Huya"
+"S 2012 (38628) 1" "Sol/Huya"  # no provisional designation
 {
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
@@ -337,20 +352,34 @@ ReferencePoint "Huya System" "Sol"
 	{
 		EclipticJ2000	{ Center "Sol/Huya System" }
 	}
-	EllipticalOrbit  # estimated
+	EllipticalOrbit  # best fit
 	{
-		Period	3.2
-		SemiMajorAxis	1520  # minimum separation
+		Epoch	2452400.0  # 2002 May 05 12:00 UT
+		Period	3.46293
+		SemiMajorAxis	1669
+		Eccentricity	0.034
+		Inclination	65.8
+		ArgOfPericenter	100
+		AscendingNode	122.9
+		MeanAnomaly	147
+	}
+	BodyFrame	{ EclipticJ2000 {} }
+	UniformRotation  # assume synchronous rotation
+	{
+		Epoch	2452400.0  # 2002 May 05 12:00 UT
+		Inclination	65.8
+		AscendingNode	122.9
+		MeridianAngle	67
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.079  # assume same albedo as primary
-	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya#Satellite"
+	InfoURL	"https://en.wikipedia.org/wiki/Satellite_of_38628_Huya"
 }
 
-# System geometric albedo from Mommert et al. (2012), A&A 541, A93
-# "TNOs are cool: A survey of the trans-Neptunian region. V.
-# Physical characterization of 18 Plutinos using Herschel-PACS observations"
-# https://ui.adsabs.harvard.edu/abs/2012A%26A...541A..93M/abstract
+# Ragozzine et al. (2024), submitted to PSJ
+# "Beyond Point Masses. I.
+# New Non-Keplerian Modeling Tools Applied to Trans-Neptunian Triple (47171) Lempo"
+# https://ui.adsabs.harvard.edu/abs/2024arXiv240312785R/abstract
 ReferencePoint "Lempo System" "Sol"
 {
 	OrbitFrame
@@ -377,30 +406,24 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 {
 	OrbitFrame
 	{
-		EquatorJ2000	{ Center "Sol/Lempo System" }
+		EclipticJ2000	{ Center "Sol/Lempo System" }
 	}
-	EllipticalOrbit
+	EllipticalOrbit  # best fit
 	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Period	50.302
-		SemiMajorAxis	445.8
-		Eccentricity	0.2949
-		Inclination	79.3
-		MeanLongitude	101.1
-		AscendingNode	325.2
-		LongOfPericenter	112.1
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Period	50.49  # from SMA and masses
+		SemiMajorAxis	138  # mass ratio from median values
+		Eccentricity	0.2902
+		Inclination	59.524
+		ArgOfPericenter	178.53
+		AscendingNode	324.65
+		MeanAnomaly	190.43
 	}
 	# Make the orbit and label visible
 	Visible true
 	Clickable true
 }
 
-# Orbits of companions from Benecchi et al. (2010), Icarus 207 (2), p. 978-991
-# "(47171) 1999 TC 36, A transneptunian triple"
-# https://ui.adsabs.harvard.edu/abs/2010Icar..207..978B/abstract
-# Masses and radii from Correia (2018), Icarus 305, p. 250-261
-# "Chaotic dynamics in the (47171) Lempo triple system"
-# https://ui.adsabs.harvard.edu/abs/2018Icar..305..250C/abstract
 "47171 Lempo:Lempo:1999 TC36:1999 TC36 A1" "Sol"
 {
 	Class	"asteroid"
@@ -408,39 +431,38 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Texture	"asteroid.*"
 	Color	[ 0.508 0.462 0.391 ]  # assume equal albedo
 	BlendTexture	true
-	Radius	136.0
+	Radius	136
+	Mass<kg>	5.725e18
+	Density	542
 	OrbitFrame
 	{
-		EquatorJ2000	{ Center "Sol/Lempo-Hiisi" }
+		EclipticJ2000	{ Center "Sol/Lempo-Hiisi" }
 	}
-	EllipticalOrbit
+	EllipticalOrbit  # best fit
 	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Period	1.9068
-		SemiMajorAxis	381.5
-		Eccentricity	0.101
-		Inclination	88.9
-		MeanLongitude	4.4
-		AscendingNode	330.0
-		LongOfPericenter	227.7
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Period	1.894  # from SMA and masses
+		SemiMajorAxis	486  # mass ratio from median values
+		Eccentricity	0.1084
+		Inclination	68.229
+		ArgOfPericenter	266.0
+		AscendingNode	324.89
+		MeanAnomaly	165.7
 	}
-	BodyFrame
+	BodyFrame	{ EclipticJ2000 {} }
+	UniformRotation  # assume synchronous rotation
 	{
-		EquatorJ2000	{ Center "Sol/Lempo-Hiisi" }
-	}
-	UniformRotation
-	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Inclination	88.9
-		AscendingNode	330.0
-		MeridianAngle	214.4
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Inclination	68.229
+		AscendingNode	324.89
+		MeridianAngle	251.7
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.079  # assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo"
 }
 
-"Hiisi:47171 Lempo II:Lempo II:S 2007 (47171) 1:1999 TC36 A2" "Sol/Lempo"
+"Hiisi:47171 Lempo II:Lempo II:1999 TC36 A2" "Sol/Lempo"
 {
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
@@ -448,70 +470,67 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Color	[ 0.508 0.462 0.391 ]  # assume equal albedo
 	BlendTexture	true
 	Radius	125.5
+	Mass<kg>	7.657e18
+	Density	925
 	OrbitFrame
 	{
-		EquatorJ2000	{ Center "Sol/Lempo-Hiisi" }
+		EclipticJ2000	{ Center "Sol/Lempo-Hiisi" }
 	}
-	EllipticalOrbit
+	EllipticalOrbit  # best fit
 	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Period	1.9068
-		SemiMajorAxis	485.5
-		Eccentricity	0.101
-		Inclination	88.9
-		MeanLongitude	184.4
-		AscendingNode	330.0
-		LongOfPericenter	47.7
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Period	1.894  # from SMA and masses
+		SemiMajorAxis	364  # mass ratio from median values
+		Eccentricity	0.1084
+		Inclination	68.229
+		ArgOfPericenter	86.0
+		AscendingNode	324.89
+		MeanAnomaly	165.7
 	}
-	BodyFrame
+	BodyFrame	{ EclipticJ2000 {} }
+	UniformRotation  # assume synchronous rotation
 	{
-		EquatorJ2000	{ Center "Sol/Lempo-Hiisi" }
-	}
-	UniformRotation
-	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Inclination	88.9
-		AscendingNode	330.0
-		MeridianAngle	34.4
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Inclination	68.229
+		AscendingNode	324.89
+		MeridianAngle	71.7
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.079  # assume equal albedo
 	InfoURL	"https://en.wikipedia.org/wiki/47171_Lempo#Hiisi"
 }
 
-"Paha:47171 Lempo I:Lempo I:S 2001 (47171) 1:1999 TC36 B" "Sol/Lempo"
+"Paha:47171 Lempo I:Lempo I:1999 TC36 B" "Sol/Lempo"
 {
 	Class	"asteroid"
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.508 0.462 0.391 ]  # assume equal albedo
 	BlendTexture	true
-	Radius	66.0
+	Radius	66
+	Mass<kg>	0.248e18
+	Density	206
 	OrbitFrame
 	{
-		EquatorJ2000	{ Center "Sol/Lempo System" }
+		EclipticJ2000	{ Center "Sol/Lempo System" }
 	}
-	EllipticalOrbit
+	EllipticalOrbit  # best fit
 	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Period	50.302
-		SemiMajorAxis	6965.2
-		Eccentricity	0.2949
-		Inclination	79.3
-		MeanLongitude	281.1
-		AscendingNode	325.2
-		LongOfPericenter	292.1
+		Epoch	2453880.0  # 2006 May 24 12:00 UT
+		Period	50.49  # from SMA and masses
+		SemiMajorAxis	7461  # mass ratio from median values
+		Eccentricity	0.2902
+		Inclination	59.524
+		ArgOfPericenter	358.53
+		AscendingNode	324.65
+		MeanAnomaly	190.43
 	}
-	BodyFrame
+	BodyFrame	{ EclipticJ2000 {} }
+	UniformRotation  # to match orbit plane
 	{
-		EquatorJ2000	{ Center "Sol/Lempo System" }
-	}
-	UniformRotation
-	{
-		Epoch	2453880  # 2006 May 24 12:00 UT
-		Inclination	79.3
-		AscendingNode	325.2
-		MeridianAngle	135.9
+		Period	8  # assumed
+		Inclination	59.524
+		AscendingNode	324.65
 	}
 	LunarLambert	0.5
 	GeomAlbedo	0.079  # assume equal albedo
@@ -606,10 +625,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 	Color	[ 0.346 0.34 0.335 ]
 	BlendTexture	true
 	Radius	142
-	OrbitFrame
-	{
-		EquatorJ2000	{ Center "Sol/Salacia" }
-	}
+	OrbitFrame	{ EquatorJ2000 {} }
 	EllipticalOrbit
 	{
 		Epoch	2454300  # 2007 Jul 18 12:00 UT
@@ -687,10 +703,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 		AscendingNode	3
 		LongOfPericenter	140
 	}
-	BodyFrame
-	{
-		EquatorJ2000	{ Center "Sol/Varda-Ilmarë" }
-	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation
 	{
 		Period	5.91
@@ -702,7 +715,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/174567_Varda"
 }
 
-"Ilmarë:174567 Varda I:Varda I:S 2009 (174567) 1" "Sol/Varda"
+"Ilmarë:174567 Varda I:Varda I" "Sol/Varda"
 {
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
@@ -725,10 +738,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 		AscendingNode	3
 		LongOfPericenter	320
 	}
-	BodyFrame
-	{
-		EquatorJ2000	{ Center "Sol/Varda-Ilmarë" }
-	}
+	BodyFrame	{ EquatorJ2000 {} }
 	UniformRotation  # to match mutual orbit
 	{
 		Epoch	2455300.0  # 2010 Apr 13 12:00
@@ -741,19 +751,15 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/Ilmar%C3%AB_(moon)"
 }
 
-# Dimensions, orientation, albedo from Dias-Oliveira et al. (2017), AJ 154 (1), 22
+# Dias-Oliveira et al. (2017), AJ 154, 22
 # "Study of the Plutino Object (208996) 2003 AZ84 from Stellar
 # Occultations: Size, Shape, and Topographic Features"
 # https://ui.adsabs.harvard.edu/abs/2017AJ....154...22D/abstract
-# Rotation period from Santos-Sanz et al. (2017), A&A 604, A95
-# ""TNOs are Cool": A survey of the trans-Neptunian region. XII.
-# Thermal light curves of Haumea, 2003 VS2 and 2003 AZ84 with Herschel/PACS"
-# https://ui.adsabs.harvard.edu/abs/2017A&A...604A..95S
 "208996 Achlys:Achlys:2003 AZ84" "Sol"
 {
 	Class	"asteroid"
 	Texture	"asteroid.*"
-	Color	[ 0.522 0.516 0.493 ]
+	Color	[ 0.516 0.51 0.48 ]
 	BlendTexture	true
 	SemiAxes	[ 470 383 245 ]  # hydrostatic equilibrium assumed
 	Density	870  # 0.87 +/- 0.01 g cm-3
@@ -776,13 +782,13 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	UniformRotation
 	{
 		Epoch	2456977.24874  # 2014-11-15, 17:58:11 UT
-		Period	6.7874
+		Period	6.7874  # Santos-Sanz et al. (2017), 2017A&A...604A..95S
 		Inclination	91
 		AscendingNode	350
 		MeridianAngle	10
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.097
+	GeomAlbedo	0.094  # Ortiz et al. (2019), arXiv:1905.04335
 	InfoURL	"https://en.wikipedia.org/wiki/208996_Achlys"
 }
 
@@ -830,7 +836,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 # Orbit and radius ratio from Grundy et al. (2019), Icarus 334, p. 30-38
 # "The mutual orbit, mass, and density of transneptunian binary Gǃkúnǁ'hòmdímà (229762 2007 UK126)"
 # https://ui.adsabs.harvard.edu/abs/2019Icar..334...30G/abstract
-"G!o'e !Hu:229762 G!kun||'homdima I:G!kun||'homdima I:S 2008 (229762) 1" "Sol/G!kun||'homdima"
+"G!o'e !Hu:229762 G!kun||'homdima I:G!kun||'homdima I" "Sol/G!kun||'homdima"
 {
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
@@ -838,10 +844,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	Color	[ 1.0 0.87 0.747 ]
 	BlendTexture	true
 	Radius	72
-	OrbitFrame
-	{
-		EquatorJ2000	{ Center "Sol/G!kun||'homdima" }
-	}
+	OrbitFrame	{ EquatorJ2000 {} }
 	EllipticalOrbit
 	{
 		Epoch	2457000  # 2014 Dec 8 12:00 UT
@@ -906,7 +909,8 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 		AscendingNode	105.6
 	}
 	LunarLambert	0.5
-	GeomAlbedo	0.1
+	# GeomAlbedo	0.1
+	Reflectivity	0.04  # for phase integral = 0.40 ± 0.03
 	InfoURL	"https://en.wikipedia.org/wiki/307261_Máni"
 }
 
@@ -1009,7 +1013,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/(532037)_2013_FY27"
 }
 
-"S 2018 (532037) 1" "Sol/2013 FY27"
+"S 2018 (532037) 1" "Sol/2013 FY27"  # no provisional designation
 {
 	Class	"minormoon"
 	Mesh	"asteroid.cms"


### PR DESCRIPTION
Haumea (+Hi'iaka and Namaka), Quaoar (+Weywot), Ixion, Huya, Lempo-Hiisi-Paha and Achlys are updated with data from recent sources.

Spherical (Bond) albedos from [Verbiscer et al. (2022)](https://iopscience.iop.org/article/10.3847/PSJ/ac63a6) have been added to other objects, and the rotations of satellites have been set to either tidal lock or reasonable guesses for non-synchronous rotation. Provisional designations for satellites were removed if not assigned by the IAU, using [Johnston's Archive](https://www.johnstonsarchive.net/astro/binastnames.html) as a reference.

Rotational parameters of Haumea are taken from an add-on by n3.