### PR TITLE
Updates the Sun and GJ 3991

### DIFF
--- a/data/stars-near.stc
+++ b/data/stars-near.stc
@@ -4150,6 +4150,9 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 #   "A Global View of Post-interaction White Dwarf-main Sequence Binaries"
 #   https://iopscience.iop.org/article/10.1088/1538-3873/ae453b
 #   https://ui.adsabs.harvard.edu/abs/2026PASP..138c4202S/abstract
+# B's Temperature and A's rotation period from O’Brien et al. (2026), MNRAS 550 (2), stag1195
+#   "Direct detections of white dwarfs in four WD+dM post-common envelope binaries within 20 pc"
+#   https://academic.oup.com/mnras/article/550/2/stag1195/8733147
 Barycenter 83945 "GJ 3991:Giclas 203-47"
 {
 	RA 257.38347212
@@ -4174,12 +4177,13 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 		ArgOfPericenter    332.0
 		MeanAnomaly        348.6
 	}
+	UniformRotation
+	{
+	    Period<d>          126.3        # tentative
+	}
 }
 
 # Mass is assumed to be 0.5 solar masses (minimum mass).
-# Temperature and rotation period from O’Brien et al. (2026), MNRAS 550 (2), stag1195
-#   "Direct detections of white dwarfs in four WD+dM post-common envelope binaries within 20 pc"
-#   https://academic.oup.com/mnras/article/550/2/stag1195/8733147
 "GJ 3991 B:Giclas 203-47 B"
 {
 	SpectralType "D"
@@ -4194,10 +4198,6 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 		Eccentricity         0.068
 		ArgOfPericenter    152.0
 		MeanAnomaly        348.6
-	}
-	UniformRotation
-	{
-	    Period<d>          100          # approximate
 	}
 }
 

--- a/data/stars-near.stc
+++ b/data/stars-near.stc
@@ -4172,7 +4172,7 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 	EllipticalOrbit                     # radial velocity-only orbit
 	{
 		Period<d>           14.909777   # ± 0.00001
-		SemiMajorAxis        0.070	    # estimated from mass ratio 0.35:0.5
+		SemiMajorAxis        0.078      # estimated from mass ratio = (0.2714 +0.0066 –0.0065):0.6
 		Eccentricity         0.068
 		ArgOfPericenter    332.0
 		MeanAnomaly        348.6
@@ -4183,18 +4183,18 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 	}
 }
 
-# Mass is assumed to be 0.5 solar masses (minimum mass).
+# Mass is assumed to be 0.6 solar masses, based on logg and white dwarf mass-radius relations.
 "GJ 3991 B:Giclas 203-47 B"
 {
 	SpectralType "D"
-	AbsMag 13.7                         # for a 0.5-solar-mass white dwarf
+	AbsMag 14.9
 	Temperature 5286
 
 	OrbitBarycenter "Giclas 203-47"
 	EllipticalOrbit                     # radial velocity-only orbit
 	{
 		Period<d>           14.909777   # ± 0.00001
-		SemiMajorAxis        0.038      # estimated from mass ratio = (0.2714 +0.0066 –0.0065):0.5
+		SemiMajorAxis        0.035      # estimated from mass ratio = (0.2714 +0.0066 –0.0065):0.6
 		Eccentricity         0.068
 		ArgOfPericenter    152.0
 		MeanAnomaly        348.6

--- a/data/stars-near.stc
+++ b/data/stars-near.stc
@@ -186,6 +186,11 @@
 #   https://iopscience.iop.org/article/10.3847/1538-3881/acd6a2
 #   https://ui.adsabs.harvard.edu/abs/2023AJ....166...16P/abstract
 
+# Pineda et al. (2021), ApJ 918 (1), id.40
+#   "The M-dwarf Ultraviolet Spectroscopic Sample. I. Determining Stellar Parameters for Field Stars"
+#   https://iopscience.iop.org/article/10.3847/1538-4357/ac0aea
+#   https://ui.adsabs.harvard.edu/abs/2021ApJ...918...40P/abstract
+
 # Pizzolato et al. (2003), A&A 397, p.147-157
 #   "The stellar activity-rotation relationship revisited: Dependence of saturated and non-saturated X-ray emission regimes on stellar mass for late-type dwarfs"
 #   https://www.aanda.org/articles/aa/abs/2003/01/aa2680/aa2680.html
@@ -259,10 +264,10 @@ Barycenter "Solar System Barycenter:SSB"
 	Distance	0
 }
 
-# Radius from Emilio et al. (2012), AJ 750 (2), id. 135
-#   "Measuring the Solar Radius from Space during the 2003 and 2006 Mercury Transits"
-#   https://iopscience.iop.org/article/10.1088/0004-637X/750/2/135
-#   https://ui.adsabs.harvard.edu/abs/2012ApJ...750..135E/abstract
+# Radius from Haberreiter et al. (2008), ApJ Letters 675 (1), L53
+#   "Solving the Discrepancy between the Seismic and Photospheric Solar Radius"
+#   https://iopscience.iop.org/article/10.1086/529492
+#   https://ui.adsabs.harvard.edu/abs/2008ApJ...675L..53H/abstract
 # AbsMag (V-band) from Willmer (2018), AJ 236 (2), id. 47
 #   "The Absolute Magnitude of the Sun in Several Filters"
 #   https://iopscience.iop.org/article/10.3847/1538-4365/aabfdf
@@ -272,7 +277,7 @@ Barycenter "Solar System Barycenter:SSB"
 	OrbitBarycenter	"Solar System Barycenter"
 	CustomOrbit	"vsop87-sun"
 
-	Radius	696342
+	Radius	695901
 	SpectralType	"G2V"
 	AbsMag	4.81
 	BoloCorrection	-0.07
@@ -4141,41 +4146,58 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 }
 
 # Delfosse et al. (1999), A&A 344, 897
+# Orbital period from Shariat & El-Badry (2026), PASP 138 (3), id.034202
+#   "A Global View of Post-interaction White Dwarf-main Sequence Binaries"
+#   https://iopscience.iop.org/article/10.1088/1538-3873/ae453b
+#   https://ui.adsabs.harvard.edu/abs/2026PASP..138c4202S/abstract
 Barycenter 83945 "GJ 3991:Giclas 203-47"
 {
-	RA	257.38347212
-	Dec	43.68010581
-	Distance	24.7840 # 131.5996 +/- 0.4285 mas
+	RA 257.38347212
+	Dec 43.68010581
+	Distance 24.7840                    # 131.5996 +/- 0.4285 mas
 }
 
+# Pineda et al. (2021), ApJ 918 (1), id.40
 "GJ 3991 A:Giclas 203-47 A"
 {
-	OrbitBarycenter "Giclas 203-47"
+	Radius<rS> 0.286
 	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.80
+	AppMag 12.41                        # total system V-band AppMag
+	Temperature 3279
 
-	EllipticalOrbit {
-		Period          0.0402836	# 14.7136 d
-		SemiMajorAxis   0.065	# estimated from mass ratio 0.35:0.5
-		Eccentricity    0.068
-		ArgOfPericenter 332.0
-		MeanAnomaly     348.6
+	OrbitBarycenter "Giclas 203-47"
+	EllipticalOrbit                     # radial velocity-only orbit
+	{
+		Period<d>           14.909777   # ± 0.00001
+		SemiMajorAxis        0.070	    # estimated from mass ratio 0.35:0.5
+		Eccentricity         0.068
+		ArgOfPericenter    332.0
+		MeanAnomaly        348.6
 	}
 }
 
+# Mass is assumed to be 0.5 solar masses (minimum mass).
+# Temperature and rotation period from O’Brien et al. (2026), MNRAS 550 (2), stag1195
+#   "Direct detections of white dwarfs in four WD+dM post-common envelope binaries within 20 pc"
+#   https://academic.oup.com/mnras/article/550/2/stag1195/8733147
 "GJ 3991 B:Giclas 203-47 B"
 {
-	OrbitBarycenter "Giclas 203-47"
 	SpectralType "D"
-	AbsMag 13.7 # for a 0.5-solar-mass white dwarf
+	AbsMag 13.7                         # for a 0.5-solar-mass white dwarf
+	Temperature 5286
 
-	EllipticalOrbit {
-		Period          0.0402836	# 14.7136 d
-		SemiMajorAxis   0.046	# estimated from mass ratio 0.35:0.5
-		Eccentricity    0.068
-		ArgOfPericenter 152.0
-		MeanAnomaly     348.6
+	OrbitBarycenter "Giclas 203-47"
+	EllipticalOrbit                     # radial velocity-only orbit
+	{
+		Period<d>           14.909777   # ± 0.00001
+		SemiMajorAxis        0.038      # estimated from mass ratio = (0.2714 +0.0066 –0.0065):0.5
+		Eccentricity         0.068
+		ArgOfPericenter    152.0
+		MeanAnomaly        348.6
+	}
+	UniformRotation
+	{
+	    Period<d>          100          # approximate
 	}
 }
 


### PR DESCRIPTION
The Sun's radius is now updated to reflect the value cited by IAU for their standard "solar unit".

GJ 3991 / G 203-47 is updated based on https://arxiv.org/abs/2607.11320. The white dwarf's true mass is not known, but here it is assumed to be 0.6 solar masses.