### PR TITLE
Rotation Axes, Bond and Geometric Albedos for Periodic Comets

### DIFF
--- a/data/comets.ssc
+++ b/data/comets.ssc
@@ -39,8 +39,12 @@
 #  "Magnitude and size distribution of long-period comets in Earth-crossing or approaching orbits"
 #   https://doi.org/10.1111/j.1365-2966.2012.20989.x
 #
+# Bond and Geometric Albedos for 19P, 153P are from Rondon (2025), MNRAS 538, 2869-2904
+#  "Secular light curves of periodic comets observed by SWAN/SOHO"
+#   https://doi.org/10.1093/mnras/staf454
 #
-# Last update: 6 March 2026
+#
+# Last update: 9 July 2026
 
 
 # Periodic Comets
@@ -119,7 +123,8 @@
 	# https://doi.org/10.1016/j.icarus.2006.11.014
 
 	RotationPeriod	11.083
-	GeomAlbedo		 0.046
+	GeomAlbedo		 0.047
+    BondAlbedo       0.008
 	InfoURL	"https://en.wikipedia.org/wiki/Comet_Encke"
 }
 
@@ -182,7 +187,8 @@
 		Inclination    90 
 		AscendingNode 315 
 	}
-	GeomAlbedo	 0.03
+	GeomAlbedo	 0.072
+	BondAlbedo	 0.019
 	InfoURL	"https://en.wikipedia.org/wiki/19P/Borrelly"
 }
 
@@ -212,7 +218,8 @@
 	# https://arxiv.org/abs/2304.09309
 
 	RotationPeriod	 7.39
-	GeomAlbedo		 0.04
+	GeomAlbedo		 0.044
+	BondAlbedo		 0.012
 	InfoURL	"https://en.wikipedia.org/wiki/21P/Giacobini-Zinner"
 }
 
@@ -299,7 +306,8 @@
 	# https://ui.adsabs.harvard.edu/abs/1997A&A...326.1268M
 
 	RotationPeriod	 7.60
-	GeomAlbedo		 0.04
+	GeomAlbedo		 0.44
+	BondAlbedo		 0.4
 	InfoURL	"https://en.wikipedia.org/wiki/46P/Wirtanen"
 }
 
@@ -332,7 +340,8 @@
 	# http://www.cbat.eps.harvard.edu/iauc/06800/06816.html
 
 	RotationPeriod	 15.31
-	GeomAlbedo		  0.06
+	GeomAlbedo		  0.78
+	BondAlbedo		  0.7
 	InfoURL	"https://en.wikipedia.org/wiki/55P/Tempel-Tuttle"
 }
 
@@ -361,7 +370,8 @@
 	# https://arxiv.org/abs/1903.10500
 	
 	RotationPeriod	 4.096
-	GeomAlbedo		 0.040
+	GeomAlbedo		 0.044
+	BondAlbedo		 0.0112
 	InfoURL	"https://en.wikipedia.org/wiki/96P/Machholz"
 }
 
@@ -435,7 +445,7 @@
 	Texture	"asteroid.jpg"
 	Radius	 2.545				# D = 5.09 km
 
-	# Albedo and Radius from Rondon (2025)
+	# Radius from Rondon (2025)
 	# https://doi.org/10.1093/mnras/staf454
 
 	EllipticalOrbit

--- a/data/comets.ssc
+++ b/data/comets.ssc
@@ -39,7 +39,8 @@
 #  "Magnitude and size distribution of long-period comets in Earth-crossing or approaching orbits"
 #   https://doi.org/10.1111/j.1365-2966.2012.20989.x
 #
-# Bond and Geometric Albedos for 19P, 153P are from Rondon (2025), MNRAS 538, 2869-2904
+# Bond and Geometric Albedos for 2P, 19P, 21P, 46P, 55P, 96P, and 153P
+# are from Rondon (2025), MNRAS 538, 2869-2904
 #  "Secular light curves of periodic comets observed by SWAN/SOHO"
 #   https://doi.org/10.1093/mnras/staf454
 #
@@ -287,6 +288,7 @@
 	Mesh	"asteroid.cms"
 	Texture	"asteroid.jpg"
 	Radius	 0.6					# D = 1.2 km
+	TailColor	[ 0.30 1.0 0.65 ]
 	Mass<kg>	3.3e11
 	Density	 400
 
@@ -339,7 +341,13 @@
 	# Rotation period from IAU Circular No. 6816 (1998)
 	# http://www.cbat.eps.harvard.edu/iauc/06800/06816.html
 
-	RotationPeriod	 15.31
+	UniformRotation
+	{
+		Period			 15.31
+		Inclination		162
+		AscendingNode	235
+	}
+
 	GeomAlbedo		  0.78
 	BondAlbedo		  0.7
 	InfoURL	"https://en.wikipedia.org/wiki/55P/Tempel-Tuttle"
@@ -369,7 +377,13 @@
 	# Rotation period from Eisner (2019)
 	# https://arxiv.org/abs/1903.10500
 	
-	RotationPeriod	 4.096
+	UniformRotation
+	{
+		Period			  4.096
+		Inclination		 82
+		AscendingNode	189
+	}
+
 	GeomAlbedo		 0.044
 	BondAlbedo		 0.0112
 	InfoURL	"https://en.wikipedia.org/wiki/96P/Machholz"
@@ -463,7 +477,13 @@
 	# Rotation period from Manzini (2007)
 	# https://doi.org/10.1007/s11038-005-9062-6
 	
-	RotationPeriod	35.52				# P = 1.48 days
+	UniformRotation
+	{
+		Period			 35.52			# P = 1.48 days
+		Inclination		 70
+		AscendingNode	322
+	}
+
 	BondAlbedo		 0.12
 	GeomAlbedo		 0.3
 	InfoURL	"https://en.wikipedia.org/wiki/153P/Ikeya-Zhang"

--- a/data/comets.ssc
+++ b/data/comets.ssc
@@ -435,7 +435,7 @@
 	Texture	"asteroid.jpg"
 	Radius	 2.545				# D = 5.09 km
 
-	# BondAlbedo and Radius from Rondon (2025)
+	# Albedo and Radius from Rondon (2025)
 	# https://doi.org/10.1093/mnras/staf454
 
 	EllipticalOrbit
@@ -455,6 +455,7 @@
 	
 	RotationPeriod	35.52				# P = 1.48 days
 	BondAlbedo		 0.12
+	GeomAlbedo		 0.3
 	InfoURL	"https://en.wikipedia.org/wiki/153P/Ikeya-Zhang"
 }
 

--- a/data/comets.ssc
+++ b/data/comets.ssc
@@ -435,7 +435,7 @@
 	Texture	"asteroid.jpg"
 	Radius	 2.545				# D = 5.09 km
 
-	# Radius from Rondon (2025)
+	# BondAlbedo and Radius from Rondon (2025)
 	# https://doi.org/10.1093/mnras/staf454
 
 	EllipticalOrbit
@@ -454,7 +454,7 @@
 	# https://doi.org/10.1007/s11038-005-9062-6
 	
 	RotationPeriod	35.52				# P = 1.48 days
-	GeomAlbedo		 0.04
+	BondAlbedo		 0.12
 	InfoURL	"https://en.wikipedia.org/wiki/153P/Ikeya-Zhang"
 }
 


### PR DESCRIPTION
BondAlbedo and Geometric Albedos from [Rondon (2025)](https://academic.oup.com/mnras/article/538/4/2869/8092654) for the following comets:
- 2P/Encke
- 19P/Borrelly
- 21P/Giacobini–Zinner
- 46P/Wirtanen
- 55P/Tempel–Tuttle
- 96P/Machholz
- 153P/Ikeya–Zhang

Additionally, rotation axes were also applied to the following comets using the same paper above (thanks @pedro-fixingstuff)
- 55P/Tempel–Tuttle
- 96P/Machholz
- 153P/Ikeya–Zhang

A custom tail color is also implemented for 46P/Wirtanen as suggested by Issue [#216](https://github.com/CelestiaProject/Celestia/issues/216) (thanks @SevenSpheres)