### PR TITLE
CMS mesh updates

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -412,7 +412,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 "Vanth:Orcus I:90482 Orcus I" "Sol/Orcus"
 {
 	Class	"moon"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.554 0.524 0.508 ]
 	BlendTexture	true

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -336,7 +336,7 @@ ReferencePoint "Huya System" "Sol"
 "38628 Huya:Huya:2000 EB173" "Sol"
 {
 	Class	"asteroid"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.522 0.463 0.388 ]
 	BlendTexture	true
@@ -674,7 +674,7 @@ ReferencePoint "Lempo-Hiisi" "Sol"
 "78799 Xewioso:Xewioso:2002 XW93" "Sol"
 {
 	Class	"asteroid"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.323 0.323 0.323 ]  # no color data
 	BlendTexture	true
@@ -844,7 +844,7 @@ ReferencePoint "Salacia-Actaea" "Sol"
 "145451 Rumina:Rumina:2005 RM43" "Sol"
 {
 	Class	"asteroid"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.539 0.529 0.515 ]
 	BlendTexture	true
@@ -979,7 +979,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 "Ilmarë:174567 Varda I:Varda I" "Sol/Varda"
 {
 	Class	"asteroid"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.478 0.429 0.386 ]
 	BlendTexture	true
@@ -1177,7 +1177,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 "471143 Dziewanna:Dziewanna:2010 EK139" "Sol"
 {
 	Class	"asteroid"
-	Mesh	"roughsphere.cms"
+	Mesh	"sphere.cms"
 	Texture	"asteroid.*"
 	Color	[ 0.938 0.866 0.802 ]
 	BlendTexture	true

--- a/models/asteroid.cms
+++ b/models/asteroid.cms
@@ -1,15 +1,14 @@
 # asteroid.cms
 
 # Random chunk of rock used to represent various small moons and asteroids
-# suitable for objects below 150 km in size
+# suitable for objects below 200 km in size
 
 SphereDisplacementMesh
-
 {
-	Size		[ 1.0 0.6 0.75 ]
+	Size		[ 1.0 0.6 0.7 ]
 	NoiseOffset	[ 15 12 60 ]
 	FeatureHeight	0.3
-	Octaves		2
+	Octaves		1
 	Slices		100
 	Rings		50
 }

--- a/models/roughsphere.cms
+++ b/models/roughsphere.cms
@@ -1,7 +1,7 @@
 # roughsphere.cms
 
 # Approximately spherical chunk of rock 
-# suitable for representation of irregular objects modeled as triaxial ellipsoids as well as objects between 200 and 600 km in size
+# suitable for representation of irregular objects modeled as triaxial ellipsoids as well as objects between 200 and 400 km in size
 
 SphereDisplacementMesh
 {

--- a/models/sphere.cms
+++ b/models/sphere.cms
@@ -1,0 +1,13 @@
+# sphere.cms
+
+# spherical chunk of rock for objects below hydrostatic equilibrium
+
+SphereDisplacementMesh
+{
+	Size [ 1.0 1.0 1.0 ]
+	NoiseOffset [ 17 42 45 ]
+	FeatureHeight  0.1
+	Octaves 4
+	Slices		100
+	Rings		50
+}


### PR DESCRIPTION
- Add 'sphere' model from FarGetaNik's Project Echoes; here it is used for objects with radii 200-300 km
- asteroid.cms is modified slightly to give it a more natural shape, and axial ratios are based on mean values from Thomas et al. (1989) for a sample of small moons in the Solar System