### PR TITLE
Titan "cloud" altitude and Mars atmo def

### DIFF
--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -1122,10 +1122,11 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 		#   CH4: 0.014
 		Absorption	[ 0.00751 0.00087 0.00001 ]
 
-		# CloudHeight uses optical limb altitude from Karkoschka & Lorenz (1997), Icarus 125 (2), pp. 369-379
+		# CloudHeight from Karkoschka & Lorenz (1997), Icarus 125 (2), pp. 369-379
 		#   "Latitudinal Variation of Aerosol Sizes Inferred from Titan's Shadow"
 		#   https://www.sciencedirect.com/science/article/abs/pii/S0019103596956213
 		#   https://ui.adsabs.harvard.edu/abs/1997Icar..125..369K/abstract
+		#   Uses optical limb altitude at southern region at 600-650 nm (~haze color).
 		# CloudSpeed derived from Read & Lebonnois (2018), AREPS 46, 175
 		#   "Superrotation on Venus, on Titan, and Elsewhere"
 		#   https://ui.adsabs.harvard.edu/abs/2018AREPS..46..175R/abstract

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -390,7 +390,7 @@
 		Height	80
 
 		# Rayleigh coefficients are hand-picked to emulate Martian daytime sky.
-		Rayleigh	[ 0.003 0.0022 0.0015 ]
+		Rayleigh	[ 0.005 0.0038 0.0025 ]
 
 		# Schneegans et al. (2024), COMPUTER GRAPHICS forum 43 (2)
 		#   "Physically Based Real-Time Rendering of Atmospheres using Mie Theory"
@@ -399,9 +399,9 @@
 		# MieHGAnisotropy from Chen-Chen et al. (2019), Icarus 330, p. 16-29
 		#   "Characterisation of Martian dust aerosol phase function from sky radiance measurements by MSL engineering cameras"
 		#   https://ui.adsabs.harvard.edu/abs/2019Icar..330...16C/abstract
-		MieScaleHeight	8  # Rayleigh scale height
+		MieScaleHeight	8  # "Rayleigh" scale height
 
-		Mie	0.00028
+		Mie	0.0012
 		MieHGAnisotropy	0.673
 
 		# Cloud height based from Määttänen & Montmessin (2021)
@@ -1114,18 +1114,22 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	{
 		Height	1000
 
-		# Scale height set so gas number density is accurate at surface and at 400 km (top of main haze)
+		# Scale height set so gas number density is accurate at surface and at 250 km (optical limb altitude)
 		Rayleigh	[ 0.02180 0.05159 0.12872 ]
-		MieScaleHeight	32
+		MieScaleHeight	36
 
 		# Approximating absorption due to gases in the atmosphere.
 		#   CH4: 0.014
 		Absorption	[ 0.00751 0.00087 0.00001 ]
 
+		# CloudHeight uses optical limb altitude from Karkoschka & Lorenz (1997), Icarus 125 (2), pp. 369-379
+		#   "Latitudinal Variation of Aerosol Sizes Inferred from Titan's Shadow"
+		#   https://www.sciencedirect.com/science/article/abs/pii/S0019103596956213
+		#   https://ui.adsabs.harvard.edu/abs/1997Icar..125..369K/abstract
 		# CloudSpeed derived from Read & Lebonnois (2018), AREPS 46, 175
 		#   "Superrotation on Venus, on Titan, and Elsewhere"
 		#   https://ui.adsabs.harvard.edu/abs/2018AREPS..46..175R/abstract
-		CloudHeight	200
+		CloudHeight	250
 		CloudSpeed	180  # degrees/day, 100 m/s wind speed
 		CloudMap	"titan-clouds.*"
 	}


### PR DESCRIPTION
Titan's clouds now use optical limb altitude, moving it up to 250 km. Atmospheric scale height now also uses 250 km for calibration, producing slightly higher scale height value of 36 km.

Mars's atmosphere is adjusted slightly in response to new atmosphere rendering.