### PR TITLE
starnames.dat Cleanup

### DIFF
--- a/data/starnames.dat
+++ b/data/starnames.dat
@@ -7714,7 +7714,7 @@
 85755:c Oph:51 Oph
 85760:NO Aps
 85790:78 Her
-85792:Tchou:Choo:ALF Ara
+85792:Choo:ALF Ara
 85805:f Dra:27 Dra
 85810:Gliese 679
 85812:V2373 Oph

--- a/data/starnames.dat
+++ b/data/starnames.dat
@@ -744,7 +744,7 @@
 8796:Mothallah:Elmuthalleth:Caput Trianguli:ALF Tri:2 Tri
 8814:55 And
 8821:V776 Cas
-8832:Mesarthim:Mesarthun:GAM1 Ari:GAM2 Ari:5 Ari
+8832:Mesarthim:GAM1 Ari:GAM2 Ari:5 Ari
 8833:XI Psc:111 Psc
 8837:PSI Phe
 8876:CN Ari
@@ -1242,7 +1242,7 @@
 14101:LTT 1445
 14109:49 Ari
 14131:TET Hyi
-14135:Menkar:Menkab:ALF Cet:92 Cet
+14135:Menkar:ALF Cet:92 Cet
 14143:93 Cet
 14146:TAU3 Eri:11 Eri:Gliese 121
 14150:51 Ari
@@ -4861,7 +4861,7 @@
 53195:45 LMi
 53213:AF Vel
 53227:AH Ant
-53229:Praecipua:Praecipula:46 LMi
+53229:Praecipua:46 LMi
 53244:Gliese 404
 53252:b3 Hya
 53253:u Car
@@ -6694,7 +6694,7 @@
 75035:KN Lup
 75049:OMI CrB:1 CrB
 75054:CY Cir
-75097:Pherkad:Pherkab:GAM UMi:13 UMi
+75097:Pherkad:GAM UMi:13 UMi
 75110:28 Lib
 75118:OMI Lib:29 Lib
 75119:6 Ser
@@ -7702,7 +7702,7 @@
 85676:V1017 Sco
 85680:V965 Sco
 85693:Maasym:LAM Her:76 Her
-85696:Lesath:Lesuth:UPS Sco:34 Sco
+85696:Lesath:UPS Sco:34 Sco
 85699:24 UMi
 85701:V482 Sco
 85703:50 Oph

--- a/data/starnames.dat
+++ b/data/starnames.dat
@@ -6563,7 +6563,7 @@
 73526:IV Lup
 73533:BE Cen
 73540:PI1 Oct
-73555:Nekkar:Nekbar:BET Boo:42 Boo
+73555:Nekkar:Nakkar:BET Boo:42 Boo
 73566:60 Hya
 73568:OME Boo:41 Boo
 73589:EV Boo


### PR DESCRIPTION
This PR checks if the proper names for the stars are reliable and worth keeping around (rather than being obscure/unsubstantiated/redundant that we can remove them).