### PR TITLE
Add stars-named.stc

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -36,6 +36,7 @@ set(DATA_SOURCES
   starnames.dat
   starnames.dat.license
   stars-charm2.stc
+  stars-named.stc
   stars-near.stc
   stars-revised.stc
   stars-spectbins.stc

--- a/data/stars-named.stc
+++ b/data/stars-named.stc
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2026 AstroChara
+# SPDX-FileCopyrightText: 2026 Pedro Garcia
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This file defines stars with proper names (whether IAU WGSN-approved or not)
+# not defined in either stars.dat or another .stc file.
+
+# Unless noted, distances are from:
+# Bailer-Jones et al. (2021), AJ 161 (3), id.147
+#   "Estimating Distances from Parallaxes. V. Geometric and Photogeometric Distances to 1.47 Billion Stars in Gaia Early Data Release 3"
+#   https://cdsarc.cds.unistra.fr/viz-bin/cat/I/352
+#   https://ui.adsabs.harvard.edu/abs/2021AJ....161..147B/abstract
+
+
+
+# IAU WGSN-APPROVED STAR NAMES
+
+# WGSN-id 10136 / Pistol Star / V4647 Sgr
+# Temperature, luminosity and assumed distance from Najarro et al. (2009), AJ 691 (2), pp. 1816-1827
+#   "Metallicity in the Galactic Center: The Quintuplet Cluster"
+#   https://iopscience.iop.org/article/10.1088/0004-637X/691/2/1816
+#   https://ui.adsabs.harvard.edu/abs/2009ApJ...691.1816N/abstract
+# A binary star system, according to https://scixplorer.org/abs/2012ASPC..464..293M/abstract
+"Pistol Star:V4647 Sgr:qF 134"
+{
+	RA 266.563500
+	Dec -28.834328
+	Distance<pc> 8000                   # assumed
+
+	SpectralType "B"                    # actually LBV, but putting that in makes the program thinks it should be "L"
+	AbsMag -10.14                       # luminosity = 1.6e6 lSun, Sun M_bol = 4.74
+	BoloCorrection -0.63                # linear extrapolation from BCv for B8V and B9V from https://www.pas.rochester.edu/~emamajek/EEM_dwarf_UBVIJHK_colors_Teff.txt
+	Extinction 25                       # Wikipedia on 2026-04-22 claims V mag is >28; I am unable to verify this claim. I am setting extinction to arbitrary value that makes AppMag go dimmer than that anyways.
+	Temperature 11800
+}
+
+# WGSN-id 10138 / Sapaki / WR 67-1
+# Zarricueta Plaza et al. (2023), A&A 675, id.A22
+#   "Sapaki: Galactic O3If* star possibly born in isolation"
+#   https://www.aanda.org/articles/aa/full_html/2023/07/aa45856-23/aa45856-23.html
+#   https://ui.adsabs.harvard.edu/abs/2023A%26A...675A..22Z/abstract
+# AppMag from Paegert et al. (2021)
+#   "TESS Input Catalog versions 8.1 and 8.2: Phantoms in the 8.0 Catalog and How to Handle Them"
+#   https://cdsarc.cds.unistra.fr/viz-bin/cat/IV/39
+#   https://arxiv.org/abs/2108.04778
+"Sapaki:WR 67-1:WR 67a"
+{
+	RA 229.1539619012933
+	Dec -58.1663452710208
+	Distance<pc> 3888.96533
+
+	SpectralType "O3If*"
+	AppMag 14.903                       # ± 0.046
+	Extinction 7.87                     # ± 0.75
+}
+
+# WGSN-id 10139 / Bajamar Star / 2MASS J20555125+4352246
+# TODO: Get proper V-band extinction value A_V.
+#       The current value is approximate, and is obtained by multiplying E(4405 − 5495) with R_5495.
+#       This is noted to be inappropriate in https://www.aanda.org/articles/aa/full_html/2018/05/aa32050-17/aa32050-17.html#app, Appendix C
+# Maíz Apellániz et al. (2016), ApJS 224 (1), article id. 4
+#   "The Galactic O-Star Spectroscopic Survey (GOSSS). III. 142 Additional O-type Systems."
+#   https://iopscience.iop.org/article/10.3847/0067-0049/224/1/4
+#   https://ui.adsabs.harvard.edu/abs/2016ApJS..224....4M/abstract
+# Maíz Apellániz et al. (2022), A&A 657, id.A72
+#   "Escape from the Bermuda cluster: Orphanization by multiple stellar ejections"
+#   https://www.aanda.org/articles/aa/full_html/2022/01/aa42366-21/aa42366-21.html
+#   https://ui.adsabs.harvard.edu/abs/2022A%26A...657A..72M/abstract
+# AppMag from Zacharias et al. (2013), AJ 145 (2), article id. 44
+#   "The Fourth US Naval Observatory CCD Astrograph Catalog (UCAC4)"
+#   https://ui.adsabs.harvard.edu/abs/2013AJ....145...44Z/abstract
+Barycenter "Bajamar Star:Bajamar:2MASS J20555125+4352246"
+{
+	RA 313.9635638398294
+	Dec 43.8734417437156
+	Distance<pc> 761.04895
+}
+
+"Bajamar Star A:Bajamar A:2MASS J20555125+4352246 A"
+{
+	SpectralType "O3.5III"              # M = 72.96 ± 0.54 MSol; Table A.2
+	AppMag 13.267                       # 13.087 ± 0.01; Maíz Apellániz et al. (2022) suggests magnitude difference of 0.18 to account for component B
+	Extinction 10.4
+	Temperature 42750                   # ± 190; Table A.2
+
+	OrbitBarycenter "2MASS J20555125+4352246"
+	EllipticalOrbit
+	{
+		Period<d>           13.38       # assuming variability in TESS data corresponds to orbital period
+		SemiMajorAxis        0.1631     # a = 0.5220 au (calculated, total system mass = 106.0 MSol); mass ratio = 2.2 ± 0.5
+		ArgOfPericenter    180
+	}
+}
+
+"Bajamar Star B:Bajamar B:2MASS J20555125+4352246 B"
+{
+	SpectralType "O8"                   # M = 33 ± 8 MSol
+	AppMag 15.02                        # derived from magnitude difference between total system magnitude and component A's magnitude
+	Extinction 10.4                     # should be the same as component A's
+
+	OrbitBarycenter "2MASS J20555125+4352246"
+	EllipticalOrbit
+	{
+		Period<d>           13.38       # assuming variability in TESS data corresponds to orbital period
+		SemiMajorAxis        0.3589     # a = 0.5220 au (calculated, total system mass = 106.0 MSol); mass ratio = 2.2 ± 0.5
+		ArgOfPericenter      0
+	}
+}
+
+# WGSN-id 10141 / Holoea / IRAS 05327+3404
+# Extinction from Magnier et al. (1999), A&A 346, p.441-452
+#   "The circumstellar environment of IRAS 05327+3404"
+#   https://ui.adsabs.harvard.edu/abs/1999A%26A...346..441M/abstract
+# May actually be a binary, according to Morata et al. (2013), AJ 146 (3), article id. 49
+"Holoea:IRAS 05327+3404"
+{
+	RA 84.0248748044887
+	Dec 34.1033056182318
+	Distance<pc> 767.804871
+
+	SpectralType "K2IIIe"
+	AppMag 18.62
+	Extinction 2.3
+}
+
+# WGSN-id 10142 / Paloma / 2MASS J05243042+4244506
+# Orbital and rotation period from Hernández-Díaz et al. (2025), A&A 703, id.A166
+#   "A systematic search for orbital periods of polars with TESS: Methods, detection limits, and results"
+#   https://www.aanda.org/articles/aa/full_html/2025/11/aa54948-25/aa54948-25.html
+#   https://ui.adsabs.harvard.edu/abs/2025A%26A...703A.166H/abstract
+# White dwarf mass and radius from Dutta and Rana (2022), AJ 940 (2), id.100
+#   "Study of Complex Absorption and Reflection in a Unique Intermediate Polar Paloma"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ac9587
+#   https://ui.adsabs.harvard.edu/abs/2022ApJ...940..100D/abstract
+Barycenter "Paloma:2MASS J05243042+4244506:1RXS J052430.2+424449:RX J0524+42:TIC 369210348"
+{
+	RA 81.1269638897459
+	Dec 42.7472866562741
+	Distance<pc> 588.02594
+}
+
+# Cataclysmic variables consist of an accretor primary and a donor secondary.
+"Paloma A:2MASS J05243042+4244506 A:1RXS J052430.2+424449 A:RX J0524+42 A:TIC 369210348 A"
+{
+	Radius<m> 7.4e6                     # R = (7.4 +0.4-0.3)e8 cm
+	SpectralType "D"                    # M = 0.74 +0.04-0.05 MSol
+	AppMag 17.163                       # actually total system V-band AppMag, converted from G-band
+
+	OrbitBarycenter "2MASS J05243042+4244506"
+	EllipticalOrbit
+	{
+		Epoch          2458836.9131
+		Period<min>        157.191      # ± 0.018; Table A.1
+		SemiMajorAxis        0.001638   # a = 0.004670 au, mass ratio = 0.74:0.4(assumed)
+		LongOfPericenter    81.126964
+	}
+	UniformRotation                     # assume alignment with orbital plane
+	{
+		Period<min>        136.235      # ± 0.025; Table B.4
+	}
+}
+
+# The donor, usually M-dwarf star, fills the Roche lobe.
+#   Source: https://iopscience.iop.org/article/10.3847/0004-637X/830/2/56
+# Donor's epoch of inferior conjunction from Littlefield et al. (2023), AJ 165 (2), id.43
+#   "Kepler K2 and TESS Observations of Two Magnetic Cataclysmic Variables: The New Asynchronous Polar SDSS J084617.11+245344.1 and Paloma"
+#   https://iopscience.iop.org/article/10.3847/1538-3881/aca1a5
+#   https://ui.adsabs.harvard.edu/abs/2023AJ....165...43L/abstract
+# The velocities of the inner and outer hemispheres are 220 km/s and 310 km/s, respectively.
+# Little is known about this star so this is mostly a placeholder.
+"Paloma B:2MASS J05243042+4244506 B:1RXS J052430.2+424449 B:RX J0524+42 B:TIC 369210348 B"
+{
+	Radius<rS> 0.4                      # placeholder
+	SpectralType "M"                    # assumed M = 0.4 MSol
+	AbsMag 10.61                        # placeholder
+	Temperature 3470                    # placeholder
+
+	OrbitBarycenter "2MASS J05243042+4244506"
+	EllipticalOrbit
+	{
+		Epoch          2458836.9131
+		Period<min>        157.191      # ± 0.018; Table A.1
+		SemiMajorAxis        0.003031   # a = 0.004670 au, mass ratio = 0.74:0.4(assumed)
+		LongOfPericenter   261.126964
+	}
+	UniformRotation                     # assume tidal locking
+	{
+		Period<min>        157.191
+	}
+}

--- a/data/stars-named.stc
+++ b/data/stars-named.stc
@@ -142,7 +142,7 @@ Barycenter "Paloma:2MASS J05243042+4244506:1RXS J052430.2+424449:RX J0524+42:TIC
 # Cataclysmic variables consist of an accretor primary and a donor secondary.
 "Paloma A:2MASS J05243042+4244506 A:1RXS J052430.2+424449 A:RX J0524+42 A:TIC 369210348 A"
 {
-	Radius<m> 7.4e6                     # R = (7.4 +0.4-0.3)e8 cm
+	Radius<cm> 7.4e8                    # R = (7.4 +0.4-0.3)e8 cm
 	SpectralType "D"                    # M = 0.74 +0.04-0.05 MSol
 	AppMag 17.163                       # actually total system V-band AppMag, converted from G-band
 


### PR DESCRIPTION
This file adds named stars (IAU or not) which are not covered by either stars.dat or another .stc file.

This version contains stars with IAU WGSN-approved name:
- Pistol Star = V4647 Sagittarii
- Sapaki = WR 67-1
- Bajamar Star = 2MASS J20555125+4352246
- Holoea = IRAS 05327+3404
- Paloma = 2MASS J05243042+4244506