### PR TITLE
Update Triton's and Pluto's atmospheres

### DIFF
--- a/data/dwarfplanets.ssc
+++ b/data/dwarfplanets.ssc
@@ -81,9 +81,10 @@ ReferencePoint "Pluto-Charon" "Sol"
 	{
 		Height	200
 
-		# Rayleigh coefficient multiplied by fudge factor to correct appearance.
-		#   Fudge factor: 3
-		Rayleigh	[ 0.0000009 0.0000022 0.0000055 ]
+		# Rayleigh coefficient multiplied by fudge factor to emulate
+		# contribution from small haze particles.
+		#   Fudge factor: 2
+		Rayleigh	[ 0.0000006 0.0000015 0.0000037 ]
 		
 		# Mie coefficient hand-picked to fit Pluto images from New Horizons.
 		# Mie anisotropy from Hillier et al. (2021), PSJ 2 (1), id.11
@@ -93,9 +94,9 @@ ReferencePoint "Pluto-Charon" "Sol"
 		# Haze scale height from Gladstone et al. (2016), Science 351 (6279), id.aad8866
 		#   "The atmosphere of Pluto as observed by New Horizons"
 		#   https://ui.adsabs.harvard.edu/abs/2016Sci...351.8866G/abstract
-		Mie	0.0000001
+		Mie	0.00000016
 		MieHGAnisotropy	0.83
-		MieScaleHeight	50
+		MieScaleHeight	50  # roughly the same as gas scale height
 	}
 	OrbitFrame
 	{

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -1724,17 +1724,15 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	{
 		Height	100
 
-		# Rayleigh coefficient multiplied by fudge factor to correct appearance.
-		#   Fudge factor: 3
 		# Rayleigh scale height and Mie anisotropy from Gao & Ohno (2024)
 		#   "Clouds and Hazes in the Atmospheres of Triton and Pluto"
 		#   https://arxiv.org/abs/2411.12031
 		#   Mie anisotropy assumed to be the same as discrete component's.
-		Rayleigh	[ 0.0000016 0.0000037 0.0000093 ]
+		Rayleigh	[ 0.0000005 0.0000012 0.0000031 ]
 		MieScaleHeight	16  # Rayleigh scale height
 		
 		# Mie coefficient scaled from Pluto's, using optical depth from Gao & Ohno (2024).
-		Mie	0.00000007
+		Mie	0.00000038
 		MieHGAnisotropy	0.6
 	}
 	CustomOrbit	"triton"


### PR DESCRIPTION
The Rayleigh coefficient fudge factor has been removed from Triton's atmosphere. On Pluto, a fudge factor of 2 is retained to simulate contributions from small haze particles. The strengths of Mie scattering on the two planets have also been modified.