### PR TITLE
Restore Earth's atmosphere to pre-1.7 data

### DIFF
--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -220,11 +220,10 @@
 	Atmosphere
 	{
 		Height	100
-		Mie	0.0002
-		MieAsymmetry	-0.7
+		Mie	0.001
+		MieAsymmetry	-0.25
+		Rayleigh	[ 0.001 0.0025 0.006 ]
 		MieScaleHeight	8.5  # Rayleigh scale height
-		Rayleigh	[ 0.0054 0.0081 0.0167 ]
-		Absorption	[ 0.0027 0.0017 0.0002 ]
 		CloudHeight	7
 		CloudMap	"earth-clouds.*"
 		CloudShadowDepth	1.0


### PR DESCRIPTION
Gives a more realistic appearance with sRGB rendering enabled, including from the ground. Scale height is kept at 8.5 km, as it is accurate (https://en.wikipedia.org/wiki/Scale_height#Planetary_examples).

<img width="600" alt="image" src="https://github.com/user-attachments/assets/e63f6f6b-6ccd-4c13-9935-4f44f290554c" />