### PR TITLE
Separate Rayleigh and Mie scale heights

### DIFF
--- a/data/solarsys.ssc
+++ b/data/solarsys.ssc
@@ -250,15 +250,14 @@
 		#   https://opg.optica.org/ao/abstract.cfm?uri=ao-34-15-2765 [Paywalled]
 		#   R = 0.68 μm, G = 0.55 μm, B = 0.44 μm
 		Rayleigh	[ 0.004847 0.01149 0.02870 ]
-		MieScaleHeight	8.5  # Rayleigh scale height
+		RayleighScaleHeight	8.5
 
         # Bruneton & Neyret (2008), Special Issue: Proceedings of the 19th Eurographics Symposium on Rendering 27 (4), pp.1079-1086
         #   "Precomputed Atmospheric Scattering"
         #   https://inria.hal.science/inria-00288758/en
-		# - Mie scattering coefficient (B{_M}{^s}) = 0.01 km^-1
-        Mie	0.0014
+        Mie	0.01
         MieHGAnisotropy	0.76
-        #MieScaleHeight	1.2  # the real Mie scale height
+        MieScaleHeight	1.2
 
 		# Approximating absorption due to gases in the atmosphere.
 		#   O2: 0.2095 (corrected with /1.004 to account for H2O)
@@ -1779,16 +1778,17 @@ AltSurface "Limit of knowledge" "Sol/Jupiter/Callisto"
 
 		# Rayleigh coefficient multiplied by fudge factor to correct appearance.
 		#   Fudge factor: 10
-		# Rayleigh scale height and Mie anisotropy from Gao & Ohno (2024)
+		# Scale heights and Mie anisotropy from Gao & Ohno (2024)
 		#   "Clouds and Hazes in the Atmospheres of Triton and Pluto"
 		#   https://arxiv.org/abs/2411.12031
 		#   Mie anisotropy assumed to be the same as discrete component's.
 		Rayleigh	[ 0.0000052 0.0000124 0.0000309 ]
-		MieScaleHeight	16  # Rayleigh scale height
+		RayleighScaleHeight	16
 		
 		# Mie coefficient scaled from Pluto's, using optical depth from Gao & Ohno (2024).
-		Mie	0.000002
+		Mie	0.000003
 		MieHGAnisotropy	0.6
+		MieScaleHeight	11
 	}
 	CustomOrbit	"triton"
 


### PR DESCRIPTION
Following https://github.com/CelestiaProject/Celestia/pull/2673, RayleighScaleHeight is now actively used. Currently it is used for Earth (RayleighH = 8.5 km, MieH = 1.2 km) and Triton (RayleighH = 16 km, MieH = 11 km).

Comments on other planets:
- Venus and the giant planets: The current Mie scattering is a fix to make the atmosphere less blue, rather than anything physical.
- Mars: Mars should feature a Rayleigh atmosphere above dusty troposphere. The problem is that currently, Rayleigh scattering itself is used for simulating dust.
- Titan: No Mie defined.
- Pluto: MieH appears to be roughly equal to RayleighH, so a new parameter is not needed.

Ideally, every entry here should use RayleighScaleHeight, but currently only defining RayleighScaleHeight is not supported.