### PR TITLE
Giant Planet atmospheres

### DIFF
--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -549,15 +549,22 @@
 	Color	[ 1.0 0.98663 0.91433 ]
 	SemiAxes	[ 71488 71488 66842 ]
 	Mass<kg>	1.898125e27
-	Atmosphere  # upper clouds at 0.6 bar
+
+	Atmosphere
 	{
-		Height	1000
-		Mie	0.0001
-		MieScaleHeight	28
-		MieHGAnisotropy	0.15
-		Rayleigh	[ 0.00095 0.00145 0.00298 ]  # from optical thickness 0.17 at 500 nm
-		Absorption	[ 0.00033 0.00010 0.00001 ]  # total absorption 0.0301 0.0094 0.00002
-	}  # assuming 2 atmospheres of light travel
+		Height	180
+
+		# Cloud-2 at 0.55 bar
+		# Irwin et al. (2026) preprint
+		#   "Cloud and ammonia vertical profiles in the equatorial atmosphere of Jupiter determined from visible to near-IR observations made by VLT/MUSE, Cassini/VIMS, IRTF/SpeX and Juno/JIRAM"
+		#   https://arxiv.org/abs/2607.25542
+		Rayleigh	[ 0.00111 0.00265 0.00665 ]
+		MieScaleHeight	18
+
+		# Approximating absorption due to gases in the atmosphere.
+		#   CH4: 0.0018
+		Absorption	[ 0.00024 0.00003 0.00000 ]
+	}
 	CustomOrbit	"vsop87-jupiter"
 
 	# Overridden by CustomOrbit
@@ -821,13 +828,18 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Color	[ 1.0 0.9476 0.81514 ]
 	SemiAxes	[ 60268 60268 54364 ]
 	Mass<kg>	5.68317e26  # GM = (37931206.234 ± 0.726) km^3/s^2
-	Atmosphere  # upper clouds at 0.4 bar
+	Atmosphere
 	{
-		Height	1000
-		Mie	0.0001
-		MieScaleHeight	59.5
-		Rayleigh	[ 0.00068 0.00103 0.00213 ]
-		Absorption	[ 0.00016 0.00005 0.00001 ]  # total absorption: 0.0306 0.0102 0.0015
+		Height	330
+
+		# Tropopause at 0.15 bar
+		#   https://scixplorer.org/abs/2013Icar..225...93R/abstract
+		Rayleigh	[ 0.00052 0.00123 0.00309 ]
+		MieScaleHeight	33
+
+		# Approximating absorption due to gases in the atmosphere.
+		#   CH4: 0.0045
+		Absorption	[ 0.00027 0.00003 0.00000 ]
 	}
 	CustomOrbit	"vsop87-saturn"
 
@@ -1342,11 +1354,21 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Mass<kg>	8.68099e25  # GM = (5793950.61 ± 2.16) km^3/s^2
 	Atmosphere
 	{
-		Height	500
-		Mie	0.0014
-		MieScaleHeight	27.7
-		MieHGAnisotropy	0.1
-		Rayleigh	[ 0.00026 0.00048 0.00100 ]
+		Height	240
+
+		# Aerosol-2 at 1 bar
+		Rayleigh	[ 0.00346 0.00822 0.02067 ]
+		MieScaleHeight	24
+
+		# Mie coefficient from Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
+		#   "Hazy Blue Worlds: A Holistic Aerosol Model for Uranus and Neptune, Including Dark Spots"
+		#   https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022JE007189
+		#   https://ui.adsabs.harvard.edu/abs/2022JGRE..12707189I/abstract
+		# Aerosol-3 opacity (τ_3) at 0.8 μm = 0.03
+		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 24 km
+		Mie	0.0025
+
+		Absorption	[ 0.002 0.002 0.003 ]
 	}
 	CustomOrbit	"vsop87-uranus"
 
@@ -1636,12 +1658,22 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Mass<kg>	1.024092e26
 	Atmosphere
 	{
-		Height	500
-		Mie	0.002
-		MieScaleHeight	20.3
-		MieHGAnisotropy	0.1
-		Rayleigh	[ 0.00104 0.00193 0.00400 ]
-		Absorption	[ 0.00000 0.00050 0.00100 ]
+		Height	180
+
+		# Aerosol-2 at 1 bar
+		Rayleigh	[ 0.00349 0.00830 0.02086 ]
+		MieScaleHeight	18
+
+		# Mie coefficient from Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
+		#   "Hazy Blue Worlds: A Holistic Aerosol Model for Uranus and Neptune, Including Dark Spots"
+		#   https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022JE007189
+		#   https://ui.adsabs.harvard.edu/abs/2022JGRE..12707189I/abstract
+		# Aerosol-3 opacity (τ_3) at 0.8 μm = 0.04
+		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 18 km
+		Mie	0.0044
+		MieHGAnisotropy	0
+
+		Absorption	[ 0.003 0.003 0.004 ]
 	}
 	CustomOrbit	"vsop87-neptune"
 

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -552,14 +552,14 @@
 
 	Atmosphere
 	{
-		Height	180
+		Height	170
 
 		# Cloud-2 at 0.55 bar
 		# Irwin et al. (2026) preprint
 		#   "Cloud and ammonia vertical profiles in the equatorial atmosphere of Jupiter determined from visible to near-IR observations made by VLT/MUSE, Cassini/VIMS, IRTF/SpeX and Juno/JIRAM"
 		#   https://arxiv.org/abs/2607.25542
-		Rayleigh	[ 0.00111 0.00265 0.00665 ]
-		MieScaleHeight	18
+		Rayleigh	[ 0.00107 0.00254 0.00639 ]
+		MieScaleHeight	17.5
 
 		# Approximating absorption due to gases in the atmosphere.
 		#   CH4: 0.0018
@@ -830,15 +830,15 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Mass<kg>	5.68317e26  # GM = (37931206.234 ± 0.726) km^3/s^2
 	Atmosphere
 	{
-		Height	330
+		Height	340
 
 		# Tropopause at 0.15 bar
 		#   https://scixplorer.org/abs/2013Icar..225...93R/abstract
-		Rayleigh	[ 0.00052 0.00123 0.00309 ]
-		MieScaleHeight	33
+		Rayleigh	[ 0.00053 0.00126 0.00318 ]
+		MieScaleHeight	34
 
 		# Approximating absorption due to gases in the atmosphere.
-		#   CH4: 0.0045
+		#   CH4: 0.0044
 		Absorption	[ 0.00027 0.00003 0.00000 ]
 	}
 	CustomOrbit	"vsop87-saturn"

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -832,6 +832,9 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 		Height	340
 
 		# Tropopause at 0.15 bar
+		# Roman et al. (2013), Icarus 225 (1), p. 93-110
+		#   "Saturn's cloud structure inferred from Cassini ISS"
+		#   https://www.sciencedirect.com/science/article/abs/pii/S0019103513001255
 		#   https://scixplorer.org/abs/2013Icar..225...93R/abstract
 		Rayleigh	[ 0.00053 0.00126 0.00318 ]
 		MieScaleHeight	34
@@ -1367,7 +1370,8 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 24 km
 		Mie	0.0025
 
-		Absorption	[ 0.002 0.002 0.003 ]
+		# Absorption from haze, assuming Titan haze absorption.
+		Absorption	[ 0.0017 0.0019 0.0025 ]
 	}
 	CustomOrbit	"vsop87-uranus"
 
@@ -1671,7 +1675,8 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 18 km
 		Mie	0.0044
 
-		Absorption	[ 0.003 0.003 0.004 ]
+		# Absorption from haze, assuming Titan haze absorption.
+		Absorption	[ 0.0029 0.0033 0.0044 ]
 	}
 	CustomOrbit	"vsop87-neptune"
 

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -549,14 +549,15 @@
 	Color	[ 1.0 0.98663 0.91433 ]
 	SemiAxes	[ 71488 71488 66842 ]
 	Mass<kg>	1.898125e27
+
+	# Atmosphere base: 0.55 bar (Cloud-2)
+	# Irwin et al. (2026) preprint
+	#   "Cloud and ammonia vertical profiles in the equatorial atmosphere of Jupiter determined from visible to near-IR observations made by VLT/MUSE, Cassini/VIMS, IRTF/SpeX and Juno/JIRAM"
+	#   https://arxiv.org/abs/2607.25542
 	Atmosphere
 	{
 		Height	170
 
-		# Cloud-2 at 0.55 bar
-		# Irwin et al. (2026) preprint
-		#   "Cloud and ammonia vertical profiles in the equatorial atmosphere of Jupiter determined from visible to near-IR observations made by VLT/MUSE, Cassini/VIMS, IRTF/SpeX and Juno/JIRAM"
-		#   https://arxiv.org/abs/2607.25542
 		Rayleigh	[ 0.00107 0.00254 0.00639 ]
 		MieScaleHeight	17.5
 
@@ -827,15 +828,16 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Color	[ 1.0 0.9476 0.81514 ]
 	SemiAxes	[ 60268 60268 54364 ]
 	Mass<kg>	5.68317e26  # GM = (37931206.234 ± 0.726) km^3/s^2
+
+	# Atmosphere base: 0.15 bar (tropopause / top of tropospheric haze)
+	# Roman et al. (2013), Icarus 225 (1), p. 93-110
+	#   "Saturn's cloud structure inferred from Cassini ISS"
+	#   https://www.sciencedirect.com/science/article/abs/pii/S0019103513001255
+	#   https://scixplorer.org/abs/2013Icar..225...93R/abstract
 	Atmosphere
 	{
 		Height	340
 
-		# Tropopause at 0.15 bar
-		# Roman et al. (2013), Icarus 225 (1), p. 93-110
-		#   "Saturn's cloud structure inferred from Cassini ISS"
-		#   https://www.sciencedirect.com/science/article/abs/pii/S0019103513001255
-		#   https://scixplorer.org/abs/2013Icar..225...93R/abstract
 		Rayleigh	[ 0.00053 0.00126 0.00318 ]
 		MieScaleHeight	34
 
@@ -1354,18 +1356,20 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Color	[ 0.86828 0.97 1.0 ]
 	SemiAxes	[ 25556.6 25556.6 24968.7 ]
 	Mass<kg>	8.68099e25  # GM = (5793950.61 ± 2.16) km^3/s^2
+
+	# Atmosphere base: 1 bar (Aerosol-2)
+	# Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
+	#   "Hazy Blue Worlds: A Holistic Aerosol Model for Uranus and Neptune, Including Dark Spots"
+	#   https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022JE007189
+	#   https://ui.adsabs.harvard.edu/abs/2022JGRE..12707189I/abstract
 	Atmosphere
 	{
 		Height	240
 
-		# Aerosol-2 at 1 bar
 		Rayleigh	[ 0.00346 0.00822 0.02067 ]
 		MieScaleHeight	24
 
 		# Mie coefficient from Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
-		#   "Hazy Blue Worlds: A Holistic Aerosol Model for Uranus and Neptune, Including Dark Spots"
-		#   https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022JE007189
-		#   https://ui.adsabs.harvard.edu/abs/2022JGRE..12707189I/abstract
 		# Aerosol-3 opacity (τ_3) at 0.8 μm = 0.03
 		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 24 km
 		Mie	0.0025
@@ -1659,18 +1663,17 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 	Color	[ 0.78302 0.91535 1.0 ]
 	SemiAxes	[ 24760.6 24760.6 24285.3 ]
 	Mass<kg>	1.024092e26
+
+	# Atmosphere base: 1 bar (Aerosol-2)
+	# Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
 	Atmosphere
 	{
 		Height	180
 
-		# Aerosol-2 at 1 bar
 		Rayleigh	[ 0.00349 0.00830 0.02086 ]
 		MieScaleHeight	18
 
 		# Mie coefficient from Irwin et al. (2022), JGR: Planets 127 (6), article id. e07189
-		#   "Hazy Blue Worlds: A Holistic Aerosol Model for Uranus and Neptune, Including Dark Spots"
-		#   https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022JE007189
-		#   https://ui.adsabs.harvard.edu/abs/2022JGRE..12707189I/abstract
 		# Aerosol-3 opacity (τ_3) at 0.8 μm = 0.04
 		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 18 km
 		Mie	0.0044

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -549,7 +549,6 @@
 	Color	[ 1.0 0.98663 0.91433 ]
 	SemiAxes	[ 71488 71488 66842 ]
 	Mass<kg>	1.898125e27
-
 	Atmosphere
 	{
 		Height	170

--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -1670,7 +1670,6 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 		# Aerosol-3 opacity (τ_3) at 0.8 μm = 0.04
 		#   scaled by 2 (fudge to get opacity at 0.55 μm), divided by scale height = 18 km
 		Mie	0.0044
-		MieHGAnisotropy	0
 
 		Absorption	[ 0.003 0.003 0.004 ]
 	}


### PR DESCRIPTION
Added atmosphere definitions for Jupiter, Saturn, Uranus, and Neptune.
- The base of the atmosphere is selected to correspond to the uppermost major aerosol layer that the planet texture contains. Rayleigh scattering and absorption coefficients use this.
- Mie is only retained for Uranus and Neptune. MieHGAnisotropy is entirely ignored.
- Jupiter's and Saturn's absorption coefficients are methane gas absorption; as warm planets, methane abundance is likely constant across the atmosphere. On Jupiter especially, upper haze does not appear to impact visible light appearance significantly.
- Uranus's and Neptune's absorption coefficients are meant to simulate upper haze absorption. This haze is assumed to have the same colour as Titan's. Methane is not factored in as it would've condensed beneath the "base" of the atmosphere, leaving very little methane in the "atmosphere".