### PR TITLE
Corrected the Sun's bolometric correction

### DIFF
--- a/data/stars-near.stc
+++ b/data/stars-near.stc
@@ -275,7 +275,7 @@ Barycenter "Solar System Barycenter:SSB"
 	Radius	696342
 	SpectralType	"G2V"
 	AbsMag	4.81
-	BoloCorrection	-0.08
+	BoloCorrection	-0.07
 	Temperature	5772
 
 	UniformRotation


### PR DESCRIPTION
Sun's bolometric absolute magnitude = 4.74
Sun's V-band absolute magnitude = 4.81

Therefore, the bolometric correction is 4.74 - 4.81 = -0.07.