### PR TITLE
IAU WGSN Star Name Update (2025-08-25)

### DIFF
--- a/data/starnames.dat
+++ b/data/starnames.dat
@@ -21,7 +21,7 @@
 262:TW And
 270:V397 Cep
 274:V639 Cas
-301:2 Cet
+301:Hydor:2 Cet
 302:V398 Cep
 316:NN Peg
 320:UU Cet
@@ -453,7 +453,7 @@
 5368:AL Cet
 5391:OX Cas
 5409:CS Psc
-5434:PHI And:42 And
+5434:Junnanmen:PHI And:42 And
 5438:AI Phe
 5447:Mirach:BET And:43 And
 5450:V361 And
@@ -679,7 +679,7 @@
 8035:CF Hyi
 8046:44 Cas
 8051:Gliese 70
-8068:PHI Per
+8068:Dajiangjunbei:PHI Per
 8070:Gliese 69
 8102:TAU Cet:52 Cet:Gliese 71
 8115:V773 Cas
@@ -875,7 +875,7 @@
 10248:CI Hyi
 10270:GZ And
 10279:Gliese 87
-10280:IOT Tri:6 Tri:TZ Tri
+10280:Triminus:IOT Tri:6 Tri:TZ Tri
 10303:66 Cet B
 10304:CV Phe
 10305:66 Cet A
@@ -10297,7 +10297,7 @@
 112935:SIG Peg:49 Peg
 112948:GAM PsA:22 PsA
 112960:V335 Peg
-112961:Hydor:LAM Aqr:73 Aqr
+112961:LAM Aqr:73 Aqr
 112969:MX Cep
 112972:V453 Cep
 112994:BH Peg


### PR DESCRIPTION
New names:
- Triminus (Iota Trianguli)
- Hydor (2 Ceti; formerly misapplied to a star in Aquarius)
- Dajiangjunbei (Phi Persei)
- Junnanmen (Phi Andromedae A)