### PR TITLE
Update names of minor-planet moons without designations

### DIFF
--- a/data/asteroids.ssc
+++ b/data/asteroids.ssc
@@ -589,7 +589,7 @@
 	InfoURL	"https://en.wikipedia.org/wiki/130_Elektra#S/2014_(130)_1"
 }
 
-"S 2014 (130) 2" "Sol/Elektra"  # no provisional designation
+"S 2014 (130) 2" "Sol/Elektra"  # unofficial provisional designation
 {
 	Class	"minormoon"
 	Mesh	"asteroid.cms"
@@ -1785,7 +1785,7 @@
 	InfoURL	"https://en.wikipedia.org/wiki/(153591)_2001_SN263"
 }
 
-"2001 SN263 Gamma" "Sol/2001 SN263"
+"2001 SN263 Gamma" "Sol/2001 SN263"  # no provisional designation
 {
 	Class	"minormoon"
 	Mesh	"153591gamma.cmod"
@@ -1822,7 +1822,7 @@
 	InfoURL	"https://en.wikipedia.org/wiki/(153591)_2001_SN263#Trinary_system"
 }
 
-"2001 SN263 Beta" "Sol/2001 SN263"
+"2001 SN263 Beta" "Sol/2001 SN263"  # no provisional designation
 {
 	Class	"minormoon"
 	Mesh	"153591beta.cmod"

--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2019, 2021 SevenSpheres
 # SPDX-FileCopyrightText: 2023 Andrew Tribick
 # SPDX-FileCopyrightText: 2023-2025 AstroChara
-# SPDX-FileCopyrightText: 2024-2025 Pedro J. Garcia
+# SPDX-FileCopyrightText: 2024-2026 Pedro J. Garcia
 # SPDX-FileCopyrightText: 2025-2026 LunaTheSilly
 # SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -650,7 +650,7 @@ ReferencePoint "Orcus-Vanth" "Sol"
 # Proudfoot et al. (2025), ApJL 993, L38
 #   "Orbital Characterization of a Newly Discovered Small Satellite around Quaoar"
 #   https://iopscience.iop.org/article/10.3847/2041-8213/ae1585
-"Quaoar's second moon" "Sol/Quaoar"  # no provisional designation
+"Quaoar Gamma" "Sol/Quaoar"  # no provisional designation
 {
 	Class	"moon"
 	Mesh	"asteroid.cms"

--- a/data/outersys.ssc
+++ b/data/outersys.ssc
@@ -5,7 +5,7 @@
 # SPDX-FileCopyrightText: 2021-2022 SevenSpheres
 # SPDX-FileCopyrightText: 2023-2025 AstroChara
 # SPDX-FileCopyrightText: 2025 DaveBowman2001
-# SPDX-FileCopyrightText: 2025 Pedro J. Garcia
+# SPDX-FileCopyrightText: 2025-2026 Pedro J. Garcia
 # SPDX-FileCopyrightText: 2026 LunaTheSilly
 # SPDX-License-Identifier: CC-BY-4.0
 
@@ -367,7 +367,7 @@ ReferencePoint "Huya System" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/38628_Huya"
 }
 
-"Huya moon" "Sol/Huya"  # no provisional designation
+"Huya B" "Sol/Huya"  # no provisional designation
 {
 	Class	"asteroid"
 	Mesh	"roughsphere.cms"
@@ -1282,7 +1282,7 @@ ReferencePoint "Varda-Ilmarë" "Sol"
 	InfoURL	"https://en.wikipedia.org/wiki/532037_Chiminigagua"
 }
 
-"Chiminigagua moon" "Sol/Chiminigagua"  # no provisional designation
+"Chiminigagua Beta" "Sol/Chiminigagua"  # no provisional designation
 {
 	Class	"minormoon"
 	Mesh	"asteroid.cms"


### PR DESCRIPTION
For satellites without provisional desginations assigned by the CBAT/MPC (the two authoritative sources for those) or found in papers authored by the discoverers, two schemes are used here:
- Small moonlets use Greek letters ("Beta"/"Gamma"/"Delta"), following usage for satellites discovered by radar, as well as some orbital dynamics papers (examples: [2001 SN263, 1994 CC](https://iopscience.iop.org/article/10.1088/0004-6256/141/5/154), [Elektra](https://academic.oup.com/mnras/article/522/4/6196/7150715)).
- Larger satellites (above the 1:25 mass ratio used to separate the "moon"/"minormoon" classes, as defined in #129) use Latin letters (examples: [Antiope](https://web.archive.org/web/20080828002632/http://astro.berkeley.edu/~fmarchis/Science/Asteroids/Antiope.html), [Lempo](https://arxiv.org/abs/0912.2074)).